### PR TITLE
Update README: Azkaban2 -> Azkaban 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Azkaban2 [![Build Status](http://img.shields.io/travis/azkaban/azkaban.svg?style=flat)](https://travis-ci.org/azkaban/azkaban)
+Azkaban 3 [![Build Status](http://img.shields.io/travis/azkaban/azkaban.svg?style=flat)](https://travis-ci.org/azkaban/azkaban)
 ========
 
 Building from Source


### PR DESCRIPTION
Just to avoid confusion. The current master is version 3.0.0, so making the README reflect that.