### PR TITLE
Bug Fix: Hardcoded build directory causes some missing files in the distribution

### DIFF
--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -174,7 +174,7 @@ distributions {
       from (dustjs) {
         into 'web/js'
       }
-      from ('build/jsToPackage') {
+      from ("${buildDir}/jsToPackage") {
         into 'web/js'
       }
       from (movingJsTojsToPackage) {


### PR DESCRIPTION
Since our internal build system uses a custom build directory, the distribution created was missing some files. Changing to $buildDir removes such issues.