### PR TITLE
Add executor_id column to execution_flows table's creation script

### DIFF
--- a/azkaban-sql/src/sql/create.execution_flows.sql
+++ b/azkaban-sql/src/sql/create.execution_flows.sql
@@ -11,6 +11,7 @@ CREATE TABLE execution_flows (
 	end_time BIGINT,
 	enc_type TINYINT,
 	flow_data LONGBLOB,
+	executor_id INT DEFAULT NULL,
 	PRIMARY KEY (exec_id)
 );
 
@@ -18,3 +19,4 @@ CREATE INDEX ex_flows_start_time ON execution_flows(start_time);
 CREATE INDEX ex_flows_end_time ON execution_flows(end_time);
 CREATE INDEX ex_flows_time_range ON execution_flows(start_time, end_time);
 CREATE INDEX ex_flows_flows ON execution_flows(project_id, flow_id);
+CREATE INDEX ex_flows_executor_id ON execution_flows(executor_id);


### PR DESCRIPTION
The column executor_id is missing from execution_flows table and it caused any brand new install does not work (java.sql.SQLException: Unknown column 'ex.executor_id'). This is the change to fix the issue.
Note: The issue does not happen if it is upgrading install since the upgrade SQL script has statement to add the column.
