### PR TITLE
Make empty table messages display correctly

### DIFF
--- a/src/java/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -17,7 +17,7 @@
 <!DOCTYPE html> 
 <html>
 	<head>
-#parse( "azkaban/webapp/servlet/velocity/style.vm" )
+#parse("azkaban/webapp/servlet/velocity/style.vm")
 		<script type="text/javascript" src="${context}/js/jquery/jquery-1.9.1.js"></script>    
 		<script type="text/javascript" src="${context}/js/underscore-1.4.4-min.js"></script>
 		<script type="text/javascript" src="${context}/js/namespace.js"></script>
@@ -35,7 +35,7 @@
 	</head>
 	<body>
 		#set($current_page="executing")
-#parse( "azkaban/webapp/servlet/velocity/nav.vm" )
+#parse("azkaban/webapp/servlet/velocity/nav.vm")
 		<div class="messaging"><p id="messageClose">X</p><p id="message"></p></div>  
 
 		<div class="content">
@@ -63,8 +63,8 @@
 						</tr>
 					</thead>
 					<tbody>
-						#if($runningFlows)
-#foreach($flow in $runningFlows)
+#if($runningFlows)
+	#foreach($flow in $runningFlows)
 						<tr class="row" >
 							<td class="tb-name">
 								<a href="${context}/executor?execid=${flow.executionId}">${flow.executionId}</a>
@@ -81,7 +81,7 @@
 							<td><div class="status ${flow.status}">$utils.formatStatus(${flow.status})</div></td>
 							<td></td>
 						</tr>
-#end
+	#end
 #else
 						<tr><td></td><td class="last">No Executing Flows</td></tr>
 #end
@@ -106,8 +106,8 @@
 						</tr>
 					</thead>
 					<tbody>
-						#if($recentlyFinished)
-#foreach($flow in $recentlyFinished)
+#if($recentlyFinished.isEmpty())
+	#foreach($flow in $recentlyFinished)
 						<tr class="row" >
 							<td class="tb-name execId">
 								<a href="${context}/executor?execid=${flow.executionId}">${flow.executionId}</a>
@@ -124,7 +124,7 @@
 							<td><div class="status ${flow.status}">$utils.formatStatus(${flow.status})</div></td>
 							<td></td>
 						</tr>
-#end
+	#end
 #else
 						<tr><td></td><td class="last">No Recently Finished</td></tr>
 #end	

--- a/src/java/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/historypage.vm
@@ -82,8 +82,8 @@
 						</tr>
 					</thead>
 					<tbody>
-						#if($flowHistory)
-#foreach($flow in $flowHistory)
+#if(!$flowHistory.isEmpty())
+	#foreach($flow in $flowHistory)
 						<tr class="row" >
 							<td class="tb-name execId">
 								<a href="${context}/executor?execid=${flow.executionId}">${flow.executionId}</a>
@@ -101,9 +101,9 @@
 							<td><div class="status ${flow.status}">$utils.formatStatus(${flow.status})</div></td>
 							<td></td>
 						</tr>
-#end
+	#end
 #else
-						<tr><td class="last">No History Results Found</td></tr>
+						<tr><td class="last" colspan="9">No History Results Found</td></tr>
 #end
 					</tbody>
 				</table>

--- a/src/java/azkaban/webapp/servlet/velocity/index.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/index.vm
@@ -17,7 +17,7 @@
 <!DOCTYPE html> 
 <html>
 	<head>
-#parse( "azkaban/webapp/servlet/velocity/style.vm" )
+#parse("azkaban/webapp/servlet/velocity/style.vm")
 		<script type="text/javascript" src="${context}/js/jquery/jquery-1.9.1.js"></script>
 		<script type="text/javascript" src="${context}/js/namespace.js"></script>
 		<script type="text/javascript" src="${context}/js/underscore-1.4.4-min.js"></script>
@@ -35,8 +35,8 @@
 		</script>
 	</head>
 	<body>
-		#set($current_page="all")
-#parse( "azkaban/webapp/servlet/velocity/nav.vm" )
+#set($current_page="all")
+#parse("azkaban/webapp/servlet/velocity/nav.vm")
 		<div class="messaging"><p id="messageClose">X</p><p id="message"></p></div>  
 
 		<div class="content">
@@ -81,8 +81,8 @@
 					</tr>
 				</thead>
 				<tbody>
-#if($projects)
-#foreach($project in $projects)
+#if(!$projects.isEmpty())
+	#foreach($project in $projects)
 					<tr class="row">
 						<td class="tb-name expand project-expand" id="${project.name}">
 							<span class="state-icon"></span>
@@ -102,7 +102,7 @@
 							</table>
 						</td>
 					</tr>
-#end
+	#end
 #else
 					<tr><td class="last">No viewable projects found.</td></tr>
 #end

--- a/src/java/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
@@ -81,8 +81,8 @@
 						</tr>
 					</thead>
 					<tbody>
-						#if($schedules)
-#foreach($sched in $schedules)
+#if(!$schedules.isEmpty())
+	#foreach($sched in $schedules)
 						<tr class="row" >
 
 							<td>${sched.scheduleId}</td>
@@ -100,7 +100,7 @@
 							<td><button id="removeSchedBtn" onclick="removeSched(${sched.scheduleId})" >Remove Schedule</button></td>
 							<td><button id="addSlaBtn" onclick="slaView.initFromSched(${sched.scheduleId}, '${sched.flowName}')" >Set SLA</button></td>
 						</tr>
-#end
+	#end
 #else
 						<tr><td class="last">No Scheduled Flow Found</td></tr>
 #end


### PR DESCRIPTION
For arrays on some Velocity templates, such as $projects on the index page, the variable is populated with an empty array rather than null. Thus, the if($projects) check returns true and an empty table, rather than the "no projects" message, is displayed.

This patch fixes those instances where the array variable in the template contains empty arrays rather than null.
