### PR TITLE
Nyx

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 import azkaban.executor.ExecutionOptions;
@@ -95,7 +96,7 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
     Map<String, String> flowParams =
         s.getExecutionOptions().getFlowParameters();
     if (flowParams != null
-        && flowParams.containsKey(ExecutionOptions.TRIGGER_SPEC)) {
+        && !StringUtils.isEmpty(flowParams.get(ExecutionOptions.TRIGGER_SPEC))) {
       ConditionChecker nyxChecker =
           new NyxTriggerChecker(flowParams.get(ExecutionOptions.TRIGGER_SPEC),
               checkerId);

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -195,8 +195,8 @@ public final class HttpRequestUtilsTest {
     Map<String, String> flowParams = new HashMap<String, String>();
     Map<String, Object> metaData = new HashMap<String, Object>();
     Map<String, String> triggerFiles = new HashMap<String, String>();
-    triggerFiles.put("t1", "spec1");
-    triggerFiles.put("t2", "spec2");
+    triggerFiles.put("t1.trigger", "spec1");
+    triggerFiles.put("t2.trigger", "spec2");
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
 
     HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");
@@ -210,7 +210,7 @@ public final class HttpRequestUtilsTest {
     Map<String, Object> metaData = new HashMap<String, Object>();
     Map<String, String> triggerFiles = new HashMap<String, String>();
     flowParams.put(ExecutionOptions.TRIGGER_SPEC, "spec2");
-    triggerFiles.put("t1", "spec1");
+    triggerFiles.put("t1.trigger", "spec1");
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
     HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");
     Assert.assertEquals("spec2", flowParams.get(ExecutionOptions.TRIGGER_SPEC));
@@ -222,8 +222,8 @@ public final class HttpRequestUtilsTest {
     Map<String, String> flowParams = new HashMap<String, String>();
     Map<String, Object> metaData = new HashMap<String, Object>();
     Map<String, String> triggerFiles = new HashMap<String, String>();
-    triggerFiles.put("t1", "spec1");
-    triggerFiles.put("t2", "spec2");
+    triggerFiles.put("t1.trigger", "spec1");
+    triggerFiles.put("t2.trigger", "spec2");
     flowParams.put(ExecutionOptions.TRIGGER_FILE, "t2");
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
     HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -41,44 +41,44 @@ public final class HttpRequestUtilsTest {
   public static ExecutableFlow createExecutableFlow() throws IOException {
     ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
     flow.getExecutionOptions().getFlowParameters()
-      .put(ExecutionOptions.FLOW_PRIORITY, "1");
+        .put(ExecutionOptions.FLOW_PRIORITY, "1");
     flow.getExecutionOptions().getFlowParameters()
-      .put(ExecutionOptions.USE_EXECUTOR, "2");
+        .put(ExecutionOptions.USE_EXECUTOR, "2");
     return flow;
   }
 
   /* Test that flow properties are removed for non-admin user */
   @Test
   public void TestFilterNonAdminOnlyFlowParams() throws IOException,
-    ExecutorManagerException, UserManagerException {
+      ExecutorManagerException, UserManagerException {
     ExecutableFlow flow = createExecutableFlow();
     UserManager manager = TestUtils.createTestXmlUserManager();
     User user = manager.getUser("testUser", "testUser");
 
     HttpRequestUtils.filterAdminOnlyFlowParams(manager,
-      flow.getExecutionOptions(), user);
+        flow.getExecutionOptions(), user);
 
     Assert.assertFalse(flow.getExecutionOptions().getFlowParameters()
-      .containsKey(ExecutionOptions.FLOW_PRIORITY));
+        .containsKey(ExecutionOptions.FLOW_PRIORITY));
     Assert.assertFalse(flow.getExecutionOptions().getFlowParameters()
-      .containsKey(ExecutionOptions.USE_EXECUTOR));
+        .containsKey(ExecutionOptions.USE_EXECUTOR));
   }
 
   /* Test that flow properties are retained for admin user */
   @Test
   public void TestFilterAdminOnlyFlowParams() throws IOException,
-    ExecutorManagerException, UserManagerException {
+      ExecutorManagerException, UserManagerException {
     ExecutableFlow flow = createExecutableFlow();
     UserManager manager = TestUtils.createTestXmlUserManager();
     User user = manager.getUser("testAdmin", "testAdmin");
 
     HttpRequestUtils.filterAdminOnlyFlowParams(manager,
-      flow.getExecutionOptions(), user);
+        flow.getExecutionOptions(), user);
 
     Assert.assertTrue(flow.getExecutionOptions().getFlowParameters()
-      .containsKey(ExecutionOptions.FLOW_PRIORITY));
+        .containsKey(ExecutionOptions.FLOW_PRIORITY));
     Assert.assertTrue(flow.getExecutionOptions().getFlowParameters()
-      .containsKey(ExecutionOptions.USE_EXECUTOR));
+        .containsKey(ExecutionOptions.USE_EXECUTOR));
   }
 
   /* Test exception, if param is a valid integer */
@@ -103,7 +103,7 @@ public final class HttpRequestUtilsTest {
     UserManager manager = TestUtils.createTestXmlUserManager();
     User adminUser = manager.getUser("testAdmin", "testAdmin");
     Assert.assertTrue(HttpRequestUtils.hasPermission(manager, adminUser,
-      Type.ADMIN));
+        Type.ADMIN));
   }
 
   /* verify permission for non-admin user */
