### PR TITLE
Auto upgrade database up to database.properties version and track draining flows

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -414,7 +414,12 @@ public class ExecutorManager extends EventHandler implements
     for (Executor executor : activeExecutors) {
       ports.add(executor.getHost() + ":" + executor.getPort());
     }
-
+    // include executor which were initially active and still has flows running
+    for (Pair<ExecutionReference, ExecutableFlow> running : runningFlows
+      .values()) {
+      ExecutionReference ref = running.getFirst();
+      ports.add(ref.getHost() + ":" + ref.getPort());
+    }
     return ports;
   }
 

--- a/azkaban-sql/src/sql/database.properties
+++ b/azkaban-sql/src/sql/database.properties
@@ -1,1 +1,1 @@
-version=
+version=3.0


### PR DESCRIPTION
At present, Azkaban neglect update* scripts while automatically creating database when we run Azkaban in Solo Server mode.