### PR TITLE
adding Application metrics

### DIFF
--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -26,5 +26,5 @@ public class ServerInternals {
   public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
-  
+
 }

--- a/azkaban-common/src/main/java/azkaban/event/Event.java
+++ b/azkaban-common/src/main/java/azkaban/event/Event.java
@@ -26,7 +26,10 @@ public class Event {
     JOB_FINISHED,
     JOB_STATUS_CHANGED,
     EXTERNAL_FLOW_UPDATED,
-    EXTERNAL_JOB_UPDATED
+    EXTERNAL_JOB_UPDATED,
+    UPLOAD_FILE_CHUNK,
+    USER_DOWNLOAD_FILE,
+    AZ_DOWNLOAD_FILE
   }
 
   private final Object runner;
@@ -38,6 +41,13 @@ public class Event {
     this.runner = runner;
     this.type = type;
     this.eventData = eventData;
+    this.time = System.currentTimeMillis();
+  }
+
+  private Event(Object runner, Type type) {
+    this.runner = runner;
+    this.type = type;
+    this.eventData = null;
     this.time = System.currentTimeMillis();
   }
 
@@ -71,4 +81,15 @@ public class Event {
     return new Event(runner, type, eventData);
   }
 
+  /**
+   * Creates a new event.
+   *
+   * @param runner runner.
+   * @param type type.
+   * @return New Event instance.
+   * @throws NullPointerException if EventData is null.
+   */
+  public static Event create(Object runner, Type type) {
+    return new Event(runner, type);
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/event/EventHandler.java
+++ b/azkaban-common/src/main/java/azkaban/event/EventHandler.java
@@ -19,25 +19,23 @@ package azkaban.event;
 import java.util.ArrayList;
 import java.util.HashSet;
 
-public class EventHandler {
-  private HashSet<EventListener> listeners = new HashSet<EventListener>();
+public interface EventHandler {
 
-  public EventHandler() {
+  public HashSet<EventListener> getListeners();
+
+  default public void addListener(EventListener listener) {
+    getListeners().add(listener);
   }
 
-  public void addListener(EventListener listener) {
-    listeners.add(listener);
-  }
-
-  public void fireEventListeners(Event event) {
+  default public void fireEventListeners(Event event) {
     ArrayList<EventListener> listeners =
-        new ArrayList<EventListener>(this.listeners);
+        new ArrayList<EventListener>(getListeners());
     for (EventListener listener : listeners) {
       listener.handleEvent(event);
     }
   }
 
-  public void removeListener(EventListener listener) {
-    listeners.remove(listener);
+  default public void removeListener(EventListener listener) {
+    getListeners().remove(listener);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.event.EventListener;
 import java.io.File;
 import java.io.IOException;
 import java.lang.Thread.State;
@@ -63,7 +64,7 @@ import azkaban.utils.Props;
  * Executor manager used to manage the client side job.
  *
  */
-public class ExecutorManager extends EventHandler implements
+public class ExecutorManager implements EventHandler,
     ExecutorManagerAdapter {
   static final String AZKABAN_EXECUTOR_SELECTOR_FILTERS =
       "azkaban.executorselector.filters";
@@ -107,6 +108,7 @@ public class ExecutorManager extends EventHandler implements
 
   private long lastThreadCheckTime = -1;
   private String updaterStage = "not started";
+  private static HashSet<EventListener> listeners = new HashSet<>();
 
   private Map<String, Alerter> alerters;
 
@@ -146,6 +148,10 @@ public class ExecutorManager extends EventHandler implements
     cleanerThread = new CleanerThread(executionLogsRetentionMs);
     cleanerThread.start();
 
+  }
+
+  public HashSet<EventListener> getListeners() {
+    return listeners;
   }
 
   private void setupMultiExecutorMode() {

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -29,7 +29,8 @@ public enum Status {
   DISABLED(100),
   QUEUED(110),
   FAILED_SUCCEEDED(120),
-  CANCELLED(130);
+  CANCELLED(130),
+  FILE_UPLOADING(140);
 
   private int numVal;
 
@@ -43,32 +44,34 @@ public enum Status {
 
   public static Status fromInteger(int x) {
     switch (x) {
-    case 10:
-      return READY;
-    case 20:
-      return PREPARING;
-    case 30:
-      return RUNNING;
-    case 40:
-      return PAUSED;
-    case 50:
-      return SUCCEEDED;
-    case 60:
-      return KILLED;
-    case 70:
-      return FAILED;
-    case 80:
-      return FAILED_FINISHING;
-    case 90:
-      return SKIPPED;
-    case 100:
-      return DISABLED;
-    case 110:
-      return QUEUED;
-    case 120:
-      return FAILED_SUCCEEDED;
-    case 130:
-      return CANCELLED;
+      case 10:
+        return READY;
+      case 20:
+        return PREPARING;
+      case 30:
+        return RUNNING;
+      case 40:
+        return PAUSED;
+      case 50:
+        return SUCCEEDED;
+      case 60:
+        return KILLED;
+      case 70:
+        return FAILED;
+      case 80:
+        return FAILED_FINISHING;
+      case 90:
+        return SKIPPED;
+      case 100:
+        return DISABLED;
+      case 110:
+        return QUEUED;
+      case 120:
+        return FAILED_SUCCEEDED;
+      case 130:
+        return CANCELLED;
+      case 140:
+        return FILE_UPLOADING;
     default:
       return READY;
     }

--- a/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.metrics;
+
+import azkaban.event.Event;
+import azkaban.event.EventListener;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import org.apache.log4j.Logger;
+
+
+/**
+ * This class MetricsWebRegister is in charge of collecting metrics from web server.
+ */
+public enum CommonMetrics implements EventListener {
+  INSTANCE;
+
+  private Meter uploadDBMeter;
+  private Meter userDownloadMeter;
+  private Meter azDownloadMeter;
+
+  private static final Logger logger = Logger.getLogger(CommonMetrics.class);
+
+  private CommonMetrics() {
+  }
+
+  public void addExecDBStateMetrics(MetricRegistry metrics) throws Exception {
+    azDownloadMeter = metrics.meter("AZ-Download-meter");
+
+    metrics.register("DB-AZ-Download-meter", new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return azDownloadMeter.getOneMinuteRate();
+      }
+    });
+  }
+
+  public void addWebDBStateMetrics(MetricRegistry metrics) throws Exception {
+    uploadDBMeter = metrics.meter("upload-DB-Meter");
+    userDownloadMeter = metrics.meter("user-Download-meter");
+
+    metrics.register("DB-Uploading-Chunks-Meter", new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return uploadDBMeter.getOneMinuteRate();
+      }
+    });
+
+    metrics.register("DB-user-Download-meter", new Gauge<Double>() {
+      @Override
+      public Double getValue() {
+        return userDownloadMeter.getOneMinuteRate();
+      }
+    });
+
+  }
+
+  @Override
+  public synchronized void handleEvent(Event event) {
+
+    /**
+     * TODO: Use switch to select event type.
+     *
+     */
+    if (event.getType() == Event.Type.UPLOAD_FILE_CHUNK) {
+      uploadDBMeter.mark();
+      logger.info("[[[]]] uploadDBMeter count =" + uploadDBMeter.getCount());
+      logger.info("[[[]]] uploadDBMeter getOneMinuteRate =" + uploadDBMeter.getOneMinuteRate());
+    } else if (event.getType() == Event.Type.USER_DOWNLOAD_FILE) {
+      userDownloadMeter.mark();
+      logger.info("[[[]]] userDownloadMeter count =" + userDownloadMeter.getCount());
+      logger.info("[[[]]] userDownloadMeter getOneMinuteRate =" + userDownloadMeter.getOneMinuteRate());
+    } else if (event.getType() == Event.Type.AZ_DOWNLOAD_FILE) {
+      azDownloadMeter.mark();
+      logger.info("[[[]]] AZDownloadMeter count =" + azDownloadMeter.getCount());
+      logger.info("[[[]]] AZDownloadMeter getOneMinuteRate =" + azDownloadMeter.getOneMinuteRate());
+    }
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -37,7 +37,7 @@ import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorManager;
 import azkaban.utils.Props;
 
-public class TriggerManager extends EventHandler implements
+public class TriggerManager implements EventHandler,
     TriggerManagerAdapter {
   private static Logger logger = Logger.getLogger(TriggerManager.class);
   public static final long DEFAULT_SCANNER_INTERVAL_MS = 60000;
@@ -53,6 +53,8 @@ public class TriggerManager extends EventHandler implements
   private long lastRunnerThreadCheckTime = -1;
   private long runnerThreadIdleTime = -1;
   private LocalTriggerJMX jmxStats = new LocalTriggerJMX();
+
+  private static HashSet<EventListener> triggerManagerListeners = new HashSet<>();
 
   private ExecutorManagerEventListener listener =
       new ExecutorManagerEventListener();
@@ -104,6 +106,10 @@ public class TriggerManager extends EventHandler implements
     }
 
     runnerThread.start();
+  }
+
+  public HashSet<EventListener> getListeners() {
+    return triggerManagerListeners;
   }
 
   protected CheckerTypeLoader getCheckerLoader() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -66,6 +66,7 @@ import azkaban.metric.IMetricEmitter;
 import azkaban.metric.MetricException;
 import azkaban.metric.MetricReportManager;
 import azkaban.metric.inmemoryemitter.InMemoryMetricEmitter;
+import azkaban.metrics.CommonMetrics;
 import azkaban.project.JdbcProjectLoader;
 import azkaban.project.ProjectLoader;
 import azkaban.server.AzkabanServer;
@@ -193,6 +194,7 @@ public class AzkabanExecutorServer {
         new MetricsExecRegister.MetricsExecRegisterBuilder("EXEC").addFlowRunnerManager(getFlowRunnerManager()).build();
     execWorker.addExecutorManagerMetrics(metrics);
 
+    CommonMetrics.INSTANCE.addExecDBStateMetrics(metrics);
     MetricsManager.INSTANCE.startReporting("AZ-EXEC", props);
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -69,7 +69,7 @@ import azkaban.utils.SwapQueue;
  * Class that handles the running of a ExecutableFlow DAG
  *
  */
-public class FlowRunner extends EventHandler implements Runnable {
+public class FlowRunner implements EventHandler, Runnable {
   private static final Layout DEFAULT_LAYOUT = new PatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
   // We check update every 5 minutes, just in case things get stuck. But for the
@@ -127,6 +127,8 @@ public class FlowRunner extends EventHandler implements Runnable {
 
   // The following is state that will trigger a retry of all failed jobs
   private boolean retryFailedJobs = false;
+
+  private static HashSet<EventListener> listeners = new HashSet<>();
 
   /**
    * Constructor. This will create its own ExecutorService for thread pools
@@ -194,6 +196,10 @@ public class FlowRunner extends EventHandler implements Runnable {
   public FlowRunner setValidateProxyUser(boolean validateUserProxy) {
     this.validateUserProxy = validateUserProxy;
     return this;
+  }
+
+  public HashSet<EventListener> getListeners() {
+    return listeners;
   }
 
   public File getExecutionDir() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -16,6 +16,7 @@
 
 package azkaban.execapp;
 
+import azkaban.event.EventListener;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -61,7 +62,7 @@ import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import azkaban.utils.UndefinedPropertyException;
 
-public class JobRunner extends EventHandler implements Runnable {
+public class JobRunner implements EventHandler, Runnable {
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
@@ -104,6 +105,7 @@ public class JobRunner extends EventHandler implements Runnable {
   private long delayStartMs = 0;
   private boolean killed = false;
   private BlockingStatus currentBlockStatus = null;
+  private static HashSet<EventListener> listeners = new HashSet<>();
 
   public JobRunner(ExecutableNode node, File workingDir, ExecutorLoader loader,
       JobTypeManager jobtypeManager, Props azkabanProps) {
@@ -131,6 +133,10 @@ public class JobRunner extends EventHandler implements Runnable {
 
   public Props getProps() {
     return props;
+  }
+
+  public HashSet<EventListener> getListeners() {
+    return listeners;
   }
 
   public void setPipeline(FlowWatcher watcher, int pipelineLevel) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -65,6 +65,8 @@ import azkaban.executor.JdbcExecutorLoader;
 import azkaban.jmx.JmxExecutorManager;
 import azkaban.jmx.JmxJettyServer;
 import azkaban.jmx.JmxTriggerManager;
+import azkaban.metrics.MetricsManager;
+import azkaban.metrics.CommonMetrics;
 import azkaban.project.JdbcProjectLoader;
 import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleLoader;
@@ -103,7 +105,6 @@ import azkaban.webapp.servlet.ProjectServlet;
 import azkaban.webapp.servlet.ScheduleServlet;
 import azkaban.webapp.servlet.StatsServlet;
 import azkaban.webapp.servlet.TriggerManagerServlet;
-import azkaban.metrics.MetricsManager;
 
 import com.linkedin.restli.server.RestliServlet;
 
@@ -231,13 +232,15 @@ public class AzkabanWebServer extends AzkabanServer {
     }
   }
 
-  private void startWebMetrics() throws Exception{
+  private void startWebMetrics() throws Exception {
     MetricRegistry metrics = MetricsManager.INSTANCE.getRegistry();
-    MetricsWebRegister execWorker = new MetricsWebRegister.MetricsWebRegisterBuilder("WEB")
+
+    MetricsWebRegister webWorker = new MetricsWebRegister.MetricsWebRegisterBuilder("WEB")
         .addExecutorManager(getExecutorManager())
         .build();
-    execWorker.addExecutorManagerMetrics(metrics);
+    webWorker.addExecutorManagerMetrics(metrics);
 
+    CommonMetrics.INSTANCE.addWebDBStateMetrics(metrics);
     MetricsManager.INSTANCE.startReporting("AZ-WEB", props);
   }
 


### PR DESCRIPTION
Before this change, we only have web and executor metrics registers, which are only able to collect metrics in exec or web packages. In order to collect more application metrics, I propose a CommonMetrics class in common repo, which is able to access code in azkaban-common more conveniently, then able to gather metrics there.