### PR TITLE
Remove execute.as.user in conf

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -108,11 +108,14 @@ public class ProcessJob extends AbstractProcessJob {
     Map<String, String> envVars = getEnvironmentVariables();
     envVars.put(KRB5CCNAME, getKrb5ccname(jobProps));
 
-    // determine whether to run as Azkaban or run as effectiveUser
+    // determine whether to run as Azkaban or run as effectiveUser,
+    // by default, run as effectiveUser
     String executeAsUserBinaryPath = null;
     String effectiveUser = null;
     boolean isExecuteAsUser = determineExecuteAsUser(sysProps, jobProps);
 
+    // nativeLibFolder specifies the path for execute-as-user file,
+    // which will change user from Azkaban to effectiveUser
     if (isExecuteAsUser) {
       String nativeLibFolder = sysProps.getString(NATIVE_LIB_FOLDER);
       executeAsUserBinaryPath =

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -175,7 +175,7 @@ public class ProcessJob extends AbstractProcessJob {
   }
 
   private boolean determineExecuteAsUser(Props sysProps, Props jobProps) {
-    return sysProps.getBoolean(EXECUTE_AS_USER, false);
+    return sysProps.getBoolean(EXECUTE_AS_USER, true);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
@@ -108,13 +108,13 @@ public class JavaProcessJobTest {
     props.put(AbstractProcessJob.WORKING_DIR, workingDir.getCanonicalPath());
     props.put("type", "java");
     props.put("fullPath", ".");
-    
+
     props.put(CommonJobProperties.PROJECT_NAME, "test_project");
     props.put(CommonJobProperties.FLOW_ID, "test_flow");
     props.put(CommonJobProperties.JOB_ID, "test_job");
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.SUBMIT_USER, "test_user");
-    
+    props.put("execute.as.user", "false");
 
     job = new JavaProcessJob("testJavaProcess", props, props, log);
   }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
@@ -46,12 +46,13 @@ public class ProcessJobTest {
     props.put(AbstractProcessJob.WORKING_DIR, workingDir.getCanonicalPath());
     props.put("type", "command");
     props.put("fullPath", ".");
-    
+
     props.put(CommonJobProperties.PROJECT_NAME, "test_project");
     props.put(CommonJobProperties.FLOW_ID, "test_flow");
     props.put(CommonJobProperties.JOB_ID, "test_job");
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.SUBMIT_USER, "test_user");
+    props.put("execute.as.user", "false");
 
     job = new ProcessJob("TestProcess", props, props, log);
   }
@@ -68,34 +69,34 @@ public class ProcessJobTest {
     job.run();
 
   }
-  
+
   /**
    * this job should run fine if the props contain user.to.proxy
    * @throws Exception
    */
   @Test
   public void testOneUnixCommandWithProxyUserInsteadOfSubmitUser() throws Exception {
-    
+
     // Initialize the Props
     props.removeLocal(CommonJobProperties.SUBMIT_USER);
     props.put("user.to.proxy", "test_user");
     props.put(ProcessJob.COMMAND, "ls -al");
-    
+
     job.run();
 
   }
-  
+
   /**
    * this job should fail because there is no user.to.proxy and no CommonJobProperties.SUBMIT_USER
    * @throws Exception
    */
   @Test (expected=RuntimeException.class)
   public void testOneUnixCommandWithNoUser() throws Exception {
-    
+
     // Initialize the Props
-    props.removeLocal(CommonJobProperties.SUBMIT_USER);    
+    props.removeLocal(CommonJobProperties.SUBMIT_USER);
     props.put(ProcessJob.COMMAND, "ls -al");
-    
+
     job.run();
 
   }


### PR DESCRIPTION
The execute-as-user feature is already applied for around 1 year. Every production cluster make it to true in configurations. We should disable this conf now, and let it be always true.

# configs for execute-as-user
execute.as.user=true

I removed the code to read execute-as-user from configuration so that jobs will always be executed by user instead of Azkaban.

Can you review the changes before I test on the clusters?

