### PR TITLE
add time param replacement

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/ParamReplacement.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ParamReplacement.java
@@ -1,0 +1,66 @@
+package azkaban.utils;
+
+import com.google.common.collect.Lists;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ParamReplacement {
+  private static abstract class Param {
+    abstract String name();
+
+    abstract String replacement(String param);
+
+    String replace(String content) {
+      Pattern p = Pattern.compile("\\$\\{" + name() + "(?:|:.*?)}");
+      Matcher m = p.matcher(content);
+      String filledContent = "";
+      int lastIndex = 0;
+      while (m.find()) {
+        String g = m.group();
+        String replacement;
+        if (("${" + name() + "}").equals(g)) {
+          replacement = replacement(null);
+        } else {
+          String pstr =
+              org.apache.commons.lang.StringUtils.removeStart(g, "${" + name()
+                  + ":");
+          pstr = org.apache.commons.lang.StringUtils.removeEnd(pstr, "}");
+          replacement = replacement(pstr);
+        }
+        filledContent += content.substring(lastIndex, m.start()) + replacement;
+        lastIndex = m.end();
+      }
+      filledContent += content.substring(lastIndex);
+      return filledContent;
+    }
+  }
+
+  private static List<Param> params = Lists.<Param> newArrayList(
+      // time param, "${time:yyy-MM-dd hh:mm:ss}" will be replaced into like
+      // "2015-09-16 11:23:45"
+      new Param() {
+        public String name() {
+          return "time";
+        }
+
+        public String replacement(String param) {
+          if (param == null) {
+            param = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+          }
+          SimpleDateFormat format = new SimpleDateFormat(param);
+          return format.format(new Date());
+        }
+      });
+
+  public static String replaceParams(String content) {
+    for (Param param : params) {
+      content = param.replace(content);
+    }
+    return content;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -167,7 +167,7 @@ public class PropsUtils {
 
     for (String key : resolvedProps.getKeySet()) {
       String value = resolvedProps.get(key);
-      String replacedValue = ParamReplacement.replaceParams(value);
+      String replacedValue = ParamReplacement.replaceParams(value, resolvedProps);
       resolvedProps.put(key, replacedValue);
     }
 

--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -167,6 +167,12 @@ public class PropsUtils {
 
     for (String key : resolvedProps.getKeySet()) {
       String value = resolvedProps.get(key);
+      String replacedValue = ParamReplacement.replaceParams(value);
+      resolvedProps.put(key, replacedValue);
+    }
+
+    for (String key : resolvedProps.getKeySet()) {
+      String value = resolvedProps.get(key);
       String expressedValue = resolveVariableExpression(value);
       resolvedProps.put(key, expressedValue);
     }


### PR DESCRIPTION
In schedule job, parameters based on current time are very common, like a daily job consumes a file named `/tmp/from/${time:-1day,yyyyMMdd}.txt`, and `${time:-1day,yyyyMMdd}` will be replaced into `20150915` if the day it execute is September 16, 2015, i.e. the real file name passed to the job will be `/tmp/from/20150915.txt`. Although technically a job can do this itself, it  would be a great convenient.

This patch enable time parameters in job configures, the grammar is `${time:<delta period>,<time format>}`. The format is following ISO8601,  and the unit of delta period could be `year`, `month`, `day`, `hour`, `minute` and `second`.
