### PR TITLE
Fixing js libraries version compatibility

### DIFF
--- a/azkaban-web-server/package.json
+++ b/azkaban-web-server/package.json
@@ -3,13 +3,13 @@
   "name": "azkaban",
   "description": "Azkaban 3 [![Build Status](http://img.shields.io/travis/azkaban/azkaban.svg?style=flat)](https://travis-ci.org/azkaban/azkaban) ========",
   "dependencies": {
-    "mocha": "^3.0.2",
-    "rewire": "^2.5.2",
-    "chai": "^3.5.0",
-    "later": "^1.2.0",
-    "eonasdan-bootstrap-datetimepicker": "^4.0.0",
-    "moment-timezone": "^0.5.5",
-    "moment": "^2.14.1"
+    "mocha": "3.0.2",
+    "rewire": "2.5.2",
+    "chai": "3.5.0",
+    "later": "1.2.0",
+    "eonasdan-bootstrap-datetimepicker": "4.17.47",
+    "moment-timezone": "0.5.5",
+    "moment": "2.14.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Issue #975 reported a bug that the name of moment-timezone js is not right, and gradle can not fetch it to distribution package.

Tried gradle build, and figured out that the latest moment-timezone js 0.5.13 is not compatible with 0.5.5, since the js file built's name doesn't keep the same.

We used to leverage `^` to specify compatible js libraries (see details in https://docs.npmjs.com/misc/semver). In this change, we disable it to in order to secure repo.

Gradle Build works, and target-version libraries are downloaded. Also, I made a bit evaluation on google chrome, and no problem.