### PR TITLE
Made a Log4j pattern layout that appends stack traces to messages

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/PatternLayoutEscaped.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PatternLayoutEscaped.java
@@ -4,23 +4,34 @@ import org.apache.log4j.PatternLayout;
 import org.apache.log4j.spi.LoggingEvent;
 
 /**
- * When we use log4j to send a JSON message the official PatternLayout will send corrupt JSON if certain characters are
- * present. We use this PatternLayoutEscaped class as a thin interface around PatternLayout to escape all these
- * characters.
+ * When we use the log4j Kafka appender, it seems that the appender simply does not log the stack trace anywhere
+ * Seeing as the stack trace is a very important piece of information, we create our own PatternLayout class that
+ * appends the stack trace to the log message that reported it, so that all the information regarding that error
+ * can be found one in place.
  */
 public class PatternLayoutEscaped extends PatternLayout {
+  @Override
   public String format(final LoggingEvent event) {
     if (event.getMessage() instanceof String) {
-      return super.format(copyAndEscapeEvent(event));
+      return super.format(appendStackTraceToEvent(event));
     }
     return super.format(event);
   }
 
   /**
-   * Create a copy of event, but escape backslashes, tabs, newlines and quotes in its message
+   * Create a copy of event, but append a stack trace to the message (if it exists).
+   * Then it escapes the backslashes, tabs, newlines and quotes in its message as we are sending it as JSON and we
+   * don't want any corruption of the JSON object.
    */
-  private LoggingEvent copyAndEscapeEvent(LoggingEvent event) {
+  private LoggingEvent appendStackTraceToEvent(LoggingEvent event) {
     String message = event.getMessage().toString();
+    // If there is a stack trace available, print it out
+    if (event.getThrowableInformation() != null) {
+      String[] s = event.getThrowableStrRep();
+      for (String line: s) {
+        message += "\n" + line;
+      }
+    }
     message = message
         .replace("\\", "\\\\")
         .replace("\n", "\\n")

--- a/azkaban-common/src/test/java/azkaban/utils/PatternLayoutEscapedTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/PatternLayoutEscapedTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Test output of PatternLayoutEscapedTest
- * It should be escaping new lines, quotes, tabs and backslashes
+ * It should be appending stack traces, escaping new lines, quotes, tabs and backslashes
  * This is necessary when we are logging these messages out as JSON objects
  */
 public class PatternLayoutEscapedTest {
@@ -38,6 +38,17 @@ public class PatternLayoutEscapedTest {
   @Before
   public void beforeTest() {
     layout.setConversionPattern("%m");
+  }
+
+  @Test
+  public void testWithException() {
+    try {
+      throw new Exception("This is an exception");
+    } catch (Exception e) {
+      LoggingEvent event = createEventWithException("There was an exception", e);
+      // Stack trace might change if the codebase changes, but this prefix should always remain the same
+      assertTrue(layout.format(event).startsWith("There was an exception\\njava.lang.Exception: This is an exception"));
+    }
   }
 
   @Test
@@ -65,11 +76,15 @@ public class PatternLayoutEscapedTest {
   }
 
   private LoggingEvent createMessageEvent(String message) {
+    return createEventWithException(message, null);
+  }
+
+  private LoggingEvent createEventWithException(String message, Exception e) {
     return new LoggingEvent(this.getClass().getCanonicalName(),
         logger,
         0,
         Level.toLevel("INFO"),
         message,
-        new Exception());
+        e);
   }
 }


### PR DESCRIPTION
When we use the log4j Kafka appender, it seems that the appender simply does not log the stack trace anywhere. Seeing as the stack trace is a very important piece of information, we create our own PatternLayout class that appends the stack trace to the log message that reported it, so that all the information regarding that error can be found one in place.