### PR TITLE
Executor to use any port if not configured. Added REST APIs to activate / deactivate executor

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -129,11 +129,13 @@ public class DataSourceUtils {
 
     private static MonitorThread monitorThread = null;
 
+    private final String url;
+
     private MySQLBasicDataSource(String host, int port, String dbName,
         String user, String password, int numConnections) {
       super();
 
-      String url = "jdbc:mysql://" + (host + ":" + port + "/" + dbName);
+      url = "jdbc:mysql://" + (host + ":" + port + "/" + dbName);
       addConnectionProperty("useUnicode", "yes");
       addConnectionProperty("characterEncoding", "UTF-8");
       setDriverClassName("com.mysql.jdbc.Driver");
@@ -196,10 +198,7 @@ public class DataSourceUtils {
           PreparedStatement query = connection.prepareStatement("SELECT 1");
           query.execute();
         } catch (SQLException e) {
-          // TODO Auto-generated catch block
-          e.printStackTrace();
-          logger
-              .error("MySQL connection test failed. Please check MySQL connection health!");
+          logger.error("Unable to reach MySQL server on " + url);
         } finally {
           DbUtils.closeQuietly(connection);
         }

--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -34,6 +34,8 @@ public interface ConnectorParams {
   public static final String ATTACHMENTS_ACTION = "attachments";
   public static final String METADATA_ACTION = "metadata";
   public static final String RELOAD_JOBTYPE_PLUGINS_ACTION = "reloadJobTypePlugins";
+  public static final String ACTIVATE = "activate";
+  public static final String DEACTIVATE = "deactivate";
 
   public static final String MODIFY_EXECUTION_ACTION = "modifyExecution";
   public static final String MODIFY_EXECUTION_ACTION_TYPE = "modifyType";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -26,25 +26,25 @@ import azkaban.utils.Pair;
 import azkaban.utils.Props;
 
 public interface ExecutorLoader {
-  public void uploadExecutableFlow(ExecutableFlow flow)
+  void uploadExecutableFlow(ExecutableFlow flow)
       throws ExecutorManagerException;
 
-  public ExecutableFlow fetchExecutableFlow(int execId)
+  ExecutableFlow fetchExecutableFlow(int execId)
       throws ExecutorManagerException;
 
-  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException;
 
-  public List<ExecutableFlow> fetchFlowHistory(int skip, int num)
+  List<ExecutableFlow> fetchFlowHistory(int skip, int num)
       throws ExecutorManagerException;
 
-  public List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
+  List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
       int skip, int num) throws ExecutorManagerException;
 
-  public List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
+  List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
       int skip, int num, Status status) throws ExecutorManagerException;
 
-  public List<ExecutableFlow> fetchFlowHistory(String projContain,
+  List<ExecutableFlow> fetchFlowHistory(String projContain,
       String flowContains, String userNameContains, int status, long startData,
       long endData, int skip, int num) throws ExecutorManagerException;
 
@@ -59,7 +59,7 @@ public interface ExecutorLoader {
    * @return List<Executor>
    * @throws ExecutorManagerException
    */
-  public List<Executor> fetchAllExecutors() throws ExecutorManagerException;
+  List<Executor> fetchAllExecutors() throws ExecutorManagerException;
 
   /**
    * <pre>
@@ -72,7 +72,7 @@ public interface ExecutorLoader {
    * @return List<Executor>
    * @throws ExecutorManagerException
    */
-  public List<Executor> fetchActiveExecutors() throws ExecutorManagerException;
+  List<Executor> fetchActiveExecutors() throws ExecutorManagerException;
 
   /**
    * <pre>
@@ -86,7 +86,7 @@ public interface ExecutorLoader {
    * @return Executor
    * @throws ExecutorManagerException
    */
-  public Executor fetchExecutor(String host, int port)
+  Executor fetchExecutor(String host, int port)
     throws ExecutorManagerException;
 
   /**
@@ -100,7 +100,7 @@ public interface ExecutorLoader {
    * @return Executor
    * @throws ExecutorManagerException
    */
-  public Executor fetchExecutor(int executorId) throws ExecutorManagerException;
+  Executor fetchExecutor(int executorId) throws ExecutorManagerException;
 
   /**
    * <pre>
@@ -114,7 +114,7 @@ public interface ExecutorLoader {
    * @return Executor
    * @throws ExecutorManagerException
    */
-  public Executor addExecutor(String host, int port)
+  Executor addExecutor(String host, int port)
     throws ExecutorManagerException;
 
   /**
@@ -129,7 +129,7 @@ public interface ExecutorLoader {
    * @param executorId
    * @throws ExecutorManagerException
    */
-  public void updateExecutor(Executor executor) throws ExecutorManagerException;
+  void updateExecutor(Executor executor) throws ExecutorManagerException;
 
   /**
    * <pre>
@@ -144,7 +144,7 @@ public interface ExecutorLoader {
    * @param message
    * @return isSuccess
    */
-  public void postExecutorEvent(Executor executor, EventType type, String user,
+  void postExecutorEvent(Executor executor, EventType type, String user,
     String message) throws ExecutorManagerException;
 
   /**
@@ -165,10 +165,10 @@ public interface ExecutorLoader {
   List<ExecutorLogEvent> getExecutorEvents(Executor executor, int num,
     int offset) throws ExecutorManagerException;
 
-  public void addActiveExecutableReference(ExecutionReference ref)
+  void addActiveExecutableReference(ExecutionReference ref)
       throws ExecutorManagerException;
 
-  public void removeActiveExecutableReference(int execId)
+  void removeActiveExecutableReference(int execId)
       throws ExecutorManagerException;
 
 
@@ -183,7 +183,7 @@ public interface ExecutorLoader {
    * @param execId
    * @throws ExecutorManagerException
    */
-  public void unassignExecutor(int executionId) throws ExecutorManagerException;
+  void unassignExecutor(int executionId) throws ExecutorManagerException;
 
   /**
    * <pre>
@@ -197,7 +197,7 @@ public interface ExecutorLoader {
    * @param execId
    * @throws ExecutorManagerException
    */
-  public void assignExecutor(int executorId, int execId)
+  void assignExecutor(int executorId, int execId)
     throws ExecutorManagerException;
 
   /**
@@ -212,7 +212,7 @@ public interface ExecutorLoader {
    * @return fetched Executor
    * @throws ExecutorManagerException
    */
-  public Executor fetchExecutorByExecutionId(int executionId)
+  Executor fetchExecutorByExecutionId(int executionId)
     throws ExecutorManagerException;
 
   /**
@@ -226,59 +226,59 @@ public interface ExecutorLoader {
    * @return List of queued flows and corresponding execution reference
    * @throws ExecutorManagerException
    */
-  public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
+  List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
     throws ExecutorManagerException;
 
-  public boolean updateExecutableReference(int execId, long updateTime)
+  boolean updateExecutableReference(int execId, long updateTime)
       throws ExecutorManagerException;
 
-  public LogData fetchLogs(int execId, String name, int attempt, int startByte,
+  LogData fetchLogs(int execId, String name, int attempt, int startByte,
       int endByte) throws ExecutorManagerException;
 
-  public List<Object> fetchAttachments(int execId, String name, int attempt)
+  List<Object> fetchAttachments(int execId, String name, int attempt)
       throws ExecutorManagerException;
 
-  public void uploadLogFile(int execId, String name, int attempt, File... files)
+  void uploadLogFile(int execId, String name, int attempt, File... files)
       throws ExecutorManagerException;
 
-  public void uploadAttachmentFile(ExecutableNode node, File file)
+  void uploadAttachmentFile(ExecutableNode node, File file)
       throws ExecutorManagerException;
 
-  public void updateExecutableFlow(ExecutableFlow flow)
+  void updateExecutableFlow(ExecutableFlow flow)
       throws ExecutorManagerException;
 
-  public void uploadExecutableNode(ExecutableNode node, Props inputParams)
+  void uploadExecutableNode(ExecutableNode node, Props inputParams)
       throws ExecutorManagerException;
 
-  public List<ExecutableJobInfo> fetchJobInfoAttempts(int execId, String jobId)
+  List<ExecutableJobInfo> fetchJobInfoAttempts(int execId, String jobId)
       throws ExecutorManagerException;
 
-  public ExecutableJobInfo fetchJobInfo(int execId, String jobId, int attempt)
+  ExecutableJobInfo fetchJobInfo(int execId, String jobId, int attempt)
       throws ExecutorManagerException;
 
-  public List<ExecutableJobInfo> fetchJobHistory(int projectId, String jobId,
+  List<ExecutableJobInfo> fetchJobHistory(int projectId, String jobId,
       int skip, int size) throws ExecutorManagerException;
 
-  public void updateExecutableNode(ExecutableNode node)
+  void updateExecutableNode(ExecutableNode node)
       throws ExecutorManagerException;
 
-  public int fetchNumExecutableFlows(int projectId, String flowId)
+  int fetchNumExecutableFlows(int projectId, String flowId)
       throws ExecutorManagerException;
 
-  public int fetchNumExecutableFlows() throws ExecutorManagerException;
+  int fetchNumExecutableFlows() throws ExecutorManagerException;
 
-  public int fetchNumExecutableNodes(int projectId, String jobId)
+  int fetchNumExecutableNodes(int projectId, String jobId)
       throws ExecutorManagerException;
 
-  public Props fetchExecutionJobInputProps(int execId, String jobId)
+  Props fetchExecutionJobInputProps(int execId, String jobId)
       throws ExecutorManagerException;
 
-  public Props fetchExecutionJobOutputProps(int execId, String jobId)
+  Props fetchExecutionJobOutputProps(int execId, String jobId)
       throws ExecutorManagerException;
 
-  public Pair<Props, Props> fetchExecutionJobProps(int execId, String jobId)
+  Pair<Props, Props> fetchExecutionJobProps(int execId, String jobId)
       throws ExecutorManagerException;
 
-  public int removeExecutionLogsByTime(long millis)
+  int removeExecutionLogsByTime(long millis)
       throws ExecutorManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/server/AbstractServiceServlet.java
+++ b/azkaban-common/src/main/java/azkaban/server/AbstractServiceServlet.java
@@ -37,8 +37,7 @@ public class AbstractServiceServlet extends HttpServlet {
   @Override
   public void init(ServletConfig config) throws ServletException {
     application =
-        (AzkabanServer) config.getServletContext().getAttribute(
-            ServerConstants.AZKABAN_SERVLET_CONTEXT_KEY);
+        (AzkabanServer) config.getServletContext().getAttribute(Constants.AZKABAN_SERVLET_CONTEXT_KEY);
 
     if (application == null) {
       throw new IllegalStateException(

--- a/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
@@ -34,10 +34,6 @@ import azkaban.server.session.SessionCache;
 
 public abstract class AzkabanServer {
   private static final Logger logger = Logger.getLogger(AzkabanServer.class);
-  public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
-  public static final String AZKABAN_PRIVATE_PROPERTIES_FILE =
-      "azkaban.private.properties";
-  public static final String DEFAULT_CONF_PATH = "conf";
   private static Props azkabanProperties = null;
 
   public static Props loadProps(String[] args) {
@@ -83,8 +79,8 @@ public abstract class AzkabanServer {
 
   private static Props loadAzkabanConfigurationFromDirectory(File dir) {
     File azkabanPrivatePropsFile =
-        new File(dir, AZKABAN_PRIVATE_PROPERTIES_FILE);
-    File azkabanPropsFile = new File(dir, AZKABAN_PROPERTIES_FILE);
+        new File(dir, Constants.AZKABAN_PRIVATE_PROPERTIES_FILE);
+    File azkabanPropsFile = new File(dir, Constants.AZKABAN_PROPERTIES_FILE);
 
     Props props = null;
     try {
@@ -128,7 +124,7 @@ public abstract class AzkabanServer {
       return null;
     }
 
-    File confPath = new File(azkabanHome, DEFAULT_CONF_PATH);
+    File confPath = new File(azkabanHome, Constants.DEFAULT_CONF_PATH);
     if (!confPath.exists() || !confPath.isDirectory() || !confPath.canRead()) {
       logger
           .error(azkabanHome + " does not contain a readable conf directory.");

--- a/azkaban-common/src/main/java/azkaban/server/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/server/Constants.java
@@ -21,6 +21,5 @@ public class Constants {
 	public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
 	public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";
 	public static final String DEFAULT_CONF_PATH = "conf";
-
-	public static final String AZKABAN_EXECUTOR_PORT_FILE = "executor.port.filename";
+	public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 }

--- a/azkaban-common/src/main/java/azkaban/server/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/server/Constants.java
@@ -16,6 +16,11 @@
 
 package azkaban.server;
 
-public class ServerConstants {
+public class Constants {
 	public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
+	public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
+	public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";
+	public static final String DEFAULT_CONF_PATH = "conf";
+
+	public static final String AZKABAN_EXECUTOR_PORT_FILE = "executor.port.filename";
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -69,7 +69,7 @@ import azkaban.utils.Props;
 import azkaban.utils.SystemMemoryInfo;
 import azkaban.utils.Utils;
 
-import static azkaban.server.Constants.AZKABAN_EXECUTOR_PORT_FILE;
+import static azkaban.server.Constants.AZKABAN_EXECUTOR_PORT_FILENAME;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -193,12 +193,12 @@ public class AzkabanExecutorServer {
 
   private void dumpPortToFile() {
     // By default this should write to the working directory
-    String filename = props.getString(AZKABAN_EXECUTOR_PORT_FILE, "executor.port");
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(AZKABAN_EXECUTOR_PORT_FILENAME))) {
       writer.write(String.valueOf(getPort()));
       writer.write("\n");
     } catch (IOException e) {
       logger.error(e);
+      Throwables.propagate(e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -16,6 +16,8 @@
 
 package azkaban.execapp;
 
+import com.google.common.base.Preconditions;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -35,6 +37,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlowBase;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.server.ServerConstants;
 import azkaban.utils.FileIOUtils.JobMetaData;
@@ -95,6 +99,12 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
         } else if (action.equals(RELOAD_JOBTYPE_PLUGINS_ACTION)) {
           logger.info("Reloading Jobtype plugins");
           handleReloadJobTypePlugins(respMap);
+        } else if (action.equals(ACTIVATE)) {
+          logger.warn("Setting ACTIVE flag to true");
+          setActive(true, respMap);
+        } else if (action.equals(DEACTIVATE)) {
+          logger.warn("Setting ACTIVE flag to false");
+          setActive(false, respMap);
         } else {
           int execid = Integer.parseInt(getParam(req, EXECID_PARAM));
           String user = getParam(req, USER_PARAM, null);
@@ -331,6 +341,25 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
       throws ServletException {
     try {
       flowRunnerManager.reloadJobTypePlugins();
+      respMap.put(STATUS_PARAM, RESPONSE_SUCCESS);
+    } catch (Exception e) {
+      logger.error(e);
+      respMap.put(RESPONSE_ERROR, e.getMessage());
+    }
+  }
+
+  private void setActive(boolean value, Map<String, Object> respMap)
+      throws ServletException {
+    try {
+      ExecutorLoader executorLoader = application.getExecutorLoader();
+      Executor executor = executorLoader.fetchExecutor(application.getHost(), application.getPort());
+      Preconditions.checkState(executor != null, "Unable to obtain self entry in DB");
+      if (executor.isActive() != value) {
+        executor.setActive(value);
+        executorLoader.updateExecutor(executor);
+      } else {
+        logger.warn("Set active action ignored. Executor is already " + (value? "active" : "inactive"));
+      }
       respMap.put(STATUS_PARAM, RESPONSE_SUCCESS);
     } catch (Exception e) {
       logger.error(e);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -40,7 +40,7 @@ import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
-import azkaban.server.ServerConstants;
+import azkaban.server.Constants;
 import azkaban.utils.FileIOUtils.JobMetaData;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.JSONUtils;
@@ -62,7 +62,7 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
   public void init(ServletConfig config) throws ServletException {
     application =
         (AzkabanExecutorServer) config.getServletContext().getAttribute(
-            ServerConstants.AZKABAN_SERVLET_CONTEXT_KEY);
+            Constants.AZKABAN_SERVLET_CONTEXT_KEY);
 
     if (application == null) {
       throw new IllegalStateException(

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -34,7 +34,7 @@ import org.apache.log4j.Logger;
 
 import azkaban.executor.ConnectorParams;
 import azkaban.server.HttpRequestUtils;
-import azkaban.server.ServerConstants;
+import azkaban.server.Constants;
 import azkaban.utils.JSONUtils;
 
 public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
@@ -45,7 +45,7 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
   public void init(ServletConfig config) throws ServletException {
     server =
         (AzkabanExecutorServer) config.getServletContext().getAttribute(
-            ServerConstants.AZKABAN_SERVLET_CONTEXT_KEY);
+            Constants.AZKABAN_SERVLET_CONTEXT_KEY);
   }
 
   public boolean hasParam(HttpServletRequest request, String param) {

--- a/azkaban-sql/src/sql/create.executors.sql
+++ b/azkaban-sql/src/sql/create.executors.sql
@@ -2,7 +2,7 @@ CREATE TABLE executors (
   id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
   host VARCHAR(64) NOT NULL,
   port INT NOT NULL,
-  active BOOLEAN DEFAULT true,
+  active BOOLEAN DEFAULT false,
   UNIQUE (host, port),
   UNIQUE INDEX executor_id (id)
 );

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -67,7 +67,7 @@ import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.ScheduleManager;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
 import azkaban.server.AzkabanServer;
-import azkaban.server.ServerConstants;
+import azkaban.server.Constants;
 import azkaban.server.session.SessionCache;
 import azkaban.trigger.JdbcTriggerLoader;
 import azkaban.trigger.TriggerLoader;
@@ -804,7 +804,7 @@ public class AzkabanWebServer extends AzkabanServer {
     // TODO: find something else to do the job
     app.getTriggerManager().start();
 
-    root.setAttribute(ServerConstants.AZKABAN_SERVLET_CONTEXT_KEY, app);
+    root.setAttribute(Constants.AZKABAN_SERVLET_CONTEXT_KEY, app);
     try {
       server.start();
     } catch (Exception e) {


### PR DESCRIPTION
When an executor server is launched, it uses the configured port or falls back to a default port. This behavior has been modified such that when the executor is not configured to a specific port it defaults to any available port that it can find on the machine. The advantage is that the user doesn't need to worry about port collisions when he/she doesn't need a specific port.

  Also, The executor now automatically adds an entry about itself to the DB post launch. Also, it exposes the following REST APIs to allow users to activate / deactivate itself
  example:
  http://localhost:1234/executor?action=activate
  http://localhost:1234/executor?action=deactivate

On a successful start, the executor writes the port to a file called executor.port by default.

Contains small refactors like consolidating constants. simplifying function signature.

No automated tests were added due to the nature of the change. No additional functionality was added by existing pieces of code was used. However, the changes were tested manually.