### PR TITLE
Make validator JARs hot-deployable, so when upgrading validators, there'...

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/validator/XmlValidatorManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/validator/XmlValidatorManager.java
@@ -105,7 +105,8 @@ public class XmlValidatorManager implements ValidatorManager {
       for (File f : validatorDir.listFiles()) {
         if (f.getName().endsWith(".jar")) {
           resources.add(f.toURI().toURL());
-          if (resourceTimestamps.get(f.getName()) != f.lastModified()) {
+          if (resourceTimestamps.get(f.getName()) == null
+              || resourceTimestamps.get(f.getName()) != f.lastModified()) {
             reloadResources = true;
             logger.info("Resource " + f.getName() + " is updated. Reload the classloader.");
             resourceTimestamps.put(f.getName(), f.lastModified());


### PR DESCRIPTION
...s no need to restart Azkaban webserver.
