### PR TITLE
Show test failure details in cmdline output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ subprojects {
    */
   test {
     testLogging {
+      exceptionFormat = 'full'
       afterSuite { desc, result ->
         if (desc.getParent()) {
           logger.info desc.getName()


### PR DESCRIPTION
It will make checking the test failure details easier especially on travis. I can't find a way to read the full test report on travis.

see http://mrhaki.blogspot.com/2013/05/gradle-goodness-show-more-information.html

Testing:
```
Introduced a test failure intentionally.
Before:

:azkaban-web-server:test

azkaban.webapp.WebMetricsTest > testWebGetCallMeter FAILED
    java.lang.AssertionError at WebMetricsTest.java:62

19 tests completed, 1 failed
:azkaban-web-server:test FAILED
```

After:
```
:azkaban-web-server:test

azkaban.webapp.WebMetricsTest > testWebGetCallMeter FAILED
    java.lang.AssertionError: failed intentionally
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at azkaban.webapp.WebMetricsTest.testWebGetCallMeter(WebMetricsTest.java:62)

19 tests completed, 1 failed
:azkaban-web-server:test FAILED
```