### PR TITLE
Fix execute as user override issue

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -176,12 +176,7 @@ public class ProcessJob extends AbstractProcessJob {
   }
 
   private boolean determineExecuteAsUser(Props sysProps, Props jobProps) {
-    boolean isExecuteAsUser = sysProps.getBoolean(EXECUTE_AS_USER, false);
-    // putting an override in case user needs to override. A temporary opening
-    if (jobProps.containsKey(EXECUTE_AS_USER_OVERRIDE))
-      isExecuteAsUser = jobProps.getBoolean(EXECUTE_AS_USER_OVERRIDE, false);
-
-    return isExecuteAsUser;
+    return sysProps.getBoolean(EXECUTE_AS_USER, false);
   }
 
   /**
@@ -189,10 +184,10 @@ public class ProcessJob extends AbstractProcessJob {
    * This method extracts the kerberos ticket cache file name from the jobprops.
    * This method will ensure that each job execution will have its own kerberos ticket cache file
    * Given that the code only sets an environmental variable, the number of files created corresponds
-   * to the number of processes that are doing kinit in their flow, which should not be an inordinately 
+   * to the number of processes that are doing kinit in their flow, which should not be an inordinately
    * high number.
    * </pre>
-   * 
+   *
    * @return file name: the kerberos ticket cache file to use
    */
   private String getKrb5ccname(Props jobProps) {
@@ -218,7 +213,7 @@ public class ProcessJob extends AbstractProcessJob {
    * 1. USER_TO_PROXY
    * 2. SUBMIT_USER
    * </pre>
-   * 
+   *
    * @param jobProps
    * @return the user that Azkaban is going to execute as
    */

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -51,8 +51,7 @@ public class ProcessJob extends AbstractProcessJob {
 
   public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   public static final String EXECUTE_AS_USER = "execute.as.user";
-  public static final String EXECUTE_AS_USER_OVERRIDE =
-      "execute.as.user.override";
+
   public static final String USER_TO_PROXY = "user.to.proxy";
   public static final String KRB5CCNAME = "KRB5CCNAME";
 


### PR DESCRIPTION
Previous execute-as-user committers left a security hole that users could make use of. In user's job conf, users are able to define EXECUTE_AS_USER_OVERRIDE's boolean value to enable or disable execute_as_user feature.

During this change, we canceled user's capability, and removed all related code.

Verified in our Experimental AZ cluster, and no issues were found.