### PR TITLE
Time graph improvements

### DIFF
--- a/src/web/js/azkaban/view/time-graph.js
+++ b/src/web/js/azkaban/view/time-graph.js
@@ -87,13 +87,29 @@ azkaban.TimeGraphView = Backbone.View.extend({
       }
     };
 
+    var yLabelFormatCallback = function(y) {
+      var seconds = y / 1000.0;
+      return seconds.toString() + " s";
+    };
+
+    var hoverCallback = function(index, options, content) {
+      // Note: series contains the data points in descending order and index
+      // is the index into Morris's internal array of data sorted in ascending
+      // x order.
+      var status = series[options.data.length - index - 1].status;
+      return content + 
+          '<div class="morris-hover-point">Status: ' + status + '</div>';
+    };
+
     Morris.Line({
       element: this.element,
       data: data,
       xkey: 'time',
       ykeys: ['duration'],
       labels: ['Duration'],
-      lineColors: lineColorsCallback
+      lineColors: lineColorsCallback,
+      yLabelFormat: yLabelFormatCallback,
+      hoverCallback: hoverCallback
     });
 	}
 });


### PR DESCRIPTION
- Time graph hover now also displays status.
- y-axis now labeled in units of seconds but should still scale similar to d3.time.scale.
