### PR TITLE
disable tests in BlockingStatusTest

### DIFF
--- a/azkaban-execserver/src/test/java/azkaban/execapp/event/BlockingStatusTest.java
+++ b/azkaban-execserver/src/test/java/azkaban/execapp/event/BlockingStatusTest.java
@@ -17,6 +17,7 @@
 package azkaban.execapp.event;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import azkaban.executor.Status;
@@ -42,7 +43,11 @@ public class BlockingStatusTest {
     }
   }
 
-  @Test
+  /**
+   * TODO: Ignore this test at present since travis in Github can not always pass this test.
+   *       We will modify the below code to make travis pass in future.
+   */
+  @Ignore @Test
   public void testFinishedBlock() {
     BlockingStatus status = new BlockingStatus(1, "test", Status.SKIPPED);
 
@@ -57,7 +62,11 @@ public class BlockingStatusTest {
     Assert.assertTrue(thread.getDiff() < 100);
   }
 
-  @Test
+  /**
+   * TODO: Ignore this test at present since travis in Github can not always pass this test.
+   *       We will modify the below code to make travis pass in future.
+   */
+  @Ignore @Test
   public void testUnfinishedBlock() throws InterruptedException {
     BlockingStatus status = new BlockingStatus(1, "test", Status.QUEUED);
 
@@ -75,7 +84,11 @@ public class BlockingStatusTest {
     Assert.assertTrue(thread.getDiff() >= 3000 && thread.getDiff() < 3100);
   }
 
-  @Test
+  /**
+   * TODO: Ignore this test at present since travis in Github can not always pass this test.
+   *       We will modify the below code to make travis pass in future.
+   */
+  @Ignore @Test
   public void testUnfinishedBlockSeveralChanges() throws InterruptedException {
     BlockingStatus status = new BlockingStatus(1, "test", Status.QUEUED);
 
@@ -100,7 +113,11 @@ public class BlockingStatusTest {
     Assert.assertTrue(thread.getDiff() >= 4000 && thread.getDiff() < 4100);
   }
 
-  @Test
+  /**
+   * TODO: Ignore this test at present since travis in Github can not always pass this test.
+   *       We will modify the below code to make travis pass in future.
+   */
+  @Ignore @Test
   public void testMultipleWatchers() throws InterruptedException {
     BlockingStatus status = new BlockingStatus(1, "test", Status.QUEUED);
 


### PR DESCRIPTION
The tests in BlockingStatusTest class often got failed in travis, even though local environment doesn't receive this failure. The team decided to disable these tests at present, in order to be able to merge other pull requests.