### PR TITLE
Track hits to Dr. Elephant which are coming from azkaban. 

### DIFF
--- a/azkaban-execserver/src/package/conf/azkaban.properties
+++ b/azkaban-execserver/src/package/conf/azkaban.properties
@@ -38,7 +38,7 @@ executor.connector.stats=true
 # Set 'execution.external.link.label' to change the button label. It may be configured
 # to reflect the analyzer application.
 #
-# execution.external.link.url=http://elephant.linkedin.com:8080/search?flow-exec-id=%url
+# execution.external.link.url=http://elephant.linkedin.com:8080/search?referrer=azkaban&flow-exec-id=%url
 # execution.external.link.label=Dr. Elephant
 
 # uncomment to enable inmemory stats for azkaban


### PR DESCRIPTION
This change enables us to track the links originating from azkaban in piwik dashboard.

Notes:
Azkaban is https and the outgoing link to Dr. Elephant is http and hence by policy "referrer" header won't be set by the browser. An alternate way will be to set the meta tag in the relevant page. Going by the above approach since it doesn't require any code change.