### PR TITLE
implementing DB retry logics

### DIFF
--- a/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
+++ b/azkaban-common/src/main/java/azkaban/constants/ServerInternals.java
@@ -34,4 +34,6 @@ public class ServerInternals {
   // Max number of memory check retry
   public static final int MEMORY_CHECK_RETRY_LIMIT = 720;
 
+  // The MAX number of Retries when looking for a DB connection. The whole waiting time will be 1 hour.
+  public static final int MAX_DB_RETRY_COUNT = 360;
 }


### PR DESCRIPTION
when DB runs unstably (or, DB switch), Azkaban today fails to respond generally. Schedule, Execution, Fetch all fail because AZ can not talk to database. In this change, we implement an DB retry logics to enforce retry fetching potential connection, when AZ could not find a stable DB connection.

Still in progress. submit PR for discussion. The main problem is the timeout setting.

Haven't done test yet.