### PR TITLE
remove project permissions from project serialization/de-serialization

### DIFF
--- a/src/java/azkaban/project/Project.java
+++ b/src/java/azkaban/project/Project.java
@@ -265,17 +265,6 @@ public class Project {
 			projectObject.put("metadata", metadata);
 		}
 
-		ArrayList<Map<String, Object>> users = new ArrayList<Map<String, Object>>();
-		for (Map.Entry<String, Permission> entry : userPermissionMap.entrySet()) {
-			HashMap<String, Object> userMap = new HashMap<String, Object>();
-			userMap.put("userId", entry.getKey());
-			userMap.put("permissions", entry.getValue().toStringArray());
-			users.add(userMap);
-		}
-		
-		projectObject.put("users", users);
-		
-
 		ArrayList<String> proxyUserList = new ArrayList<String>(proxyUsers);
 		projectObject.put("proxyUsers", proxyUserList);
 		
@@ -310,18 +299,6 @@ public class Project {
 		}
 		if (metadata != null) {
 			project.setMetadata(metadata);
-		}
-		
-		List<Map<String, Object>> users = (List<Map<String, Object>>) projectObject
-				.get("users");
-
-		for (Map<String, Object> user : users) {
-			String userid = (String) user.get("userId");
-			Permission perm = new Permission();
-			List<String> list = (List<String>) user.get("permissions");
-			perm.addPermissionsByName(list);
-
-			project.setUserPermission(userid, perm);
 		}
 		
 		List<String> proxyUserList = (List<String>) projectObject.get("proxyUsers");


### PR DESCRIPTION
HADOOP-4422 Added user don't have permission to access Azkaban workflow
The user add/remove was not trimming white spaces, which caused problems with DB persistence. 
After fixing DB, the permission problem was still not resoled as project permission was encoded/decoded in projects. This patch is to remove it from projects so that project permission is only in project_permission table.
