### PR TITLE
add utf-8 encoding to avoid test failed due to korean characters in azkaban-com...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,11 @@ project(':azkaban-common') {
     testCompile('junit:junit:4.11')
     testCompile('org.hamcrest:hamcrest-all:1.3')
   }
+  
+  tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+  }
+  
 }
 
 project(':azkaban-migration') {


### PR DESCRIPTION
there are some foreign string in FileIOUtilsTest.testForeignUTF, if our platform encoding is not utf-8, this test case will failed, so i add "utf-8" encoding in azkaban-common project 
