### PR TITLE
Was resetting flow start time unnecessarily when restarting job. 

### DIFF
--- a/src/java/azkaban/execapp/FlowRunner.java
+++ b/src/java/azkaban/execapp/FlowRunner.java
@@ -971,8 +971,6 @@ public class FlowRunner extends EventHandler implements Runnable {
 		}
 		flow.setUpdateTime(System.currentTimeMillis());
 		flow.setEndTime(-1);
-		flow.setStartTime(maxStartTime);
-		
 		logger.info("Resetting flow '" + flow.getNestedId() + "' from " + oldFlowState + " to " + flow.getStatus());
 	}
 	

--- a/src/web/js/azkaban/view/flow-execution-list.js
+++ b/src/web/js/azkaban/view/flow-execution-list.js
@@ -145,7 +145,7 @@ azkaban.ExecutionListView = Backbone.View.extend({
 						$(attemptBox).bind("contextmenu", attemptRightClick);
 						
 						$(progressBar).before(attemptBox);
-						attemptBox.job = nodeId;
+						attemptBox.job = node.id;
 						attemptBox.attempt = a;
 					}
 				}


### PR DESCRIPTION
We should be be preserving it.
Fixing javascript bug for flow restart. Incorrect id

Both of these issues contributed to an incorrect display on a retry restart.
