### PR TITLE
Fix broken HTML entities

### DIFF
--- a/documents/2.1/ajaxapi.markdown
+++ b/documents/2.1/ajaxapi.markdown
@@ -37,7 +37,7 @@ A session can expire if you log out, change machines or location, Azkaban is res
 session timeout is a day. You can re-login if the session expires.
 
 <pre class="code">
-curl -k --data "action=login&username=azkaban&password=azkaban" https://localhost:8443
+curl -k --data "action=login&amp;username=azkaban&amp;password=azkaban" https://localhost:8443
 </pre>
 
 <hr/>

--- a/documents/2.1/xmlusermanager.markdown
+++ b/documents/2.1/xmlusermanager.markdown
@@ -86,7 +86,7 @@ _roles_ tag.
   &lt;user username="a" ... groups="groupa" roles="readall" / &gt;
   &lt;user username="b" ... / &gt;
   ...
-  &lt;group name="groupa" roles="admin" / &gt
+  &lt;group name="groupa" roles="admin" / &gt;
   ...
   &lt;role name="admin" permissions="ADMIN" / &gt;
   &lt;role name="readall" permissions="READ" / &gt;


### PR DESCRIPTION
These broken entities prevent the site from being built by jekyll (and thus, the docs are potentially out of date).
