### PR TITLE
Fix Gradle warning: Task.leftShift(Closure) method has been deprecated

### DIFF
--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -124,12 +124,14 @@ task restliTemplateGenerator(type: JavaExec) {
   classpath = configurations.generateRestli
 }
 
-task restliRestSpecGenerator(dependsOn: [restliTemplateGenerator], type: JavaExec) << {
-  mkdir 'src/restli/generatedRestSpec'
+task restliRestSpecGenerator(dependsOn: [restliTemplateGenerator], type: JavaExec) {
+  doLast {
+    mkdir 'src/restli/generatedRestSpec'
 
-  main = 'com.linkedin.restli.tools.idlgen.RestLiResourceModelExporterCmdLineApp'
-  args = ['-outdir', 'src/restli/generatedRestSpec', '-sourcepath', 'src/restli/java']
-  classpath = configurations.generateRestli
+    main = 'com.linkedin.restli.tools.idlgen.RestLiResourceModelExporterCmdLineApp'
+    args = ['-outdir', 'src/restli/generatedRestSpec', '-sourcepath', 'src/restli/java']
+    classpath = configurations.generateRestli
+  }
 }
 
 task restli(dependsOn: restliTemplateGenerator) << {


### PR DESCRIPTION
The update resolved a build warning in the web server sub-project:
"The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead."

see
http://mrhaki.blogspot.com/2016/11/gradle-goodness-replacing-operator-for.html