### PR TITLE
Use callouts instead of alerts for placeholder boxes.

### DIFF
--- a/src/java/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -147,7 +147,7 @@
       <div id="flow-stats-container">
         <div class="row">
           <div class="col-xs-12">
-            <div class="alert alert-info">
+            <div class="callout callout-info">
               <h4>Analyze last run</h4>
               <p>Analyze the last run for aggregate performance statistics. <strong>Note:</strong> this may take a few minutes, especially if your flow is large.</p>
               <p>

--- a/src/java/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -85,7 +85,7 @@
             </div>
 		#end
 	#else
-            <div class="alert alert-default">
+            <div class="callout callout-default">
               <h4>No Flows</h4>
               <p>No flows have been uploaded to this project yet.</p>
             </div>

--- a/src/less/Makefile
+++ b/src/less/Makefile
@@ -19,7 +19,8 @@ azkaban_css_DEPS = \
 	non-responsive.less \
 	off-canvas.less \
 	project.less \
-	tables.less
+	tables.less \
+	callout.less
 
 $(OBJ_DIR)/azkaban.css: $(azkaban_css_DEPS)
 	$(LESSC) $< $@

--- a/src/less/azkaban.less
+++ b/src/less/azkaban.less
@@ -8,6 +8,7 @@
 
 @import "context-menu.less";
 @import "tables.less";
+@import "callout.less";
 
 @import "login.less";
 @import "project.less";

--- a/src/less/callout.less
+++ b/src/less/callout.less
@@ -1,0 +1,64 @@
+/*
+ * Callouts
+ *
+ * Not quite alerts, but custom and helpful notes for folks reading the docs.
+ * Requires a base and modifier class.
+ */
+
+/* Common styles for all types */
+.callout {
+  margin: 20px 0;
+  padding: 20px;
+  border-left: 3px solid #eee;
+
+  h4 {
+    margin-top: 0;
+    margin-bottom: 5px;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  code {
+    background-color: #fff;
+    border-radius: 3px;
+  }
+}
+
+/* Variations */
+.callout-danger {
+  background-color: #fdf7f7;
+  border-color: #d9534f;
+  
+  h4 {
+    color: #d9534f;
+  }
+}
+
+.callout-warning {
+  background-color: #fcf8f2;
+  border-color: #f0ad4e;
+
+  h4 {
+    color: #f0ad4e;
+  }
+}
+
+.callout-info {
+  background-color: #f4f8fa;
+  border-color: #5bc0de;
+
+  h4 {
+    color: #5bc0de;
+  }
+}
+
+.callout-default {  
+  background-color: #f5f5f5;
+  border-color: #dddddd;
+
+  h4 {
+    color: #a0a0a0;
+  }
+}

--- a/src/tl/flowstats-no-data.tl
+++ b/src/tl/flowstats-no-data.tl
@@ -1,6 +1,6 @@
       <div class="row">
         <div class="col-xs-12">
-          <div class="alert alert-default">
+          <div class="callout callout-default">
             <h4>No Flow Stats Available</h4>
             <p>{message}</p>
           </div>

--- a/src/tl/flowsummary.tl
+++ b/src/tl/flowsummary.tl
@@ -58,7 +58,7 @@
             </tbody>
           </table>
           {:else}
-            <div class="alert alert-default">
+            <div class="callout callout-default">
               <h4>None</h4>
               <p>This flow has not been scheduled.</p>
             </div>


### PR DESCRIPTION
Fixes Issue #164

![screen shot 2014-02-11 at 4 33 54 pm](https://f.cloud.github.com/assets/5283042/2144025/7c5a0614-937d-11e3-9315-052bfcae125c.png)
