### PR TITLE
Removed unused imports

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleStatisticManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleStatisticManager.java
@@ -20,13 +20,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import azkaban.executor.ExecutableFlow;
-import azkaban.executor.ExecutorManagerAdapter;
-import azkaban.executor.ExecutorManagerException;
-import azkaban.executor.Status;
 import azkaban.utils.JSONUtils;
 
 /**

--- a/azkaban-common/src/test/java/azkaban/database/AzkabanDatabaseSetupTest.java
+++ b/azkaban-common/src/test/java/azkaban/database/AzkabanDatabaseSetupTest.java
@@ -27,7 +27,6 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.apache.commons.dbutils.QueryRunner;
-import org.apache.commons.io.FileUtils;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/azkaban-common/src/test/java/azkaban/database/AzkabanDatabaseUpdaterTest.java
+++ b/azkaban-common/src/test/java/azkaban/database/AzkabanDatabaseUpdaterTest.java
@@ -19,17 +19,13 @@ package azkaban.database;
 import com.google.common.io.Resources;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
 import org.apache.commons.dbutils.QueryRunner;
-import org.apache.commons.io.FileUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
@@ -19,12 +19,10 @@ package azkaban.jobExecutor;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.StringTokenizer;
 
 import org.apache.log4j.Logger;

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 
-import org.apache.commons.io.FileUtils;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/azkaban-execserver/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-execserver/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -125,7 +125,7 @@ public class FlowRunnerPropertyResolutionTest {
     createNodeMap(runner.getExecutableFlow(), nodeMap);
 
     // 1. Start flow. Job 2 should start
-    Thread thread = runFlowRunnerInThread(runner);
+    runFlowRunnerInThread(runner);
     pause(250);
 
     // Job 2 is a normal job.

--- a/azkaban-execserver/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-execserver/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -40,7 +40,6 @@ import azkaban.executor.SleepJavaJob;
 import azkaban.executor.Status;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.jobtype.JobTypeManager;
-import azkaban.project.MockProjectLoader;
 import azkaban.utils.Props;
 
 public class JobRunnerTest {

--- a/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -88,7 +88,6 @@ import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.Utils;
-import azkaban.webapp.servlet.AzkabanServletContextListener;
 import azkaban.webapp.servlet.AbstractAzkabanServlet;
 import azkaban.webapp.servlet.ExecutorServlet;
 import azkaban.webapp.servlet.IndexRedirectServlet;

--- a/azkaban-webserver/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -35,7 +35,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 import azkaban.server.AzkabanServer;
 import azkaban.server.HttpRequestUtils;
-import azkaban.server.ServerConstants;
 import azkaban.server.session.Session;
 import azkaban.utils.Props;
 import azkaban.utils.JSONUtils;

--- a/azkaban-webserver/src/main/java/azkaban/webapp/servlet/AzkabanServletContextListener.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/servlet/AzkabanServletContextListener.java
@@ -19,7 +19,6 @@ package azkaban.webapp.servlet;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import azkaban.server.ServerConstants;
 import azkaban.webapp.AzkabanWebServer;
 
 /**


### PR DESCRIPTION
Fixed Eclipse warnings by removing unused imports and variables.  We should try to keep the warnings clean so we will catch any future, potentially serious, warnings.
