### PR TITLE
Warn Users that DOW and DOM fields can not have * simultaneously 

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/messagedialog.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/messagedialog.vm
@@ -14,7 +14,7 @@
  * the License.
 *#
 
-      <script type="text/javascript" src="${context}/js/azkaban/view/message-dialog.js"></script>
+      <script type="text/javascript" src="${context}/js/azkaban/view/message-dialog.js?version=20161031"></script>
 
       <div class="modal" id="azkaban-message-dialog">
         <div class="modal-dialog">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -14,8 +14,8 @@
  * the License.
 *#
 
-<script type="text/javascript" src="${context}/js/azkaban/util/date.js?version=20161003"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/schedule-panel.js?version=20161003"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/date.js?version=20161031"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/schedule-panel.js?version=20161031"></script>
 <script type="text/javascript" src="${context}/js/moment.min.js" ></script>
 <script type="text/javascript" src="${context}/js/later.min.js"></script>
 <script type="text/javascript" src="${context}/js/moment-timezone-with-data-2010-2020.min.js"></script>

--- a/azkaban-web-server/src/web/js/azkaban/test/test.js
+++ b/azkaban-web-server/src/web/js/azkaban/test/test.js
@@ -50,3 +50,23 @@ describe('CronTransformation', function() {
    assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5 2016'), '0 3 * * 0,2-4 2016');
   });
 });
+
+//Test the Validity of a Quartz Cron String
+describe('ValidateQuartzStr', function() {
+
+  var validateQuartzStr = dateJs.__get__('validateQuartzStr');
+
+  it('validate Quartz String corretly', function() {
+
+   assert.equal(validateQuartzStr('0 3 * * 5'), 'NUM_FIELDS_ERROR');
+   assert.equal(validateQuartzStr('0 3 * *'), 'NUM_FIELDS_ERROR');
+   assert.equal(validateQuartzStr('0 3 * * 5 23 3 2017'), 'NUM_FIELDS_ERROR');
+   assert.equal(validateQuartzStr('0 3 * * 5 *'), 'DOW_DOM_STAR_ERROR');
+   assert.equal(validateQuartzStr('0 3 * * 5 *'), 'DOW_DOM_STAR_ERROR');
+   assert.equal(validateQuartzStr('0 3 * 5 5 * 2019'), 'DOW_DOM_STAR_ERROR');
+   assert.equal(validateQuartzStr('0 3 * 5 5 ? 2018'), 'VALID');
+   assert.equal(validateQuartzStr('0 3 * ? 5 FRI'), 'VALID');
+   assert.equal(validateQuartzStr('0 3 * ? 5 3-6'), 'VALID');
+
+  });
+});

