### PR TITLE
Fix issue #668: SlaAlertAction Error

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/AbstractMailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/AbstractMailer.java
@@ -30,6 +30,7 @@ public class AbstractMailer {
   private String mailPassword;
   private String mailSender;
   private String azkabanName;
+  private String tls;
 
   private String referenceURL;
 
@@ -40,6 +41,7 @@ public class AbstractMailer {
     this.mailHost = props.getString("mail.host", "localhost");
     this.mailUser = props.getString("mail.user", "");
     this.mailPassword = props.getString("mail.password", "");
+    this.tls = props.getString("mail.tls", "false");
     long maxAttachmentSizeInMB =
         props.getInt("mail.max.attachment.size.mb", 100);
 
@@ -75,6 +77,7 @@ public class AbstractMailer {
     message.setMimeType(mimetype);
     message.setSubject(subject);
     message.setAuth(usesAuth);
+    message.setTLS(tls);
 
     return message;
   }


### PR DESCRIPTION
Fix broken e-mail sending (SLA and SendEmailAction)
- There was an NPE because lately added field `EmailMessage._tls` wasn't set
- This broke SLA alert e-mail sending entirely

Issue: https://github.com/azkaban/azkaban/issues/668