### PR TITLE
use full moment-timezone js and add test

### DIFF
--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -93,7 +93,7 @@ task movingJsTojsToPackage(dependsOn: ['npm_install']) {
       into "${buildDir}/jsToPackage"
     }
     copy {
-      from "node_modules/moment-timezone/builds/moment-timezone-with-data-2010-2020.min.js"
+      from "node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"
       into "${buildDir}/jsToPackage"
     }
   }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -18,7 +18,7 @@
 <script type="text/javascript" src="${context}/js/azkaban/view/schedule-panel.js?version=20161031"></script>
 <script type="text/javascript" src="${context}/js/moment.min.js" ></script>
 <script type="text/javascript" src="${context}/js/later.min.js"></script>
-<script type="text/javascript" src="${context}/js/moment-timezone-with-data-2010-2020.min.js"></script>
+<script type="text/javascript" src="${context}/js/moment-timezone-with-data.min.js"></script>
 <style type="text/css">
   .input-box { position: relative; }
   .input-box input { display: block; border: 1px solid #d7d6d6; background: #fff; padding: 10px 10px 10px 20px; width: 195px; }

--- a/azkaban-web-server/src/web/js/azkaban/test/test.js
+++ b/azkaban-web-server/src/web/js/azkaban/test/test.js
@@ -7,8 +7,11 @@ function addClass(el, newClass) {
 var rewire = require('rewire'),
     dateJs = rewire('../util/date.js');
 
-var chai = require('chai');
-var assert = chai.assert;
+var moment = require('moment-timezone');
+
+var chai = require('chai'),
+    assert = chai.assert;
+
 
 //Some Test instances
 describe('addClass', function() {
@@ -50,7 +53,7 @@ describe('CronTransformation', function() {
    assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5 2016'), '0 3 * * 0,2-4 2016');
    assert.equal(testStrFromCronToQuartz('0 3 * * 5#3'), '0 3 * * 4#3');
    assert.equal(testStrFromCronToQuartz('0 3 * * 5-7#3'), '0 3 * * 4-6#3');
-   assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5#3 2016'), '0 3 * * 0,2-4#3 2016'); 
+   assert.equal(testStrFromCronToQuartz('0 3 * * 1,3-5#3 2016'), '0 3 * * 0,2-4#3 2016');
   });
 });
 
@@ -71,5 +74,23 @@ describe('ValidateQuartzStr', function() {
    assert.equal(validateQuartzStr('0 3 * ? 5 FRI'), 'VALID');
    assert.equal(validateQuartzStr('0 3 * ? 5 3-6'), 'VALID');
 
+  });
+});
+
+//Test moment js and moment timezone js
+describe('momentJSTest', function() {
+
+  var momentObj= moment();
+
+  it('momentJSTest', function() {
+    assert.equal(moment('20170411', 'YYYYMMDD').format('MM-YYYY'), '04-2017');
+  });
+
+  it('momentTimezoneTest', function() {
+
+    // Refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC
+    // month: 3 represents April
+    var dateTime = Date.UTC(2017, 3, 11, 11, 17, 0);
+    assert.equal(moment(dateTime).tz('America/Los_Angeles').format("LLL"), 'April 11, 2017 4:17 AM');
   });
 });


### PR DESCRIPTION
We previously used timezone-2010-to-2020 js file, which wis working. However, its name got changed when moment timezone upgraded to 0.5.13. In this change, we replace the file by the full-time-range timezone js, which will permanently stay and should not be changed in future. Also, we add some moment js tests to guarantee moment js working.