### PR TITLE
Fixing date.js function issue #845 and #856

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/test/test.js
+++ b/azkaban-web-server/src/web/js/azkaban/test/test.js
@@ -48,6 +48,9 @@ describe('CronTransformation', function() {
    assert.equal(testStrFromCronToQuartz('0 3 * * 5'), '0 3 * * 4');
    assert.equal(testStrFromCronToQuartz('0 3 * * 5-7'), '0 3 * * 4-6');
    assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5 2016'), '0 3 * * 0,2-4 2016');
+   assert.equal(testStrFromCronToQuartz('0 3 * * 5#3'), '0 3 * * 4#3');
+   assert.equal(testStrFromCronToQuartz('0 3 * * 5-7#3'), '0 3 * * 4-6#3');
+   assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5#3 2016'), '0 3 * * 0,2-4#3 2016'); 
   });
 });
 

--- a/azkaban-web-server/src/web/js/azkaban/util/date.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/date.js
@@ -110,10 +110,15 @@ var validateQuartzStr = function (str){
   return "VALID";
 }
 
+// Users enter values 1-7 for day of week, but UnixCronSyntax requires
+// day of week to be values 0-6. However, when using "#" syntax, we
+// do not want to apply the modulo operation to the number following "#" 
 var modifyStrToUnixCronSyntax = function (str){
-  return str.replace(/[0-7]/g, function upperToHyphenLower(match) {
+  var res = str.split("#");
+  res[0] = res[0].replace(/[0-7]/g, function upperToHyphenLower(match) {
     return (parseInt(match)+6)%7;
   });
+  return res.join("#");
 }
 
 // Unix Cron use 0-6 as Sun--Sat, but Quartz use 1-7. Due to later.js only supporting Unix Cron, we have to make this transition.


### PR DESCRIPTION
This changes the method modifyStrToUnixCronSyntax in date.js so that the "#" syntax can be used in the day of week option and the correct dates will be displayed under "Next 10 scheduled executions" on the schedule-panel page.