### PR TITLE
Make time values on JMX page consistent.

### DIFF
--- a/src/java/azkaban/jmx/JmxTriggerManager.java
+++ b/src/java/azkaban/jmx/JmxTriggerManager.java
@@ -1,7 +1,5 @@
 package azkaban.jmx;
 
-import org.joda.time.DateTime;
-
 import azkaban.trigger.TriggerManagerAdapter;
 import azkaban.trigger.TriggerManagerAdapter.TriggerJMX;
 
@@ -13,8 +11,8 @@ public class JmxTriggerManager implements JmxTriggerManagerMBean {
 	}
 
 	@Override
-	public String getLastRunnerThreadCheckTime() {
-		return new DateTime(jmxStats.getLastRunnerThreadCheckTime()).toString();
+	public long getLastRunnerThreadCheckTime() {
+		return jmxStats.getLastRunnerThreadCheckTime();
 	}
 
 	@Override
@@ -57,7 +55,4 @@ public class JmxTriggerManager implements JmxTriggerManagerMBean {
 		// TODO Auto-generated method stub
 		return jmxStats.getScannerThreadStage();
 	}
-	
-	
-	
 }

--- a/src/java/azkaban/jmx/JmxTriggerManagerMBean.java
+++ b/src/java/azkaban/jmx/JmxTriggerManagerMBean.java
@@ -3,7 +3,7 @@ package azkaban.jmx;
 public interface JmxTriggerManagerMBean {	
 	
 	@DisplayName("OPERATION: getLastThreadCheckTime")
-	public String getLastRunnerThreadCheckTime();
+	public long getLastRunnerThreadCheckTime();
 
 	@DisplayName("OPERATION: isThreadActive")
 	public boolean isRunnerThreadActive();

--- a/src/java/azkaban/trigger/TriggerManager.java
+++ b/src/java/azkaban/trigger/TriggerManager.java
@@ -294,8 +294,6 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
 					logger.info("Doing trigger actions");
 					action.doAction();
 				} catch (Exception e) {
-					// TODO Auto-generated catch block
-					//throw new TriggerManagerException("action failed to execute", e);
 					logger.error("Failed to do action " + action.getDescription(), e);
 				} catch (Throwable th) {
 					logger.error("Failed to do action " + action.getDescription(), th);
@@ -322,8 +320,6 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
 					logger.info("Doing expire actions");
 					action.doAction();
 				} catch (Exception e) {
-					// TODO Auto-generated catch block
-					//throw new TriggerManagerException("action failed to execute", e);
 					logger.error("Failed to do expire action " + action.getDescription(), e);
 				} catch (Throwable th) {
 					logger.error("Failed to do expire action " + action.getDescription(), th);
@@ -433,13 +429,11 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
 
 		@Override
 		public long getLastRunnerThreadCheckTime() {
-			// TODO Auto-generated method stub
 			return lastRunnerThreadCheckTime;
 		}
 
 		@Override
 		public boolean isRunnerThreadActive() {
-			// TODO Auto-generated method stub
 			return runnerThread.isAlive();
 		}
 
@@ -450,7 +444,6 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
 
 		@Override
 		public int getNumTriggers() {
-			// TODO Auto-generated method stub
 			return triggerIdMap.size();
 		}
 
@@ -470,7 +463,6 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
 
 		@Override
 		public long getScannerIdleTime() {
-			// TODO Auto-generated method stub
 			return runnerThreadIdleTime;
 		}
 

--- a/src/java/azkaban/webapp/servlet/velocity/jmxpage.vm
+++ b/src/java/azkaban/webapp/servlet/velocity/jmxpage.vm
@@ -1,12 +1,12 @@
 #*
  * Copyright 2012 LinkedIn Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,13 +14,14 @@
  * the License.
 *#
 
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html lang="en">
 	<head>
-		
+
 #parse ("azkaban/webapp/servlet/velocity/style.vm")
 #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
+		<script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
 		<script type="text/javascript" src="${context}/js/azkaban/view/jmx.js"></script>
 		<script type="text/javascript">
 			var contextURL = "${context}";
@@ -31,7 +32,7 @@
 		</script>
 	</head>
 	<body>
-		
+
 #set ($current_page="all")
 #set ($counter = 0)
 #parse ("azkaban/webapp/servlet/velocity/nav.vm")
@@ -48,7 +49,7 @@
 
 		<div class="container-full">
 
-  ## Web Client JMX 
+  ## Web Client JMX
 
 			<div class="row">
 				<div class="col-xs-12">
@@ -98,7 +99,7 @@
 					</div>
 				</div>
 			</div>
-			
+
   #foreach ($executor in $executorRemoteMBeans.entrySet())
 			<div class="row">
 				<div class="col-xs-12">
@@ -140,14 +141,14 @@
 									</td>
 							</tr>
       #set ($counter = $counter + 1)
-    #end 
+    #end
 							</tbody>
 						</table>
 					</div>
 				</div>
 			</div>
   #end
-			
+
   #foreach ($triggerserver in $triggerserverRemoteMBeans.entrySet())
 			<div class="row">
 				<div class="col-xs-12">
@@ -189,7 +190,7 @@
 									</td>
 							</tr>
       #set ($counter = $counter + 1)
-    #end 
+    #end
 							</tbody>
 						</table>
 

--- a/src/web/js/azkaban/util/date.js
+++ b/src/web/js/azkaban/util/date.js
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 LinkedIn Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -14,12 +14,14 @@
  * the License.
  */
 
+var TIMESTAMP_LENGTH = 13;
+
 var getDuration = function(startMs, endMs) {
 	if (startMs) {
 		if (endMs == null || endMs < startMs) {
 			return "-";
 		}
-		
+
 		var diff = endMs - startMs;
 		return formatDuration(diff, false);
 	}
@@ -30,7 +32,7 @@ var getDuration = function(startMs, endMs) {
 var formatDuration = function(duration, millisecSig) {
 	var diff = duration;
 	var seconds = Math.floor(diff / 1000);
-	
+
 	if (seconds < 60) {
 		if (millisecSig) {
 			return (diff / 1000).toFixed(millisecSig) + " s";
@@ -39,7 +41,7 @@ var formatDuration = function(duration, millisecSig) {
 			return seconds + " sec";
 		}
 	}
-	
+
 	var mins = Math.floor(seconds / 60);
 	seconds = seconds % 60;
 	if (mins < 60) {
@@ -51,10 +53,10 @@ var formatDuration = function(duration, millisecSig) {
 	if (hours < 24) {
 		return hours + "h " + mins + "m " + seconds + "s";
 	}
-	
+
 	var days = Math.floor(hours / 24);
 	hours = hours % 24;
-	
+
 	return days + "d " + hours + "h " + mins + "m";
 }
 
@@ -62,12 +64,12 @@ var getDateFormat = function(date) {
 	var year = date.getFullYear();
 	var month = getTwoDigitStr(date.getMonth() + 1);
 	var day = getTwoDigitStr(date.getDate());
-	
+
 	var hours = getTwoDigitStr(date.getHours());
 	var minutes = getTwoDigitStr(date.getMinutes());
 	var second = getTwoDigitStr(date.getSeconds());
 
-	var datestring = year + "-" + month + "-" + day + "  " + hours + ":" + 
+	var datestring = year + "-" + month + "-" + day + "  " + hours + ":" +
 			minutes + " " + second + "s";
 	return datestring;
 }
@@ -76,7 +78,7 @@ var getHourMinSec = function(date) {
 	var hours = getTwoDigitStr(date.getHours());
 	var minutes = getTwoDigitStr(date.getMinutes());
 	var second = getTwoDigitStr(date.getSeconds());
-	
+
 	var timestring = hours + ":" + minutes + " " + second + "s";
 	return timestring;
 }
@@ -85,6 +87,6 @@ var getTwoDigitStr = function(value) {
 	if (value < 10) {
 		return "0" + value;
 	}
-	
+
 	return value;
 }

--- a/src/web/js/azkaban/view/jmx.js
+++ b/src/web/js/azkaban/view/jmx.js
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 LinkedIn Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -25,92 +25,114 @@ azkaban.JMXTableView = Backbone.View.extend({
 
 	initialize: function(settings) {
 	},
-	
+
+	formatValue: function(value) {
+		if (String(value).length != TIMESTAMP_LENGTH) {
+			return value;
+		}
+		if (isNaN(parseInt(value))) {
+			return value;
+		}
+		var date = new Date(value);
+		if (date.getTime() <= 0) {
+			return value;
+		}
+		return value + " (" + date.toISOString() + ")";
+	},
+
 	queryJMX: function(evt) {
 		var target = evt.currentTarget;
 		var id = target.id;
-		
+
 		var childID = id + "-child";
 		var tbody = id + "-tbody";
-		
+
 		var requestURL = contextURL + "/jmx";
 		var canonicalName=$(target).attr("domain") + ":name=" + $(target).attr("name");
 
 		var data = {
-			"ajax": "getAllMBeanAttributes", 
+			"ajax": "getAllMBeanAttributes",
 			"mBean": canonicalName
 		};
 		if ($(target).attr("hostPort")) {
 			data.ajax = "getAllExecutorAttributes";
 			data.hostPort = $(target).attr("hostPort");
 		}
+		var view = this;
 		var successHandler = function(data) {
 			var table = $('#' + tbody);
 			$(table).empty();
-			
+
 			for (var key in data.attributes) {
 				var value = data.attributes[key];
-				
+
 				var tr = document.createElement("tr");
 				var tdName = document.createElement("td");
 				var tdVal = document.createElement("td");
-				
+
+				$(tdName).addClass('property-key');
 				$(tdName).text(key);
+
+				value = view.formatValue(value);
 				$(tdVal).text(value);
-				
+
 				$(tr).append(tdName);
 				$(tr).append(tdVal);
-				
+
 				$('#' + tbody).append(tr);
 			}
-			
+
 			var child = $("#" + childID);
 			$(child).fadeIn();
 		};
 		$.get(requestURL, data, successHandler);
 	},
-	
+
 	queryRemote: function(evt) {
 		var target = evt.currentTarget;
 		var id = target.id;
-		
+
 		var childID = id + "-child";
 		var tbody = id + "-tbody";
-		
+
 		var requestURL = contextURL + "/jmx";
 		var canonicalName = $(target).attr("domain") + ":name=" + $(target).attr("name");
 		var hostPort = $(target).attr("hostport");
 		var requestData = {
-			"ajax": "getAllExecutorAttributes", 
-			"mBean": canonicalName, 
+			"ajax": "getAllExecutorAttributes",
+			"mBean": canonicalName,
 			"hostPort": hostPort
 		};
+		var view = this;
 		var successHandler = function(data) {
 			var table = $('#' + tbody);
 			$(table).empty();
-			
+
 			for (var key in data.attributes) {
 				var value = data.attributes[key];
-				
+
 				var tr = document.createElement("tr");
 				var tdName = document.createElement("td");
 				var tdVal = document.createElement("td");
-				
+
+				$(tdName).addClass('property-key');
 				$(tdName).text(key);
+
+				value = view.formatValue(value);
 				$(tdVal).text(value);
-				
+
 				$(tr).append(tdName);
 				$(tr).append(tdVal);
-				
+
 				$('#' + tbody).append(tr);
 			}
-			
+
 			var child = $("#" + childID);
 				$(child).fadeIn();
 		};
 		$.get(requestURL, requestData, successHandler);
 	},
-	
+
 	collapseRow: function(evt) {
 		$(evt.currentTarget).parent().parent().fadeOut();
 	},
@@ -122,7 +144,7 @@ azkaban.JMXTableView = Backbone.View.extend({
 var remoteTables = new Array();
 $(function() {
 	jmxTableView = new azkaban.JMXTableView({el:$('#all-jmx')});
-	
+
 	$(".remoteJMX").each(function(item) {
 		var newTableView = new azkaban.JMXTableView({el:$(this)});
 		remoteTables.push(newTableView);


### PR DESCRIPTION
Fixes #204

The bulk of the changes are on the client side. The only change I made on the server side is to change the value of `LastRunnerThreadCheckTime` of `azkaban.jmx.JmxTriggerManager:name=triggerManager` to a timestamp instead of a datetime string.

Note: my editor automatically removes trailing whitespace.
