### PR TITLE
make project directory as shared among multiple deployments

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -357,6 +357,7 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
       if (executor.isActive() != value) {
         executor.setActive(value);
         executorLoader.updateExecutor(executor);
+        flowRunnerManager.setActive(value);
       } else {
         logger.warn("Set active action ignored. Executor is already " + (value? "active" : "inactive"));
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
@@ -18,6 +18,8 @@ package azkaban.execapp;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.io.FileUtils;
@@ -78,8 +80,7 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
           logger.info("Downloading zip file.");
           ZipFile zip = new ZipFile(projectFileHandler.getLocalFile());
           Utils.unzip(zip, tempDir);
-
-          tempDir.renameTo(installedDir);
+          Files.move(tempDir.toPath(), installedDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
         } else {
           throw new IOException("The file type hasn't been decided yet.");
         }


### PR DESCRIPTION
Since we are moving projects dir to a shared dir among multiple deployments, we have to deal with race condition where multiple deployments are trying to modifying the same project file. 
The commit consists of following changes:

1. make rename operation atomic so that it's safer for multiple deployments to perform rename.
2. For simplicity, only active deployment is allowed to perform deletion of projects.
