### PR TITLE
Add current Uploader userId field to Project class and set it in ProjectManager

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -39,6 +39,7 @@ public class Project {
   private int version = -1;
   private long createTimestamp;
   private long lastModifiedTimestamp;
+  private String currentUploaderID;
   private String lastModifiedUser;
   private String source;
   private LinkedHashMap<String, Permission> userPermissionMap =
@@ -331,6 +332,24 @@ public class Project {
 
   public void setLastModifiedUser(String lastModifiedUser) {
     this.lastModifiedUser = lastModifiedUser;
+  }
+
+  /**
+   * Getter method for current uploader userId
+   *
+   * @return currentUploaderId
+   */
+  public String getCurrentUploaderID() {
+    return currentUploaderID;
+  }
+
+  /**
+   * Setter method for current Uploader userId
+   *
+   * @param currentUploaderID
+   */
+  public void setCurrentUploaderID(String currentUploaderID) {
+    this.currentUploaderID = currentUploaderID;
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -473,6 +473,9 @@ public class ProjectManager {
       throw new ProjectManagerException("Error unzipping file.", e);
     }
 
+    // Set current Upload user
+    project.setCurrentUploaderID(uploader.getUserId());
+
     // Since props is an instance variable of ProjectManager, and each
     // invocation to the uploadProject manager needs to pass a different
     // value for the PROJECT_ARCHIVE_FILE_PATH key, it is necessary to


### PR DESCRIPTION
Useful for Validating Projects based on current Uploader ID. 

Context:
Currently ProjectValidator interface passes Project object to validate an uploaded project. The Project object has no infomation on user who is trying to upload the project Zip. So, adding a field currentUploaderId makes it possible for classes extending ProjectValidator to validate on basis of current uploader. 
