### PR TITLE
Fix Bug: Timezone default settings doesn't work

### DIFF
--- a/src/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/src/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -174,6 +174,7 @@ public class AzkabanExecutorServer {
 		// Setup time zone
 		if (azkabanSettings.containsKey(DEFAULT_TIMEZONE_ID)) {
 			String timezone = azkabanSettings.getString(DEFAULT_TIMEZONE_ID);
+			System.setProperty("user.timezone", timezone);
 			TimeZone.setDefault(TimeZone.getTimeZone(timezone));
 			DateTimeZone.setDefault(DateTimeZone.forID(timezone));
 

--- a/src/java/azkaban/webapp/AzkabanWebServer.java
+++ b/src/java/azkaban/webapp/AzkabanWebServer.java
@@ -200,6 +200,7 @@ public class AzkabanWebServer extends AzkabanServer {
 		// Setup time zone
 		if (props.containsKey(DEFAULT_TIMEZONE_ID)) {
 			String timezone = props.getString(DEFAULT_TIMEZONE_ID);
+			System.setProperty("user.timezone", timezone);
 			TimeZone.setDefault(TimeZone.getTimeZone(timezone));
 			DateTimeZone.setDefault(DateTimeZone.forID(timezone));
 			logger.info("Setting timezone to " + timezone);


### PR DESCRIPTION
We found timezone settings doesn't work. When I use property of system, it can work. So I fix it.
