### PR TITLE
Update Gauva,Error Prone. Fix errors

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -34,7 +34,7 @@ model {
 dependencies {
   compile project(':azkaban-spi')
 
-  compile('com.google.guava:guava:13.0.1')
+  compile('com.google.guava:guava:21.0')
   compile('commons-collections:commons-collections:3.2.2')
   compile('org.apache.commons:commons-dbcp2:2.1.1')
   compile('commons-dbutils:commons-dbutils:1.5')

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -328,8 +328,7 @@ public class JobTypeManager {
       if (jobType == null || jobType.length() == 0) {
         /* throw an exception when job name is null or empty */
         throw new JobExecutionException(String.format(
-            "The 'type' parameter for job[%s] is null or empty", jobProps,
-            logger));
+            "The 'type' parameter for job[%s] is null or empty", jobProps));
       }
 
       logger.info("Building " + jobType + " job executor. ");

--- a/azkaban-common/src/test/java/azkaban/trigger/MockTriggerLoader.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/MockTriggerLoader.java
@@ -37,7 +37,7 @@ public class MockTriggerLoader implements TriggerLoader {
   @Override
   public synchronized void removeTrigger(Trigger s)
       throws TriggerLoaderException {
-    triggers.remove(s);
+    triggers.remove(s.getTriggerId());
   }
 
   @Override

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -447,8 +447,6 @@ public class FlowRunnerManager implements EventListener,
             } catch (IOException e) {
               logger.error(e);
             }
-
-            installedVersions.remove(versionKey);
           }
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.cinnober.gradle:semver-git:2.2.1'
-    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.8'
+    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
   }
 }
 
@@ -29,10 +29,6 @@ subprojects {
 
   // Set the same version for all sub-projects to root project version
   version = rootProject.version
-
-  configurations.errorprone {
-    resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.0.5'
-  }
 
   plugins.withType(JavaPlugin) {
     sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
The update flagged three errors.

"installedVersions.remove(versionKey);"
The type of the value doesn't match the actual type defined in the list.
Upon close inspection, it turns out that if the entry were
correctly removed, it would cause a logical error since the
for loop access the list by an index the list should not be modified
within the same loop.
Since this is only a local variable, it is ok not updating it after old project versions are deleted.