### PR TITLE
ExecutorFilter: fix debug info

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorFilter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorFilter.java
@@ -163,7 +163,7 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
         ExecutorInfo stats = filteringTarget.getExecutorInfo();
         if (null == stats) {
           logger.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
-              MINIMUMFREEMEMORY_FILTER_NAME,
+              CPUSTATUS_FILTER_NAME,
               filteringTarget.toString()));
           return false;
         }


### PR DESCRIPTION
Fixed copy & paste error (logging inside CpuStatusFilter should use CPUSTATUS_FILTER_NAME, not MINIMUMFREEMEMORY_FILTER_NAME)