### PR TITLE
Fix for concurrent modification exception during schedule load

### DIFF
--- a/src/java/azkaban/scheduler/JdbcScheduleLoader.java
+++ b/src/java/azkaban/scheduler/JdbcScheduleLoader.java
@@ -17,28 +17,25 @@
 package azkaban.scheduler;
 
 
+import azkaban.utils.DataSourceUtils;
+import azkaban.utils.GZIPUtils;
+import azkaban.utils.JSONUtils;
+import azkaban.utils.Props;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
-
 import javax.sql.DataSource;
-
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.log4j.Logger;
-
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
-
-import azkaban.utils.DataSourceUtils;
-import azkaban.utils.GZIPUtils;
-import azkaban.utils.JSONUtils;
-import azkaban.utils.Props;
 
 
 public class JdbcScheduleLoader implements ScheduleLoader {
@@ -149,10 +146,12 @@ public class JdbcScheduleLoader implements ScheduleLoader {
 		logger.info("Now trying to update the schedules");
 		
 		// filter the schedules
-		for(Schedule sched : schedules) {
+        Iterator<Schedule> scheduleIterator = schedules.iterator();
+        while (scheduleIterator.hasNext()) {
+            Schedule sched = scheduleIterator.next();
 			if(!sched.updateTime()) {
 				logger.info("Schedule " + sched.getScheduleName() + " was scheduled before azkaban start, skipping it.");
-				schedules.remove(sched);
+				scheduleIterator.remove();
 				removeSchedule(sched);
 			}
 			else {


### PR DESCRIPTION
We were seeing the following exception during Azkaban startup:

Caused by: java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:819)
        at java.util.ArrayList$Itr.next(ArrayList.java:791)
        at azkaban.scheduler.JdbcScheduleLoader.loadSchedules(JdbcScheduleLoader.java:152)
        at azkaban.scheduler.ScheduleManager.<init>(ScheduleManager.java:92)
        at azkaban.webapp.AzkabanWebServer.loadScheduleManager(AzkabanWebServer.java:224)
        at azkaban.webapp.AzkabanWebServer.<init>(AzkabanWebServer.java:163)
        at azkaban.webapp.AzkabanWebServer.main(AzkabanWebServer.java:420)
        ... 8 more

which is caused by the call to schedules.remove inside the for each loop. This patch fixes the issue by switching to explicitly iterating using a iterator.
