### PR TITLE
Fix issue #605: Azkaban HTTP callback may skip notification

### DIFF
--- a/azkaban-common/src/main/java/azkaban/event/Event.java
+++ b/azkaban-common/src/main/java/azkaban/event/Event.java
@@ -16,6 +16,8 @@
 
 package azkaban.event;
 
+import com.google.common.base.Preconditions;
+
 public class Event {
   public enum Type {
     FLOW_STARTED,
@@ -29,16 +31,14 @@ public class Event {
 
   private final Object runner;
   private final Type type;
-  private final Object eventData;
+  private final EventData eventData;
   private final long time;
-  private final boolean shouldUpdate;
 
-  private Event(Object runner, Type type, Object eventData, boolean shouldUpdate) {
+  private Event(Object runner, Type type, EventData eventData) {
     this.runner = runner;
     this.type = type;
     this.eventData = eventData;
     this.time = System.currentTimeMillis();
-    this.shouldUpdate = shouldUpdate;
   }
 
   public Object getRunner() {
@@ -53,24 +53,22 @@ public class Event {
     return time;
   }
 
-  public Object getData() {
+  public EventData getData() {
     return eventData;
   }
 
-  public static Event create(Object runner, Type type) {
-    return new Event(runner, type, null, true);
+  /**
+   * Creates a new event.
+   *
+   * @param runner runner.
+   * @param type type.
+   * @param eventData EventData, null is not allowed.
+   * @return New Event instance.
+   * @throws NullPointerException if EventData is null.
+   */
+  public static Event create(Object runner, Type type, EventData eventData) throws NullPointerException {
+    Preconditions.checkNotNull(eventData, "EventData was null");
+    return new Event(runner, type, eventData);
   }
 
-  public static Event create(Object runner, Type type, Object eventData) {
-    return new Event(runner, type, eventData, true);
-  }
-
-  public static Event create(Object runner, Type type, Object eventData,
-      boolean shouldUpdate) {
-    return new Event(runner, type, eventData, shouldUpdate);
-  }
-
-  public boolean isShouldUpdate() {
-    return shouldUpdate;
-  }
 }

--- a/azkaban-common/src/main/java/azkaban/event/EventData.java
+++ b/azkaban-common/src/main/java/azkaban/event/EventData.java
@@ -1,0 +1,42 @@
+package azkaban.event;
+
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.Status;
+
+/**
+ * Carries an immutable snapshot of the status data, suitable for asynchronous message passing.
+ */
+public class EventData {
+
+  private final Status status;
+  private final String nestedId;
+
+  /**
+   * Creates a new EventData instance.
+   *
+   * @param status node status.
+   */
+  public EventData(Status status) {
+    this(status, null);
+  }
+
+  /**
+   * Creates a new EventData instance.
+   *
+   * @param status node status.
+   * @param nestedId node id, corresponds to {@link ExecutableNode#getNestedId()}.
+   */
+  public EventData(Status status, String nestedId) {
+    this.status = status;
+    this.nestedId = nestedId;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public String getNestedId() {
+    return nestedId;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -45,6 +45,7 @@ import org.joda.time.DateTime;
 import azkaban.alert.Alerter;
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
+import azkaban.event.EventData;
 import azkaban.event.EventHandler;
 import azkaban.executor.selector.ExecutorComparator;
 import azkaban.executor.selector.ExecutorFilter;
@@ -1349,7 +1350,7 @@ public class ExecutorManager extends EventHandler implements
                 ScheduleStatisticManager.invalidateCache(flow.getScheduleId(),
                     cacheDir);
               }
-              fireEventListeners(Event.create(flow, Type.FLOW_FINISHED));
+              fireEventListeners(Event.create(flow, Type.FLOW_FINISHED, new EventData(flow.getStatus())));
               recentlyFinished.put(flow.getExecutionId(), flow);
             }
 
@@ -1415,7 +1416,7 @@ public class ExecutorManager extends EventHandler implements
 
       updaterStage = "finalizing flow " + execId + " cleaning from memory";
       runningFlows.remove(execId);
-      fireEventListeners(Event.create(dsFlow, Type.FLOW_FINISHED));
+      fireEventListeners(Event.create(dsFlow, Type.FLOW_FINISHED, new EventData(dsFlow.getStatus())));
       recentlyFinished.put(execId, dsFlow);
 
     } catch (ExecutorManagerException e) {

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
   testCompile('org.hamcrest:hamcrest-all:1.3')
   testCompile(project(':azkaban-common').sourceSets.test.output)
+  testCompile('com.google.guava:guava:13.0.1')
 }
 
 distributions {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -19,6 +19,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
 import azkaban.event.Event;
+import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.execapp.JobRunner;
 import azkaban.execapp.jmx.JmxJobCallback;
@@ -135,6 +136,7 @@ public class JobCallbackManager implements EventListener {
 
   private void processJobCallOnFinish(Event event) {
     JobRunner jobRunner = (JobRunner) event.getRunner();
+    EventData eventData = event.getData();
 
     if (!JobCallbackUtil.isThereJobCallbackProperty(jobRunner.getProps(),
         ON_COMPLETION_JOB_CALLBACK_STATUS)) {
@@ -151,7 +153,7 @@ public class JobCallbackManager implements EventListener {
     JobCallbackStatusEnum jobCallBackStatusEnum = null;
     Logger jobLogger = jobRunner.getLogger();
 
-    Status jobStatus = jobRunner.getNode().getStatus();
+    Status jobStatus = eventData.getStatus();
 
     if (jobStatus == Status.SUCCEEDED) {
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -36,6 +36,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
 import azkaban.event.Event;
+import azkaban.event.EventData;
 import azkaban.execapp.JobRunner;
 import azkaban.executor.ExecutableNode;
 import azkaban.jobcallback.JobCallbackStatusEnum;
@@ -244,6 +245,7 @@ public class JobCallbackUtil {
     if (event.getRunner() instanceof JobRunner) {
       JobRunner jobRunner = (JobRunner) event.getRunner();
       ExecutableNode node = jobRunner.getNode();
+      EventData eventData = event.getData();
       String projectName = node.getParentFlow().getProjectName();
       String flowName = node.getParentFlow().getFlowId();
       String executionId =
@@ -256,7 +258,7 @@ public class JobCallbackUtil {
       result.put(CONTEXT_FLOW_TOKEN, flowName);
       result.put(CONTEXT_EXECUTION_ID_TOKEN, executionId);
       result.put(CONTEXT_JOB_TOKEN, jobId);
-      result.put(CONTEXT_JOB_STATUS_TOKEN, node.getStatus().name().toLowerCase());
+      result.put(CONTEXT_JOB_STATUS_TOKEN, eventData.getStatus().name().toLowerCase());
 
       /*
        * if (node.getStatus() == Status.SUCCEEDED || node.getStatus() ==

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
@@ -18,6 +18,7 @@ package azkaban.execapp.event;
 
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
+import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.execapp.FlowRunner;
 import azkaban.execapp.JobRunner;
@@ -58,10 +59,9 @@ public class LocalFlowWatcher extends FlowWatcher {
       if (event.getType() == Type.JOB_FINISHED) {
         if (event.getRunner() instanceof FlowRunner) {
           // The flow runner will finish a job without it running
-          Object data = event.getData();
-          if (data instanceof ExecutableNode) {
-            ExecutableNode node = (ExecutableNode) data;
-            handleJobStatusChange(node.getNestedId(), node.getStatus());
+          EventData eventData = event.getData();
+          if (eventData.getNestedId() != null) {
+            handleJobStatusChange(eventData.getNestedId(), eventData.getStatus());
           }
         } else if (event.getRunner() instanceof JobRunner) {
           // A job runner is finished

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMBeanManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMBeanManager.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.log4j.Logger;
 
 import azkaban.event.Event;
+import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.execapp.JobRunner;
 import azkaban.executor.ExecutableNode;
@@ -101,12 +102,13 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
 
     if (event.getRunner() instanceof JobRunner) {
       JobRunner jobRunner = (JobRunner) event.getRunner();
+      EventData eventData = event.getData();
       ExecutableNode node = jobRunner.getNode();
 
       if (logger.isDebugEnabled()) {
         logger.debug("*** got " + event.getType() + " " + node.getId() + " "
             + event.getRunner().getClass().getName() + " status: "
-            + node.getStatus());
+            + eventData.getStatus());
       }
 
       if (event.getType() == Event.Type.JOB_STARTED) {
@@ -121,13 +123,13 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
               + Event.Type.JOB_FINISHED);
         }
 
-        if (node.getStatus() == Status.FAILED) {
+        if (eventData.getStatus() == Status.FAILED) {
           totalFailedJobCount.incrementAndGet();
-        } else if (node.getStatus() == Status.SUCCEEDED) {
+        } else if (eventData.getStatus() == Status.SUCCEEDED) {
           totalSucceededJobCount.incrementAndGet();
         }
 
-        handleJobFinishedCount(node.getStatus(), node.getType());
+        handleJobFinishedCount(eventData.getStatus(), node.getType());
       }
 
     } else {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedJobMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedJobMetric.java
@@ -18,6 +18,7 @@ package azkaban.execapp.metric;
 
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
+import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.execapp.JobRunner;
 import azkaban.executor.Status;
@@ -44,8 +45,7 @@ public class NumFailedJobMetric extends TimeBasedReportingMetric<Integer> implem
    */
   @Override
   public synchronized void handleEvent(Event event) {
-    JobRunner runner = (JobRunner) event.getRunner();
-    if (event.getType() == Type.JOB_FINISHED && runner.getStatus().equals(Status.FAILED)) {
+    if (event.getType() == Type.JOB_FINISHED && Status.FAILED.equals(event.getData().getStatus())) {
       value = value + 1;
     }
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
+import azkaban.event.EventData;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutorLoader;
@@ -82,12 +83,12 @@ public class JobRunnerTest {
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     ExecutableNode node = runner.getNode();
 
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED));
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED, new EventData(node.getStatus())));
     Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED
         || runner.getStatus() != Status.FAILED);
 
     runner.run();
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED));
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED, new EventData(node.getStatus())));
 
     Assert.assertTrue(runner.getStatus() == node.getStatus());
     Assert.assertTrue("Node status is " + node.getStatus(),
@@ -281,12 +282,11 @@ public class JobRunnerTest {
     long startTime = System.currentTimeMillis();
     ExecutableNode node = runner.getNode();
 
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED));
-    Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED
-        || runner.getStatus() != Status.FAILED);
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED, new EventData(node.getStatus())));
+    Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED);
 
     runner.run();
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED));
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED, new EventData(node.getStatus())));
 
     Assert.assertTrue(runner.getStatus() == node.getStatus());
     Assert.assertTrue("Node status is " + node.getStatus(),
@@ -321,9 +321,8 @@ public class JobRunnerTest {
     long startTime = System.currentTimeMillis();
     ExecutableNode node = runner.getNode();
 
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED));
-    Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED
-        || runner.getStatus() != Status.FAILED);
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_STARTED, new EventData(node.getStatus())));
+    Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED);
 
     Thread thread = new Thread(runner);
     thread.start();
@@ -344,7 +343,7 @@ public class JobRunnerTest {
       }
     }
 
-    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED));
+    eventCollector.handleEvent(Event.create(null, Event.Type.JOB_FINISHED, new EventData(node.getStatus())));
 
     Assert.assertTrue(runner.getStatus() == node.getStatus());
     Assert.assertTrue("Node status is " + node.getStatus(),


### PR DESCRIPTION
Fix issue #605: Azkaban HTTP callback may skip notification.

- Instead of getting the mutable node status in callbacks, passing the job status - as at the time of firing the event - in additional event data.