### PR TITLE
Insert azkaban.job.id before building job type

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -58,10 +58,6 @@ public class ProcessJob extends AbstractProcessJob {
   public ProcessJob(final String jobId, final Props sysProps,
       final Props jobProps, final Logger log) {
     super(jobId, sysProps, jobProps, log);
-
-    // this is in line with what other job types (hadoopJava, spark, pig, hive)
-    // is doing
-    jobProps.put(CommonJobProperties.JOB_ID, jobId);
   }
 
   @Override

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -599,6 +599,7 @@ public class JobRunner extends EventHandler implements Runnable {
       insertJobMetadata();
       insertJVMAargs();
 
+      props.put(CommonJobProperties.JOB_ID, this.jobId);
       props.put(CommonJobProperties.JOB_ATTEMPT, node.getAttempt());
       props.put(CommonJobProperties.JOB_METADATA_FILE,
           createMetaDataFileName(node));


### PR DESCRIPTION
We've seen issues where 'azkaban.job.id' cannot be resolved when building job type:
"Failed to build job executor for job TestJobId_CommandCould not find variable substitution for variable(s) [command->azkaban.job.id]"
 'azkaban.job.id' is common to all job types. It should be inserted into jobProps before building job types. 