### PR TITLE
Package hadoop-security-plugin with the executor

### DIFF
--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 
   testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
   testCompile(project(':azkaban-common').sourceSets.test.output)
-  testCompile('com.google.guava:guava:13.0.1')
+
+  runtime(project(':azkaban-hadoop-security-plugin'))
 }
 
 distributions {

--- a/azkaban-hadoop-security-plugin/build.gradle
+++ b/azkaban-hadoop-security-plugin/build.gradle
@@ -5,23 +5,8 @@ ext.hadoopVersion = "2.6.1"
 dependencies {
   compile project(":azkaban-common")
 
-  compile "org.apache.hadoop:hadoop-common:$hadoopVersion"
-  compile "org.apache.hadoop:hadoop-mapreduce-client-common:$hadoopVersion"
-  compile "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion"
-  compile "org.apache.hive:hive-metastore:0.13.1"
-}
-
-/**
- * Just package the jar.
- * Since, rest of the dependencies are just hadoop and hive. They are not packaged inside the plugin.
- * It is assumed that classpaths of hadoop, hive, pig, etc will be externally fed into the application.
- */
-distributions {
-  main {
-    contents {
-      from(jar) {
-        into 'lib'
-      }
-    }
-  }
+  compileOnly "org.apache.hadoop:hadoop-common:$hadoopVersion"
+  compileOnly "org.apache.hadoop:hadoop-mapreduce-client-common:$hadoopVersion"
+  compileOnly "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoopVersion"
+  compileOnly "org.apache.hive:hive-metastore:0.13.1"
 }


### PR DESCRIPTION
Currently Azkaban doesn't ship the hadoop-security-plugin with the executor.
Although this is clean since the executor doesn't depend on the plugin it
doesn't make Azkaban any usable since most use cases of Azkaban requires
hadoop. For folks who aren't using Azkaban for hadoop, this would be sitting
idle.

However, the strong assumption to use this plugin is that Hadoop classes must
be on the classpath. Else those jobs using the plugin will fail.

Tested this on the solo server and this works fine.