### PR TITLE
Remove the DB monitoring thread

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -127,8 +127,6 @@ public class DataSourceUtils {
    */
   public static class MySQLBasicDataSource extends AzkabanDataSource {
 
-    private static MonitorThread monitorThread = null;
-
     private final String url;
 
     private MySQLBasicDataSource(String host, int port, String dbName,
@@ -145,11 +143,6 @@ public class DataSourceUtils {
       setMaxActive(numConnections);
       setValidationQuery("/* ping */ select 1");
       setTestOnBorrow(true);
-
-      if (monitorThread == null) {
-        monitorThread = new MonitorThread(this);
-        monitorThread.start();
-      }
     }
 
     @Override
@@ -161,51 +154,6 @@ public class DataSourceUtils {
     public String getDBType() {
       return "mysql";
     }
-
-    private class MonitorThread extends Thread {
-      private static final long MONITOR_THREAD_WAIT_INTERVAL_MS = 30 * 1000;
-      private boolean shutdown = false;
-      MySQLBasicDataSource dataSource;
-
-      public MonitorThread(MySQLBasicDataSource mysqlSource) {
-        this.setName("MySQL-DB-Monitor-Thread");
-        setDaemon(true);
-        dataSource = mysqlSource;
-      }
-
-      @SuppressWarnings("unused")
-      public void shutdown() {
-        shutdown = true;
-        this.interrupt();
-      }
-
-      public void run() {
-        while (!shutdown) {
-          synchronized (this) {
-            try {
-              pingDB();
-              wait(MONITOR_THREAD_WAIT_INTERVAL_MS);
-            } catch (InterruptedException e) {
-              logger.info("Interrupted. Probably to shut down.");
-            }
-          }
-        }
-      }
-
-      private void pingDB() {
-        Connection connection = null;
-        try {
-          connection = dataSource.getConnection();
-          PreparedStatement query = connection.prepareStatement("SELECT 1");
-          query.execute();
-        } catch (SQLException e) {
-          logger.error("Unable to reach MySQL server on " + url);
-        } finally {
-          DbUtils.closeQuietly(connection);
-        }
-      }
-    }
-
   }
 
   /**


### PR DESCRIPTION
Since the datasource using the Apache DBCP library has the following
Properties set:

  setValidationQuery("/* ping */ select 1");
  setTestOnBorrow(true);

The library will do the validation of the connection every time
a connection is borrowed from the pool.
See
https://arviarya.wordpress.com/2013/02/15/apache-dbcp-connection-pool-revisited/

The DB monitoring thread is not necessary and adds overhead and
complexity.

Testing:
Ran unit tests.
Ran a simple test flow in solo server mode.