### PR TITLE
Fix log level of printing plugin class name

### DIFF
--- a/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -1065,7 +1065,7 @@ public class AzkabanWebServer extends AzkabanServer {
       if (pluginClass == null) {
         logger.error("Viewer class is not set.");
       } else {
-        logger.error("Plugin class " + pluginClass);
+        logger.info("Plugin class " + pluginClass);
       }
 
       URLClassLoader urlClassLoader = null;


### PR DESCRIPTION
It's not an error, just informative logging.