### PR TITLE
fix create project bug

### DIFF
--- a/azkaban-webserver/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-webserver/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1608,10 +1608,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     String message = null;
     HashMap<String, Object> params = null;
 
-    if (lockdownCreateProjects) {
-      message = "Project creation is locked out";
-      status = "error";
-    } else if (!hasPermissionToCreateProject(user)) {
+    if (lockdownCreateProjects && !hasPermissionToCreateProject(user)) {
       message =
           "User " + user.getUserId()
               + " doesn't have permission to create projects.";


### PR DESCRIPTION
This pull request revert the create project permission logic.  If lockdownCreateProjects is true, only admin is able to create project; otherwise, users (including admins) are always able to create project without being checked.