### PR TITLE
Hide-able job list to give graph more real-estate

### DIFF
--- a/src/java/azkaban/webapp/servlet/velocity/flowgraphview.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/flowgraphview.vm
@@ -16,12 +16,12 @@
 
 	## Graph view.
 		<div class="container-full container-fill" id="graphView">
-			<div class="glyphicon glyphicon-th-list" id="openJobList" title="Open Job List Panel"></div>
+			<div class="glyphicon glyphicon-th-list" id="open-joblist-btn" title="Open Job List Panel"></div>
 			<div class="graph-sidebar">
-				<div class="panel panel-default" id="joblistpanel">
+				<div class="panel panel-default" id="joblist-panel">
 					<div class="panel-heading">
-						<div id="closebtn" title="Close Panel"><span class="glyphicon glyphicon-remove"> </span></div>
-						<div id="inputboxpanel">
+						<div id="close-btn" title="Close Panel"><span class="glyphicon glyphicon-remove"></span></div>
+						<div id="inputbox-panel">
 							<input id="filter" type="text" placeholder="Job Filter" class="form-control input-sm">
 						</div>
 					</div>

--- a/src/less/azkaban-graph.less
+++ b/src/less/azkaban-graph.less
@@ -1,12 +1,12 @@
 .nodebox {
   text {
     pointer-events: none;
-  	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   image {

--- a/src/less/flow.less
+++ b/src/less/flow.less
@@ -173,12 +173,12 @@ td {
   bottom: 0px;
 }
 
-#inputboxpanel {
+#inputbox-panel {
 	width: 206px;
 	margin: 0px;
 }
 
-#closebtn {
+#close-btn {
 	float: right;
 	color: #CCC;
 	padding: 5px 0px;
@@ -188,7 +188,7 @@ td {
 	}
 }
 
-#joblistpanel {
+#joblist-panel {
 	height: 100%;
 	
 	.panel-heading {
@@ -196,7 +196,7 @@ td {
 	}
 }
 
-#openJobList {
+#open-joblist-btn {
 	position: absolute;
 	margin: 10px;
 	color: #CCC;
@@ -236,7 +236,7 @@ li.tree-list-item {
     display: block;
     border-bottom-width: 0;
     padding: 5px 15px;
-	font-size: 8pt;
+    font-size: 8pt;
 
     &:hover,
     &:focus {

--- a/src/web/js/azkaban/util/svg-navigate.js
+++ b/src/web/js/azkaban/util/svg-navigate.js
@@ -108,7 +108,7 @@
 		var x = evt.offsetX;
 
 		evt.stopPropagation();
-        evt.preventDefault();
+		evt.preventDefault();
 		
 		scaleGraph(target, scale, x, y);
 	}

--- a/src/web/js/azkaban/view/exflow.js
+++ b/src/web/js/azkaban/view/exflow.js
@@ -546,7 +546,7 @@ $(function() {
 	});
 	
 	jobsListView = new azkaban.JobListView({
-		el: $('#joblistpanel'), 
+		el: $('#joblist-panel'), 
 		model: graphModel, 
 		contextMenuCallback: jobClickCallback
 	});

--- a/src/web/js/azkaban/view/flow.js
+++ b/src/web/js/azkaban/view/flow.js
@@ -423,7 +423,7 @@ $(function() {
 	});
 	
   jobsListView = new azkaban.JobListView({
-		el: $('#joblistpanel'), 
+		el: $('#joblist-panel'), 
 		model: graphModel, 
 		contextMenuCallback: jobClickCallback
 	});

--- a/src/web/js/azkaban/view/job-list.js
+++ b/src/web/js/azkaban/view/job-list.js
@@ -26,7 +26,7 @@ azkaban.JobListView = Backbone.View.extend({
 		"click #autoPanZoomBtn": "handleAutoPanZoom",
 		"contextmenu li.listElement": "handleContextMenuClick",
 		"click .expandarrow": "handleToggleMenuExpand",
-		"click #closebtn" : "handleClose"
+		"click #close-btn" : "handleClose"
 	},
 	
 	initialize: function(settings) {
@@ -35,8 +35,8 @@ azkaban.JobListView = Backbone.View.extend({
 		this.model.bind('change:graph', this.render, this);
 		this.model.bind('change:update', this.handleStatusUpdate, this);
 		
-		$("#openJobList").click(this.handleOpen);
-		$("#joblistpanel").hide();
+		$("#open-joblist-btn").click(this.handleOpen);
+		$("#joblist-panel").hide();
 		
 		this.filterInput = $(this.el).find("#filter");
 		this.list = $(this.el).find("#joblist");
@@ -336,9 +336,9 @@ azkaban.JobListView = Backbone.View.extend({
 	},
 	
 	handleClose: function(evt) {
-		$("#joblistpanel").fadeOut();
+		$("#joblist-panel").fadeOut();
 	},
 	handleOpen: function(evt) {
-		$("#joblistpanel").fadeIn();
+		$("#joblist-panel").fadeIn();
 	}
 });


### PR DESCRIPTION
Addresses https://github.com/azkaban/azkaban2/issues/148 and partially https://github.com/azkaban/azkaban2/issues/149.

The job list is now hidden by default, but expandable. The nodes aren't selectable, but we currently can't pan while dragging them due to unknown svg behaviour.
