### PR TITLE
Added mail.tls option, which enables TLS over SMTP for email notifications

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
+++ b/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
@@ -47,6 +47,7 @@ public class EmailMessage {
   private String _subject;
   private String _fromAddress;
   private String _mimeType = "text/plain";
+  private String _tls;
   private StringBuffer _body = new StringBuffer();
   private static int _mailTimeout = 10000;
   private static int _connectionTimeout = 10000;
@@ -106,6 +107,11 @@ public class EmailMessage {
     return this;
   }
 
+  public EmailMessage setTLS(String tls) {
+    _tls = tls;
+    return this;
+  }
+
   public EmailMessage addAttachment(File file) throws MessagingException {
     return addAttachment(file.getName(), file);
   }
@@ -155,6 +161,8 @@ public class EmailMessage {
     props.put("mail.password", _mailPassword);
     props.put("mail." + protocol + ".timeout", _mailTimeout);
     props.put("mail." + protocol + ".connectiontimeout", _connectionTimeout);
+    props.put("mail.smtp.starttls.enable", _tls);
+    props.put("mail.smtp.ssl.trust", _mailHost);
 
     Session session = Session.getInstance(props, null);
     Message message = new MimeMessage(session);

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -16,6 +16,7 @@
 
 package azkaban.utils;
 
+import java.lang.String;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,6 +54,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   private String mailPassword;
   private String mailSender;
   private String azkabanName;
+  private String tls;
 
   public Emailer(Props props) {
     super(props);
@@ -61,6 +63,7 @@ public class Emailer extends AbstractMailer implements Alerter {
     this.mailUser = props.getString("mail.user", "");
     this.mailPassword = props.getString("mail.password", "");
     this.mailSender = props.getString("mail.sender", "");
+    this.tls = props.getString("mail.tls", "false");
 
     int mailTimeout = props.getInt("mail.timeout.millis", 10000);
     EmailMessage.setTimeout(mailTimeout);
@@ -106,6 +109,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   public void sendFirstErrorMessage(ExecutableFlow flow) {
     EmailMessage message = new EmailMessage(mailHost, mailUser, mailPassword);
     message.setFromAddress(mailSender);
+    message.setTLS(tls);
 
     ExecutionOptions option = flow.getExecutionOptions();
 
@@ -131,6 +135,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   public void sendErrorEmail(ExecutableFlow flow, String... extraReasons) {
     EmailMessage message = new EmailMessage(mailHost, mailUser, mailPassword);
     message.setFromAddress(mailSender);
+    message.setTLS(tls);
 
     ExecutionOptions option = flow.getExecutionOptions();
 
@@ -155,6 +160,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   public void sendSuccessEmail(ExecutableFlow flow) {
     EmailMessage message = new EmailMessage(mailHost, mailUser, mailPassword);
     message.setFromAddress(mailSender);
+    message.setTLS(tls);
 
     ExecutionOptions option = flow.getExecutionOptions();
 


### PR DESCRIPTION
Fixes #268

Email notifications work with gmail now.
