### PR TITLE
get self executor status by writing a simple executor API

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -36,6 +36,7 @@ public interface ConnectorParams {
   public static final String RELOAD_JOBTYPE_PLUGINS_ACTION = "reloadJobTypePlugins";
   public static final String ACTIVATE = "activate";
   public static final String DEACTIVATE = "deactivate";
+  public static final String GET_STATUS = "getStatus";
 
   public static final String MODIFY_EXECUTION_ACTION = "modifyExecution";
   public static final String MODIFY_EXECUTION_ACTION_TYPE = "modifyType";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -45,6 +45,9 @@ import azkaban.utils.FileIOUtils.JobMetaData;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.JSONUtils;
 
+import static java.util.Objects.requireNonNull;
+
+
 public class ExecutorServlet extends HttpServlet implements ConnectorParams {
   private static final long serialVersionUID = 1L;
   private static final Logger logger = Logger.getLogger(ExecutorServlet.class
@@ -102,6 +105,9 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
         } else if (action.equals(ACTIVATE)) {
           logger.warn("Setting ACTIVE flag to true");
           setActive(true, respMap);
+        } else if (action.equals(GET_STATUS)) {
+          logger.debug("Get Executor Status: ");
+          getStatus(respMap);
         } else if (action.equals(DEACTIVATE)) {
           logger.warn("Setting ACTIVE flag to false");
           setActive(false, respMap);
@@ -361,6 +367,22 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
       } else {
         logger.warn("Set active action ignored. Executor is already " + (value? "active" : "inactive"));
       }
+      respMap.put(STATUS_PARAM, RESPONSE_SUCCESS);
+    } catch (Exception e) {
+      logger.error(e);
+      respMap.put(RESPONSE_ERROR, e.getMessage());
+    }
+  }
+
+  private void getStatus(Map<String, Object> respMap)
+      throws ServletException {
+    try {
+      ExecutorLoader executorLoader = application.getExecutorLoader();
+      final Executor executor = requireNonNull(executorLoader.fetchExecutor(application.getHost(), application.getPort()),
+          "The executor can not be null");
+
+      respMap.put("executor_id", Integer.toString(executor.getId()));
+      respMap.put("isActive", String.valueOf(executor.isActive()));
       respMap.put(STATUS_PARAM, RESPONSE_SUCCESS);
     } catch (Exception e) {
       logger.error(e);


### PR DESCRIPTION
The acceptance tests need to specify the target executor ID, which has to be fetched from DB directly. This pull request writes a new API to have it.

Verified in localhost.