### PR TITLE
[Prototype code] Storage API: Add hash to Storage Metadata

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -63,7 +63,7 @@ public class LocalStorage implements Storage {
       log.info("Created project dir: " + projectDir.getAbsolutePath());
     }
 
-    final File targetFile = new File(projectDir, metadata.getVersion() + "." + metadata.getExtension());
+    final File targetFile = new File(projectDir, generateFilename(metadata));
 
     if (targetFile.exists()) {
       throw new StorageException(String.format(
@@ -77,6 +77,16 @@ public class LocalStorage implements Storage {
       throw new StorageException(e);
     }
     return createRelativeURI(targetFile);
+  }
+
+  private String generateFilename(StorageMetadata metadata) {
+    return new StringBuilder()
+        .append(metadata.getProjectId())
+        .append("_")
+        .append(metadata.getHash())
+        .append(".")
+        .append(metadata.getExtension())
+        .toString();
   }
 
   private URI createRelativeURI(File targetFile) {
@@ -98,7 +108,7 @@ public class LocalStorage implements Storage {
 
   private static File validateBaseDirectory(File baseDirectory) {
     checkArgument(baseDirectory.isDirectory());
-    if (!FileIOUtils.isDirWritable(baseDirectory)) {
+    if (!baseDirectory.canWrite()) {
       throw new IllegalArgumentException("Directory not writable: " + baseDirectory);
     }
     return baseDirectory;

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -84,7 +84,8 @@ public class StorageManager {
   }
 
   private String getLatestVersion(int id) {
-    return "version";
+    // TODO Implement
+    return "-1";
   }
 
   private void updateDatabase(StorageMetadata metadata, String filename, String uploader) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -42,31 +42,6 @@ import org.apache.log4j.Logger;
 public class FileIOUtils {
   private final static Logger logger = Logger.getLogger(FileIOUtils.class);
 
-  /**
-   * Check if a directory is writable
-   *
-   * @param dir directory file object
-   * @return true if it is writable. false, otherwise
-   */
-  public static boolean isDirWritable(File dir) {
-    File testFile = null;
-    try {
-      testFile = new File(dir, "_tmp");
-      /*
-       * Create and delete a dummy file in order to check file permissions. Maybe
-       * there is a safer way for this check.
-       */
-      testFile.createNewFile();
-    } catch (IOException e) {
-      return false;
-    } finally {
-      if (testFile != null) {
-        testFile.delete();
-      }
-    }
-    return true;
-  }
-
   public static class PrefixSuffixFileFilter implements FileFilter {
     private String prefix;
     private String suffix;

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -56,20 +56,25 @@ public class LocalStorageTest {
     ClassLoader classLoader = getClass().getClassLoader();
     File testFile = new File(classLoader.getResource(SAMPLE_FILE).getFile());
 
+    final String testProjectId = "testProjectId";
+    final String hash = "myhash";
+
     URI key;
     try (InputStream is = new FileInputStream(testFile)) {
       // test put
-      key = localStorage.put(new StorageMetadata("testProjectId", "1", "zip"), is);
+      key = localStorage.put(new StorageMetadata(testProjectId, "1", "zip", hash), is);
     }
     assertNotNull(key);
     log.info("Key URI: " + key);
 
     File expectedTargetFile = new File(BASE_DIRECTORY, new StringBuilder()
-        .append("testProjectId")
+        .append(testProjectId)
         .append(File.separator)
-        .append("1.zip")
-        .toString()
-    );
+        .append(testProjectId)
+        .append("_")
+        .append(hash)
+        .append(".zip")
+        .toString());
     assertTrue(expectedTargetFile.exists());
     assertTrue(FileUtils.contentEquals(testFile, expectedTargetFile));
 

--- a/azkaban-spi/src/main/java/azkaban/spi/StorageMetadata.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/StorageMetadata.java
@@ -26,16 +26,19 @@ public class StorageMetadata {
   private final String projectId;
   private final String version;
   private final String extension;
+  private final String hash;
 
-  public StorageMetadata(String projectId, String version, String extension) {
+  public StorageMetadata(String projectId, String version, String extension, String hash) {
     this.projectId = requireNonNull(projectId);
     this.version = requireNonNull(version);
     this.extension = requireNonNull(extension);
+    this.hash = requireNonNull(hash);
   }
 
   @Override
   public String toString() {
-    return "StorageMetadata{" + "projectId='" + projectId + '\'' + ", version='" + version + '\'' + '}';
+    return "StorageMetadata{" + "projectId='" + projectId + '\'' + ", version='" + version + '\'' + ", extension='"
+        + extension + '\'' + ", hash='" + hash + '\'' + '}';
   }
 
   public String getProjectId() {
@@ -50,6 +53,10 @@ public class StorageMetadata {
     return extension;
   }
 
+  public String getHash() {
+    return hash;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -58,14 +65,13 @@ public class StorageMetadata {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    StorageMetadata that = (StorageMetadata) o;
-    return Objects.equals(projectId, that.projectId) &&
-        Objects.equals(version, that.version) &&
-        Objects.equals(extension, that.extension);
+    StorageMetadata metadata = (StorageMetadata) o;
+    return Objects.equals(projectId, metadata.projectId) && Objects.equals(version, metadata.version) && Objects.equals(
+        extension, metadata.extension) && Objects.equals(hash, metadata.hash);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(projectId, version, extension);
+    return Objects.hash(projectId, version, extension, hash);
   }
 }


### PR DESCRIPTION
Adding hash information to storage metadata since it may be required during storage.

**Please note** that the code changes here do not affect any module since they are not yet wired up and thus can't get executed. [No static code injection]