### PR TITLE
disable cache fetch when it is looking for job state.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -536,21 +536,14 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /**
-   * Fetch ExecutableFlow from an active (running, non-dispatched) or from
-   * database {@inheritDoc}
+   * Fetch ExecutableFlow from database {@inheritDoc}
    *
    * @see azkaban.executor.ExecutorManagerAdapter#getExecutableFlow(int)
    */
   @Override
   public ExecutableFlow getExecutableFlow(int execId)
     throws ExecutorManagerException {
-    if (runningFlows.containsKey(execId)) {
-      return runningFlows.get(execId).getSecond();
-    } else if (queuedFlows.hasExecution(execId)) {
-      return queuedFlows.getFlow(execId);
-    } else {
       return executorLoader.fetchExecutableFlow(execId);
-    }
   }
 
   /**


### PR DESCRIPTION
Welcome comments to this pull request.

One issue was found in our production cluster: Even though one job is actually running, but it shows preparation state in job graph page. It affects our users checking logs. 

I did an investigation on this issue, and found that it should be something wrong with the cache implementation, since database has the right job state info. 

I just disabled cache fetching logic in getExecutableFlow method. Checked all callers of this method, and they all come from web server logics. Then I believe this should be a safe change.

Verified in our experimental cluster, and no issues were found.