### PR TITLE
fix typo in documentation

### DIFF
--- a/_includes/docs/latest/ajax-api.html
+++ b/_includes/docs/latest/ajax-api.html
@@ -1128,7 +1128,7 @@ An example failure response for invalid schedule period:
 }
 </pre>
 
-<h3 id="api-schedule-a-flow">Flexible scheduling using cron</h3>
+<h3 id="api-flexible-schedule">Flexible scheduling using Cron</h3>
 
 <p>
 This API call schedules a flow by a cron Expression. Cron is a UNIX tool that has been widely used for a long time, and we use <a href="http://www.quartz-scheduler.org/">Quartz library</a> to parse cron Expression. All cron schedules follow the timezone defined in azkaban web server (the timezone ID is obtained by <i>java.util.TimeZone.getDefault().getID()</i>).
@@ -1173,7 +1173,7 @@ This API call schedules a flow by a cron Expression. Cron is a UNIX tool that ha
     </tr>
     <tr>
       <td>cronExpression</td>
-      <td>A CRON expression is a string comprising 6 or 7 fields separated by white space[8] that represents a set of times. In azkaban, we use <a href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html"> Quartz Cron Format</a>.</td>
+      <td>A CRON expression is a string comprising 6 or 7 fields separated by white space that represents a set of times. In azkaban, we use <a href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html"> Quartz Cron Format</a>.</td>
     </tr>
   </tbody>
 </table>

--- a/_includes/docs/latest/sidebar.html
+++ b/_includes/docs/latest/sidebar.html
@@ -69,7 +69,8 @@
 	          <li><a href="#api-fetch-running-executions-of-a-flow"> Fetch Running Executions </a></li>
 	          <li><a href="#api-execute-a-flow">Execute a Flow</a></li>
 	          <li><a href="#api-cancel-a-flow-execution"> Cancel a Flow Execution</a></li>
-	          <li><a href="#api-schedule-a-flow">Schedule a Flow</a></li>
+	          <li><a href="#api-schedule-a-flow">Schedule a period Flow (Deprecated)</a></li>
+	          <li><a href="#api-flexible-schedule">Flexible scheduling using Cron</a></li>
 	          <li><a href="#api-unschedule-a-flow">Unschedule a Flow</a></li>
 	          <li><a href="#api-pause-a-flow-execution"> Pause a Flow Execution</a></li>
 	          <li><a href="#api-resume-a-flow-execution"> Resume a Flow Execution</a></li>


### PR DESCRIPTION
Found some typos.

Set up your GitHub Pages site locally with Jekyll.
