### PR TITLE
Remove .tl from servlet web sources

### DIFF
--- a/src/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/src/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -64,7 +64,6 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
 		contextType.put(".jpeg", "image/jpeg");
 		contextType.put(".gif", "image/gif");
 		contextType.put(".jpg", "image/jpeg");
-		contextType.put(".tl", "text/dust-template");
 	}
 	
 	private File webResourceDirectory = null;


### PR DESCRIPTION
Removing this because dustjs templates are compiled on the server side so the client only receives the JavaScript that the templates are compiled to.
