### PR TITLE
Fix #661 : Log download timeout is too short

### DIFF
--- a/azkaban-webserver/src/web/js/azkaban/model/job-log.js
+++ b/azkaban-webserver/src/web/js/azkaban/model/job-log.js
@@ -26,9 +26,6 @@ azkaban.JobLogModel = Backbone.Model.extend({
     var requestURL = contextURL + "/executor";
     var finished = false;
 
-    var date = new Date();
-    var startTime = date.getTime();
-
     while (!finished) {
       var requestData = {
         "execid": execId,
@@ -51,13 +48,6 @@ azkaban.JobLogModel = Backbone.Model.extend({
           finished = true;
         }
         else {
-          var date = new Date();
-          var endTime = date.getTime();
-          if ((endTime - startTime) > 10000) {
-            finished = true;
-            showDialog("Alert", "The log is taking a long time to finish loading. Azkaban has stopped loading them. Please click Refresh to restart the load.");
-          }
-
           self.set("offset", data.offset + data.length);
           self.set("logData", self.get("logData") + data.data);
         }


### PR DESCRIPTION
Issue:

There is a hard coded timeout of 10 seconds from the start of the download of execution logs to the end. This is too short for longer logs and for connections that have longer latencies.

The suggested action item to refresh the page won't help either.

"
The log is taking a long time to finish loading. Azkaban has stopped loading them. Please click Refresh to restart the load.
"

Fix:
Removed the limit which is set in the client side Javascript.

Test:
Manually shortened the timeout value to 10 milliseconds to reproduce the behavior. Applied the fix and verified that the log displayed correctly.