### PR TITLE
Azkaban showing bogus elapsed time when a job is in prepared state #292

### DIFF
--- a/azkaban-webserver/src/web/js/azkaban/util/date.js
+++ b/azkaban-webserver/src/web/js/azkaban/util/date.js
@@ -18,6 +18,9 @@ var TIMESTAMP_LENGTH = 13;
 
 var getDuration = function(startMs, endMs) {
   if (startMs) {
+    if (startMs == -1) {
+      return "-";
+    }
     if (endMs == null || endMs < startMs) {
       return "-";
     }


### PR DESCRIPTION
When a job is preparing state, the start time is -1.

Fixes #292
