### PR TITLE
Create jars in dist.jars.dir instead of source tree root.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -169,7 +169,7 @@ ${current.time}
 	
 	<target name="jars" depends="build" description="Create azkaban jar">
 		<mkdir dir="${dist.jar.dir}" />
-		<jar destfile="azkaban-${git.tag}.jar">
+		<jar destfile="${dist.jar.dir}/azkaban-${git.tag}.jar">
 			<fileset dir="${dist.classes.dir}">
 				<include name="**/*.*" />
 			</fileset>
@@ -243,7 +243,7 @@ ${current.time}
 		<mkdir dir="${dist.web.package.dir}/extlib" />	
 			
 		<!-- Copy Azkaban jars and libs-->
-		<copy file="azkaban-${git.tag}.jar" todir="${dist.web.package.dir}/lib" />
+		<copy file="${dist.jar.dir}/azkaban-${git.tag}.jar" todir="${dist.web.package.dir}/lib" />
 		<copy todir="${dist.web.package.dir}/lib" >
 			<fileset dir="${lib.dir}" >
 				<exclude name="hadoop-core*.jar"/>
@@ -298,7 +298,7 @@ ${current.time}
 		<mkdir dir="${dist.exec.package.dir}/extlib" />
 				
 		<!-- Copy Azkaban jars and libs-->
-		<copy file="azkaban-${git.tag}.jar" todir="${dist.exec.package.dir}/lib" />
+		<copy file="${dist.jar.dir}/azkaban-${git.tag}.jar" todir="${dist.exec.package.dir}/lib" />
 		<copy todir="${dist.exec.package.dir}/lib" >
 			<fileset dir="${lib.dir}" >
 				<exclude name="hadoop-core*.jar"/>
@@ -339,7 +339,7 @@ ${current.time}
 		<mkdir dir="${dist.solo.package.dir}/sql" />
 				
 		<!-- Copy Azkaban jars and libs-->
-		<copy file="azkaban-${git.tag}.jar" todir="${dist.solo.package.dir}/lib" />
+		<copy file="${dist.jar.dir}/azkaban-${git.tag}.jar" todir="${dist.solo.package.dir}/lib" />
 		<copy todir="${dist.solo.package.dir}/lib" >
 			<fileset dir="${lib.dir}" >
 				<exclude name="hadoop-core*.jar"/>
@@ -368,7 +368,7 @@ ${current.time}
 		
 		<!-- Copy compiled less CSS -->
 		<copy todir="${dist.solo.package.dir}/web/css">
-      <fileset dir="${dist.less.dir}" />
+			<fileset dir="${dist.less.dir}" />
 		</copy>
 		
 		<!-- Copy sql files -->


### PR DESCRIPTION
Fixes #153
