### PR TITLE
Fixes Custom context path

### DIFF
--- a/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -759,7 +759,7 @@ public class AzkabanWebServer extends AzkabanServer {
     String staticDir =
         azkabanSettings.getString("web.resource.dir", DEFAULT_STATIC_DIR);
     logger.info("Setting up web resource dir " + staticDir);
-    Context root = new Context(server, "/", Context.SESSIONS);
+    Context root = new Context(server, azkabanSettings.getString("jetty.contextPath", "/"), Context.SESSIONS);
     root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
 
     String defaultServletPath =

--- a/azkaban-webserver/src/main/java/azkaban/webapp/servlet/IndexRedirectServlet.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/servlet/IndexRedirectServlet.java
@@ -42,12 +42,12 @@ public class IndexRedirectServlet extends LoginAbstractAzkabanServlet {
   @Override
   protected void handleGet(HttpServletRequest req, HttpServletResponse resp,
       Session session) throws ServletException, IOException {
-    resp.sendRedirect(defaultServletPath);
+    resp.sendRedirect(req.getContextPath() + defaultServletPath);
   }
 
   @Override
   protected void handlePost(HttpServletRequest req, HttpServletResponse resp,
       Session session) throws ServletException, IOException {
-    resp.sendRedirect(defaultServletPath);
+    resp.sendRedirect(req.getContextPath() + defaultServletPath);
   }
 }

--- a/azkaban-webserver/src/main/less/navbar.less
+++ b/azkaban-webserver/src/main/less/navbar.less
@@ -49,7 +49,7 @@
   margin-bottom: 0;
 
   .navbar-logo {
-    background: url('../../images/logo.png') top left no-repeat;
+    background: url('../images/logo.png') top left no-repeat;
     color: #ffffff;
     font-size: 156.25%;
     font-weight: bold;

--- a/azkaban-webserver/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-webserver/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -19,8 +19,8 @@
 
     <link rel="shortcut icon" href="${context}/favicon.ico" />
     <!-- Bootstrap core CSS -->
-    <link href="/css/bootstrap.css" rel="stylesheet">
-    <link href="/css/azkaban.css" rel="stylesheet">
+    <link href="${context}/css/bootstrap.css" rel="stylesheet">
+    <link href="${context}/css/azkaban.css" rel="stylesheet">
     <style type="text/css">
       .navbar-enviro .navbar-enviro-name {
         color: ${azkaban_color};
@@ -35,6 +35,6 @@
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
-      <script src="/js/html5shiv.js"></script>
-      <script src="/js/respond.min.js"></script>
+      <script src="${context}/js/html5shiv.js"></script>
+      <script src="${context}/js/respond.min.js"></script>
     <![endif]-->

--- a/azkaban-webserver/src/web/css/bootstrap.css
+++ b/azkaban-webserver/src/web/css/bootstrap.css
@@ -2634,8 +2634,8 @@ input[type="button"].btn-block {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../../fonts/glyphicons-halflings-regular.eot');
-  src: url('../../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../fonts/glyphicons-halflings-regular.eot');
+  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 
 .glyphicon {

--- a/azkaban-webserver/src/web/js/azkaban/view/login.js
+++ b/azkaban-webserver/src/web/js/azkaban/view/login.js
@@ -34,7 +34,7 @@ azkaban.LoginView = Backbone.View.extend({
 
     $.ajax({
       async: "false",
-      url: contextURL,
+      url: contextURL + "/",
       dataType: "json",
       type: "POST",
       data: {


### PR DESCRIPTION
Fixes #653

Exposes jetty.contextPath configuration setting and updates Web Server to serve resources relative to the defined context path setting.

Using the pull request, it is possible to host azkaban at mydomain:8081/azkaban and then use a reverse proxy (such as Apache HTTPD) to server azkaban at mydomain/azkaban along with other web apps on the same server (eg. mydomain/jira).