### PR TITLE
adding update trigger to db function

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -60,7 +60,7 @@ public class TriggerManager extends EventHandler implements
   private final Object syncObj = new Object();
 
   private String scannerStage = "";
-  
+
   public TriggerManager(Props props, TriggerLoader triggerLoader,
       ExecutorManager executorManager) throws TriggerManagerException {
 
@@ -156,6 +156,12 @@ public class TriggerManager extends EventHandler implements
     synchronized (syncObj) {
       runnerThread.deleteTrigger(triggerIdMap.get(t.getTriggerId()));
       runnerThread.addTrigger(t);
+
+      try {
+        triggerLoader.updateTrigger(t);
+      } catch (TriggerLoaderException e) {
+        throw new TriggerManagerException(e);
+      }
       triggerIdMap.put(t.getTriggerId(), t);
     }
   }


### PR DESCRIPTION
This pull request is for fixing #701. After one schedule is created, if users want to modify the existing schedule, the current workaround has to recreate a new schedule request. Then updateTrigger is called, but no writes to database occurred during this process, until nextTriggerTime. I added the updating database step to fixe this bug.

Test/Experiment is conducted in our test cluster, and this fix worked.