@@ -112,21 +112,21 @@ public final class HttpRequestUtilsTest {
     UserManager manager = TestUtils.createTestXmlUserManager();
     User testUser = manager.getUser("testUser", "testUser");
     Assert.assertFalse(HttpRequestUtils.hasPermission(manager, testUser,
-      Type.ADMIN));
-  }
-  
-  @Test
-  public void testInvalidParamSetTriggerSpecification() throws Exception {
-    HttpRequestUtils.setTriggerSpecification(null, null);
-    HttpRequestUtils.setTriggerSpecification(null,
-        new HashMap<String, Object>());
-    HttpRequestUtils.setTriggerSpecification(new HashMap<String, String>(),
-        null);
+        Type.ADMIN));
   }
 
   @Test
-  public void testFlowParamPrecedenceSetTriggerSpecification()
-      throws Exception {
+  public void testInvalidParamSetTriggerSpecification() throws Exception {
+    HttpRequestUtils.setTriggerSpecification(null, null, null);
+    HttpRequestUtils.setTriggerSpecification(null,
+        new HashMap<String, Object>(), null);
+    HttpRequestUtils.setTriggerSpecification(new HashMap<String, String>(),
+        null, null);
+    HttpRequestUtils.setTriggerSpecification(null, null, "");
+  }
+
+  @Test
+  public void testFlowParamPrecedenceSetTriggerSpecification() throws Exception {
     Map<String, String> flowParams = new HashMap<String, String>();
     Map<String, Object> metaData = new HashMap<String, Object>();
     Map<String, String> triggerFiles = new HashMap<String, String>();
@@ -135,7 +135,7 @@ public final class HttpRequestUtilsTest {
     flowParams.put(ExecutionOptions.TRIGGER_SPEC, "spec2");
     flowParams.put(ExecutionOptions.TRIGGER_FILE, "t1");
 
-    HttpRequestUtils.setTriggerSpecification(flowParams, metaData);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, null);
     Assert.assertEquals(
         "TriggerSpec should have higher precendence over TriggerFile", "spec2",
         flowParams.get(ExecutionOptions.TRIGGER_SPEC));
@@ -150,22 +150,21 @@ public final class HttpRequestUtilsTest {
     triggerFiles.put("t1", "spec1");
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
 
-    HttpRequestUtils.setTriggerSpecification(flowParams, metaData);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, null);
     Assert.assertFalse(flowParams.containsKey(ExecutionOptions.TRIGGER_SPEC));
   }
 
-  @Test(expected=IllegalArgumentException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testMissingMetaDataSetTriggerSpecification() throws Exception {
     Map<String, String> flowParams = new HashMap<String, String>();
     Map<String, Object> metaData = new HashMap<String, Object>();
 
     flowParams.put(ExecutionOptions.TRIGGER_FILE, "t1");
 
-    HttpRequestUtils.setTriggerSpecification(flowParams, metaData);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, null);
   }
-  
-  
-  @Test(expected=IllegalArgumentException.class)
+
+  @Test(expected = IllegalArgumentException.class)
   public void testInvalidTriggerFileSetTriggerSpecification() throws Exception {
     Map<String, String> flowParams = new HashMap<String, String>();
     Map<String, Object> metaData = new HashMap<String, Object>();
@@ -174,10 +173,9 @@ public final class HttpRequestUtilsTest {
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
     flowParams.put(ExecutionOptions.TRIGGER_FILE, "t2");
 
-    HttpRequestUtils.setTriggerSpecification(flowParams, metaData);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, null);
   }
-  
-  
+
   @Test
   public void testHappyCaseSetTriggerSpecification() throws Exception {
     Map<String, String> flowParams = new HashMap<String, String>();
@@ -187,7 +185,49 @@ public final class HttpRequestUtilsTest {
     metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
     flowParams.put(ExecutionOptions.TRIGGER_FILE, "t1");
 
-    HttpRequestUtils.setTriggerSpecification(flowParams, metaData);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, null);
     Assert.assertEquals("spec1", flowParams.get(ExecutionOptions.TRIGGER_SPEC));
   }
+
+  @Test
+  public void testUseFlowNameAsTriggerFileNameWhenTriggerFileIsNotSet()
+      throws Exception {
+    Map<String, String> flowParams = new HashMap<String, String>();
+    Map<String, Object> metaData = new HashMap<String, Object>();
+    Map<String, String> triggerFiles = new HashMap<String, String>();
+    triggerFiles.put("t1", "spec1");
+    triggerFiles.put("t2", "spec2");
+    metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
+
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");
+    Assert.assertEquals("spec1", flowParams.get(ExecutionOptions.TRIGGER_SPEC));
+  }
+
+  @Test
+  public void testFlowNameAsTriggerFileNameIsNotUsedWhenSpecSpecified()
+      throws Exception {
+    Map<String, String> flowParams = new HashMap<String, String>();
+    Map<String, Object> metaData = new HashMap<String, Object>();
+    Map<String, String> triggerFiles = new HashMap<String, String>();
+    flowParams.put(ExecutionOptions.TRIGGER_SPEC, "spec2");
+    triggerFiles.put("t1", "spec1");
+    metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");
+    Assert.assertEquals("spec2", flowParams.get(ExecutionOptions.TRIGGER_SPEC));
+  }
+
+  @Test
+  public void testFlowNameAsTriggerFileNameIsNotUsedWhenTriggerFileSpecified()
+      throws Exception {
+    Map<String, String> flowParams = new HashMap<String, String>();
+    Map<String, Object> metaData = new HashMap<String, Object>();
+    Map<String, String> triggerFiles = new HashMap<String, String>();
+    triggerFiles.put("t1", "spec1");
+    triggerFiles.put("t2", "spec2");
+    flowParams.put(ExecutionOptions.TRIGGER_FILE, "t2");
+    metaData.put(ProjectManager.TRIGGER_DATA, triggerFiles);
+    HttpRequestUtils.setTriggerSpecification(flowParams, metaData, "t1");
+    Assert.assertEquals("spec2", flowParams.get(ExecutionOptions.TRIGGER_SPEC));
+  }
+
 }

--- a/azkaban-webserver/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -655,7 +655,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     try {
       flowOptions = HttpRequestUtils.parseFlowOptions(req);
       HttpRequestUtils.filterAdminOnlyFlowParams(userManager, flowOptions, user);
-      HttpRequestUtils.setTriggerSpecification(flowOptions.getFlowParameters(), project.getMetadata());
+      HttpRequestUtils.setTriggerSpecification(flowOptions.getFlowParameters(), project.getMetadata(), flowName);
 
       schedule =
           scheduleManager.scheduleFlow(-1, projectId, projectName, flowName, "ready", firstSchedTime.getMillis(),


### PR DESCRIPTION
Updated the logic to perform the following when deciding if a trigger spec is specified - 
1.  if triggerSpec is specified directly in the flow params. 
2.  else if triggerFile is specified . 
3.  else if a  file with name "[FlowName].trigger" presents. 

Note :
1. the decision of which to be used as the trigger spec is prioritized as the order of the steps listed above, once the spec is fetched system will NOT go further to try other options.  
2. In the case if a user specified a trigger file in the project package that matches the name of a flow and at the time of executing the very flow user has the option to disable the data trigger by specifying the "triggerSpec" parameter with an empty content .
