### PR TITLE
Add Travis build tag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Azkaban2
 
+[![Build Status](https://travis-ci.org/azkaban/azkaban2.png?branch=master)](https://travis-ci.org/azkaban/azkaban2)
+
 For Azkaban documentation, please go to
 [Azkaban Project Site](http://azkaban.github.io/azkaban2/)
 There is a google groups: [Azkaban Group](https://groups.google.com/forum/?fromgroups#!forum/azkaban-dev)


### PR DESCRIPTION
A Travis build image in the README shows whether the CI builds are passing or failing (or in progress).
