### PR TITLE
number of processed based executor refresh invalidates inferred global state 

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1872,7 +1872,11 @@ public class ExecutorManager extends EventHandler implements
           // process flow with current snapshot of activeExecutors
           selectExecutorAndDispatchFlow(reference, exflow, new HashSet<Executor>(activeExecutors));
         }
-        currentContinuousFlowProcessed++;
+
+        // do not count failed flow processsing (flows still in queue)
+        if(queuedFlows.getFlow(exflow.getExecutionId()) == null) {
+          currentContinuousFlowProcessed++;
+        }
       }
     }
 


### PR DESCRIPTION
a number of processed based executor refresh invalidates logic to identify global busy state