### PR TITLE
constructing new app metrics structure to collect and send app metrics.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/AbstractJdbcLoader.java
+++ b/azkaban-common/src/main/java/azkaban/database/AbstractJdbcLoader.java
@@ -16,6 +16,9 @@
 
 package azkaban.database;
 
+import azkaban.metrics.CommonMetrics;
+import azkaban.utils.Props;
+
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -26,7 +29,6 @@ import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 
-import azkaban.utils.Props;
 
 public abstract class AbstractJdbcLoader {
   /**
@@ -65,6 +67,7 @@ public abstract class AbstractJdbcLoader {
 
   protected Connection getDBConnection(boolean autoCommit) throws IOException {
     Connection connection = null;
+    CommonMetrics.INSTANCE.markDBConnection();
     try {
       connection = dataSource.getConnection();
       connection.setAutoCommit(autoCommit);

--- a/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
@@ -16,42 +16,40 @@
 
 package azkaban.metrics;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
 /**
  * This singleton class CommonMetrics is in charge of collecting varieties of metrics
- * from azkaban-common modules.
+ * which are accessed in both web and exec modules. That said, these metrics will be
+ * exposed in both Web server and executor.
  */
 public enum CommonMetrics {
   INSTANCE;
 
-  private Meter _dbConnectionMeter;
-  private MetricRegistry _metrics;
+  private Meter dbConnectionMeter;
+  private MetricRegistry registry;
 
   CommonMetrics() {
-    _metrics = MetricsManager.INSTANCE.getRegistry();
+    registry = MetricsManager.INSTANCE.getRegistry();
     setupAllMetrics();
   }
 
   private void setupAllMetrics() {
-    _dbConnectionMeter = addMeter("DB-Connection-meter");
+    dbConnectionMeter = MetricsUtility.addMeter("DB-Connection-meter", registry);
   }
 
-  public Meter addMeter(String name) {
-    Meter curr = _metrics.meter(name);
-    _metrics.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
-    return curr;
-  }
-
+  /**
+   * Mark the occurrence of an DB query event.
+   */
   public void markDBConnection() {
 
     /*
+     * This method should be Thread Safe.
      * Two reasons that we don't make this function call synchronized:
-     * 1). code hale metrics deals with concurrency internally;
+     * 1). drop wizard metrics deals with concurrency internally;
      * 2). mark is basically a math addition operation, which should not cause race condition issue.
      */
-    _dbConnectionMeter.mark();
+    dbConnectionMeter.mark();
   }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * This singleton class CommonMetrics is in charge of collecting varieties of metrics
+ * from azkaban-common modules.
+ */
+public enum CommonMetrics {
+  INSTANCE;
+
+  private Meter _dbConnectionMeter;
+  private MetricRegistry _metrics;
+
+  CommonMetrics() {
+    _metrics = MetricsManager.INSTANCE.getRegistry();
+    setupAllMetrics();
+  }
+
+  private void setupAllMetrics() {
+    _dbConnectionMeter = addMeter("DB-Connection-meter");
+  }
+
+  public Meter addMeter(String name) {
+    Meter curr = _metrics.meter(name);
+    _metrics.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
+    return curr;
+  }
+
+  public void markDBConnection() {
+
+    /*
+     * Two reasons that we don't make this function call synchronized:
+     * 1). code hale metrics deals with concurrency internally;
+     * 2). mark is basically a math addition operation, which should not cause race condition issue.
+     */
+    _dbConnectionMeter.mark();
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/metrics/MetricsUtility.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/MetricsUtility.java
@@ -30,7 +30,7 @@ public final class MetricsUtility {
    * A {@link Gauge} is an instantaneous reading of a particular value.
    * This method adds an AtomicLong number/metric to registry.
    */
-  public static void addLongGauge(String name, AtomicLong atomicLong, MetricRegistry registry) {
-    registry.register(name, (Gauge<Long>) atomicLong::get);
+  public static void addLongGauge(String name, AtomicLong value, MetricRegistry registry) {
+    registry.register(name, (Gauge<Long>) value::get);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/MetricsUtility.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/MetricsUtility.java
@@ -1,0 +1,36 @@
+package azkaban.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Creating an utility class to facilitate metrics class like {@link azkaban.metrics.CommonMetrics}
+ * to share common operations easily.
+ */
+public final class MetricsUtility {
+
+  private MetricsUtility() {
+    //Utility class's constructor should not be called
+  }
+
+  /**
+   * A {@link Meter} measures the rate of events over time (e.g., “requests per second”).
+   * Here we track 1-minute moving averages.
+   */
+  public static Meter addMeter(String name, MetricRegistry registry) {
+    Meter curr = registry.meter(name);
+    registry.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
+    return curr;
+  }
+
+  /**
+   * A {@link Gauge} is an instantaneous reading of a particular value.
+   * This method adds an AtomicLong number/metric to registry.
+   */
+  public static void addLongGauge(String name, AtomicLong atomicLong, MetricRegistry registry) {
+    registry.register(name, (Gauge<Long>) atomicLong::get);
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
+++ b/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CommonMetricsTest {
+
+  private DummyReporter dr;
+
+  @Before
+  public void setup() {
+    dr = new DummyReporter(MetricsManager.INSTANCE.getRegistry());
+    dr.start(Duration.ofMillis(2).toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  @After
+  public void shutdown() {
+    if (null != dr)
+      dr.stop();
+
+    dr = null;
+  }
+
+  /**
+   * One Dummy Reporter extending {@link ScheduledReporter} collects metrics in various maps,
+   * which test methods are able to access easily.
+   */
+  public static class DummyReporter extends ScheduledReporter{
+
+    private Map<String, String> map;
+
+    private Map<String, Long> meterMap;
+
+    public DummyReporter(MetricRegistry registry) {
+      super(registry, "dummy-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+      this.map = new HashMap<>();
+      this.meterMap = new HashMap<>();
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+        SortedMap<String, Counter> counters,
+        SortedMap<String, Histogram> histograms,
+        SortedMap<String, Meter> meters,
+        SortedMap<String, Timer> timers) {
+
+      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        map.put(entry.getKey(), entry.getValue().getValue().toString());
+      }
+
+      for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        meterMap.put(entry.getKey(), entry.getValue().getCount());
+      }
+    }
+
+    public String getGuage(String key) {
+      return map.get(key);
+    }
+
+    public long getMeter(String key) {
+      return meterMap.getOrDefault(key, 0L);
+    }
+  }
+
+
+  @Test
+  public void testuploadDbMetrics() {
+
+    sleep20Millis();
+    long currMeter = dr.getMeter("DB-Connection-meter");
+    CommonMetrics.INSTANCE.markDBConnection();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("DB-Connection-meter"), currMeter + 1);
+
+    CommonMetrics.INSTANCE.markDBConnection();
+    CommonMetrics.INSTANCE.markDBConnection();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("DB-Connection-meter"), currMeter + 3);
+  }
+
+
+  /**
+   * Helper method to sleep 20 milli seconds.
+   */
+  private void sleep20Millis() {
+    try {
+      Thread.sleep(20);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
+++ b/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
@@ -16,23 +16,11 @@
 
 package azkaban.metrics;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
+import azkaban.metrics.MetricsTestUtility.DummyReporter;
 
-import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.Timer;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 import java.time.Duration;
 
-import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,73 +43,8 @@ public class CommonMetricsTest {
     dr = null;
   }
 
-  /**
-   * One Dummy Reporter extending {@link ScheduledReporter} collects metrics in various maps,
-   * which test methods are able to access easily.
-   */
-  public static class DummyReporter extends ScheduledReporter{
-
-    private Map<String, String> map;
-
-    private Map<String, Long> meterMap;
-
-    public DummyReporter(MetricRegistry registry) {
-      super(registry, "dummy-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
-      this.map = new HashMap<>();
-      this.meterMap = new HashMap<>();
-    }
-
-    @Override
-    public void report(SortedMap<String, Gauge> gauges,
-        SortedMap<String, Counter> counters,
-        SortedMap<String, Histogram> histograms,
-        SortedMap<String, Meter> meters,
-        SortedMap<String, Timer> timers) {
-
-      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-        map.put(entry.getKey(), entry.getValue().getValue().toString());
-      }
-
-      for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-        meterMap.put(entry.getKey(), entry.getValue().getCount());
-      }
-    }
-
-    public String getGuage(String key) {
-      return map.get(key);
-    }
-
-    public long getMeter(String key) {
-      return meterMap.getOrDefault(key, 0L);
-    }
-  }
-
-
   @Test
-  public void testuploadDbMetrics() {
-
-    sleep20Millis();
-    long currMeter = dr.getMeter("DB-Connection-meter");
-    CommonMetrics.INSTANCE.markDBConnection();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("DB-Connection-meter"), currMeter + 1);
-
-    CommonMetrics.INSTANCE.markDBConnection();
-    CommonMetrics.INSTANCE.markDBConnection();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("DB-Connection-meter"), currMeter + 3);
+  public void testMarkDBConnectionMetrics() {
+    MetricsTestUtility.testMeter("DB-Connection-meter", dr, CommonMetrics.INSTANCE::markDBConnection);
   }
-
-
-  /**
-   * Helper method to sleep 20 milli seconds.
-   */
-  private void sleep20Millis() {
-    try {
-      Thread.sleep(20);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-  }
-
 }

--- a/azkaban-common/src/test/java/azkaban/metrics/MetricsTestUtility.java
+++ b/azkaban-common/src/test/java/azkaban/metrics/MetricsTestUtility.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+
+import org.junit.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * This class is designed for a utility class to test drop wizard metrics
+ */
+public class MetricsTestUtility {
+
+  /**
+   * One Dummy Reporter extending {@link ScheduledReporter} collects metrics in various maps,
+   * which test methods are able to access easily.
+   */
+  public static class DummyReporter extends ScheduledReporter{
+
+    private Map<String, String> gaugeMap;
+
+    private Map<String, Long> meterMap;
+
+    public DummyReporter(MetricRegistry registry) {
+      super(registry, "dummy-reporter", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+      this.gaugeMap = new HashMap<>();
+      this.meterMap = new HashMap<>();
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+        SortedMap<String, Counter> counters,
+        SortedMap<String, Histogram> histograms,
+        SortedMap<String, Meter> meters,
+        SortedMap<String, Timer> timers) {
+
+      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        gaugeMap.put(entry.getKey(), entry.getValue().getValue().toString());
+      }
+
+      for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        meterMap.put(entry.getKey(), entry.getValue().getCount());
+      }
+    }
+
+    private String getGauge(String key) {
+      return gaugeMap.get(key);
+    }
+
+    private long getMeter(String key) {
+      return meterMap.getOrDefault(key, 0L);
+    }
+  }
+
+  public static void testMeter(String meterName, DummyReporter dr, Runnable runnable) {
+
+    sleepMillis(20);
+    long currMeter = dr.getMeter(meterName);
+    runnable.run();
+    sleepMillis(20);
+    Assert.assertEquals(dr.getMeter(meterName), currMeter + 1);
+
+    runnable.run();
+    runnable.run();
+    sleepMillis(20);
+    Assert.assertEquals(dr.getMeter(meterName), currMeter + 3);
+  }
+
+  public static void testGauge(String GaugeName, DummyReporter dr, Consumer<Long> func) {
+    func.accept(1L);
+    sleepMillis(20);
+    Assert.assertEquals(dr.getGauge(GaugeName), "1");
+    func.accept(99L);
+    sleepMillis(20);
+    Assert.assertEquals(dr.getGauge(GaugeName), "99");
+  }
+
+
+  /**
+   * Helper method to sleep milli seconds.
+   */
+  private static void sleepMillis(int numMilli) {
+    try {
+      Thread.sleep(numMilli);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   testCompile('org.hamcrest:hamcrest-all:1.3')
   testCompile('org.mockito:mockito-all:1.10.19')
 
-  // Tests in azkaban-wer-server module need some Dummy classes put in azkaban-common
+  //AZ web module tests need to access classes defined in azkaban-common test module
   testCompile project(':azkaban-common').sourceSets.test.output
 
   generateRestli('com.linkedin.pegasus:generator:' + pegasusVersion)

--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -58,6 +58,9 @@ dependencies {
   testCompile('org.hamcrest:hamcrest-all:1.3')
   testCompile('org.mockito:mockito-all:1.10.19')
 
+  // Tests in azkaban-wer-server module need some Dummy classes put in azkaban-common
+  testCompile project(':azkaban-common').sourceSets.test.output
+
   generateRestli('com.linkedin.pegasus:generator:' + pegasusVersion)
   generateRestli('com.linkedin.pegasus:restli-tools:' + pegasusVersion)
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/WebMetrics.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/WebMetrics.java
@@ -38,7 +38,7 @@ public enum WebMetrics {
   private Meter webPostCall;
 
   // How long does user log fetch take when user call fetch-log api.
-  private AtomicLong _logFetchLatency = new AtomicLong(0L);
+  private AtomicLong logFetchLatency = new AtomicLong(0L);
 
   WebMetrics() {
     registry = MetricsManager.INSTANCE.getRegistry();
@@ -48,7 +48,7 @@ public enum WebMetrics {
   private void setupAllMetrics() {
     webGetCall = MetricsUtility.addMeter("Web-Get-Call-Meter", registry);
     webPostCall = MetricsUtility.addMeter("Web-Post-Call-Meter", registry);
-    MetricsUtility.addLongGauge("fetchLogLatency", _logFetchLatency, registry);
+    MetricsUtility.addLongGauge("fetchLogLatency", logFetchLatency, registry);
   }
 
   public void markWebGetCall() {
@@ -68,6 +68,6 @@ public enum WebMetrics {
   }
 
   public void setFetchLogLatency(long milliseconds) {
-    _logFetchLatency.set(milliseconds);
+    logFetchLatency.set(milliseconds);
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/WebMetrics.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/WebMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.webapp;
+
+import azkaban.metrics.MetricsManager;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * This singleton class WebMetrics is in charge of collecting varieties of metrics
+ * from azkaban-web-server modules.
+ */
+public enum WebMetrics {
+  INSTANCE;
+
+  private MetricRegistry _metrics;
+  private Meter _webGetCall;
+  private Meter _webPostCall;
+
+  // How long does user log fetch take when user call fetch-log api.
+  private AtomicLong _logFetchLatency = new AtomicLong(0L);
+
+  WebMetrics() {
+    _metrics = MetricsManager.INSTANCE.getRegistry();
+    setupAllMetrics();
+  }
+
+  private void setupAllMetrics() {
+    _webGetCall = addMeter("Web-Get-Call-Meter");
+    _webPostCall = addMeter("Web-Post-Call-Meter");
+    addLongGauge("fetchLogLatency", _logFetchLatency);
+  }
+
+  public Meter addMeter(String name) {
+    Meter curr = _metrics.meter(name);
+    _metrics.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
+    return curr;
+  }
+
+  public void addLongGauge(String name, AtomicLong ai) {
+    _metrics.register(name, (Gauge<Long>) ai::get);
+  }
+
+  public void markWebGetCall() {
+
+    /*
+     * Two reasons that we don't make this function call synchronized:
+     * 1). code hale metrics deals with concurrency internally;
+     * 2). mark is basically a math addition operation, which should not cause race condition issue.
+     */
+    _webGetCall.mark();
+  }
+
+  public void markWebPostCall() {
+
+    _webPostCall.mark();
+  }
+
+  public void setFetchLogLatency(long milliseconds) {
+    _logFetchLatency.set(milliseconds);
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -517,6 +517,13 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     } catch (ExecutorManagerException e) {
       throw new ServletException(e);
     }
+
+    /*
+     * We originally consider leverage Drop Wizard's Timer API {@link com.codahale.metrics.Timer}
+     * to measure the duration time.
+     * However, Timer will result in too many accompanying metrics (e.g., min, max, 99th quantile)
+     * regarding one metrics. We decided to use gauge to do that and monitor how it behaves.
+     */
     WebMetrics.INSTANCE.setFetchLogLatency(System.currentTimeMillis() - startMs);
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -18,6 +18,7 @@ package azkaban.webapp.servlet;
 
 import azkaban.executor.ExecutorManager;
 import azkaban.utils.FlowUtils;
+import azkaban.webapp.WebMetrics;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -489,6 +490,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private void ajaxFetchExecFlowLogs(HttpServletRequest req,
       HttpServletResponse resp, HashMap<String, Object> ret, User user,
       ExecutableFlow exFlow) throws ServletException {
+    long startMs = System.currentTimeMillis();
     Project project =
         getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
@@ -515,6 +517,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     } catch (ExecutorManagerException e) {
       throw new ServletException(e);
     }
+    WebMetrics.INSTANCE.setFetchLogLatency(System.currentTimeMillis() - startMs);
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -16,23 +16,6 @@
 
 package azkaban.webapp.servlet;
 
-import azkaban.executor.ExecutorManager;
-import azkaban.utils.FlowUtils;
-import azkaban.webapp.WebMetrics;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
-
 import azkaban.constants.ServerProperties;
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlow;
@@ -58,11 +41,28 @@ import azkaban.user.User;
 import azkaban.user.UserManager;
 import azkaban.utils.ExternalLinkUtils;
 import azkaban.utils.FileIOUtils.LogData;
+import azkaban.utils.FlowUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.webapp.AzkabanWebServer;
 import azkaban.webapp.plugin.PluginRegistry;
 import azkaban.webapp.plugin.ViewerPlugin;
+import azkaban.webapp.WebMetrics;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.log4j.Logger;
+
 
 public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private static final Logger LOGGER =

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -16,6 +16,7 @@
 
 package azkaban.webapp.servlet;
 
+import azkaban.webapp.WebMetrics;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -99,6 +100,8 @@ public abstract class LoginAbstractAzkabanServlet extends
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
+
+    WebMetrics.INSTANCE.markWebGetCall();
     // Set session id
     Session session = getSessionFromRequest(req);
     logRequest(req, session);
@@ -133,7 +136,7 @@ public abstract class LoginAbstractAzkabanServlet extends
 
   /**
    * Log out request - the format should be close to Apache access log format
-   * 
+   *
    * @param req
    * @param session
    */
@@ -167,7 +170,7 @@ public abstract class LoginAbstractAzkabanServlet extends
         buf.append("not-browser");
       }
     }
-    
+
     logger.info(buf.toString());
   }
 
@@ -276,7 +279,7 @@ public abstract class LoginAbstractAzkabanServlet extends
   protected void doPost(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
     Session session = getSessionFromRequest(req);
-
+    WebMetrics.INSTANCE.markWebPostCall();
     logRequest(req, session);
 
     // Handle Multipart differently from other post messages

--- a/azkaban-web-server/src/test/java/azkaban/webapp/WebMetricsTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/WebMetricsTest.java
@@ -17,12 +17,12 @@
 package azkaban.webapp;
 
 import azkaban.metrics.MetricsManager;
-import azkaban.metrics.CommonMetricsTest.DummyReporter;
+import azkaban.metrics.MetricsTestUtility.DummyReporter;
+import azkaban.metrics.MetricsTestUtility;
 
-import java.util.concurrent.TimeUnit;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,54 +48,16 @@ public class WebMetricsTest{
 
   @Test
   public void testLogFetchLatencyMetrics() {
-    WebMetrics.INSTANCE.setFetchLogLatency(1L);
-    sleep20Millis();
-    Assert.assertEquals(dr.getGuage("fetchLogLatency"), "1");
-
-    WebMetrics.INSTANCE.setFetchLogLatency(99L);
-    sleep20Millis();
-    Assert.assertEquals(dr.getGuage("fetchLogLatency"), "99");
+    MetricsTestUtility.testGauge("fetchLogLatency", dr, WebMetrics.INSTANCE::setFetchLogLatency);
   }
 
   @Test
   public void testWebPostCallMeter() {
-
-    sleep20Millis();
-    long currMeterNum = dr.getMeter("Web-Post-Call-Meter");
-    WebMetrics.INSTANCE.markWebPostCall();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("Web-Post-Call-Meter"), currMeterNum + 1);
-
-    WebMetrics.INSTANCE.markWebPostCall();
-    WebMetrics.INSTANCE.markWebPostCall();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("Web-Post-Call-Meter"), currMeterNum + 3);
+    MetricsTestUtility.testMeter("Web-Post-Call-Meter", dr, WebMetrics.INSTANCE::markWebPostCall);
   }
 
   @Test
   public void testWebGetCallMeter() {
-
-    sleep20Millis();
-    long currMeterNum = dr.getMeter("Web-Get-Call-Meter");
-    WebMetrics.INSTANCE.markWebGetCall();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("Web-Get-Call-Meter"), currMeterNum + 1);
-
-    WebMetrics.INSTANCE.markWebGetCall();
-    WebMetrics.INSTANCE.markWebGetCall();
-    sleep20Millis();
-    Assert.assertEquals(dr.getMeter("Web-Get-Call-Meter"), currMeterNum + 3);
+    MetricsTestUtility.testMeter("Web-Get-Call-Meter", dr, WebMetrics.INSTANCE::markWebGetCall);
   }
-
-  /**
-   * Helper method to sleep 20 milli seconds.
-   */
-  private void sleep20Millis() {
-    try {
-      Thread.sleep(20);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-  }
-
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/WebMetricsTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/WebMetricsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.webapp;
+
+import azkaban.metrics.MetricsManager;
+import azkaban.metrics.CommonMetricsTest.DummyReporter;
+
+import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class WebMetricsTest{
+
+  private DummyReporter dr;
+
+  @Before
+  public void setup() {
+    dr = new DummyReporter(MetricsManager.INSTANCE.getRegistry());
+    dr.start(Duration.ofMillis(2).toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  @After
+  public void shutdown() {
+    if (null != dr)
+      dr.stop();
+
+    dr = null;
+  }
+
+  @Test
+  public void testLogFetchLatencyMetrics() {
+    WebMetrics.INSTANCE.setFetchLogLatency(1L);
+    sleep20Millis();
+    Assert.assertEquals(dr.getGuage("fetchLogLatency"), "1");
+
+    WebMetrics.INSTANCE.setFetchLogLatency(99L);
+    sleep20Millis();
+    Assert.assertEquals(dr.getGuage("fetchLogLatency"), "99");
+  }
+
+  @Test
+  public void testWebPostCallMeter() {
+
+    sleep20Millis();
+    long currMeterNum = dr.getMeter("Web-Post-Call-Meter");
+    WebMetrics.INSTANCE.markWebPostCall();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("Web-Post-Call-Meter"), currMeterNum + 1);
+
+    WebMetrics.INSTANCE.markWebPostCall();
+    WebMetrics.INSTANCE.markWebPostCall();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("Web-Post-Call-Meter"), currMeterNum + 3);
+  }
+
+  @Test
+  public void testWebGetCallMeter() {
+
+    sleep20Millis();
+    long currMeterNum = dr.getMeter("Web-Get-Call-Meter");
+    WebMetrics.INSTANCE.markWebGetCall();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("Web-Get-Call-Meter"), currMeterNum + 1);
+
+    WebMetrics.INSTANCE.markWebGetCall();
+    WebMetrics.INSTANCE.markWebGetCall();
+    sleep20Millis();
+    Assert.assertEquals(dr.getMeter("Web-Get-Call-Meter"), currMeterNum + 3);
+  }
+
+  /**
+   * Helper method to sleep 20 milli seconds.
+   */
+  private void sleep20Millis() {
+    try {
+      Thread.sleep(20);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+}


### PR DESCRIPTION
This commits create two singletone metrics classes, CommonMetrics and WebMetrics, which are in charge of dealing with collecting and reporting metrics, like user log fetch latency, the number of get rest call in web side. Also added corresponding tests to verify. This commit kicks off the following metrics:
* the rate of Rest Get Call in Webserver
* the rate of Rest Post Call in Webserver
* The rate of DB connection in both web and executor
* user log fetch latency

More metrics could be added easily after the app metrics structure is created.