--- a/azkaban-web-server/src/web/js/azkaban/util/date.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/date.js
@@ -104,13 +104,10 @@ var validateQuartzStr = function (str){
   // Quartz currently doesn't support specifying both a day-of-week and a day-of-month value
   // (you must currently use the ‘?’ character in one of these fields).
   // http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html#notes
-  if(len==6 && res[len-1] != '?' && res[len-3] != '?') return "DOW_DOM_STAR_ERROR";
-
-  // When year field exists,
-  if(len==7 && res[len-2] != '?' && res[len-4] != '?') return "DOW_DOM_STAR_ERROR";
+  if(res[3] != '?' && res[5] != '?') return "DOW_DOM_STAR_ERROR";
 
   //valid string
-  return "valid";
+  return "VALID";
 }
 
 var modifyStrToUnixCronSyntax = function (str){

--- a/azkaban-web-server/src/web/js/azkaban/util/date.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/date.js
@@ -99,15 +99,18 @@ var validateQuartzStr = function (str){
   var res = str.split(" "), len=res.length;
 
   // A valid Quartz Cron Expression should have 6 or 7 fields.
-  if(len<6 || len>=8) return 1;
+  if(len<6 || len>=8) return "NUM_FIELDS_ERROR";
 
   // Quartz currently doesn't support specifying both a day-of-week and a day-of-month value
   // (you must currently use the ‘?’ character in one of these fields).
-  if(len==6 && res[len-1] != '?' && res[len-3] != '?') return 2;
-  if(len==7 && res[len-2] != '?' && res[len-4] != '?') return 2;
+  // http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html#notes
+  if(len==6 && res[len-1] != '?' && res[len-3] != '?') return "DOW_DOM_STAR_ERROR";
+
+  // When year field exists,
+  if(len==7 && res[len-2] != '?' && res[len-4] != '?') return "DOW_DOM_STAR_ERROR";
 
   //valid string
-  return 0;
+  return "valid";
 }
 
 var modifyStrToUnixCronSyntax = function (str){

--- a/azkaban-web-server/src/web/js/azkaban/util/date.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/date.js
@@ -94,6 +94,21 @@ var getTwoDigitStr = function(value) {
   return value;
 }
 
+// Verify if a cron String meets the requirement of Quartz Cron Expression.
+var validateQuartzStr = function (str){
+  var res = str.split(" "), len=res.length;
+
+  // A valid Quartz Cron Expression should have 6 or 7 fields.
+  if(len<6 || len>=8) return 1;
+
+  // Quartz currently doesn't support specifying both a day-of-week and a day-of-month value
+  // (you must currently use the ‘?’ character in one of these fields).
+  if(res[len-1] != '?' && res[len-3] != '?') return 2;
+
+  //valid string
+  return 0;
+}
+
 var modifyStrToUnixCronSyntax = function (str){
   return str.replace(/[0-7]/g, function upperToHyphenLower(match) {
     return (parseInt(match)+6)%7;

--- a/azkaban-web-server/src/web/js/azkaban/util/date.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/date.js
@@ -103,7 +103,8 @@ var validateQuartzStr = function (str){
 
   // Quartz currently doesn't support specifying both a day-of-week and a day-of-month value
   // (you must currently use the ‘?’ character in one of these fields).
-  if(res[len-1] != '?' && res[len-3] != '?') return 2;
+  if(len==6 && res[len-1] != '?' && res[len-3] != '?') return 2;
+  if(len==7 && res[len-2] != '?' && res[len-4] != '?') return 2;
 
   //valid string
   return 0;

--- a/azkaban-web-server/src/web/js/azkaban/view/message-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/message-dialog.js
@@ -26,7 +26,7 @@ azkaban.MessageDialogView = Backbone.View.extend({
 
   show: function(title, message, callback) {
     $("#azkaban-message-dialog-title").text(title);
-    $("#azkaban-message-dialog-text").text(message);
+    $("#azkaban-message-dialog-text").html(message);
     this.callback = callback;
     $(this.el).on('hidden.bs.modal', function() {
       if (callback) {

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
@@ -58,10 +58,10 @@ azkaban.SchedulePanelView = Backbone.View.extend({
     console.log("cronExpression = " +  scheduleData.cronExpression);
     var retSignal = validateQuartzStr(scheduleData.cronExpression);
 
-    if(retSignal == 1) {
+    if(retSignal == "NUM_FIELDS_ERROR") {
       messageDialogView.show("Cron Syntax Error", "A valid Quartz Cron Expression should have 6 or 7 fields.");
       return;
-    } else if (retSignal == 2) {
+    } else if (retSignal == "DOW_DOM_STAR_ERROR") {
       messageDialogView.show("Cron Syntax Error", "Currently Quartz doesn't support specifying both a day-of-week and a day-of-month value"
           + "(you must use the ‘?’ character in one of these fields). <a href=\"http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html\">Detailed Explanation</a>");
       return;

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
@@ -56,6 +56,16 @@ azkaban.SchedulePanelView = Backbone.View.extend({
 
     console.log("current Time = " + scheduleDate + "  " + scheduleTime );
     console.log("cronExpression = " +  scheduleData.cronExpression);
+    var retSignal = validateQuartzStr(scheduleData.cronExpression);
+
+    if(retSignal == 1) {
+      messageDialogView.show("Cron Syntax Error", "A valid Quartz Cron Expression should have 6 or 7 fields.");
+      return;
+    } else if (retSignal == 2) {
+      messageDialogView.show("Cron Syntax Error", "Currently Quartz doesn't support specifying both a day-of-week and a day-of-month value"
+          + "(you must use the ‘?’ character in one of these fields). <a href=\"http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html\">Detailed Explanation</a>");
+      return;
+    }
 
     var successHandler = function(data) {
       if (data.error) {


### PR DESCRIPTION
In [Quartz Documentation](http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html):

> `Support for specifying both a day-of-week and a day-of-month value is not complete (you must currently use the ‘?’ character in one of these fields).`

Since Quartz doesn't support both DOW and MOW fields filling in * key, we should warn users about this wrong settings. In this pull request, Users will receive warning/error if they fill in wrong cron strings.