### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ project(':azkaban-common') {
     compile('com.google.guava:guava:13.0.1')
     compile('com.h2database:h2:1.3.170')
     compile('commons-codec:commons-codec:1.9')
-    compile('commons-collections:commons-collections:3.2.1')
+    compile('commons-collections:commons-collections:3.2.2')
     compile('commons-configuration:commons-configuration:1.8')
     compile('commons-dbcp:commons-dbcp:1.4')
     compile('commons-dbutils:commons-dbutils:1.5')


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/