### PR TITLE
Issue 331 : For job with retry - the attempt count doesn't match with lo...

### DIFF
--- a/azkaban-webserver/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-webserver/src/web/js/azkaban/view/flow-execution-list.js
@@ -145,7 +145,7 @@ azkaban.ExecutionListView = Backbone.View.extend({
             $(attemptBox).bind("contextmenu", attemptRightClick);
 
             $(progressBar).before(attemptBox);
-            attemptBox.job = node.id;
+            attemptBox.job = node.nestedId;
             attemptBox.attempt = a;
           }
         }
@@ -205,7 +205,7 @@ azkaban.ExecutionListView = Backbone.View.extend({
 
       // Add all the attempts
       if (node.pastAttempts) {
-        var logURL = contextURL + "/executor?execid=" + execId + "&job=" + node.id + "&attempt=" +  node.pastAttempts.length;
+        var logURL = contextURL + "/executor?execid=" + execId + "&job=" + node.nestedId + "&attempt=" +  node.pastAttempts.length;
         var anchor = $(tr).find("> td.details > a");
         if (anchor.length != 0) {
           $(anchor).attr("href", logURL);


### PR DESCRIPTION
I looked deeper in this issue. Issue with job within embedded flows is that ExecutorServlet in azkaban-webserver expect nested path for job names. for example:-
_Following will not work_
https://localhost:8081/executor?project=test-command&execid=76459&job=test&attempt=0
_Following will work fine_
https://localhost:8081/executor?project=test-command&execid=76459&job= **embeddedFlow:** test&attempt=0

This nested path is required due to 2 reasons:-
- We store job name as nested path in database
- We need to reach to job node (at https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java#L134) which require us to know the subflow path in which a job exists.
