### PR TITLE
Add more error logging to the code that fetches project properties fr…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -1112,6 +1112,8 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
 
       return properties.get(0).getSecond();
     } catch (SQLException e) {
+      logger.error("Error fetching property " + propsName
+          + " Project " + projectId + " version " + projectVer, e);
       throw new ProjectManagerException("Error fetching property " + propsName,
           e);
     }
@@ -1120,6 +1122,7 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
   @Override
   public Props fetchProjectProperty(Project project, String propsName)
       throws ProjectManagerException {
+    // TODO: 11/23/16 call the other overloaded method fetchProjectProperty internally.
     QueryRunner runner = createQueryRunner();
 
     ProjectPropertiesResultsHandler handler =
@@ -1130,13 +1133,17 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
               handler, project.getId(), project.getVersion(), propsName);
 
       if (properties == null || properties.isEmpty()) {
+        logger.warn("Project " + project.getId() + " version " + project.getVersion()
+          + " property " + propsName + " is empty.");
         return null;
       }
 
       return properties.get(0).getSecond();
     } catch (SQLException e) {
-      throw new ProjectManagerException("Error fetching property " + propsName,
-          e);
+      logger.error("Error fetching property " + propsName
+          + "Project " + project.getId() + " version " + project.getVersion(), e);
+      throw new ProjectManagerException("Error fetching property " + propsName
+          + "Project " + project.getId() + " version " + project.getVersion(), e);
     }
   }
 
@@ -1236,6 +1243,7 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
       }
       return props;
     } catch (SQLException e) {
+      logger.error("Error fetching properties, project id" + projectId + " version " + version, e);
       throw new ProjectManagerException("Error fetching properties", e);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -330,17 +330,10 @@ public class PropsUtils {
     return map;
   }
 
-  @SuppressWarnings("unchecked")
-  public static Props fromJSONString(String json) {
-    try {
-      Map<String, String> obj =
-          (Map<String, String>) JSONUtils.parseJSONFromString(json);
-      Props props = new Props(null, obj);
-      return props;
-    } catch (IOException e) {
-      logger.error("Encountered error during parsing project properties json. ", e);
-      return null;
-    }
+  public static Props fromJSONString(String json) throws IOException {
+    Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
+    Props props = new Props(null, obj);
+    return props;
   }
 
   @SuppressWarnings("unchecked")

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1425,6 +1425,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       project = projectManager.getProject(projectName);
       if (project == null) {
         page.add("errorMsg", "Project " + projectName + " not found.");
+        logger.info("Display project property. Project " + projectName + " not found.");
         page.render();
         return;
       }
@@ -1438,6 +1439,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       flow = project.getFlow(flowName);
       if (flow == null) {
         page.add("errorMsg", "Flow " + flowName + " not found.");
+        logger.info("Display project property. Project " + projectName +
+            " Flow " + flowName + " not found.");
         page.render();
         return;
       }
@@ -1446,11 +1449,22 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
+        logger.info("Display project property. Project " + projectName +
+            " Flow " + flowName + " Job " + jobName + " not found.");
         page.render();
         return;
       }
 
       Props prop = projectManager.getProperties(project, propSource);
+      if (prop == null) {
+        page.add("errorMsg", "Property " + propSource + " not found.");
+        logger.info("Display project property. Project " + projectName +
+            " Flow " + flowName + " Job " + jobName +
+            " Property " + propSource + " not found.");
+        page.render();
+        return;
+
+      }
       page.add("property", propSource);
       page.add("jobid", node.getId());
 


### PR DESCRIPTION
…om DB

Let the exception from JSON decode method PropsUtils.fromJSONString to throw and catch it in the caller where more information is available to be logged.
 This way it is easier to identify which project is having this issue from logs.

PropsUtils.fromJSONString is called only in one place and the exception is caught.
