### PR TITLE
Updating the azkaban-web-start.sh to be more robust and fixing some bugs...

### DIFF
--- a/azkaban-webserver/src/package/bin/azkaban-web-start.sh
+++ b/azkaban-webserver/src/package/bin/azkaban-web-start.sh
@@ -21,17 +21,36 @@ do
   CLASSPATH=$CLASSPATH:$file
 done
 
-if [ "$HADOOP_HOME" != "" ]; then
-        echo "Using Hadoop from $HADOOP_HOME"
-        CLASSPATH=$CLASSPATH:$HADOOP_HOME/conf:$HADOOP_HOME/*
-        JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
+if [ -n "$HADOOP_HOME" ] && [ -d "$HADOOP_HOME" ]; then
+  echo "Using Hadoop from $HADOOP_HOME"
+  CLASSPATH=$CLASSPATH:$HADOOP_HOME/conf:$HADOOP_HOME/*
+  if [ -d "$HADOOP_HOME/lib/native/Linux-amd64-64" ]; then
+    JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
+  elif [ -n "$HADOOP_MR1_HOME" ] && [ -d "$HADOOP_MR1_HOME/lib/native/Linux-amd64-64" ]; then
+    JAVA_LIB_PATH="-Djava.library.path=$HADOOP_MR1_HOME/lib/native/Linux-amd64-64"
+  fi
 else
-        echo "Error: HADOOP_HOME is not set. Hadoop job types will not run properly."
+        echo "Error: HADOOP_HOME is not set or doesn't exist. Hadoop job types will not run properly."
 fi
 
-if [ "$HIVE_HOME" != "" ]; then
-        echo "Using Hive from $HIVE_HOME"
-        CLASSPATH=$CLASSPATH:$HIVE_HOME/conf:$HIVE_HOME/lib/*
+if [ -n "$HADOOP_HDFS_HOME" ] && [ -n "$HADOOP_HDFS_HOME" ]; then
+  echo "Picking HDFS jars from $HADOOP_HDFS_HOME"
+  CLASSPATH=$CLASSPATH:$HADOOP_HDFS_HOME/*
+fi
+
+if [ -n "$HADOOP_CONF_DIR" ] && [ -n "$HADOOP_CONF_DIR" ]; then
+  echo "Picking up hadoop configuration from $HADOOP_CONF_DIR"
+  CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR
+fi
+
+if [ "HIVE_HOME" != "" ]; then
+  echo "Using Hive from $HIVE_HOME"
+  CLASSPATH=$CLASSPATH:$HIVE_HOME/conf:$HIVE_HOME/lib/*
+fi
+
+if [ -n "HIVE_CONF_DIR" ] && [ -d "HIVE_CONF_DIR" ]; then
+  echo "Using Hive configuration from $HIVE_CONF_DIR"
+  CLASSPATH=$CLASSPATH:$HIVE_CONF_DIR
 fi
 
 echo $azkaban_dir;


### PR DESCRIPTION
....
1. HADOOP_HOME was not being checked correctly. The literal was being checked instead of the variable. There was no check for the directory existing either.
2. It was being assumed that the Hadoop MR1 native bits were under HADOOP_HOME. With Hadoop 2 coming out, MR1 bits are usually picked from a separate location. So, I added a new variable called HADOOP_MR1_HOME which if exists, and has native bits, those native bits would be added to the Java Library Path.
3. Hadoop HDFS home doesn't have to be the same location as Hadoop Home. Many distributions including Apache Bigtop, CDH, etc. put HDFS in a separate location other than HADOOP_HOME. Added support for a new variable called HADOOP_HDFS_HOME, which if it's set and exists, will be used to pick HDFS jars in the classpth.
4. It was also previously assumed that Hadoop configuration always exists under $HADOOP_HOME/conf. That's not always the case. Added support for a new variable called HADOOP_CONF_DIR which can be used to specify the location of hadoop configuration.
5. Added HIVE_CONF_DIR in the same vein, as well.

All of this was done with backwards compatibility in mind, so any existing setup and variables should take precendence and this wouldn't break anything. If existing variables are defined, the script will leverage them.

Example invocation:

HADOOP_HOME=/opt/cloudera/parcels/CDH/lib/hadoop HADOOP_HDFS_HOME=/opt/cloudera/parcels/CDH/lib/hadoop-hdfs HADOOP_CONF_DIR=/etc/hadoop/conf HIVE_HOME=/opt/cloudera/parcels/CDH/lib/hive HADOOP_CONF_DIR=/etc/hadoop/conf bin/start-web.sh
