### PR TITLE
Change the Azkaban executor and web start script to redirect error ou…

### DIFF
--- a/azkaban-exec-server/src/main/bash/start-exec.sh
+++ b/azkaban-exec-server/src/main/bash/start-exec.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # pass along command line arguments to azkaban-executor-start.sh script
-bin/azkaban-executor-start.sh "$@" 2>&1>logs/executorServerLog__`date +%F+%T`.out &
+bin/azkaban-executor-start.sh "$@" >logs/executorServerLog__`date +%F+%T`.out 2>&1 &
 

--- a/azkaban-web-server/src/main/bash/start-web.sh
+++ b/azkaban-web-server/src/main/bash/start-web.sh
@@ -2,4 +2,4 @@
 
 base_dir=$(dirname $0)/..
 
-bin/azkaban-web-start.sh $base_dir 2>&1>logs/webServerLog_`date +%F+%T`.out &
+bin/azkaban-web-start.sh $base_dir >logs/webServerLog_`date +%F+%T`.out 2>&1 &


### PR DESCRIPTION
…tput to a log file correctly

Previously the error output was still sent to the stdout.

The change has been tested in our production clusters.