### PR TITLE
Increasing HeaderBufferSize on AzkabanExecutorServer

### DIFF
--- a/azkaban-execserver/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -66,7 +66,13 @@ public class AzkabanExecutorServer {
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
   public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
+
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
+
+  public static final int HEADER_BUFFER_SIZE = 4 * 1024;
+  public static final int RESPONSE_BUFFER_SIZE = 24 * 1024;
+  public static final int REQUEST_BUFFER_SIZE = 8 * 1024;
+
   public static final int DEFAULT_PORT_NUMBER = 12321;
 
   private static final String DEFAULT_TIMEZONE_ID = "default.timezone.id";
@@ -100,10 +106,16 @@ public class AzkabanExecutorServer {
     server.setThreadPool(httpThreadPool);
 
     boolean isStatsOn = props.getBoolean("executor.connector.stats", true);
-    logger.info("Setting up connector with stats on: " + isStatsOn);
+    int headerBufferSize = props.getInt("headerBufferSize", HEADER_BUFFER_SIZE);
+    int requestBufferSize = props.getInt("requestBufferSize", REQUEST_BUFFER_SIZE);
+    int responseBufferSize = props.getInt("responseBufferSize", RESPONSE_BUFFER_SIZE);
+    logger.info("Setting up connector with stats on: " + isStatsOn + " headerBufferSize : " + headerBufferSize + " requestBufferSize : " + requestBufferSize + " responseBufferSize : " + responseBufferSize );
 
     for (Connector connector : server.getConnectors()) {
       connector.setStatsOn(isStatsOn);
+      connector.setHeaderBufferSize(headerBufferSize);
+      connector.setResponseBufferSize(responseBufferSize);
+      connector.setRequestBufferSize(requestBufferSize);
     }
 
     Context root = new Context(server, "/", Context.SESSIONS);

--- a/azkaban-execserver/src/package/conf/azkaban.properties
+++ b/azkaban-execserver/src/package/conf/azkaban.properties
@@ -25,6 +25,12 @@ executor.flow.threads=30
 jetty.connector.stats=true
 executor.connector.stats=true
 
+
 # uncomment to enable inmemory stats for azkaban
 #executor.metric.reports=true
 #executor.metric.milisecinterval.default=60000
+
+#ConnectorBufferSizes
+headerBufferSize=4096
+requestBufferSize=8192
+responseBufferSize=24576

--- a/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -16,6 +16,7 @@
 
 package azkaban.webapp;
 
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -72,15 +73,10 @@ import azkaban.trigger.JdbcTriggerLoader;
 import azkaban.trigger.TriggerLoader;
 import azkaban.trigger.TriggerManager;
 import azkaban.trigger.TriggerManagerException;
-import azkaban.trigger.builtin.BasicTimeChecker;
-import azkaban.trigger.builtin.CreateTriggerAction;
-import azkaban.trigger.builtin.ExecuteFlowAction;
-import azkaban.trigger.builtin.ExecutionChecker;
-import azkaban.trigger.builtin.KillExecutionAction;
-import azkaban.trigger.builtin.SlaAlertAction;
-import azkaban.trigger.builtin.SlaChecker;
+import azkaban.trigger.builtin.*;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
+
 import azkaban.utils.Emailer;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
@@ -96,9 +92,12 @@ import azkaban.webapp.servlet.ProjectServlet;
 import azkaban.webapp.servlet.ProjectManagerServlet;
 import azkaban.webapp.servlet.StatsServlet;
 import azkaban.webapp.servlet.TriggerManagerServlet;
+
+import azkaban.utils.*;
+import azkaban.webapp.plugin.PluginRegistry;
+
 import azkaban.webapp.plugin.TriggerPlugin;
 import azkaban.webapp.plugin.ViewerPlugin;
-import azkaban.webapp.plugin.PluginRegistry;
 
 /**
  * The Azkaban Jetty server class
@@ -130,7 +129,9 @@ public class AzkabanWebServer extends AzkabanServer {
       "azkaban.private.properties";
 
   private static final int MAX_FORM_CONTENT_SIZE = 10 * 1024 * 1024;
-  private static final int MAX_HEADER_BUFFER_SIZE = 10 * 1024 * 1024;
+  private static final int HEADER_BUFFER_SIZE = 4 * 1024;
+  private static final int RESPONSE_BUFFER_SIZE = 24 * 1024;
+  private static final int REQUEST_BUFFER_SIZE = 8 * 1024;
   private static AzkabanWebServer app;
 
   private static final String DEFAULT_TIMEZONE_ID = "default.timezone.id";
@@ -676,9 +677,12 @@ public class AzkabanWebServer extends AzkabanServer {
 
     int maxThreads =
         azkabanSettings.getInt("jetty.maxThreads", DEFAULT_THREAD_NUMBER);
-    boolean isStatsOn =
-        azkabanSettings.getBoolean("jetty.connector.stats", true);
-    logger.info("Setting up connector with stats on: " + isStatsOn);
+
+    boolean isStatsOn = azkabanSettings.getBoolean("jetty.connector.stats", true);
+    int headerBufferSize = azkabanSettings.getInt("headerBufferSize", HEADER_BUFFER_SIZE);
+    int requestBufferSize = azkabanSettings.getInt("requestBufferSize", REQUEST_BUFFER_SIZE);
+    int responseBufferSize = azkabanSettings.getInt("responseBufferSize", RESPONSE_BUFFER_SIZE);
+    logger.info("Setting up connector with stats on: " + isStatsOn + " headerBufferSize : " + headerBufferSize + " requestBufferSize : " + requestBufferSize + " responseBufferSize : " + responseBufferSize);
 
     boolean ssl;
     int port;
@@ -701,7 +705,9 @@ public class AzkabanWebServer extends AzkabanServer {
           .getString("jetty.truststore"));
       secureConnector.setTrustPassword(azkabanSettings
           .getString("jetty.trustpassword"));
-      secureConnector.setHeaderBufferSize(MAX_HEADER_BUFFER_SIZE);
+      secureConnector.setHeaderBufferSize(headerBufferSize);
+      secureConnector.setResponseBufferSize(responseBufferSize);
+      secureConnector.setRequestBufferSize(requestBufferSize);
 
       server.addConnector(secureConnector);
     } else {
@@ -709,7 +715,10 @@ public class AzkabanWebServer extends AzkabanServer {
       port = azkabanSettings.getInt("jetty.port", DEFAULT_PORT_NUMBER);
       SocketConnector connector = new SocketConnector();
       connector.setPort(port);
-      connector.setHeaderBufferSize(MAX_HEADER_BUFFER_SIZE);
+      connector.setHeaderBufferSize(headerBufferSize);
+      connector.setResponseBufferSize(responseBufferSize);
+      connector.setRequestBufferSize(requestBufferSize);
+
       server.addConnector(connector);
     }
 

--- a/azkaban-webserver/src/package/conf/azkaban.properties
+++ b/azkaban-webserver/src/package/conf/azkaban.properties
@@ -51,3 +51,8 @@ cache.directory=cache
 # JMX stats
 jetty.connector.stats=true
 executor.connector.stats=true
+
+#ConnectorBufferSizes
+headerBufferSize=4096
+requestBufferSize=8192
+responseBufferSize=24576


### PR DESCRIPTION
No of total flows in running and preparing state increase leads to increase in headerbuffer size(by get api call of Line 703 of ExecutorManager.java) 

and there by leading to FULL HEAD (httpclient. Response Exception) as it exceeding 4k which is default value 
and there by throwing IOException from handleAjaxUpdateRequest of ExecutorServlet and there by all flows in preparing state are getting Evicted. (Evicting flow " + flow.getExecutionId() + ". The executor is unresponsive. Line 854 of ExecutorManager.java).
