### PR TITLE
Add docs for files generated by ./gradlew distTar

### DIFF
--- a/_includes/docs/latest/building-from-source.html
+++ b/_includes/docs/latest/building-from-source.html
@@ -12,3 +12,5 @@ $ ./gradelw distTar
 <pre>
 $ gradlew distTar
 </pre>
+
+Gradle creates <code>.tar.gz</code> files inside project directories. eg. <code>./azkaban-solo-server/build/distributions/azkaban-solo-server-0.1.0-SNAPSHOT.tar.gz</code>. You can now un-archive the distribution using <code>tar xvzf azkaban....tar.gz</code>.


### PR DESCRIPTION
Mention the location of tar files and how they can be un-archived.