### PR TITLE
Fixing advanced filter by project on history page, addresses issue #403

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -320,7 +320,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
 
     boolean first = true;
     if (projContain != null && !projContain.isEmpty()) {
-      query += " ef JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?";
+      query += " JOIN projects p ON ef.project_id = p.id WHERE p.name LIKE ?";
       params.add('%' + projContain + '%');
       first = false;
     }
@@ -1390,7 +1390,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
   private static class FetchExecutableFlows implements
       ResultSetHandler<List<ExecutableFlow>> {
     private static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows ";
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef ";
     private static String FETCH_EXECUTABLE_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE exec_id=?";


### PR DESCRIPTION
Changed the SQL statement to avoid ambiguous column: enc_type. This should correct the problem.