### PR TITLE
Replace all the tokens in the jobcall back headers and body

### DIFF
--- a/azkaban-common/src/main/java/azkaban/alert/Alerter.java
+++ b/azkaban-common/src/main/java/azkaban/alert/Alerter.java
@@ -21,9 +21,10 @@ import azkaban.sla.SlaOption;
 
 public interface Alerter {
   void alertOnSuccess(ExecutableFlow exflow) throws Exception;
+
   void alertOnError(ExecutableFlow exflow, String ... extraReasons) throws Exception;
 
   void alertOnFirstError(ExecutableFlow exflow) throws Exception;
 
-  void alertOnSla(SlaOption slaOption, String slaMessage) throws Exception;
+  void alertOnSla(SlaOption slaOption, ExecutableFlow exFlow) throws Exception;
 }

--- a/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
@@ -209,6 +209,58 @@ public class DefaultMailCreator implements MailCreator {
     return false;
   }
 
+  @Override
+  public boolean createSlaAlertEmail(ExecutableFlow flow, EmailMessage message,
+                                  String azkabanName, String scheme, String clientHostname,
+                                  String clientPortNumber, List<String> emailList, String... vars) {
+
+    ExecutionOptions option = flow.getExecutionOptions();
+
+    int execId = flow.getExecutionId();
+
+    if (emailList != null && !emailList.isEmpty()) {
+      message.addAllToAddress(emailList);
+      message.setMimeType("text/html");
+      message.setSubject("Flow '" + flow.getFlowId() + "' didn't meet its SLA on "
+              + azkabanName);
+
+      message.println("<h2 style=\"color:#FF0000\"> Execution '" + execId
+              + "' of flow '" + flow.getFlowId() + "' has violated its SLA on " + azkabanName
+              + "</h2>");
+      message.println("<table>");
+      message.println("<tr><td>Start Time</td><td>"
+              + convertMSToString(flow.getStartTime()) + "</td></tr>");
+      message.println("<tr><td>End Time</td><td>"
+              + convertMSToString(flow.getEndTime()) + "</td></tr>");
+      message.println("<tr><td>Duration</td><td>"
+              + Utils.formatDuration(flow.getStartTime(), flow.getEndTime())
+              + "</td></tr>");
+      message.println("</table>");
+      message.println("");
+      String executionUrl =
+              scheme + "://" + clientHostname + ":" + clientPortNumber + "/"
+                      + "executor?" + "execid=" + execId;
+      message.println("<a href=\"" + executionUrl + "\">" + flow.getFlowId()
+              + " Execution Link</a>");
+
+      message.println("");
+      message.println("<h3>Reason</h3>");
+      List<String> failedJobs = Emailer.findFailedJobs(flow);
+      message.println("<ul>");
+      for (String jobId : failedJobs) {
+        message.println("<li><a href=\"" + executionUrl + "&job=" + jobId
+                + "\">Failed job '" + jobId + "' Link</a></li>");
+      }
+      for (String reasons : vars) {
+        message.println("<li>" + reasons + "</li>");
+      }
+
+      message.println("</ul>");
+      return true;
+    }
+    return false;
+  }
+
   private static String convertMSToString(long timeInMS) {
     if (timeInMS < 0) {
       return "N/A";

--- a/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
@@ -19,6 +19,8 @@ package azkaban.executor.mail;
 import azkaban.executor.ExecutableFlow;
 import azkaban.utils.EmailMessage;
 
+import java.util.List;
+
 public interface MailCreator {
   public boolean createFirstErrorMessage(ExecutableFlow flow,
       EmailMessage message, String azkabanName, String scheme,
@@ -31,4 +33,8 @@ public interface MailCreator {
   public boolean createSuccessEmail(ExecutableFlow flow, EmailMessage message,
       String azkabanName, String scheme, String clientHostname,
       String clientPortNumber, String... vars);
+
+  public boolean createSlaAlertEmail(ExecutableFlow flow, EmailMessage message,
+                                     String azkabanName, String scheme, String clientHostname,
+                                     String clientPortNumber, List<String> emailList, String... vars);
 }

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -151,7 +151,7 @@ public class SlaOption {
           "SLA Alert: Your flow " + flowName + " failed to FINISH within "
               + duration + "</br>";
       String expected =
-          "Here is details : </br>" + "Flow " + flowName + " in execution "
+          "Here are the details : </br>" + "Flow " + flowName + " in execution "
               + execId + " is expected to FINISH within " + duration + " from "
               + fmt.print(new DateTime(flow.getStartTime())) + "</br>";
       String actual = "Actual flow status is " + flow.getStatus();
@@ -165,7 +165,7 @@ public class SlaOption {
           "SLA Alert: Your flow " + flowName + " failed to SUCCEED within "
               + duration + "</br>";
       String expected =
-          "Here is details : </br>" + "Flow " + flowName + " in execution "
+          "Here are the details : </br>" + "Flow " + flowName + " in execution "
               + execId + " expected to FINISH within " + duration + " from "
               + fmt.print(new DateTime(flow.getStartTime())) + "</br>";
       String actual = "Actual flow status is " + flow.getStatus();

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
@@ -107,8 +107,7 @@ public class SlaAlertAction implements TriggerAction {
       if (alerter != null) {
         try {
           ExecutableFlow flow = executorManager.getExecutableFlow(execId);
-          alerter.alertOnSla(slaOption,
-              SlaOption.createSlaMessage(slaOption, flow));
+          alerter.alertOnSla(slaOption, flow);
         } catch (Exception e) {
           e.printStackTrace();
           logger.error("Failed to alert by " + alertType);

--- a/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -182,11 +182,11 @@ public class JobCallbackUtil {
             headersKey.replace(SEQUENCE_TOKEN, sequenceStr);
         String headersValue = props.get(headersKeyPerSequence);
 		
-		// replace all the tokens in the header
-		if(headersValue != null)
-		{
-			headersValue = replaceTokens(headersValue, contextInfo, false);
-		}
+	// replace all the tokens in the header
+	if(headersValue != null)
+	{
+		headersValue = replaceTokens(headersValue, contextInfo, false);
+	}
 		
         privateLogger.info("headers: " + headersValue);
         Header[] headers = parseHttpHeaders(headersValue);

--- a/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -182,11 +182,10 @@ public class JobCallbackUtil {
             headersKey.replace(SEQUENCE_TOKEN, sequenceStr);
         String headersValue = props.get(headersKeyPerSequence);
 		
-	// replace all the tokens in the header
-	if(headersValue != null)
-	{
-		headersValue = replaceTokens(headersValue, contextInfo, false);
-	}
+		// replace all the tokens in the header
+		if(headersValue != null)  {
+			headersValue = replaceTokens(headersValue, contextInfo, false);
+		}
 		
         privateLogger.info("headers: " + headersValue);
         Header[] headers = parseHttpHeaders(headersValue);

--- a/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -181,6 +181,13 @@ public class JobCallbackUtil {
         String headersKeyPerSequence =
             headersKey.replace(SEQUENCE_TOKEN, sequenceStr);
         String headersValue = props.get(headersKeyPerSequence);
+		
+		// replace all the tokens in the header
+		if(headersValue != null)
+		{
+			headersValue = replaceTokens(headersValue, contextInfo, false);
+		}
+		
         privateLogger.info("headers: " + headersValue);
         Header[] headers = parseHttpHeaders(headersValue);
         if (headers != null) {
@@ -287,25 +294,25 @@ public class JobCallbackUtil {
     String result = value;
     String tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_SERVER_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_SERVER_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_SERVER_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_PROJECT_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_PROJECT_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_PROJECT_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_FLOW_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_FLOW_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_FLOW_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_JOB_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_JOB_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_JOB_TOKEN), tokenValue);
 
     tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_EXECUTION_ID_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_EXECUTION_ID_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_EXECUTION_ID_TOKEN), tokenValue);
 
     tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_JOB_STATUS_TOKEN), withEncoding);
 
-    result = result.replaceFirst(Pattern.quote(CONTEXT_JOB_STATUS_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_JOB_STATUS_TOKEN), tokenValue);
 
     return result;
   }

--- a/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-execserver/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -182,7 +182,7 @@ public class JobCallbackUtil {
             headersKey.replace(SEQUENCE_TOKEN, sequenceStr);
         String headersValue = props.get(headersKeyPerSequence);
 		
-		// replace all the tokens in the header
+        // replace all the tokens in the header
 		if(headersValue != null)  {
 			headersValue = replaceTokens(headersValue, contextInfo, false);
 		}

--- a/azkaban-execserver/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
+++ b/azkaban-execserver/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
@@ -223,6 +223,7 @@ public class JobCallbackUtilTest {
 		+ CONTEXT_JOB_STATUS_TOKEN;
 
 	String result =
+		JobCallbackUtil.replaceTokens(urlWithMultipleTokens, contextInfo, true);
 
 	String expectedResult =
 		"http://www.linkedin.com?server=" + SERVER_NAME + "&project="
@@ -232,6 +233,7 @@ public class JobCallbackUtilTest {
 		+ EXECUTION_ID + "&job=" + JOB_NAME + "&status=" + JOB_STATUS_NAME;
 
 	Assert.assertEquals(expectedResult, result);
+  }
 
   @Test
   public void tokenWithEncoding() throws Exception {

--- a/azkaban-execserver/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
+++ b/azkaban-execserver/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
@@ -211,6 +211,29 @@ public class JobCallbackUtilTest {
   }
 
   @Test
+  public void multipleTokensTest() {
+
+	String urlWithMultipleTokens =
+		"http://www.linkedin.com?server=" + SERVER_NAME + "&project="
+		+ CONTEXT_PROJECT_TOKEN + "&flow=" + CONTEXT_FLOW_TOKEN + "&executionId="
+		+ CONTEXT_EXECUTION_ID_TOKEN + "&job=" + CONTEXT_JOB_TOKEN + "&status="
+		+ CONTEXT_JOB_STATUS_TOKEN + "&project="
+		+ CONTEXT_PROJECT_TOKEN + "&flow=" + CONTEXT_FLOW_TOKEN + "&executionId="
+		+ CONTEXT_EXECUTION_ID_TOKEN + "&job=" + CONTEXT_JOB_TOKEN + "&status="
+		+ CONTEXT_JOB_STATUS_TOKEN;
+
+	String result =
+
+	String expectedResult =
+		"http://www.linkedin.com?server=" + SERVER_NAME + "&project="
+		+ PROJECT_NAME + "&flow=" + FLOW_NAME + "&executionId="
+		+ EXECUTION_ID + "&job=" + JOB_NAME + "&status=" + JOB_STATUS_NAME
+		+ "&project=" + PROJECT_NAME + "&flow=" + FLOW_NAME + "&executionId="
+		+ EXECUTION_ID + "&job=" + JOB_NAME + "&status=" + JOB_STATUS_NAME;
+
+	Assert.assertEquals(expectedResult, result);
+
+  @Test
   public void tokenWithEncoding() throws Exception {
     String jobNameWithSpaces = "my job";
     String encodedJobName = URLEncoder.encode(jobNameWithSpaces, "UTF-8");


### PR DESCRIPTION
Currently we are only replacing the first instance of the tokens in the header and bbody for job call back. This doesn't work in cases where we want to craft a body or header which needs the token to be replaced at all places.

Fixes #559
