### PR TITLE
Have scheduled flow's job disabled/enabled status be picked up by next execution.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -174,7 +174,6 @@ public class FlowRunnerManager implements EventListener,
 
     this.validateProxyUser = azkabanProps.getBoolean("proxy.user.lock.down", false);
 
-    setActive(true);
 
     cleanerThread = new CleanerThread();
     cleanerThread.start();


### PR DESCRIPTION
When manually start a flow, the initial job disabled/enabled state ( if a job is disabled or not ) should come from the last ( and only ) schedule of the flow if any modification to job states are made. The current behavior is that the initial state will be the state when the flow is uploaded. However when a job state is changed in a manual execution, the state is not persisted.