### PR TITLE
closing streams correctly to avoid resource leaks

### DIFF
--- a/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -305,18 +305,16 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements ProjectLoad
 					runner.update(connection, INSERT_PROJECT_FILES, project.getId(), version, chunk, size, buf);
 					logger.info("Finished update for " + filename + " chunk " + chunk);
 				} catch (SQLException e) {
-					IOUtils.closeQuietly(bufferedStream);
 					throw new ProjectManagerException("Error chunking", e);
 				}
 				++chunk;
 				
 				size = bufferedStream.read(buffer);
 			}
-			
-			bufferedStream.close();
 		} catch (IOException e) {
-			IOUtils.closeQuietly(bufferedStream);
 			throw new ProjectManagerException("Error chunking file " + filename);
+		} finally {
+			IOUtils.closeQuietly(bufferedStream);
 		}
 
 		final String INSERT_PROJECT_VERSION =
@@ -380,45 +378,45 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements ProjectLoad
 		BufferedOutputStream bStream = null;
 		File file = null;
 		try {
-			file = File.createTempFile(projHandler.getFileName(), String.valueOf(version), tempDir);
-	
-			bStream = new BufferedOutputStream(new FileOutputStream(file));
-		}
-		catch (IOException e) {
-			IOUtils.closeQuietly(bStream);
-			throw new ProjectManagerException("Error creating temp file for stream.");
-		}
+			try {
+				file = File.createTempFile(projHandler.getFileName(), String.valueOf(version), tempDir);
 		
-		int collect = 5;
-		int fromChunk = 0;
-		int toChunk = collect;
-		do {
-			ProjectFileChunkResultHandler chunkHandler = new ProjectFileChunkResultHandler();
-			List<byte[]> data = null;
-			try {
-				data = runner.query(connection, ProjectFileChunkResultHandler.SELECT_PROJECT_CHUNKS_FILE, chunkHandler, projectId, version, fromChunk, toChunk);
-			}
-			catch(SQLException e) {
-				logger.error(e);
-				IOUtils.closeQuietly(bStream);
-				throw new ProjectManagerException("Query for uploaded file for " + projectId + " failed.", e);
-			}
-			
-			try {
-				for (byte[] d : data) {
-					bStream.write(d);
-				}
+				bStream = new BufferedOutputStream(new FileOutputStream(file));
 			}
 			catch (IOException e) {
-				IOUtils.closeQuietly(bStream);
-				throw new ProjectManagerException("Error writing file", e);
+				throw new ProjectManagerException("Error creating temp file for stream.");
 			}
 			
-			// Add all the bytes to the stream.
-			fromChunk += collect;
-			toChunk += collect;
-		} while (fromChunk <= numChunks);
-		IOUtils.closeQuietly(bStream);
+			int collect = 5;
+			int fromChunk = 0;
+			int toChunk = collect;
+			do {
+				ProjectFileChunkResultHandler chunkHandler = new ProjectFileChunkResultHandler();
+				List<byte[]> data = null;
+				try {
+					data = runner.query(connection, ProjectFileChunkResultHandler.SELECT_PROJECT_CHUNKS_FILE, chunkHandler, projectId, version, fromChunk, toChunk);
+				}
+				catch(SQLException e) {
+					logger.error(e);
+					throw new ProjectManagerException("Query for uploaded file for " + projectId + " failed.", e);
+				}
+				
+				try {
+					for (byte[] d : data) {
+						bStream.write(d);
+					}
+				}
+				catch (IOException e) {
+					throw new ProjectManagerException("Error writing file", e);
+				}
+				
+				// Add all the bytes to the stream.
+				fromChunk += collect;
+				toChunk += collect;
+			} while (fromChunk <= numChunks);
+		} finally {
+			IOUtils.closeQuietly(bStream);
+		}
 		
 		// Check md5.
 		byte[] md5 = null;

