### PR TITLE
fix exception while property value is null

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -151,6 +151,9 @@ public class PropsUtils {
     LinkedHashSet<String> visitedVariables = new LinkedHashSet<String>();
     for (String key : props.getKeySet()) {
       String value = props.get(key);
+      if (value == null) {
+        continue;
+      }
 
       visitedVariables.add(key);
       String replacedValue =


### PR DESCRIPTION
The value of properties may be null when using hadoop 2. We should ignore them to avoid exceptions when passing to `Matcher#matcher` in `resolveVariableReplacement()`
