### PR TITLE
Fixed comments for execute.as.user changes (#807)

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -112,7 +112,7 @@ public class ProcessJob extends AbstractProcessJob {
     // by default, run as effectiveUser
     String executeAsUserBinaryPath = null;
     String effectiveUser = null;
-    boolean isExecuteAsUser = determineExecuteAsUser(sysProps, jobProps);
+    boolean isExecuteAsUser = sysProps.getBoolean(EXECUTE_AS_USER, true);
 
     // nativeLibFolder specifies the path for execute-as-user file,
     // which will change user from Azkaban to effectiveUser
@@ -175,10 +175,6 @@ public class ProcessJob extends AbstractProcessJob {
 
     // Get the output properties from this job.
     generateProperties(propFiles[1]);
-  }
-
-  private boolean determineExecuteAsUser(Props sysProps, Props jobProps) {
-    return sysProps.getBoolean(EXECUTE_AS_USER, true);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
@@ -114,7 +114,11 @@ public class JavaProcessJobTest {
     props.put(CommonJobProperties.JOB_ID, "test_job");
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.SUBMIT_USER, "test_user");
-    props.put("execute.as.user", "false");
+
+    //The execute-as-user binary requires special permission. It's not convenient to 
+    //set up in a unit test that is self contained. So EXECUTE_AS_USER is set to false 
+    //so that we don't have to rely on the binary file to change user in the test case.
+    props.put(ProcessJob.EXECUTE_AS_USER, "false");
 
     job = new JavaProcessJob("testJavaProcess", props, props, log);
   }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
@@ -52,7 +52,11 @@ public class ProcessJobTest {
     props.put(CommonJobProperties.JOB_ID, "test_job");
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.SUBMIT_USER, "test_user");
-    props.put("execute.as.user", "false");
+
+    //The execute-as-user binary requires special permission. It's not convenient to 
+    //set up in a unit test that is self contained. So EXECUTE_AS_USER is set to false 
+    //so that we don't have to rely on the binary file to change user in the test case.
+    props.put(ProcessJob.EXECUTE_AS_USER, "false");
 
     job = new ProcessJob("TestProcess", props, props, log);
   }


### PR DESCRIPTION
Removed a private function to make the code easier to read.
Added comments to the changes in test cases.
Abandoned previous pull request (#807).