### PR TITLE
Fix broken Azkaban Solo Server due to removed h2database dependency

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -39,6 +39,8 @@ dependencies {
   compile('org.mortbay.jetty:jetty-util:6.1.26')
   compile('org.quartz-scheduler:quartz:2.2.1')
 
+  runtime('com.h2database:h2:1.4.192')
+
   testCompile(project(':azkaban-test').sourceSets.test.output)
   testCompile('org.hamcrest:hamcrest-all:1.3')
 }


### PR DESCRIPTION
Deploying Azkaban Solo Server throws Class Not Found error : org.h2.Driver.
Azkaban-Solo-Server uses in-memory h2 DB (runtime dependency), when deployed locally and has been removed recently while refactoring.
