### PR TITLE
make the upload process compatible with chrome/firefox

### DIFF
--- a/src/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/src/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1249,7 +1249,10 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 			String type = null;
 			
 			final String contentType = item.getContentType();
-			if(contentType != null && (contentType.startsWith("application/zip") || contentType.startsWith("application/x-zip-compressed"))) {
+            if (contentType != null
+                && (contentType.startsWith("application/zip")
+                    || contentType.startsWith("application/x-zip-compressed")
+                    || contentType.startsWith("application/octet-stream"))) {
 				type = "zip";
 			}
 			else {


### PR DESCRIPTION
As is mentioned in [issue29](https://github.com/azkaban/azkaban2/issues/29), the upload process refuses a zip file uploaded with MIME type 'application/octec-stream', which is set by chrome/firefox. This pull request would solve the problem.
