### PR TITLE
Added ability to use a shared thread pool for all jobs

### DIFF
--- a/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunner.java
@@ -81,6 +81,7 @@ public class FlowRunner extends EventHandler implements Runnable {
   private File logFile;
 
   private ExecutorService executorService;
+  private ExecutorService sharedExecutorService;
   private ExecutorLoader executorLoader;
   private ProjectLoader projectLoader;
 
@@ -180,6 +181,11 @@ public class FlowRunner extends EventHandler implements Runnable {
     numJobThreads = jobs;
     return this;
   }
+  
+  public FlowRunner setSharedJobThreadPool(ExecutorService executorService) {
+	    sharedExecutorService = executorService;
+	    return this;
+	  }
 
   public FlowRunner setJobLogSettings(String jobLogFileSize, int jobLogNumFiles) {
     this.jobLogFileSize = jobLogFileSize;
@@ -199,7 +205,7 @@ public class FlowRunner extends EventHandler implements Runnable {
 
   public void run() {
     try {
-      if (this.executorService == null) {
+      if (this.sharedExecutorService == null && this.executorService == null) {
         this.executorService = Executors.newFixedThreadPool(numJobThreads);
       }
       setupFlowExecution();
@@ -393,7 +399,9 @@ public class FlowRunner extends EventHandler implements Runnable {
     }
 
     logger.info("Finishing up flow. Awaiting Termination");
-    executorService.shutdown();
+    if (executorService != null) {
+    	executorService.shutdown();
+    }
 
     updateFlow();
     logger.info("Finished Flow");
@@ -1136,7 +1144,7 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   public boolean isThreadPoolShutdown() {
-    return executorService.isShutdown();
+    return executorService != null ? executorService.isShutdown() : true;
   }
 
   public int getNumRunningJobs() {

--- a/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
@@ -91,6 +93,8 @@ public class FlowRunnerManager implements EventListener,
       "executor.threadpool.workqueue.size";
   private static final String EXECUTOR_FLOW_THREADS = "executor.flow.threads";
   private static final String FLOW_NUM_JOB_THREADS = "flow.num.job.threads";
+  private static final String FLOW_JOB_USE_GLOBAL_THREADPOOL = "flow.job.use.global.threadpool";
+  
   private static Logger logger = Logger.getLogger(FlowRunnerManager.class);
   private File executionDirectory;
   private File projectDirectory;
@@ -120,9 +124,11 @@ public class FlowRunnerManager implements EventListener,
 
   private CleanerThread cleanerThread;
   private int numJobThreadPerFlow = DEFAULT_FLOW_NUM_JOB_TREADS;
+  private boolean jobUseGlobalThreadPool = false;
 
   private ExecutorLoader executorLoader;
   private ProjectLoader projectLoader;
+  private ExecutorService jobExecutorService;
 
   private JobTypeManager jobtypeManager;
 
@@ -172,6 +178,8 @@ public class FlowRunnerManager implements EventListener,
         props.getInt(EXECUTOR_FLOW_THREADS, DEFAULT_NUM_EXECUTING_FLOWS);
     numJobThreadPerFlow =
         props.getInt(FLOW_NUM_JOB_THREADS, DEFAULT_FLOW_NUM_JOB_TREADS);
+    jobUseGlobalThreadPool  =
+            props.getBoolean(FLOW_JOB_USE_GLOBAL_THREADPOOL, false);
     executorService = createExecutorService(numThreads);
 
     this.executorLoader = executorLoader;
@@ -487,6 +495,13 @@ public class FlowRunnerManager implements EventListener,
         .setJobLogSettings(jobLogChunkSize, jobLogNumFiles)
         .setValidateProxyUser(validateProxyUser)
         .setNumJobThreads(numJobThreads).addListener(this);
+    
+    if (jobUseGlobalThreadPool) {
+    	if (jobExecutorService == null) {
+    		jobExecutorService = Executors.newFixedThreadPool(numJobThreads);
+    	}
+    	runner.setSharedJobThreadPool(jobExecutorService);
+    }
 
     configureFlowLevelMetrics(runner);
 


### PR DESCRIPTION
I added an option to use a global thread pool for all flow jobs instead of one separate thread pool per flow.

The default behaviour is the current model (one job thread pool per flow) but if the config option "flow.job.use.global.threadpool" is set to true, the FlowRunnerManager will provide a shared thread pool to all flows.

This allows easier management of upper limit of concurrent running jobs and better utilization of resources since less threads will be idle.

In order to keep the configuration overhead low, I re-used the config param "flow.num.job.thread" to define the size of the global thread pool.