### PR TITLE
fix copyJSLibs must dependon bowerInstall (bowerInstall is not completed before copyJSLibs)

### DIFF
--- a/azkaban-webserver/build.gradle
+++ b/azkaban-webserver/build.gradle
@@ -1,3 +1,24 @@
+plugins {
+    id 'com.craigburke.bower-installer' version '2.5.1'
+}
+
+bower {
+    installBase = 'bower' // <1>
+
+    'moment'('2.14.1'){
+      source 'min/moment.min.js' >> '/'
+    }
+
+    'moment-timezone'('0.5.5') {
+      source 'builds/moment-timezone-with-data-2010-2020.min.js'  >> '/'
+    }
+
+    'eonasdan-bootstrap-datetimepicker'('4.0.0') {
+      source 'build/js/*.min.js'  >> '/'
+      excludes 'jquery'
+    }
+}
+
 apply plugin: 'lesscss'
 apply plugin: 'dustjs'
 
@@ -114,8 +135,8 @@ task copyDust(type: Copy, dependsOn: ['dustjs', 'copyWeb']) {
   into('build/package/web/js')
 }
 
-task copyJSLibs(type: Copy, dependsOn: ['dustjs', 'copyWeb']) {
-  from('../bower/')
+task copyJSLibs(type: Copy, dependsOn: ['bowerInstall', 'dustjs', 'copyWeb']) {
+  from('bower/')
   into('build/package/web/js')
 }
 
@@ -145,3 +166,5 @@ task copy(dependsOn: [
         'copyLibs',
         'copyPackage']) {
 }
+
+clean.dependsOn 'bowerClean'

--- a/build.gradle
+++ b/build.gradle
@@ -13,27 +13,6 @@ buildscript {
   }
 }
 
-plugins {
-    id 'com.craigburke.bower-installer' version '2.5.1'
-}
-
-bower {
-    installBase = 'bower' // <1>
-
-    'moment'('2.14.1'){
-      source 'min/moment.min.js' >> '/'
-    }
-
-    'moment-timezone'('0.5.5') {
-      source 'builds/moment-timezone-with-data-2010-2020.min.js'  >> '/'
-    }
-
-    'eonasdan-bootstrap-datetimepicker'('4.0.0') {
-      source 'build/js/*.min.js'  >> '/'
-      excludes 'jquery'
-    }
-}
-
 apply plugin: 'com.cinnober.gradle.semver-git'
 apply plugin: 'idea'
 apply plugin: 'distribution'
@@ -166,7 +145,7 @@ migrationDistTar.compression = Compression.GZIP
 migrationDistTar.extension = 'tar.gz'
 migrationDistZip.dependsOn ':azkaban-common:build', ':azkaban-migration:copy'
 
-webserverDistTar.dependsOn ':azkaban-common:build', 'bowerInstall', ':azkaban-webserver:copy'
+webserverDistTar.dependsOn ':azkaban-common:build', ':azkaban-webserver:copy'
 webserverDistTar.compression = Compression.GZIP
 webserverDistTar.extension = 'tar.gz'
 webserverDistZip.dependsOn ':azkaban-common:build', ':azkaban-webserver:copy'


### PR DESCRIPTION
Yesterday, we faced an issue that build folder (under web-server) doesn't have js files downloaded by bower plugin.

In the previous pull request commit #718 , bowerInstall and **copyJSLibs** are at the same dependency level. As a result, bowerInstall always takes longer time than **copyJSLibs**. JS lib files are often not ready before the copy. In this pull request, we enforce copyJSLibs has to depend on bowerInstall, in order to let bower js libraries are all set before coping them.