### PR TITLE
Show queued jobs in the execution list

### DIFF
--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -165,6 +165,10 @@ td {
     &.FAILED_SUCCEEDED {
       background-color: @flow-failed-succeeded-color;
     }
+
+    &.QUEUED {
+      background-color: @flow-queued-color;
+    }
   }
 }
 

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -421,12 +421,45 @@ var updateStatus = function (updateTime) {
   ajaxCall(requestURL, requestData, successHandler);
 }
 
+function updatePastAttempts(data, update) {
+	if (!update.pastAttempts) {
+	    return;
+	}
+
+	if (data.pastAttempts) {
+		for (var i = 0; i < update.pastAttempts.length; ++i) {
+			var updatedAttempt = update.pastAttempts[i];
+			var found = false;
+			for (var j = 0; j < data.pastAttempts.length; ++j) {
+				var attempt = data.pastAttempts[j];
+				if (attempt.attempt == updatedAttempt.attempt) {
+					attempt.startTime = updatedAttempt.startTime;
+					attempt.endTime = updatedAttempt.endTime;
+					attempt.status = updatedAttempt.status;
+					found = true;
+					break;
+				}
+			}
+
+			if (!found) {
+				data.pastAttempts.push(updatedAttempt);
+			}
+		}
+	}
+	else {
+		data.pastAttempts = update.pastAttempts;
+	}
+}
+
 var updateGraph = function (data, update) {
   var nodeMap = data.nodeMap;
   data.startTime = update.startTime;
   data.endTime = update.endTime;
   data.updateTime = update.updateTime;
   data.status = update.status;
+
+  updatePastAttempts(data, update);
+
   update.changedNode = data;
 
   if (update.nodes) {

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -95,9 +95,11 @@ azkaban.ExecutionListView = Backbone.View.extend({
     for (var i = 0; i < nodes.length; ++i) {
       var node = nodes[i].changedNode ? nodes[i].changedNode : nodes[i];
 
-      if (node.startTime < 0) {
+
+      if (node.status == 'READY') {
         continue;
       }
+
       //var nodeId = node.id.replace(".", "\\\\.");
       var row = node.joblistrow;
       if (!row) {
@@ -110,8 +112,13 @@ azkaban.ExecutionListView = Backbone.View.extend({
       $(statusDiv).attr("class", "status " + node.status);
 
       var startTimeTd = $(row).find("> td.startTime");
-      var startdate = new Date(node.startTime);
-      $(startTimeTd).text(getDateFormat(startdate));
+      if (node.startTime == -1) {
+          $(startTimeTd).text("-");
+      }
+      else {
+          var startdate = new Date(node.startTime);
+          $(startTimeTd).text(getDateFormat(startdate));
+      }
 
       var endTimeTd = $(row).find("> td.endTime");
       if (node.endTime == -1) {
@@ -173,10 +180,6 @@ azkaban.ExecutionListView = Backbone.View.extend({
   },
 
   updateProgressBar: function (data, flowStartTime, flowLastTime) {
-    if (data.startTime == -1) {
-      return;
-    }
-
     var outerWidth = $(".flow-progress").css("width");
     if (outerWidth) {
       if (outerWidth.substring(outerWidth.length - 2, outerWidth.length)
@@ -243,10 +246,13 @@ azkaban.ExecutionListView = Backbone.View.extend({
 
       var nodeLastTime = node.endTime == -1 ? (new Date()).getTime()
           : node.endTime;
-      var left = Math.max((node.startTime - parentStartTime) * factor,
+      var nodeStartTime = node.startTime == -1 ? (new Date()).getTime()
+          : node.startTime;
+      var left = Math.max((nodeStartTime - parentStartTime) * factor,
           minOffset);
       var margin = left - offsetLeft;
-      var width = Math.max((nodeLastTime - node.startTime) * factor, 3);
+      var width = Math.max((nodeLastTime - nodeStartTime) * factor, 3);
+
       width = Math.min(width, outerWidth);
 
       progressBar.css("margin-left", left)


### PR DESCRIPTION
The PR fixes a problem when a queued job would disappear from the job list view when its state changes to **QUEUED**.

Currently, you can access job logs for current and failed attempts in the **Job List** tab of an execution.

If some job failed and has retries, it goes into **QUEUED** state while sleeping before the next attempt.

1. If you want to see why any of the previous attempts failed, you can right-click the _grey attempt bar_
2. To see how long it's going to sleep, you can **check the job log**

Without this fix you can't do either of those if the job is sleeping, because it's hidden if the state is **QUEUED**.

Also if you have a job that hasn't yet started to run but is in **QUEUED** state (ie. blocked by pipeline), if you want to know why it's queued, you should **check the job log**. If you can't access the job log via Job List tab, this is not easily accomplished.

It looks like this:
![queuedjob](https://cloud.githubusercontent.com/assets/4446608/26760436/6bec67f2-4920-11e7-9a7a-18b7539a490f.png)
