### PR TITLE
Fix HADOOP_HOME and HIVE_HOME checks

### DIFF
--- a/src/package/execserver/bin/azkaban-executor-start.sh
+++ b/src/package/execserver/bin/azkaban-executor-start.sh
@@ -21,7 +21,7 @@ do
   CLASSPATH=$CLASSPATH:$file
 done
 
-if [ "HADOOP_HOME" != "" ]; then
+if [ "$HADOOP_HOME" != "" ]; then
         echo "Using Hadoop from $HADOOP_HOME"
         CLASSPATH=$CLASSPATH:$HADOOP_HOME/conf:$HADOOP_HOME/*
         JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
@@ -29,7 +29,7 @@ else
         echo "Error: HADOOP_HOME is not set. Hadoop job types will not run properly."
 fi
 
-if [ "HIVE_HOME" != "" ]; then
+if [ "$HIVE_HOME" != "" ]; then
         echo "Using Hive from $HIVE_HOME"
         CLASSPATH=$CLASSPATH:$HIVE_HOME/conf:$HIVE_HOME/lib/*
 fi

--- a/src/package/soloserver/bin/azkaban-solo-start.sh
+++ b/src/package/soloserver/bin/azkaban-solo-start.sh
@@ -21,7 +21,7 @@ do
   CLASSPATH=$CLASSPATH:$file
 done
 
-if [ "HADOOP_HOME" != "" ]; then
+if [ "$HADOOP_HOME" != "" ]; then
         echo "Using Hadoop from $HADOOP_HOME"
         CLASSPATH=$CLASSPATH:$HADOOP_HOME/conf:$HADOOP_HOME/*
         JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
@@ -29,7 +29,7 @@ else
         echo "Error: HADOOP_HOME is not set. Hadoop job types will not run properly."
 fi
 
-if [ "HIVE_HOME" != "" ]; then
+if [ "$HIVE_HOME" != "" ]; then
         echo "Using Hive from $HIVE_HOME"
         CLASSPATH=$CLASSPATH:$HIVE_HOME/conf:$HIVE_HOME/lib/*
 fi

--- a/src/package/webserver/bin/azkaban-web-start.sh
+++ b/src/package/webserver/bin/azkaban-web-start.sh
@@ -21,7 +21,7 @@ do
   CLASSPATH=$CLASSPATH:$file
 done
 
-if [ "HADOOP_HOME" != "" ]; then
+if [ "$HADOOP_HOME" != "" ]; then
         echo "Using Hadoop from $HADOOP_HOME"
         CLASSPATH=$CLASSPATH:$HADOOP_HOME/conf:$HADOOP_HOME/*
         JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
@@ -29,7 +29,7 @@ else
         echo "Error: HADOOP_HOME is not set. Hadoop job types will not run properly."
 fi
 
-if [ "HIVE_HOME" != "" ]; then
+if [ "$HIVE_HOME" != "" ]; then
         echo "Using Hive from $HIVE_HOME"
         CLASSPATH=$CLASSPATH:$HIVE_HOME/conf:$HIVE_HOME/lib/*
 fi


### PR DESCRIPTION
The current start scripts always assume that `HADOOP_HOME` and `HIVE_HOME` are set because the test is not against the actual value of the environment variable.
