### PR TITLE
this test missed the type classes, and fixed

### DIFF
--- a/azkaban-common/src/test/java/azkaban/trigger/JdbcTriggerLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/JdbcTriggerLoaderTest.java
@@ -76,9 +76,14 @@ public class JdbcTriggerLoaderTest {
     loader = new JdbcTriggerLoader(props);
     checkerLoader = new CheckerTypeLoader();
     checkerLoader.init(new Props());
+    checkerLoader.registerCheckerType(BasicTimeChecker.type,
+        BasicTimeChecker.class);
     Condition.setCheckerLoader(checkerLoader);
     actionLoader = new ActionTypeLoader();
     actionLoader.init(new Props());
+
+    actionLoader.registerActionType(ExecuteFlowAction.type,
+        ExecuteFlowAction.class);
     Trigger.setActionTypeLoader(actionLoader);
     setupDB();
   }


### PR DESCRIPTION
Was working on this JDBC Test, and found this bug.

Since we always ignored tests by inserting @ignore, no failing message show up. Actually, without this fix, the following individual tests will fail

fixed by this change.