### PR TITLE
AzkabanProcess uses misleading log level to log statements for Pig and Hive jobs - issue #282

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcess.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcess.java
@@ -34,7 +34,7 @@ import azkaban.utils.LogGobbler;
 import com.google.common.base.Joiner;
 
 /**
- * A less shitty version of java.lang.Process.
+ * An improved version of java.lang.Process.
  * 
  * Output is read by separate threads to avoid deadlock and logged to log4j
  * loggers.


### PR DESCRIPTION
From Azkaban process's perspective, it makes sense to log out the log statements from the subprocess using INFO level.  

For some reason the log statements from Pig and Hive are sent through the error stream.  So it is necessary to redirect the standard output and error output to the same stream.

Fixes #282
