### PR TITLE
Fix to use appropriate flow watcher for pipelined execution

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -453,14 +453,12 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /**
-   * <pre>
    * Gets a list of all the active (running flows and non-dispatched flows)
    * executions for a given project and flow {@inheritDoc}. Results should
    * be sorted as we assume this while setting up pipelined execution Id.
    *
    * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows(int,
    *      java.lang.String)
-   * </pre>
    */
   @Override
   public List<Integer> getRunningFlows(int projectId, String flowId) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -453,11 +453,14 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /**
+   * <pre>
    * Gets a list of all the active (running flows and non-dispatched flows)
-   * executions for a given project and flow {@inheritDoc}
+   * executions for a given project and flow {@inheritDoc}. Results should
+   * be sorted as we assume this while setting up pipelined execution Id.
    *
    * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows(int,
    *      java.lang.String)
+   * </pre>
    */
   @Override
   public List<Integer> getRunningFlows(int projectId, String flowId) {
@@ -466,6 +469,7 @@ public class ExecutorManager extends EventHandler implements
       queuedFlows.getAllEntries()));
     executionIds.addAll(getRunningFlowsHelper(projectId, flowId,
       runningFlows.values()));
+    Collections.sort(executionIds);
     return executionIds;
   }
 


### PR DESCRIPTION
Pipelined flow watcher depends on execution ids to be a sorted list.