### PR TITLE
Mention gradle clean in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The above command builds all Azkaban packages and packages them into GZipped Tar
 ./gradlew distZip
 ```
 
+If not building for the first time, it's good to clean first:
+
+```
+./gradlew clean
+```
+
 Documentation
 -------------
 


### PR DESCRIPTION
- For people not familiar with gradle (like me), it's nice to tell how project can be cleaned.
- For me the build failed with error like this (and cleaning fixed it):

```
:azkaban-common:linkMainExecutable
duplicate symbol _change_user in:
    ~/azkaban/azkaban-common/build/objs/mainExecutable/mainC/61ijqvjtfdjwfrkpl4kf313ll/execute-as-user.o
    ~/azkaban/azkaban-common/build/objs/mainExecutable/mainC/9duz2i01oqevnxg1cn9bywo1k/execute-as-user.o
```
