### PR TITLE
Update DBCP library to 2.1.1

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
   compile('com.google.guava:guava:13.0.1')
   compile('commons-collections:commons-collections:3.2.2')
-  compile('commons-dbcp:commons-dbcp:1.4')
+  compile('org.apache.commons:commons-dbcp2:2.1.1')
   compile('commons-dbutils:commons-dbutils:1.5')
   compile('commons-fileupload:commons-fileupload:1.2.1')
   compile('commons-io:commons-io:2.4')

--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDataSource.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDataSource.java
@@ -16,7 +16,7 @@
 
 package azkaban.database;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 public abstract class AzkabanDataSource extends BasicDataSource {
   public abstract boolean allowsOnDuplicateKey();

--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -137,7 +137,7 @@ public class DataSourceUtils {
       setUsername(user);
       setPassword(password);
       setUrl(url);
-      setMaxActive(numConnections);
+      setMaxTotal(numConnections);
       setValidationQuery("/* ping */ select 1");
       setTestOnBorrow(true);
     }


### PR DESCRIPTION
Fix #932

The getParentLogger method was added in the new JDBC API since Java 7.
The old version of DBCP doesn't support it and causes Intellij to give
an error.

The new DBCP library is not backward compatible.
Changed a method to use a new method available in the new library.

From DBCP release history page
https://commons.apache.org/proper/commons-dbcp/changes-report.html

2.0
"This release includes new features as well as bug fixes and enhancements. Version 2.0.x supports JDBC 4.1, so requires Java 7. The Java package name has been changed from 'org.apache.commons.dbcp' to 'org.apache.commons.dbcp2'. Also the Maven groupId is now 'org.apache.commons' and the artifactId is 'commons-dbcp2' These changes are necessary because the API is not strictly binary compatible with the 1.x releases. To convert from the earlier releases, update the package name in imports, update the dependencies and recompile. There may be a few other changes to be made. Applications running under Java 7 should use DBCP 2.0.x. Java 6 users should use DBCP 1.4.x which supports JDBC 4. Java 1.4 and Java 5 users should use DBCP 1.3.x which supports JDBC 3."

Testing:

Ran some basic tests locally and in a test cluster.