### PR TITLE
make later.js output compatible with quartz

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -41,31 +41,31 @@
             </div>
             <div class="form-group">
               <div class="col-sm-6">
-                <label class="col-sm-3 control-label" id="min_label">Min</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="min_label">Min</label>
+                <div class="col-sm-8">
                   <input type="text" id="minute_input" value="0" class="form-control" oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="hour_label">Hours</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="hour_label">Hours</label>
+                <div class="col-sm-8">
                   <input type="text" id="hour_input" value="5,7-10" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="dom_label">DOM</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="dom_label" style="margin-top:-8px">Day of Month</label>
+                <div class="col-sm-8">
                   <input type="text" id="dom_input" value="?" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="mon_label">Month</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="mon_label">Month</label>
+                <div class="col-sm-8">
                   <input type="text" id="month_input" value="*" class="form-control"
                          oninput="updateOutput()">
                 </div>
                 <br/> <br/> <br/>
-                <label class="col-sm-3 control-label" id="dow_label">DOW</label>
-                <div class="col-sm-9">
+                <label class="col-sm-4 control-label" id="dow_label" style="margin-top:-8px">Day of Week</label>
+                <div class="col-sm-8">
                   <input type="text" id="dow_input" value="4-6" class="form-control"
                          oninput="updateOutput()">
                 </div>


### PR DESCRIPTION
Closing #732 for duplicates.

Unix Cron use 0-6 as Sun-Sat, but Quartz use 1-7. Due to later.js only supporting Unix Cron, we have to make this transition.

This change transform 1-7 to 0-6 in Cron's weekday field.

Tests are verified in our experimental cluster.