### PR TITLE
append version date to the end of js import

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -27,7 +27,7 @@
     <script type="text/javascript" src="${context}/js/morris.min.js"></script>
 
     <script type="text/javascript" src="${context}/js/dust-full-2.2.3.min.js"></script>
-    <script type="text/javascript" src="${context}/js/flowsummary.js"></script>
+    <script type="text/javascript" src="${context}/js/flowsummary.js?version=20161003"></script>
     <script type="text/javascript" src="${context}/js/flowstats-no-data.js"></script>
     <script type="text/javascript" src="${context}/js/flowstats.js"></script>
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -14,8 +14,8 @@
  * the License.
 *#
 
-<script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/schedule-panel.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/date.js?version=20161003"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/schedule-panel.js?version=20161003"></script>
 <script type="text/javascript" src="${context}/js/moment.min.js" ></script>
 <script type="text/javascript" src="${context}/js/later.min.js"></script>
 <script type="text/javascript" src="${context}/js/moment-timezone-with-data-2010-2020.min.js"></script>


### PR DESCRIPTION
During last deployment, we enabled flexible scheduling function and met a problem: Web browser kept using cached js, and not fetching the latest js files. In this change, we enforced browser to fetch the latest schedule-panel.js

evaluated in our test cluster and it works.