### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+languages: java
+install:
+ - time npm install -g less dustjs-linkedin
+script: ant


### PR DESCRIPTION
Add .travis.yml to enable Travis CI to enable automatic builds. Adding unit test support will be as simple as adding an Ant target for running unit tests and updating the `script` property in .travis.yml.

I have already enabled azkaban/azkaban2 in Travis.
