### PR TITLE
[Bux Fix]add cron Expression info in flow summary page.

### DIFF
--- a/azkaban-web-server/src/main/tl/flowsummary.tl
+++ b/azkaban-web-server/src/main/tl/flowsummary.tl
@@ -37,8 +37,23 @@
               <tr>
                 <td class="property-key">First Scheduled to Run</td>
                 <td class="property-value-half">{schedule.firstSchedTime}</td>
-                <td class="property-key">Repeats Every</td>
-                <td class="property-value-half">{schedule.period}</td>
+
+                <td class="property-key">
+                  {?schedule.cronExpression}
+                  Cron Expression
+                  {:else}
+                  Repeats Every
+                  {/schedule.cronExpression}
+                </td>
+
+                <td class="property-value-half">
+                  {?schedule.cronExpression}
+                    {schedule.cronExpression}
+                  {:else}
+                    {schedule.period}
+                  {/schedule.cronExpression}
+                </td>
+
               </tr>
               <tr>
                 <td class="property-key">Next Execution Time</td>


### PR DESCRIPTION
As #735 explained, the flow summary page does not have enough info for Cron Expression. We made this change to let the page showing either cronExpression or period depending on which type the schedule is belonged to.

Verified locally, and it works.