### PR TITLE
Creating a new log4j pattern to log the current host.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/AzkabanPatternLayout.java
+++ b/azkaban-common/src/main/java/azkaban/utils/AzkabanPatternLayout.java
@@ -1,0 +1,112 @@
+package azkaban.utils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.apache.log4j.helpers.PatternConverter;
+import org.apache.log4j.helpers.PatternParser;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+
+
+/**
+ * When we use the log4j Kafka appender, it seems that the appender simply does not log the stack trace anywhere
+ * Seeing as the stack trace is a very important piece of information, we create our own PatternLayout class that
+ * appends the stack trace to the log message that reported it, so that all the information regarding that error
+ * can be found one in place. In addition, we create a new PatternParser to deliver logs with current host name.
+ */
+public class AzkabanPatternLayout extends PatternLayout {
+  protected String host;
+
+  public AzkabanPatternLayout(String s) {
+    super(s);
+  }
+
+  public AzkabanPatternLayout() {
+    super();
+  }
+
+  // TODO: There is no easy way to get Jetty Server's port by InetAddress API.
+  // We might need to find some other way to find this application's port
+  protected String getPort() {
+    return "";
+  }
+
+  protected String getHostname() {
+    if (host == null) {
+      try {
+        InetAddress addr = InetAddress.getLocalHost();
+        this.host = addr.getHostName();
+      } catch (UnknownHostException e) {
+
+        // Prevent exposing exceptions when something goes wrong.
+        this.host = "localhost";
+      }
+    }
+    return host;
+  }
+
+  @Override
+  protected PatternParser createPatternParser(String pattern) {
+    return new PatternParser(pattern) {
+
+      @Override
+      protected void finalizeConverter(char c) {
+        PatternConverter pc = null;
+
+        switch (c) {
+          case 'h':
+            pc = new PatternConverter() {
+              @Override
+              protected String convert(LoggingEvent event) {
+                return getHostname();
+              }
+            };
+            break;
+        }
+        if (pc==null)
+          super.finalizeConverter(c);
+        else
+          addConverter(pc);
+      }
+    };
+  }
+
+  @Override
+  public String format(final LoggingEvent event) {
+    if (event.getMessage() instanceof String) {
+      return super.format(appendStackTraceToEvent(event));
+    }
+    return super.format(event);
+  }
+
+  /**
+   * Create a copy of event, but append a stack trace to the message (if it exists).
+   * Then it escapes the backslashes, tabs, newlines and quotes in its message as we are sending it as JSON and we
+   * don't want any corruption of the JSON object.
+   */
+  private LoggingEvent appendStackTraceToEvent(LoggingEvent event) {
+    String message = event.getMessage().toString();
+    // If there is a stack trace available, print it out
+    if (event.getThrowableInformation() != null) {
+      String[] s = event.getThrowableStrRep();
+      for (String line: s) {
+        message += "\n" + line;
+      }
+    }
+    message = message
+        .replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\"", "\\\"")
+        .replace("\t", "\\t");
+
+    Throwable throwable = event.getThrowableInformation() == null ? null
+        : event.getThrowableInformation().getThrowable();
+    return new LoggingEvent(event.getFQNOfLoggerClass(),
+        event.getLogger(),
+        event.getTimeStamp(),
+        event.getLevel(),
+        message,
+        throwable);
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/utils/AzkabanPatternLayoutTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/AzkabanPatternLayoutTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.utils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Test output of AzkabanPatternLayoutTest
+ * It should be appending stack traces, escaping new lines, quotes, tabs and backslashes
+ * This is necessary when we are logging these messages out as JSON objects
+ */
+public class AzkabanPatternLayoutTest {
+  private Logger logger = Logger.getLogger(this.getClass());
+  private PatternLayout layout = new AzkabanPatternLayout();
+
+  @Before
+  public void beforeTest() {
+    layout.setConversionPattern("%m");
+  }
+
+  @Test
+  public void testWithException() {
+    try {
+      throw new Exception("This is an exception");
+    } catch (Exception e) {
+      LoggingEvent event = createEventWithException("There was an exception", e);
+      // Stack trace might change if the codebase changes, but this prefix should always remain the same
+      assertTrue(layout.format(event).startsWith("There was an exception\\njava.lang.Exception: This is an exception"));
+    }
+  }
+
+  @Test
+  public void testNewLine() {
+    LoggingEvent event = createMessageEvent("This message contains \n new lines");
+    assertTrue(layout.format(event).equals("This message contains \\n new lines"));
+  }
+
+  @Test
+  public void testQuote() {
+    LoggingEvent event = createMessageEvent("This message contains \" quotes");
+    assertTrue(layout.format(event).equals("This message contains \\\" quotes"));
+  }
+
+  @Test
+  public void testTab() {
+    LoggingEvent event = createMessageEvent("This message contains a tab \t");
+    assertTrue(layout.format(event).equals("This message contains a tab \\t"));
+  }
+
+  @Test
+  public void testBackSlash() {
+    LoggingEvent event = createMessageEvent("This message contains a backslash \\");
+    assertTrue(layout.format(event).equals("This message contains a backslash \\\\"));
+  }
+
+  @Test
+  public void testHostEvent() {
+
+    PatternLayout layoutWithHost = new AzkabanPatternLayout();
+    try {
+      InetAddress addr = InetAddress.getLocalHost();
+      layoutWithHost.setConversionPattern("%h : %m%n");
+      LoggingEvent event = createMessageEvent("This message contains this host name.");
+      assertTrue(layoutWithHost.format(event).equals(addr.getHostName() + " : This message contains this host name.\n"));
+    } catch (UnknownHostException e) {
+      e.printStackTrace();
+    }
+
+  }
+
+  private LoggingEvent createMessageEvent(String message) {
+    return createEventWithException(message, null);
+  }
+
+  private LoggingEvent createEventWithException(String message, Exception e) {
+    return new LoggingEvent(this.getClass().getCanonicalName(),
+        logger,
+        0,
+        Level.toLevel("INFO"),
+        message,
+        e);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -57,11 +57,11 @@ import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.jobExecutor.Job;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypeManagerException;
+import azkaban.utils.AzkabanPatternLayout;
 import azkaban.utils.ExternalLinkUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import azkaban.utils.UndefinedPropertyException;
-import azkaban.utils.PatternLayoutEscaped;
 
 public class JobRunner extends EventHandler implements Runnable {
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
@@ -315,7 +315,7 @@ public class JobRunner extends EventHandler implements Runnable {
     layout.put("projectversion", props.getString(FlowProperties.AZKABAN_FLOW_PROJECT_VERSION));
     layout.put("logsource", "userJob");
 
-    kafkaProducer.setLayout(new PatternLayoutEscaped(layout.toString()));
+    kafkaProducer.setLayout(new AzkabanPatternLayout(layout.toString()));
     kafkaProducer.activateOptions();
 
     flowLogger.info("Created kafka appender for " + this.jobId);


### PR DESCRIPTION
The current log4j doesn't support delivering hostname inside a log message. We construct a custom log4j pattern to address this problem. Basically, this new pattern is integrated with an existing pattern about fixing exception. We didn't change the existing pattern (PatternLayoutEscape) created by @KyleFung . After rolling this out to all clusters, we could remove that class.