### PR TITLE
Fix Flow Overrides editable table

### DIFF
--- a/src/java/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -165,7 +165,7 @@
 												<tbody>
 													<tr id="addRow" class="addRow">
 														<td id="addRow-col" colspan="2">
-															<button type="button" class="btn btn-success btn-xs">Add Row</button>
+															<button type="button" class="btn btn-success btn-xs" id="add-btn">Add Row</button>
 														</td>
 													</tr>
 												</tbody>

--- a/src/java/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -196,7 +196,7 @@
 								<tbody>
 									<tr id="addRow">
 										<td id="addRow-col" colspan="2">
-											<button type="button" class="btn btn-xs btn-success">Add Row</button>
+											<button type="button" class="btn btn-xs btn-success" id="add-btn">Add Row</button>
 										</td>
 									</tr>
 								</tbody>

--- a/src/java/azkaban/webapp/servlet/velocity/slapanel.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/slapanel.vm
@@ -44,7 +44,7 @@
 									<tr id="addRow">
 										<td id="addRow-col" colspan="5">
 											<span class="addIcon"></span>
-											<button type="button" class="btn btn-xs btn-success">Add Row</button>
+											<button type="button" class="btn btn-xs btn-success" id="add-btn">Add Row</button>
 										</td>
 									</tr>
 								</tbody>

--- a/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -314,9 +314,9 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
 var editTableView;
 azkaban.EditTableView = Backbone.View.extend({
 	events: {
-		"click table .addRow": "handleAddRow",
+		"click table #add-btn": "handleAddRow",
 		"click table .editable": "handleEditColumn",
-		"click table .removeIcon": "handleRemoveColumn"
+		"click table .remove-btn": "handleRemoveColumn"
 	},
 
 	initialize: function(setting) {

--- a/src/web/js/azkaban/view/job-edit.js
+++ b/src/web/js/azkaban/view/job-edit.js
@@ -23,7 +23,7 @@ azkaban.JobEditView = Backbone.View.extend({
 		"click #set-btn": "handleSet",	
 		"click #cancel-btn": "handleCancel",
 		"click #close-btn": "handleCancel",
-		"click #addRow": "handleAddRow",
+		"click #add-btn": "handleAddRow",
 		"click table .editable": "handleEditColumn",
 		"click table .remove-btn": "handleRemoveColumn"
 	},

--- a/src/web/js/azkaban/view/schedule-sla.js
+++ b/src/web/js/azkaban/view/schedule-sla.js
@@ -21,7 +21,7 @@ azkaban.ChangeSlaView = Backbone.View.extend({
 		"click": "closeEditingTarget",
 		"click #set-sla-btn": "handleSetSla",	
 		"click #remove-sla-btn": "handleRemoveSla",
-		"click #addRow": "handleAddRow"
+		"click #add-btn": "handleAddRow"
 	},
 	
 	initialize: function(setting) {


### PR DESCRIPTION
Fixes #141
- Fix issue where 'Delete' is being prepended to flow override values.
- Fix issue where 'Delete' button does not work in flow overrides.
- Trigger add row only when clicking 'Add row' button and not the row itself.
