### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Here are a few features:
 * Project workspaces
 * Logging and auditing of workflow and jobs
 
-To go to the package download links: [Download-Packages](azkaban2/wiki/Download-Packages)
+To go to the package download links: [Download-Packages](https://github.com/azkaban/azkaban2/wiki/Download-Packages)
 
-To go to the azkaban-plugins github repo: [Azkaban-plugins](azkaban-plugins)
+To go to the azkaban-plugins github repo: [Azkaban-plugins](https://github.com/azkaban/azkaban-plugins)
 
 There is a google groups: [Azkaban Group](https://groups.google.com/forum/?fromgroups#!forum/azkaban-dev)


### PR DESCRIPTION
Due to Github's new relative links - https://github.com/blog/1395-relative-links-in-markup-files the links to Downloads the plugins were broken. Using full url fixes this issue.
