### PR TITLE
repair ProjectManager setJobOverrideProperty throws null Exception #878

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -360,6 +360,7 @@ public class ProjectManager {
         projectLoader.fetchProjectProperty(project, prop.getSource());
 
     if (oldProps == null) {
+      oldProps = new Props();
       projectLoader.uploadProjectProperty(project, prop);
     } else {
       projectLoader.updateProjectProperty(project, prop);


### PR DESCRIPTION
in order to avoid throw exception when oldProps is null, add add `oldProps = new Props()` code.