### PR TITLE
Add documentation for new Hive jobtype and hadoop-inject Hadoop configuration injection mechanism

### DIFF
--- a/_includes/docs/2.5/hadoopjava-type.html
+++ b/_includes/docs/2.5/hadoopjava-type.html
@@ -73,6 +73,10 @@ if (System.getenv("HADOOP_TOKEN_FILE_LOCATION") != null) {
       <td>jvm.args</td>
       <td>The <code>-D</code> for the new jvm process</td>
     </tr>
+    <tr>
+      <td>hadoop-inject.FOO</td>
+      <td>FOO is automatically added to the Configuration of any Hadoop job launched.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/_includes/docs/2.5/new-hive-type.html
+++ b/_includes/docs/2.5/new-hive-type.html
@@ -1,0 +1,124 @@
+<h2 id="new-hive-type">New Hive Jobtype</h2>
+
+<p>We've added a new Hive jobtype whose jobtype class is <code>azkaban.jobtype.HadoopHiveJob</code>. The configurations have changed from the old Hive jobtype.</p>
+
+<p>Here are the configurations that a user can set:</p>
+
+<table class="table table-striped table-condensed table-bordered">
+  <thead>
+    <tr>
+      <th class="parameter">Parameter</th>
+      <th class="description"> Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>type</td>
+      <td>The type name as set by the admin, e.g. <code>hive</code></td>
+    </tr>
+    <tr>
+      <td>hive.script</td>
+      <td>The relative path of your Hive script inside your Azkaban zip</td>
+    </tr>
+    <tr>
+      <td>user.to.proxy</td>
+      <td>The hadoop user this job should run under.</td>
+    </tr>
+    <tr>
+      <td>hiveconf.FOO</td>
+      <td>FOO is automatically added as a hiveconf variable. You can reference it in your script using ${hiveconf:FOO}. These variables also get added to the configuration of any launched Hadoop jobs.</td>
+    </tr>
+    <tr>
+      <td>hivevar.FOO</td>
+      <td>FOO is automatically added as a hivevar variable. You can reference it in your script using ${hivevar:FOO}. These variables are NOT added to the configuration of launched Hadoop jobs.</td>
+    </tr>
+    <tr>
+      <td>hadoop-inject.FOO</td>
+      <td>FOO is automatically added to the Configuration of any Hadoop job launched.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Here are what's needed and normally configured by the admin. The following properties go into private.properties (or into ../commonprivate.properties):</p>
+
+<table class="table table-striped table-bordered table-condensed">
+  <thead>
+    <tr>
+      <th class='parameter'>Parameter</th>
+      <th class='description'>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>hadoop.security.manager.class</td>
+      <td>The class that handles talking to hadoop clusters.</td>
+    </tr>
+    <tr>
+      <td>azkaban.should.proxy</td>
+      <td>Whether Azkaban should proxy as individual user hadoop accounts.</td>
+    </tr>
+    <tr>
+      <td>proxy.user</td>
+      <td>The Azkaban user configured with kerberos and hadoop, for secure clusters.</td>
+    </tr>
+    <tr>
+      <td>proxy.keytab.location</td>
+      <td>The location of the keytab file with which Azkaban can authenticate with Kerberos for the specified proxy.user</td>
+    </tr>
+    <tr>
+      <td>hadoop.home</td>
+      <td>The hadoop home where the jars and conf resources are installed.</td>
+    </tr>
+    <tr>
+      <td>jobtype.classpath</td>
+      <td>The items that every such job should have on its classpath.</td>
+    </tr>
+    <tr>
+      <td>jobtype.class</td>
+      <td>Should be set to <code>azkaban.jobtype.HadoopHiveJob</code></td>
+    </tr>
+    <tr>
+      <td>obtain.binary.token</td>
+      <td>Whether Azkaban should request tokens. Set this to true for secure clusters.</td>
+    </tr>
+    <tr>
+      <td>obtain.hcat.token</td>
+      <td>Whether Azkaban should request HCatalog/Hive Metastore tokens. If true, the HadoopSecurityManager will acquire an HCatalog token.</td>
+    </tr>
+    <tr>
+      <td>hive.aux.jars.path</td>
+      <td>Where to find auxiliary library jars</td>
+    </tr>
+    <tr>
+      <td>hive.home</td>
+      <td><code>$HIVE_HOME</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>These go into plugin.properties (or into ../common.properties):</p>
+
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th class='parameter'>Parameter</th>
+      <th class='description'>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style='text-align: left;'>hive.aux.jars.path</td>
+      <td style='text-align: left;'>Where to find auxiliary library jars</td>
+    </tr>
+    <tr>
+      <td style='text-align: left;'>hive.home</td>
+      <td style='text-align: left;'><code>$HIVE_HOME</code></td>
+    </tr>
+    <tr>
+      <td style='text-align: left;'>jobtype.jvm.args</td>
+      <td style='text-align: left;'><code>-Dhive.querylog.location=.</code> <code>-Dhive.exec.scratchdir=YOUR_HIVE_SCRATCH_DIR</code> <code>-Dhive.aux.jars.path=${hive.aux.jars.path}</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>Since hive jobs are essentially java programs, the configurations for Java jobs can also be set.</p>

--- a/_includes/docs/2.5/pig-type.html
+++ b/_includes/docs/2.5/pig-type.html
@@ -54,6 +54,10 @@
       <td>use.user.pig.jar</td>
       <td>If true, will use the user-provided Pig jar to launch the job. If false, the Pig jar provided by Azkaban will be used. Defaults to false.</td>
     </tr>
+    <tr>
+      <td>hadoop-inject.FOO</td>
+      <td>FOO is automatically added to the Configuration of any Hadoop job launched.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/_includes/docs/2.5/sidebar.html
+++ b/_includes/docs/2.5/sidebar.html
@@ -88,6 +88,7 @@
         <li><a href="#hadoopjava-type">Hadoop Java</a></li>
         <li><a href="#pig-type">Pig</a></li>
         <li><a href="#hive-type">Hive</a></li>
+        <li><a href="#new-hive-type">Hive v2</a></li>
         <li><a href="#voldemortbuildandpush-type">VoldemortBuildAndPush</a></li>
         <li><a href="#create-job-types">Create Types</a></li>
       </ul>

--- a/docs/2.5/index.html
+++ b/docs/2.5/index.html
@@ -97,6 +97,8 @@ context: ../..
             <hr>
             {% include docs/2.5/hive-type.html %}
             <hr>
+            {% include docs/2.5/new-hive-type.html %}
+            <hr>
             {% include docs/2.5/voldemortbuildandpush-type.html %}
             <hr>
             {% include docs/2.5/create-job-types.html %}


### PR DESCRIPTION
Here's what the documentation for the new Hive jobtype looks like:
![newhivejobtype](https://cloud.githubusercontent.com/assets/544734/6090845/bcb62fa2-ae3f-11e4-8e07-af2c3e262c5e.png)
![newhivejobtype2](https://cloud.githubusercontent.com/assets/544734/6090846/bdeef6b0-ae3f-11e4-88ef-041173120029.png)