--- a/src/main/java/azkaban/scheduler/ScheduleStatisticManager.java
+++ b/src/main/java/azkaban/scheduler/ScheduleStatisticManager.java
@@ -113,8 +113,11 @@ public class ScheduleStatisticManager {
 				File cache = getCacheFile(scheduleId);
 				cache.createNewFile();
 				OutputStream output = new FileOutputStream(cache);
-				JSONUtils.toJSON(data, output, false);
-				output.close();
+				try {
+					JSONUtils.toJSON(data, output, false);
+				} finally {
+					output.close();
+				}
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/main/java/azkaban/utils/JSONUtils.java
+++ b/src/main/java/azkaban/utils/JSONUtils.java
@@ -84,8 +84,11 @@ public class JSONUtils {
 	
 	public static void toJSON(Object obj, File file, boolean prettyPrint) throws IOException {
 		BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(file));
-		toJSON(obj, stream, prettyPrint);
-		stream.close();
+		try {
+			toJSON(obj, stream, prettyPrint);
+		} finally {
+			stream.close();
+		}
 	}
 	
 	public static Object parseJSONFromStringQuiet(String json) {

--- a/src/main/java/azkaban/utils/Props.java
+++ b/src/main/java/azkaban/utils/Props.java
@@ -89,10 +89,10 @@ public class Props {
 		try {
 			loadFrom(input);
 		} catch (IOException e) {
-			input.close();
 			throw e;
+		} finally {
+			input.close();
 		}
-		input.close();
 	}
 
 	/**

--- a/src/main/java/azkaban/utils/Utils.java
+++ b/src/main/java/azkaban/utils/Utils.java
@@ -132,20 +132,26 @@ public class Utils {
 	public static void zip(File input, File output) throws IOException {
 		FileOutputStream out = new FileOutputStream(output);
 		ZipOutputStream zOut = new ZipOutputStream(out);
-		zipFile("", input, zOut);
-		zOut.close();
+		try {
+			zipFile("", input, zOut);
+		} finally {
+			zOut.close();
+		}
 	}
 
 	public static void zipFolderContent(File folder, File output) throws IOException {
 		FileOutputStream out = new FileOutputStream(output);
 		ZipOutputStream zOut = new ZipOutputStream(out);
-		File[] files = folder.listFiles();
-		if (files != null) {
-			for (File f : files) {
-				zipFile("", f, zOut);
+		try {
+			File[] files = folder.listFiles();
+			if (files != null) {
+				for (File f : files) {
+					zipFile("", f, zOut);
+				}
 			}
+		} finally {
+			zOut.close();
 		}
-		zOut.close();
 	}
 
 	private static void zipFile(String path, File input, ZipOutputStream zOut) throws IOException {
@@ -165,8 +171,11 @@ public class Utils {
 			zOut.putNextEntry(entry);
 			InputStream fileInputStream = new BufferedInputStream(
 					new FileInputStream(input));
-			IOUtils.copy(fileInputStream, zOut);
-			fileInputStream.close();
+			try {
+				IOUtils.copy(fileInputStream, zOut);
+			} finally {
+				fileInputStream.close();
+			}
 		}
 	}
 
@@ -180,11 +189,17 @@ public class Utils {
 			} else {
 				newFile.getParentFile().mkdirs();
 				InputStream src = source.getInputStream(entry);
-				OutputStream output = new BufferedOutputStream(
-						new FileOutputStream(newFile));
-				IOUtils.copy(src, output);
-				src.close();
-				output.close();
+				try {
+					OutputStream output = new BufferedOutputStream(
+							new FileOutputStream(newFile));
+					try {
+						IOUtils.copy(src, output);
+					} finally {
+						output.close();
+					}
+				} finally {
+					src.close();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

we had lots of trouble running azkaban services for a longer time. We found out that lots of streams are not closed when required. Especially streams of processes causes "too many open files exception" on our servers.

So this request will add missing closing of streams (mostly file streams) and will add try { ... } finally { ... } pattern.

Best regards
