### PR TITLE
Bug Fix: Later js's weekday syntax is different from Quartz. 

### DIFF
--- a/azkaban-webserver/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-webserver/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -41,31 +41,31 @@
             </div>
             <div class="form-group">
               <div class="col-sm-6">
-                <label class="col-sm-3 control-label" id="min_label">Min</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="min_label">Min</label>
+                <div class="col-sm-8">
                   <input type="text" id="minute_input" value="0" class="form-control" oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="hour_label">Hours</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="hour_label">Hours</label>
+                <div class="col-sm-8">
                   <input type="text" id="hour_input" value="5,7-10" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="dom_label">DOM</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="dom_label" style="margin-top:-8px">Day of Month</label>
+                <div class="col-sm-8">
                   <input type="text" id="dom_input" value="?" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="mon_label">Month</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="mon_label">Month</label>
+                <div class="col-sm-8">
                   <input type="text" id="month_input" value="*" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="dow_label">DOW</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="dow_label" style="margin-top:-8px">Day of Week</label>
+                <div class="col-sm-8">
                   <input type="text" id="dow_input" value="4-6" class="form-control"
                          oninput="updateOutput()">
                 </div>

--- a/azkaban-webserver/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-webserver/src/web/js/azkaban/view/schedule-panel.js
@@ -194,16 +194,18 @@ function transformFromQuartzToUnixCron(str){
 
   // If the cron doesn't include year field
   if(res.length == 5)
-    res[res.length -1] = res[res.length -1].replace(/[0-7]/g, function upperToHyphenLower(match) {
-      return (parseInt(match)+6)%7;
-    });
+    res[res.length -1] = modifyStrToUnixCronSyntax(res[res.length - 1]);
   // If the cron Str does include year field
   else if(res.length == 6)
-    res[res.length - 2] = res[res.length -1].replace(/[0-7]/g, function upperToHyphenLower(match) {
-      return (parseInt(match)+6)%7;
-    });
+    res[res.length - 2] = modifyStrToUnixCronSyntax(res[res.length - 2]);
 
   return res.join(" ");
+}
+
+function modifyStrToUnixCronSyntax(str){
+  return str.replace(/[0-7]/g, function upperToHyphenLower(match) {
+    return (parseInt(match)+6)%7;
+  });
 }
 
 function updateOutput() {

--- a/azkaban-webserver/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-webserver/src/web/js/azkaban/view/schedule-panel.js
@@ -186,12 +186,23 @@ var cron_output_id  = "#cron-output";
 var cron_translate_id  = "#cronTranslate";
 var cron_translate_warning_id  = "#translationWarning";
 
-// Cron use 0-6 as Sun--Sat, but Quartz use 1-7. Therefore, a translation is necessary.
-function transformFromCronToQuartz(str){
+// Uni Cron use 0-6 as Sun--Sat, but Quartz use 1-7. Due to later.js only supporting Unix Cron, we have to make this transition.
+// The detailed Unix Cron Syntax: https://en.wikipedia.org/wiki/Cron
+// The input is a 5 field string (without year) or 6 field String (with year).
+function transformFromQuartzToUnixCron(str){
   var res = str.split(" ");
-  res[res.length -1] = res[res.length -1].replace(/[0-7]/g, function upperToHyphenLower(match) {
-    return (parseInt(match)+6)%7;
-  });
+
+  // If the cron doesn't include year field
+  if(res.length == 5)
+    res[res.length -1] = res[res.length -1].replace(/[0-7]/g, function upperToHyphenLower(match) {
+      return (parseInt(match)+6)%7;
+    });
+  // If the cron Str does include year field
+  else if(res.length == 6)
+    res[res.length - 2] = res[res.length -1].replace(/[0-7]/g, function upperToHyphenLower(match) {
+      return (parseInt(match)+6)%7;
+    });
+
   return res.join(" ");
 }
 
@@ -204,9 +215,9 @@ function updateOutput() {
 
 function updateExpression() {
   $('#nextRecurId').html("");
-
-  console.log("cron Input = " + $(cron_output_id).val());
-  var laterCron = later.parse.cron($(cron_output_id).val());
+  var unixCronStr = transformFromQuartzToUnixCron($(cron_output_id).val());
+  console.log("Parsed Unix cron = " + unixCronStr);
+  var laterCron = later.parse.cron(unixCronStr);
 
   //Get the current time given the server timezone.
   var serverTime = moment().tz(timezone);


### PR DESCRIPTION
Unix Cron use 0-6 as Sun-Sat, but Quartz use 1-7. Due to later.js only supporting Unix Cron, we have to make this transition.

This change transform 1-7 to 0-6 in Cron's weekday field.

Tests are verified in our experimental cluster.
