### PR TITLE
increase default char limit for execution log names

### DIFF
--- a/azkaban-sql/src/sql/update.execution_logs.2.6.4.sql
+++ b/azkaban-sql/src/sql/update.execution_logs.2.6.4.sql
@@ -1,0 +1,1 @@
+ALTER TABLE execution_logs MODIFY name VARCHAR(255);


### PR DESCRIPTION
Increasing the default char limit for execution log names to avoid cases where we cannot access the logs.

example:
```Caused by: java.sql.SQLException: Value too long for column "NAME VARCHAR(128) NOT NULL SELECTIVITY 1": "'<redacted>... (136)"; SQL statement:```

@orenmazor

