### PR TITLE
Issue #924 - new lookup table and guards on table create SQL statements.

### DIFF
--- a/azkaban-sql/src/sql/create.active_executing_flows.sql
+++ b/azkaban-sql/src/sql/create.active_executing_flows.sql
@@ -1,5 +1,6 @@
-CREATE TABLE active_executing_flows (
+CREATE TABLE if NOT EXISTS active_executing_flows (
 	exec_id INT,
 	update_time BIGINT,
 	PRIMARY KEY (exec_id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/azkaban-sql/src/sql/create.active_sla.sql
+++ b/azkaban-sql/src/sql/create.active_sla.sql
@@ -1,4 +1,4 @@
-CREATE TABLE active_sla (
+CREATE TABLE if NOT EXISTS active_sla (
 	exec_id INT NOT NULL,
 	job_name VARCHAR(128) NOT NULL,
 	check_time BIGINT NOT NULL,
@@ -6,4 +6,4 @@ CREATE TABLE active_sla (
 	enc_type TINYINT,
 	options LONGBLOB NOT NULL,
 	primary key(exec_id, job_name)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/azkaban-sql/src/sql/create.execution_flows.sql
+++ b/azkaban-sql/src/sql/create.execution_flows.sql
@@ -1,4 +1,4 @@
-CREATE TABLE execution_flows (
+CREATE TABLE if NOT EXISTS execution_flows (
 	exec_id INT NOT NULL AUTO_INCREMENT,
 	project_id INT NOT NULL,
 	version INT NOT NULL,
@@ -13,7 +13,8 @@ CREATE TABLE execution_flows (
 	flow_data LONGBLOB,
 	executor_id INT DEFAULT NULL,
 	PRIMARY KEY (exec_id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX ex_flows_start_time ON execution_flows(start_time);
 CREATE INDEX ex_flows_end_time ON execution_flows(end_time);

--- a/azkaban-sql/src/sql/create.execution_flows_status.sql
+++ b/azkaban-sql/src/sql/create.execution_flows_status.sql
@@ -1,0 +1,26 @@
+-- -----------------------------------------------------------------
+-- Create lookup table for 'status' values in execution_flows table
+-- -----------------------------------------------------------------
+CREATE TABLE if NOT EXISTS execution_flows_status (
+	name VARCHAR(64),
+	status INT,
+	PRIMARY KEY (name)
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
+-- -----------------------------------------------------------------
+-- Populate enum values into lookup table
+-- -----------------------------------------------------------------
+INSERT INTO execution_flows_status (name, status) VALUES 
+  ("READY",10),
+  ("PREPARING",20),
+  ("RUNNING",30),
+  ("PAUSED",40),
+  ("SUCCEEDED",50),
+  ("KILLED",60),
+  ("FAILED",70),
+  ("FAILED_FINISHING",80),
+  ("SKIPPED",90),
+  ("DISABLED",100),
+  ("QUEUED",110),
+  ("FAILED_SUCCEEDED",120),
+  ("CANCELED",130);

--- a/azkaban-sql/src/sql/create.execution_jobs.sql
+++ b/azkaban-sql/src/sql/create.execution_jobs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE execution_jobs (
+CREATE TABLE if NOT EXISTS execution_jobs (
 	exec_id INT NOT NULL,
 	project_id INT NOT NULL,
 	version INT NOT NULL,
@@ -12,7 +12,8 @@ CREATE TABLE execution_jobs (
 	output_params LONGBLOB,
 	attachments LONGBLOB,
 	PRIMARY KEY (exec_id, job_id, attempt)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX exec_job ON execution_jobs(exec_id, job_id);
 CREATE INDEX exec_id ON execution_jobs(exec_id);

--- a/azkaban-sql/src/sql/create.execution_logs.sql
+++ b/azkaban-sql/src/sql/create.execution_logs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE execution_logs (
+CREATE TABLE if NOT EXISTS execution_logs (
 	exec_id INT NOT NULL,
 	name VARCHAR(128),
 	attempt INT,
@@ -8,7 +8,8 @@ CREATE TABLE execution_logs (
 	log LONGBLOB,
 	upload_time BIGINT,
 	PRIMARY KEY (exec_id, name, attempt, start_byte)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX ex_log_attempt ON execution_logs(exec_id, name, attempt);
 CREATE INDEX ex_log_index ON execution_logs(exec_id, name);

--- a/azkaban-sql/src/sql/create.executor_events.sql
+++ b/azkaban-sql/src/sql/create.executor_events.sql
@@ -1,9 +1,10 @@
-CREATE TABLE executor_events (
+CREATE TABLE if NOT EXISTS executor_events (
   executor_id INT NOT NULL,
   event_type TINYINT NOT NULL,
   event_time DATETIME NOT NULL,
   username VARCHAR(64),
   message VARCHAR(512)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX executor_log ON executor_events(executor_id, event_time);

--- a/azkaban-sql/src/sql/create.executors.sql
+++ b/azkaban-sql/src/sql/create.executors.sql
@@ -1,10 +1,11 @@
-CREATE TABLE executors (
+CREATE TABLE if NOT EXISTS executors (
   id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
   host VARCHAR(64) NOT NULL,
   port INT NOT NULL,
   active BOOLEAN DEFAULT false,
   UNIQUE (host, port),
   UNIQUE INDEX executor_id (id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX executor_connection ON executors(host, port);

--- a/azkaban-sql/src/sql/create.project_events.sql
+++ b/azkaban-sql/src/sql/create.project_events.sql
@@ -1,9 +1,10 @@
-CREATE TABLE project_events (
+CREATE TABLE if NOT EXISTS project_events (
 	project_id INT NOT NULL,
 	event_type TINYINT NOT NULL,
 	event_time BIGINT NOT NULL,
 	username VARCHAR(64),
 	message VARCHAR(512)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX log ON project_events(project_id, event_time);

--- a/azkaban-sql/src/sql/create.project_files.sql
+++ b/azkaban-sql/src/sql/create.project_files.sql
@@ -1,10 +1,11 @@
-CREATE TABLE project_files (
+CREATE TABLE if NOT EXISTS project_files (
 	project_id INT NOT NULL,
 	version INT not NULL,
 	chunk INT,
 	size INT,
 	file LONGBLOB,
 	PRIMARY KEY (project_id, version, chunk)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX file_version ON project_files(project_id, version);

--- a/azkaban-sql/src/sql/create.project_flows.sql
+++ b/azkaban-sql/src/sql/create.project_flows.sql
@@ -1,4 +1,4 @@
-CREATE TABLE project_flows (
+CREATE TABLE if NOT EXISTS project_flows (
 	project_id INT NOT NULL,
 	version INT NOT NULL,
 	flow_id VARCHAR(128),
@@ -6,6 +6,7 @@ CREATE TABLE project_flows (
 	encoding_type TINYINT,
 	json BLOB,
 	PRIMARY KEY (project_id, version, flow_id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX flow_index ON project_flows(project_id, version);

--- a/azkaban-sql/src/sql/create.project_permissions.sql
+++ b/azkaban-sql/src/sql/create.project_permissions.sql
@@ -1,10 +1,11 @@
-CREATE TABLE project_permissions (
+CREATE TABLE if NOT EXISTS project_permissions (
 	project_id VARCHAR(64) NOT NULL,
 	modified_time BIGINT NOT NULL,
 	name VARCHAR(64) NOT NULL,
 	permissions INT NOT NULL,
 	isGroup BOOLEAN NOT NULL,
 	PRIMARY KEY (project_id, name)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX permission_index ON project_permissions(project_id);

--- a/azkaban-sql/src/sql/create.project_properties.sql
+++ b/azkaban-sql/src/sql/create.project_properties.sql
@@ -1,4 +1,4 @@
-CREATE TABLE project_properties (
+CREATE TABLE if NOT EXISTS project_properties (
 	project_id INT NOT NULL,
 	version INT NOT NULL,
 	name VARCHAR(255),
@@ -6,6 +6,7 @@ CREATE TABLE project_properties (
 	encoding_type TINYINT,
 	property BLOB,
 	PRIMARY KEY (project_id, version, name)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX properties_index ON project_properties(project_id, version);

--- a/azkaban-sql/src/sql/create.project_versions.sql
+++ b/azkaban-sql/src/sql/create.project_versions.sql
@@ -1,4 +1,4 @@
-CREATE TABLE project_versions (
+CREATE TABLE if NOT EXISTS project_versions (
 	project_id INT NOT NULL,
 	version INT not NULL,
 	upload_time BIGINT NOT NULL,
@@ -8,6 +8,7 @@ CREATE TABLE project_versions (
 	md5 BINARY(16),
 	num_chunks INT,
 	PRIMARY KEY (project_id, version)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX version_index ON project_versions(project_id);

--- a/azkaban-sql/src/sql/create.projects.sql
+++ b/azkaban-sql/src/sql/create.projects.sql
@@ -1,4 +1,4 @@
-CREATE TABLE projects (
+CREATE TABLE if NOT EXISTS projects (
 	id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	name VARCHAR(64) NOT NULL,
 	active BOOLEAN,
@@ -10,6 +10,7 @@ CREATE TABLE projects (
 	enc_type TINYINT,
 	settings_blob LONGBLOB,
 	UNIQUE INDEX project_id (id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE INDEX project_name ON projects(name);

--- a/azkaban-sql/src/sql/create.properties.sql
+++ b/azkaban-sql/src/sql/create.properties.sql
@@ -1,7 +1,8 @@
-CREATE TABLE properties (
+CREATE TABLE if NOT EXISTS properties (
 	name VARCHAR(64) NOT NULL,
 	type INT NOT NULL,
 	modified_time BIGINT NOT NULL,
 	value VARCHAR(256),
 	PRIMARY KEY (name, type)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/azkaban-sql/src/sql/create.triggers.sql
+++ b/azkaban-sql/src/sql/create.triggers.sql
@@ -1,8 +1,9 @@
-CREATE TABLE triggers (
+CREATE TABLE if NOT EXISTS triggers (
 	trigger_id INT NOT NULL AUTO_INCREMENT,
 	trigger_source VARCHAR(128),
 	modify_time BIGINT NOT NULL,
 	enc_type TINYINT,
 	data LONGBLOB,
 	PRIMARY KEY (trigger_id)
-);
+)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
As described in [issue #924](https://github.com/azkaban/azkaban/issues/924), this PR is to add a lookup table to allow backend DB queries to expand the numeric values in the execution_flows.status field.   Additionally guards were put in place to prevent 'create table' statements from overwriting existing tables.  I also specified that InnoDB should be the default DB engine for each table.  (InnoDB is the default in MySQL 5.5.5 & newer.)

Testing was done manually.  After running 'gradlew distTar', I ran the schema script on a new database, followed by mysqldump to confirm the contents looked sane.   If there's a better way to test sql statements, I would be happy to test them.  

Thanks.