### PR TITLE
Add /bin/bash magic cookies to startup scripts

### DIFF
--- a/src/package/execserver/bin/azkaban-executor-start.sh
+++ b/src/package/execserver/bin/azkaban-executor-start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 azkaban_dir=$(dirname $0)/..
 
 if [[ -z "$tmpdir" ]]; then

--- a/src/package/execserver/bin/start-exec.sh
+++ b/src/package/execserver/bin/start-exec.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 base_dir=$(dirname $0)/..
 
 bin/azkaban-executor-start.sh $base_dir 2>&1>logs/executorServerLog__`date +%F+%T`.out &

--- a/src/package/soloserver/bin/azkaban-solo-start.sh
+++ b/src/package/soloserver/bin/azkaban-solo-start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 azkaban_dir=$(dirname $0)/..
 
 if [[ -z "$tmpdir" ]]; then

--- a/src/package/triggerserver/bin/azkaban-trigger-start.sh
+++ b/src/package/triggerserver/bin/azkaban-trigger-start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 azkaban_dir=$(dirname $0)/..
 
 if [[ -z "$tmpdir" ]]; then

--- a/src/package/webserver/bin/azkaban-web-start.sh
+++ b/src/package/webserver/bin/azkaban-web-start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 azkaban_dir=$(dirname $0)/..
 
 if [[ -z "$tmpdir" ]]; then

--- a/src/package/webserver/bin/start-web.sh
+++ b/src/package/webserver/bin/start-web.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 base_dir=$(dirname $0)/..
 
 bin/azkaban-web-start.sh $base_dir 2>&1>logs/webServerLog_`date +%F+%T`.out &


### PR DESCRIPTION
The shutdown scripts have #!/bin/bash magic cookies but the startup scripts do not.

This PR also addresses Issue #75.
