### PR TITLE
Add jetty.hostname property to properly generate email links within Azkaban email notifications (even on tomcat)

### DIFF
--- a/azkaban-soloserver/src/package/conf/azkaban.properties
+++ b/azkaban-soloserver/src/package/conf/azkaban.properties
@@ -24,6 +24,7 @@ h2.create.tables=true
 velocity.dev.mode=false
 
 # Azkaban Jetty server properties. Ignored in tomcat
+jetty.hostname=localhost
 jetty.use.ssl=false
 jetty.ssl.port=8043
 jetty.maxThreads=25

--- a/azkaban-webserver/src/package/conf/azkaban.properties
+++ b/azkaban-webserver/src/package/conf/azkaban.properties
@@ -26,6 +26,7 @@ mysql.numconnections=100
 velocity.dev.mode=false
 
 # Azkaban Jetty server properties.
+jetty.hostname=localhost
 jetty.maxThreads=25
 jetty.ssl.port=8443
 jetty.port=8081


### PR DESCRIPTION
Simple change to add jetty.hostname property for correct email url links.
