### PR TITLE
Ignore the top level "temp" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 Gemfile.lock
 vendor/
 
+# temp directory is ignored so that it can be used to store temporary files such as local testing configurations.
+temp/
+
 # Intellij files
 .idea
 *.iml


### PR DESCRIPTION
"temp" directory is ignored so that it can be used to store temporary files such as local testing configurations.