### PR TITLE
Allow users to specify host alias in azkaban property file.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -26,4 +26,5 @@ public class ServerInternals {
   public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
+  
 }

--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -26,5 +26,4 @@ public class ServerInternals {
   public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
-
 }

--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -26,5 +26,5 @@ public class ServerInternals {
   public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
-  
+
 }

--- a/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
@@ -51,8 +51,8 @@ public class ServerProperties {
   // Hostname for the host, if not specified, canonical hostname will be used
   public static final String AZKABAN_SERVER_HOST_NAME = "azkaban.server.hostname";
 
-  // Legacy configs section, new configs should follow the naming convention of azkaban.server. for server configs
+  // Legacy configs section, new configs should follow the naming convention of azkaban.server.<rest of the name> for server configs.
 
-  // The property is used for web server to get the host name of the executor when running in SOLO mode,
+  // The property is used for the web server to get the host name of the executor when running in SOLO mode.
   public static final String EXECUTOR_HOST = "executor.host";
 }

--- a/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
@@ -48,6 +48,11 @@ public class ServerProperties {
   public static final String IS_METRICS_ENABLED =
       "azkaban.is.metrics.enabled";
 
-  public static final String EXECUTOR_HOST = "executor.host";
+  // Hostname for the host, if not specified, canonical hostname will be used
+  public static final String AZKABAN_SERVER_HOST_NAME = "azkaban.server.hostname";
 
+  // Legacy configs section, new configs should follow the naming convention of azkaban.server. for server configs
+
+  // The property is used for web server to get the host name of the executor when running in SOLO mode,
+  public static final String EXECUTOR_HOST = "executor.host";
 }

--- a/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerProperties.java
@@ -47,4 +47,7 @@ public class ServerProperties {
 
   public static final String IS_METRICS_ENABLED =
       "azkaban.is.metrics.enabled";
+
+  public static final String EXECUTOR_HOST = "executor.host";
+
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.constants.ServerProperties;
 import azkaban.utils.FlowUtils;
 import java.io.File;
 import java.io.IOException;
@@ -196,7 +197,7 @@ public class ExecutorManager extends EventHandler implements
       newExecutors.addAll(executorLoader.fetchActiveExecutors());
     } else if (azkProps.containsKey("executor.port")) {
       // Add local executor, if specified as per properties
-      String executorHost = azkProps.getString("executor.host", "localhost");
+      String executorHost = azkProps.getString(ServerProperties.EXECUTOR_HOST, "localhost");
       int executorPort = azkProps.getInt("executor.port");
       logger.info(String.format("Initializing local executor %s:%d",
         executorHost, executorPort));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -553,8 +553,8 @@ public class AzkabanExecutorServer {
    * @return hostname
    */
   public String getHost() {
-    if(props.containsKey(ServerProperties.EXECUTOR_HOST)) {
-      String hostName = props.getString(ServerProperties.EXECUTOR_HOST);
+    if(props.containsKey(ServerProperties.AZKABAN_SERVER_HOST_NAME)) {
+      String hostName = props.getString(ServerProperties.AZKABAN_SERVER_HOST_NAME);
       if(!StringUtils.isEmpty(hostName)) {
         return hostName;
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -18,6 +18,7 @@ package azkaban.execapp;
 
 import com.google.common.base.Throwables;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.mortbay.jetty.Connector;
@@ -552,6 +553,13 @@ public class AzkabanExecutorServer {
    * @return hostname
    */
   public String getHost() {
+    if(props.containsKey(ServerProperties.EXECUTOR_HOST)) {
+      String hostName = props.getString(ServerProperties.EXECUTOR_HOST);
+      if(!StringUtils.isEmpty(hostName)) {
+        return hostName;
+      }
+    }
+
     String host = "unkownHost";
     try {
       host = InetAddress.getLocalHost().getCanonicalHostName();


### PR DESCRIPTION
User can fill in their own alias in property file. It will be used as hostname in getHost(). If not configured we will use canonical hostname as fallback.