### PR TITLE
Update com.cinnober.gradle.semver-git plugin to 2.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.cinnober.gradle:semver-git:2.2.1'
+    classpath 'com.cinnober.gradle:semver-git:2.2.3'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
   }
 }


### PR DESCRIPTION
The update resolved a build warning:
"The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead."

see
https://github.com/cinnober/semver-git/releases