### PR TITLE
Purge all data for already deleted project #454

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -169,6 +169,67 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
     return project;
   }
 
+    /**
+     * Fetch first project with a given name {@inheritDoc}
+     *
+     * @see azkaban.project.ProjectLoader#fetchProjectByName(java.lang.String)
+     */
+    @Override
+    public Project fetchProjectByName(String name)
+        throws ProjectManagerException {
+        Connection connection = getConnection();
+
+        Project project = null;
+        try {
+            project = fetchProjectByName(connection, name);
+        } finally {
+            DbUtils.closeQuietly(connection);
+        }
+
+        return project;
+    }
+
+    private Project fetchProjectByName(Connection connection, String name)
+        throws ProjectManagerException {
+        QueryRunner runner = new QueryRunner();
+        // Fetch the project
+        Project project = null;
+        ProjectResultHandler handler = new ProjectResultHandler();
+        try {
+            List<Project> projects =
+                runner.query(connection,
+                    ProjectResultHandler.SELECT_PROJECT_BY_NAME, handler, name);
+            if (projects.isEmpty()) {
+                throw new ProjectManagerException(
+                    "No active project with name " + name + " exists in db.");
+            }
+
+            project = projects.get(0);
+        } catch (SQLException e) {
+            logger.error(ProjectResultHandler.SELECT_PROJECT_BY_NAME
+                + " failed.");
+            throw new ProjectManagerException(
+                "Query for existing project failed. Project " + name, e);
+        }
+
+        // Fetch the user permissions
+        List<Triple<String, Boolean, Permission>> permissions =
+            fetchPermissionsForProject(connection, project);
+
+        for (Triple<String, Boolean, Permission> perm : permissions) {
+            if (perm.getThird().toFlags() != 0) {
+                if (perm.getSecond()) {
+                    project
+                        .setGroupPermission(perm.getFirst(), perm.getThird());
+                } else {
+                    project.setUserPermission(perm.getFirst(), perm.getThird());
+                }
+            }
+        }
+
+        return project;
+    }
+
   private List<Triple<String, Boolean, Permission>> fetchPermissionsForProject(
       Connection connection, Project project) throws ProjectManagerException {
     ProjectPermissionsResultHandler permHander =
@@ -1136,6 +1197,9 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
 
   private static class ProjectResultHandler implements
       ResultSetHandler<List<Project>> {
+    private static String SELECT_PROJECT_BY_NAME =
+        "SELECT id, name, active, modified_time, create_time, version, last_modified_by, description, enc_type, settings_blob FROM projects WHERE name=?";
+
     private static String SELECT_PROJECT_BY_ID =
         "SELECT id, name, active, modified_time, create_time, version, last_modified_by, description, enc_type, settings_blob FROM projects WHERE id=?";
 

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -141,7 +141,7 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
           runner.query(connection, ProjectResultHandler.SELECT_PROJECT_BY_ID,
               handler, id);
       if (projects.isEmpty()) {
-        throw new ProjectManagerException("No active project with id " + id
+        throw new ProjectManagerException("No project with id " + id
             + " exists in db.");
       }
 
@@ -201,7 +201,7 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
                     ProjectResultHandler.SELECT_PROJECT_BY_NAME, handler, name);
             if (projects.isEmpty()) {
                 throw new ProjectManagerException(
-                    "No active project with name " + name + " exists in db.");
+                    "No project with name " + name + " exists in db.");
             }
 
             project = projects.get(0);

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -48,6 +48,14 @@ public interface ProjectLoader {
   public Project fetchProjectById(int id) throws ProjectManagerException;
 
   /**
+   * Loads whole project, including permissions, by the project name.
+   * @param name
+   * @return
+   * @throws ProjectManagerException
+   */
+  public Project fetchProjectByName(String name) throws ProjectManagerException;
+
+  /**
    * Should create an empty project with the given name and user and adds it to
    * the data store. It will auto assign a unique id for this project if
    * successful.
@@ -269,5 +277,4 @@ public interface ProjectLoader {
       throws ProjectManagerException;
 
   void updateProjectSettings(Project project) throws ProjectManagerException;
-
 }

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLogEvent.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLogEvent.java
@@ -32,7 +32,8 @@ public class ProjectLogEvent {
     UPLOADED(6),
     SCHEDULE(7),
     SLA(8),
-    PROXY_USER(9);
+    PROXY_USER(9),
+    PURGE(10);
 
     private int numVal;
 
@@ -64,6 +65,8 @@ public class ProjectLogEvent {
         return SLA;
       case 9:
         return PROXY_USER;
+      case 10:
+        return PURGE;
       case 128:
         return ERROR;
       default:

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -229,8 +229,7 @@ public class ProjectManager {
             try {
                 fetchedProject = projectLoader.fetchProjectByName(name);
             } catch (ProjectManagerException e) {
-                throw new RuntimeException(
-                    "Could not load project from store.", e);
+                logger.error("Could not load project from store.", e);
             }
         }
         return fetchedProject;
@@ -251,8 +250,7 @@ public class ProjectManager {
             try {
                 fetchedProject = projectLoader.fetchProjectById(id);
             } catch (ProjectManagerException e) {
-                throw new RuntimeException(
-                    "Could not load project from store.", e);
+                logger.error("Could not load project from store.", e);
             }
         }
         return fetchedProject;

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -204,6 +204,34 @@ public class ProjectManager {
     return projectsById.get(id);
   }
 
+    /**
+     * fetch inactive project from db by project_id
+     *
+     * @param name
+     * @return
+     */
+    public Project getInactiveProject(String name) {
+        try {
+            return projectLoader.fetchProjectByName(name);
+        } catch (ProjectManagerException e) {
+            throw new RuntimeException("Could not load project from store.", e);
+        }
+    }
+
+    /**
+     * fetch inactive project from db by project_name
+     *
+     * @param name
+     * @return
+     */
+    public Project getInactiveProject(int id) {
+        try {
+            return projectLoader.fetchProjectById(id);
+        } catch (ProjectManagerException e) {
+            throw new RuntimeException("Could not load project from store.", e);
+        }
+    }
+
   public Project createProject(String projectName, String description,
       User creator) throws ProjectManagerException {
     if (projectName == null || projectName.trim().isEmpty()) {
@@ -248,6 +276,25 @@ public class ProjectManager {
 
     return newProject;
   }
+
+    /**
+     * Permanently delete all project files and properties data for all versions
+     * of a project and log event in project_events table
+     *
+     * @param project
+     * @param deleter
+     * @return
+     * @throws ProjectManagerException
+     */
+    public synchronized Project purgeProject(Project project, User deleter)
+        throws ProjectManagerException {
+        projectLoader.cleanOlderProjectVersion(project.getId(),
+            project.getVersion() + 1);
+        projectLoader
+            .postEvent(project, EventType.PURGE, deleter.getUserId(), String
+                .format("Purged versions before %d", project.getVersion() + 1));
+        return project;
+    }
 
   public synchronized Project removeProject(Project project, User deleter)
       throws ProjectManagerException {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -196,40 +196,66 @@ public class ProjectManager {
     return allProjects;
   }
 
-  public Project getProject(String name) {
-    return projectsByName.get(name);
-  }
-
-  public Project getProject(int id) {
-    return projectsById.get(id);
-  }
-
     /**
-     * fetch inactive project from db by project_id
+     * Checks if a project is active using project_name
      *
      * @param name
-     * @return
      */
-    public Project getInactiveProject(String name) {
-        try {
-            return projectLoader.fetchProjectByName(name);
-        } catch (ProjectManagerException e) {
-            throw new RuntimeException("Could not load project from store.", e);
-        }
+    public Boolean isActiveProject(String name) {
+        return projectsByName.containsKey(name);
     }
 
     /**
-     * fetch inactive project from db by project_name
+     * Checks if a project is active using project_id
+     *
+     * @param name
+     */
+    public Boolean isActiveProject(int id) {
+        return projectsById.containsKey(id);
+    }
+
+    /**
+     * fetch active project from cache and inactive projects from db by
+     * project_name
      *
      * @param name
      * @return
      */
-    public Project getInactiveProject(int id) {
-        try {
-            return projectLoader.fetchProjectById(id);
-        } catch (ProjectManagerException e) {
-            throw new RuntimeException("Could not load project from store.", e);
+    public Project getProject(String name) {
+        Project fetchedProject = null;
+        if (isActiveProject(name)) {
+            fetchedProject = projectsByName.get(name);
+        } else {
+            try {
+                fetchedProject = projectLoader.fetchProjectByName(name);
+            } catch (ProjectManagerException e) {
+                throw new RuntimeException(
+                    "Could not load project from store.", e);
+            }
         }
+        return fetchedProject;
+    }
+
+    /**
+     * fetch active project from cache and inactive projects from db by
+     * project_id
+     *
+     * @param id
+     * @return
+     */
+    public Project getProject(int id) {
+        Project fetchedProject = null;
+        if (isActiveProject(id)) {
+            fetchedProject = projectsById.get(id);
+        } else {
+            try {
+                fetchedProject = projectLoader.fetchProjectById(id);
+            } catch (ProjectManagerException e) {
+                throw new RuntimeException(
+                    "Could not load project from store.", e);
+            }
+        }
+        return fetchedProject;
     }
 
   public Project createProject(String projectName, String description,

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
@@ -244,7 +244,7 @@ public class JdbcProjectLoaderTest {
 
     /** Default Test case for fetchProjectByName **/
     @Test
-    public void testProjectRetrivalByFetchProjectByName()
+    public void testProjectRetrievalByFetchProjectByName()
         throws ProjectManagerException {
         if (!isTestSetup()) {
             return;
@@ -300,7 +300,7 @@ public class JdbcProjectLoaderTest {
         } catch (ProjectManagerException ex) {
             System.out.println("Test true");
         }
-        Assert.fail("No exception");
+        Assert.fail("Expecting exception, but didn't get one");
     }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
@@ -28,7 +28,6 @@ import javax.sql.DataSource;
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
-
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -213,6 +212,96 @@ public class JdbcProjectLoaderTest {
 
     DbUtils.closeQuietly(connection);
   }
+
+    /** Test case to validated permissions for fetchProjectByName **/
+    @Test
+    public void testPermissionRetrivalByFetchProjectByName()
+        throws ProjectManagerException {
+        if (!isTestSetup()) {
+            return;
+        }
+
+        ProjectLoader loader = createLoader();
+        String projectName = "mytestProject";
+        String projectDescription = "This is my new project";
+        User user = new User("testUser");
+
+        Project project =
+            loader.createNewProject(projectName, projectDescription, user);
+
+        Permission perm = new Permission(0x2);
+        loader.updatePermission(project, user.getUserId(), perm, false);
+        loader.updatePermission(project, "group", perm, true);
+
+        Permission permOverride = new Permission(0x6);
+        loader.updatePermission(project, user.getUserId(), permOverride, false);
+
+        Project fetchedProject = loader.fetchProjectByName(project.getName());
+        assertProjectMemberEquals(project, fetchedProject);
+        Assert.assertEquals(permOverride,
+            fetchedProject.getUserPermission(user.getUserId()));
+    }
+
+    /** Default Test case for fetchProjectByName **/
+    @Test
+    public void testProjectRetrivalByFetchProjectByName()
+        throws ProjectManagerException {
+        if (!isTestSetup()) {
+            return;
+        }
+
+        ProjectLoader loader = createLoader();
+        String projectName = "mytestProject";
+        String projectDescription = "This is my new project";
+        User user = new User("testUser");
+
+        Project project =
+            loader.createNewProject(projectName, projectDescription, user);
+
+        Project fetchedProject = loader.fetchProjectByName(project.getName());
+        assertProjectMemberEquals(project, fetchedProject);
+    }
+
+    /** Default Test case for fetchProjectByName **/
+    @Test
+    public void testDuplicateRetrivalByFetchProjectByName()
+        throws ProjectManagerException {
+        if (!isTestSetup()) {
+            return;
+        }
+
+        ProjectLoader loader = createLoader();
+        String projectName = "mytestProject";
+        String projectDescription = "This is my new project";
+        User user = new User("testUser");
+
+        Project project =
+            loader.createNewProject(projectName, projectDescription, user);
+
+        loader.removeProject(project, user.getUserId());
+
+        Project newProject =
+            loader.createNewProject(projectName, projectDescription, user);
+
+        Project fetchedProject = loader.fetchProjectByName(project.getName());
+        Assert.assertEquals(newProject.getId(), fetchedProject.getId());
+
+    }
+
+    /** Test case for NonExistantProject project fetch **/
+    @Test
+    public void testInvalidProjectByFetchProjectByName() {
+        if (!isTestSetup()) {
+            return;
+        }
+        ProjectLoader loader = createLoader();
+        try {
+            loader.fetchProjectByName("NonExistantProject");
+        } catch (ProjectManagerException ex) {
+            System.out.println("Test true");
+        }
+        Assert.fail("No exception");
+    }
 
   @Test
   public void testCreateProject() throws ProjectManagerException {

--- a/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
+++ b/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
@@ -243,4 +243,10 @@ public class MockProjectLoader implements ProjectLoader {
     // TODO Auto-generated method stub
 
   }
+
+@Override
+public Project fetchProjectByName(String name) throws ProjectManagerException {
+    // TODO Auto-generated method stub
+    return null;
+}
 }


### PR DESCRIPTION
Azkaban already has method cleanOlderProjectVersion in place to hard delete a project version (https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java#L1038), which is used by Azkaban to do house keeping when a new project version is uploaded (https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/project/ProjectManager.java#L496). I have leveraged this exisitng functionality.