### PR TITLE
Fix soloserver start script

### DIFF
--- a/azkaban-soloserver/src/package/bin/azkaban-solo-start.sh
+++ b/azkaban-soloserver/src/package/bin/azkaban-solo-start.sh
@@ -43,7 +43,7 @@ serverpath=`pwd`
 if [ -z $AZKABAN_OPTS ]; then
   AZKABAN_OPTS=-Xmx3G
 fi
-AZKABAN_OPTS="$AZKABAN_OPTS -server -Dcom.sun.management.jmxremote -Djava.io.tmpdir=$tmpdir -Dexecutorport=$executorport -Dserverpath=$serverpath"
+AZKABAN_OPTS="$AZKABAN_OPTS -server -Dcom.sun.management.jmxremote -Djava.io.tmpdir=$tmpdir -Dexecutorport=$executorport -Dserverpath=$serverpath -Dlog4j.log.dir=$azkaban_dir/logs"
 
 java $AZKABAN_OPTS -cp $CLASSPATH azkaban.soloserver.AzkabanSingleServer -conf $azkaban_dir/conf $@ &
 


### PR DESCRIPTION
Gets rid of this kind of error:

```
log4j:ERROR setFile(null,true) call failed.
java.io.FileNotFoundException: /azkaban-execserver.log (Permission denied)
```
