### PR TITLE
Removed 2 unused imports in TriggerManagerDeadlockTest.java

### DIFF
--- a/unit/java/azkaban/test/trigger/TriggerManagerDeadlockTest.java
+++ b/unit/java/azkaban/test/trigger/TriggerManagerDeadlockTest.java
@@ -1,13 +1,10 @@
 package azkaban.test.trigger;
 
-import static org.junit.Assert.*;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Removed unused imports so that no warnings appear in the Eclipse Problems view.
