### PR TITLE
Allow users to specify hostname alias in getHost()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build 
+script: ./gradlew clean build

--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -26,5 +26,7 @@ public class ServerInternals {
   public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
-  
+
+  public static final String HOST_NAME_ALIAS_SCRIPT = "host_name_alias.perl";
+
 }

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -117,16 +117,17 @@ public class FileIOUtils {
     runShellCommand(buffer.toString(), destDir);
   }
 
-  private static void runShellCommand(String command, File workingDir)
+  public static String runShellCommand(String command, File workingDir)
       throws IOException {
     ProcessBuilder builder = new ProcessBuilder().command("sh", "-c", command);
     builder.directory(workingDir);
 
     // XXX what about stopping threads ??
     Process process = builder.start();
+    NullLogger errorLogger = new NullLogger(process.getErrorStream());
+    NullLogger inputLogger = new NullLogger(process.getInputStream());
+
     try {
-      NullLogger errorLogger = new NullLogger(process.getErrorStream());
-      NullLogger inputLogger = new NullLogger(process.getInputStream());
       errorLogger.start();
       inputLogger.start();
 
@@ -148,8 +149,8 @@ public class FileIOUtils {
       IOUtils.closeQuietly(process.getInputStream());
       IOUtils.closeQuietly(process.getOutputStream());
       IOUtils.closeQuietly(process.getErrorStream());
+      return inputLogger.getLastMessages();
     }
-
   }
 
   private static void createDirsFindFiles(File baseDir, File sourceDir,

--- a/azkaban-common/src/main/resources/host_name_alias.perl
+++ b/azkaban-common/src/main/resources/host_name_alias.perl
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+
+# A script to get the VIP name of the current host.
+
+use strict;
+use warnings;
+
+# Get a list of IP addresses that the host has.
+sub get_ip_addrs() {
+    my @ip_addrs = ();
+    # Use the absolute path of ifconfig
+    # since the script may be invoked without PATH being set.
+    for my $line (`/sbin/ifconfig -a`) {
+        # Parse the output of the ifconfig command
+        # looking for patterns of IP addresses
+        if ($line =~ /.*inet addr:(\d+\.\d+\.\d+\.\d+).*/) {
+            push @ip_addrs, $1;
+        }
+    }
+    @ip_addrs;
+}
+
+sub get_hostname_for_ip {
+    my ($ip) = @_;
+    my $result = `getent hosts $ip`;
+    chomp($result);
+    (split(/ /, $result))[-1];
+}
+
+sub get_vip_hostname {
+    my $vip_hostname;
+    for my $ip (get_ip_addrs()) {
+        next if $ip eq '127.0.0.1';
+        $vip_hostname = get_hostname_for_ip($ip);
+        next if $vip_hostname =~ /hcl\d+/;
+    }
+    $vip_hostname;
+}
+
+sub get_shortname {
+    my ($name) = @_;
+    (split(/\./, $name))[0];
+}
+
+print get_vip_hostname(), "\n";


### PR DESCRIPTION
User can fill in their own alias generating logic in the newly added perl script in resource dir. The perl script will only be executed once in the first time executing getHost(). The result of execution of the script will be used as the hostname. If there's error in executing the script we will use regular hostname as fallback.