### PR TITLE
Fix ClassCanBeStatic warnings in common sub-project

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerLoader.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerLoader.java
@@ -266,7 +266,7 @@ public class JdbcTriggerLoader extends AbstractJdbcLoader implements
 
   }
 
-  public class TriggerResultHandler implements ResultSetHandler<List<Trigger>> {
+  public static class TriggerResultHandler implements ResultSetHandler<List<Trigger>> {
 
     @Override
     public List<Trigger> handle(ResultSet rs) throws SQLException {

--- a/azkaban-common/src/test/java/azkaban/executor/SelectorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/SelectorTest.java
@@ -36,7 +36,7 @@ import azkaban.utils.JSONUtils;
 
 public class SelectorTest {
   // mock executor object.
-  protected static class MockExecutorObject implements Comparable <MockExecutorObject>{
+  static class MockExecutorObject implements Comparable <MockExecutorObject>{
     public String name;
     public int    port;
     public double percentOfRemainingMemory;
@@ -78,7 +78,7 @@ public class SelectorTest {
   }
 
   // Mock flow object.
-  protected static class MockFlowObject{
+  static class MockFlowObject{
     public String name;
     public int    requiredRemainingMemory;
     public int    requiredTotalMemory;
@@ -106,7 +106,7 @@ public class SelectorTest {
   }
 
   // mock Filter class.
-  protected static class MockFilter
+  static class MockFilter
   extends CandidateFilter<MockExecutorObject,MockFlowObject>{
 
     @Override
@@ -182,7 +182,7 @@ public class SelectorTest {
   }
 
   // mock comparator class.
-  protected static class MockComparator
+  static class MockComparator
   extends CandidateComparator<MockExecutorObject>{
 
     @Override

--- a/azkaban-common/src/test/java/azkaban/executor/SelectorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/SelectorTest.java
@@ -36,7 +36,7 @@ import azkaban.utils.JSONUtils;
 
 public class SelectorTest {
   // mock executor object.
-  protected class MockExecutorObject implements Comparable <MockExecutorObject>{
+  protected static class MockExecutorObject implements Comparable <MockExecutorObject>{
     public String name;
     public int    port;
     public double percentOfRemainingMemory;
@@ -78,7 +78,7 @@ public class SelectorTest {
   }
 
   // Mock flow object.
-  protected class MockFlowObject{
+  protected static class MockFlowObject{
     public String name;
     public int    requiredRemainingMemory;
     public int    requiredTotalMemory;
@@ -106,7 +106,7 @@ public class SelectorTest {
   }
 
   // mock Filter class.
-  protected class MockFilter
+  protected static class MockFilter
   extends CandidateFilter<MockExecutorObject,MockFlowObject>{
 
     @Override
@@ -182,7 +182,7 @@ public class SelectorTest {
   }
 
   // mock comparator class.
-  protected class MockComparator
+  protected static class MockComparator
   extends CandidateComparator<MockExecutorObject>{
 
     @Override

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -75,7 +75,7 @@ public class TriggerManagerDeadlockTest {
     System.out.println("No dead lock.");
   }
 
-  public class AlwaysOnChecker implements ConditionChecker {
+  public static class AlwaysOnChecker implements ConditionChecker {
 
     public static final String type = "AlwaysOnChecker";
 

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
@@ -122,7 +122,7 @@ public class TriggerManagerTest {
 
   }
 
-  public class MockTriggerLoader implements TriggerLoader {
+  public static class MockTriggerLoader implements TriggerLoader {
 
     private Map<Integer, Trigger> triggers = new HashMap<Integer, Trigger>();
     private int idIndex = 0;

--- a/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
  */
 public class RestfulApiClientTest {
 
-  protected class MockRestfulApiClient extends RestfulApiClient<String> {
+  protected static class MockRestfulApiClient extends RestfulApiClient<String> {
     private int  status = HttpStatus.SC_OK;
 
     @Override

--- a/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
  */
 public class RestfulApiClientTest {
 
-  protected static class MockRestfulApiClient extends RestfulApiClient<String> {
+  static class MockRestfulApiClient extends RestfulApiClient<String> {
     private int  status = HttpStatus.SC_OK;
 
     @Override


### PR DESCRIPTION
See http://errorprone.info/bugpattern/ClassCanBeStatic

e.g.
/Users/ruyang/oss/azkaban/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java:47:
warning: [ClassCanBeStatic] Inner class is non-static but does not
reference enclosing class
  protected class MockRestfulApiClient extends RestfulApiClient<String>
  {
              ^
	          (see
		  http://errorprone.info/bugpattern/ClassCanBeStatic)
		    Did you mean 'protected static class
		    MockRestfulApiClient extends
		    RestfulApiClient<String> {'?

Fix:
Made these inner classes static inner classes.
Also removed protected from a few static classes introduced.

See http://stackoverflow.com/questions/24289070/why-we-should-not-use-protected-static-in-java

These classes only need package private access.
