### PR TITLE
Issue #924 - new sql lookup table

### DIFF
--- a/azkaban-sql/src/sql/create.execution_flows_status.sql
+++ b/azkaban-sql/src/sql/create.execution_flows_status.sql
@@ -1,0 +1,25 @@
+-- -----------------------------------------------------------------
+-- Create lookup table for 'status' values in execution_flows table
+-- -----------------------------------------------------------------
+CREATE TABLE if NOT EXISTS execution_flows_status (
+	name VARCHAR(64),
+	status INT,
+	PRIMARY KEY (name)
+);
+-- -----------------------------------------------------------------
+-- Populate enum values into lookup table
+-- -----------------------------------------------------------------
+INSERT INTO execution_flows_status (name, status) VALUES 
+  ("READY",10),
+  ("PREPARING",20),
+  ("RUNNING",30),
+  ("PAUSED",40),
+  ("SUCCEEDED",50),
+  ("KILLED",60),
+  ("FAILED",70),
+  ("FAILED_FINISHING",80),
+  ("SKIPPED",90),
+  ("DISABLED",100),
+  ("QUEUED",110),
+  ("FAILED_SUCCEEDED",120),
+  ("CANCELED",130);


### PR DESCRIPTION
As disscussed in #924, I'd like to add a lookup table to allow backend DB queries to expand the numeric values in the execution_flows.status field.   This table is external to the azkaban application and is being added as a convenience for external reporting.  

For example, using an external program I may want to query the execution_flows table to see how many failed jobs we had in the last month?  Currently, I would have to copy the  status enum datatype values from Status.java into my script.  With the proposed lookup table, I can perform a join on the status column during my sql query and have these values printed as part of the SQL return statement.

Testing was done manually. After running 'gradlew distTar', I ran the schema script on a new database to create the new table.  This was followed by mysqldump to confirm the contents looked sane.