### PR TITLE
Wiring get calls via StorageManager

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -16,12 +16,12 @@
 
 package azkaban.executor;
 
+import com.google.inject.Inject;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.lang.annotation.Inherited;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -58,6 +58,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
 
   private EncodingType defaultEncodingType = EncodingType.GZIP;
 
+  @Inject
   public JdbcExecutorLoader(Props props) {
     super(props);
   }

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -515,22 +515,6 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
     }
   }
 
-
-  @Override
-  public ProjectFileHandler getUploadedFile(Project project, int version)
-      throws ProjectManagerException {
-    logger.info("Retrieving to " + project.getName() + " version:" + version);
-    Connection connection = getConnection();
-    ProjectFileHandler handler = null;
-    try {
-      handler = getUploadedFile(connection, project.getId(), version);
-    } finally {
-      DbUtils.closeQuietly(connection);
-    }
-
-    return handler;
-  }
-
   @Override
   public ProjectFileHandler getUploadedFile(int projectId, int version)
       throws ProjectManagerException {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -139,14 +139,6 @@ public interface ProjectLoader {
    *
    * @return
    */
-  ProjectFileHandler getUploadedFile(Project project, int version)
-      throws ProjectManagerException;
-
-  /**
-   * Get file that's uploaded.
-   *
-   * @return
-   */
   ProjectFileHandler getUploadedFile(int projectId, int version)
       throws ProjectManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -413,7 +413,7 @@ public class ProjectManager {
     if (version == -1) {
       version = projectLoader.getLatestProjectVersion(project);
     }
-    return projectLoader.getUploadedFile(project.getId(), version);
+    return storageManager.getProjectFile(project.getId(), version);
   }
 
   public Map<String, ValidationReport> uploadProject(Project project,

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -413,7 +413,7 @@ public class ProjectManager {
     if (version == -1) {
       version = projectLoader.getLatestProjectVersion(project);
     }
-    return projectLoader.getUploadedFile(project, version);
+    return projectLoader.getUploadedFile(project.getId(), version);
   }
 
   public Map<String, ValidationReport> uploadProject(Project project,

--- a/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
@@ -17,18 +17,14 @@
 
 package azkaban.storage;
 
+import azkaban.project.ProjectFileHandler;
 import azkaban.project.ProjectLoader;
 import azkaban.spi.Storage;
-import azkaban.spi.StorageException;
 import azkaban.spi.StorageMetadata;
-import com.google.common.base.Splitter;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
 import javax.inject.Inject;
-import org.apache.http.client.utils.URIBuilder;
 
 
 /**
@@ -49,34 +45,13 @@ public class DatabaseStorage implements Storage {
     this.projectLoader = projectLoader;
   }
 
-  public static URI toURI(int projectId, int version) {
-    try {
-      return new URIBuilder()
-          .setScheme("database")
-          .setPath("/") // required. inserting dummy path "/". else query parsing does not work.
-          .setParameter(PROJECT_ID, String.valueOf(projectId))
-          .setParameter(VERSION, String.valueOf(version))
-          .build();
-    } catch (URISyntaxException e) {
-      throw new StorageException(e);
-    }
-  }
-
-  public static Map<String, String> getQueryMapFromUri(URI uri) {
-    return Splitter.on('&')
-          .trimResults()
-          .withKeyValueSeparator("=")
-          .split(uri.getQuery());
-  }
-
   @Override
   public InputStream get(URI key) {
-    Map<String, String> queryMap = getQueryMapFromUri(key);
-    final int projectId = Integer.valueOf(queryMap.get(PROJECT_ID));
-    final int version = Integer.valueOf(queryMap.get(VERSION));
+    throw new UnsupportedOperationException("Not implemented yet. Use get(projectId, version) instead");
+  }
 
-    projectLoader.getUploadedFile(projectId, version);
-    return null;
+  public ProjectFileHandler get(int projectId, int version) {
+    return projectLoader.getUploadedFile(projectId, version);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -19,7 +19,6 @@ package azkaban.storage;
 
 import azkaban.project.Project;
 import azkaban.project.ProjectFileHandler;
-import azkaban.project.ProjectLoader;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageMetadata;
 import azkaban.user.User;
@@ -36,12 +35,10 @@ public class StorageManager {
   private static final Logger log = Logger.getLogger(StorageManager.class);
 
   private final Storage storage;
-  private final ProjectLoader projectLoader;
 
   @Inject
-  public StorageManager(Storage storage, ProjectLoader projectLoader) {
+  public StorageManager(Storage storage) {
     this.storage = storage;
-    this.projectLoader = projectLoader;
   }
 
   /**
@@ -77,6 +74,10 @@ public class StorageManager {
    * @return Handler object containing hooks to fetched project file
    */
   public ProjectFileHandler getProjectFile(final int projectId, final int version) {
-    return projectLoader.getUploadedFile(projectId, version);
+    // TODO remove huge hack !
+    if (storage instanceof DatabaseStorage) {
+      return ((DatabaseStorage) storage).get(projectId, version);
+    }
+    throw new UnsupportedOperationException("Operation currently unsupported for other types.");
   }
 }

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -75,7 +75,7 @@ public class StorageManager {
    */
   public ProjectFileHandler getProjectFile(final int projectId, final int version) {
     log.info(String.format("Fetching project file. project ID: %d version: %d", projectId, version));
-    // TODO remove huge hack !
+    // TODO spyne: remove huge hack ! There should not be any special handling for Database Storage.
     if (storage instanceof DatabaseStorage) {
       return ((DatabaseStorage) storage).get(projectId, version);
     }

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -74,6 +74,7 @@ public class StorageManager {
    * @return Handler object containing hooks to fetched project file
    */
   public ProjectFileHandler getProjectFile(final int projectId, final int version) {
+    log.info(String.format("Fetching project file. project ID: %d version: %d", projectId, version));
     // TODO remove huge hack !
     if (storage instanceof DatabaseStorage) {
       return ((DatabaseStorage) storage).get(projectId, version);

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -18,18 +18,13 @@
 package azkaban.storage;
 
 import azkaban.project.Project;
+import azkaban.project.ProjectFileHandler;
 import azkaban.project.ProjectLoader;
-import azkaban.project.ProjectManagerException;
 import azkaban.spi.Storage;
-import azkaban.spi.StorageException;
 import azkaban.spi.StorageMetadata;
 import azkaban.user.User;
 import com.google.inject.Inject;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.net.URI;
 import org.apache.log4j.Logger;
 
 
@@ -41,10 +36,12 @@ public class StorageManager {
   private static final Logger log = Logger.getLogger(StorageManager.class);
 
   private final Storage storage;
+  private final ProjectLoader projectLoader;
 
   @Inject
-  public StorageManager(Storage storage) {
+  public StorageManager(Storage storage, ProjectLoader projectLoader) {
     this.storage = storage;
+    this.projectLoader = projectLoader;
   }
 
   /**
@@ -70,5 +67,16 @@ public class StorageManager {
     log.info(String.format("Adding archive to storage. Meta:%s File: %s[%d bytes]",
         metadata, localFile.getName(), localFile.length()));
     storage.put(metadata, localFile);
+  }
+
+  /**
+   * Fetch project file from storage.
+   *
+   * @param projectId required project ID
+   * @param version version to be fetched
+   * @return Handler object containing hooks to fetched project file
+   */
+  public ProjectFileHandler getProjectFile(final int projectId, final int version) {
+    return projectLoader.getUploadedFile(projectId, version);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectLoaderTest.java
@@ -541,7 +541,7 @@ public class JdbcProjectLoaderTest {
 
     loader.uploadProjectFile(project.getId(), 1, testFile, user.getUserId());
 
-    ProjectFileHandler handler = loader.getUploadedFile(project, 1);
+    ProjectFileHandler handler = loader.getUploadedFile(project.getId(), 1);
     Assert.assertEquals(handler.getProjectId(), project.getId());
     Assert.assertEquals(handler.getFileName(), "testjob.zip");
     Assert.assertEquals(handler.getVersion(), 1);

--- a/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
+++ b/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
@@ -123,13 +123,6 @@ public class MockProjectLoader implements ProjectLoader {
   }
 
   @Override
-  public ProjectFileHandler getUploadedFile(Project project, int version)
-      throws ProjectManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
   public ProjectFileHandler getUploadedFile(int projectId, int version)
       throws ProjectManagerException {
     // TODO Auto-generated method stub

--- a/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
@@ -20,8 +20,6 @@ package azkaban.storage;
 import azkaban.project.ProjectLoader;
 import azkaban.spi.StorageMetadata;
 import java.io.File;
-import java.net.URI;
-import java.util.Map;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -31,22 +29,6 @@ import static org.mockito.Mockito.*;
 public class DatabaseStorageTest {
   private final ProjectLoader projectLoader = mock(ProjectLoader.class);
   private final DatabaseStorage databaseStorage = new DatabaseStorage(projectLoader);
-
-  @Test
-  public void testUriConversion() {
-    final int projectId = 1;
-    final int version = 12;
-    final URI uri = DatabaseStorage.toURI(projectId, version);
-    final Map<String, String> queryMap = DatabaseStorage.getQueryMapFromUri(uri);
-
-    assertEquals(String.valueOf(projectId), queryMap.get("projectId"));
-    assertEquals(String.valueOf(version), queryMap.get("version"));
-  }
-
-  @Test
-  public void testGet() throws Exception {
-
-  }
 
   @Test
   public void testPut() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
@@ -20,6 +20,8 @@ package azkaban.storage;
 import azkaban.project.ProjectLoader;
 import azkaban.spi.StorageMetadata;
 import java.io.File;
+import java.net.URI;
+import java.util.Map;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -29,6 +31,22 @@ import static org.mockito.Mockito.*;
 public class DatabaseStorageTest {
   private final ProjectLoader projectLoader = mock(ProjectLoader.class);
   private final DatabaseStorage databaseStorage = new DatabaseStorage(projectLoader);
+
+  @Test
+  public void testUriConversion() {
+    final int projectId = 1;
+    final int version = 12;
+    final URI uri = DatabaseStorage.toURI(projectId, version);
+    final Map<String, String> queryMap = DatabaseStorage.getQueryMapFromUri(uri);
+
+    assertEquals(String.valueOf(projectId), queryMap.get("projectId"));
+    assertEquals(String.valueOf(version), queryMap.get("version"));
+  }
+
+  @Test
+  public void testGet() throws Exception {
+
+  }
 
   @Test
   public void testPut() throws Exception {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -17,6 +17,8 @@
 
 package azkaban.execapp;
 
+import azkaban.executor.ExecutorLoader;
+import azkaban.executor.JdbcExecutorLoader;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 
@@ -29,6 +31,7 @@ import com.google.inject.Scopes;
 public class AzkabanExecServerModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(ExecutorLoader.class).to(JdbcExecutorLoader.class).in(Scopes.SINGLETON);
     bind(AzkabanExecutorServer.class).in(Scopes.SINGLETON);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -95,7 +95,6 @@ public class AzkabanExecutorServer {
   private static AzkabanExecutorServer app;
 
   private final ExecutorLoader executionLoader;
-  private final ProjectLoader projectLoader;
   private final FlowRunnerManager runnerManager;
   private final Props props;
   private final Server server;
@@ -103,19 +102,15 @@ public class AzkabanExecutorServer {
   private final ArrayList<ObjectName> registeredMBeans = new ArrayList<ObjectName>();
   private MBeanServer mbeanServer;
 
-  /**
-   * Constructor
-   *
-   * @throws Exception
-   */
   @Inject
-  public AzkabanExecutorServer(Props props) throws Exception {
+  public AzkabanExecutorServer(Props props,
+      ExecutorLoader executionLoader,
+      FlowRunnerManager runnerManager) throws Exception {
     this.props = props;
-    server = createJettyServer(props);
+    this.executionLoader = executionLoader;
+    this.runnerManager = runnerManager;
 
-    executionLoader = new JdbcExecutorLoader(props);
-    projectLoader = new JdbcProjectLoader(props);
-    runnerManager = new FlowRunnerManager(props, executionLoader, projectLoader, getClass().getClassLoader());
+    server = createJettyServer(props);
 
     JmxJobMBeanManager.getInstance().initialize(props);
 
@@ -312,11 +307,6 @@ public class AzkabanExecutorServer {
       logger.info("No value for property: "
           + CUSTOM_JMX_ATTRIBUTE_PROCESSOR_PROPERTY + " was found");
     }
-  }
-
-
-  public ProjectLoader getProjectLoader() {
-    return projectLoader;
   }
 
   public ExecutorLoader getExecutorLoader() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -41,9 +41,9 @@ import static java.util.Objects.*;
 public class FlowPreparer {
   private static final Logger log = Logger.getLogger(FlowPreparer.class);
 
-  // TODO move to config class
+  // TODO spyne: move to config class
   private final File executionsDir;
-  // TODO move to config class
+  // TODO spyne: move to config class
   private final File projectsDir;
 
   private final Map<Pair<Integer, Integer>, ProjectVersion> installedProjects;
@@ -114,7 +114,7 @@ public class FlowPreparer {
 
     File tempDir = new File(projectsDir, "_temp." + projectDir + "." + System.currentTimeMillis());
 
-    // TODO Why mkdirs? This path should be already set up.
+    // TODO spyne: Why mkdirs? This path should be already set up.
     tempDir.mkdirs();
 
     ProjectFileHandler projectFileHandler = null;
@@ -150,7 +150,7 @@ public class FlowPreparer {
     File execDir = new File(executionsDir, String.valueOf(execId));
     flow.setExecutionPath(execDir.getPath());
 
-    // TODO Why mkdirs? This path should be already set up.
+    // TODO spyne: Why mkdirs? This path should be already set up.
     execDir.mkdirs();
     return execDir;
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -19,8 +19,8 @@ package azkaban.execapp;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.project.ProjectFileHandler;
-import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManagerException;
+import azkaban.storage.StorageManager;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Utils;
@@ -47,13 +47,11 @@ public class FlowPreparer {
   private final File projectsDir;
 
   private final Map<Pair<Integer, Integer>, ProjectVersion> installedProjects;
-  private final ProjectLoader projectLoader;
+  private final StorageManager storageManager;
 
-  public FlowPreparer(ProjectLoader projectLoader,
-      File executionsDir,
-      File projectsDir,
+  public FlowPreparer(StorageManager storageManager, File executionsDir, File projectsDir,
       Map<Pair<Integer, Integer>, ProjectVersion> installedProjects) {
-    this.projectLoader = projectLoader;
+    this.storageManager = storageManager;
     this.executionsDir = executionsDir;
     this.projectsDir = projectsDir;
     this.installedProjects = installedProjects;
@@ -121,7 +119,7 @@ public class FlowPreparer {
 
     ProjectFileHandler projectFileHandler = null;
     try {
-      projectFileHandler = requireNonNull(projectLoader.getUploadedFile(projectId, version));
+      projectFileHandler = requireNonNull(storageManager.getProjectFile(projectId, version));
       checkState("zip".equals(projectFileHandler.getFileType()));
 
       log.info("Downloading zip file.");

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -18,6 +18,8 @@ package azkaban.execapp;
 
 import azkaban.Constants;
 import azkaban.executor.Status;
+import azkaban.storage.StorageManager;
+import com.google.inject.Inject;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -145,11 +147,13 @@ public class FlowRunnerManager implements EventListener,
   // whether the current executor is active
   private volatile boolean isExecutorActive = false;
 
-  public FlowRunnerManager(Props props, ExecutorLoader executorLoader,
-      ProjectLoader projectLoader, ClassLoader parentClassLoader) throws IOException {
+  @Inject
+  public FlowRunnerManager(Props props,
+      ExecutorLoader executorLoader,
+      ProjectLoader projectLoader,
+      StorageManager storageManager) throws IOException {
     azkabanProps = props;
 
-    // JobWrappingFactory.init(props, getClass().getClassLoader());
     executionDirRetention = props.getLong("execution.dir.retention", executionDirRetention);
     logger.info("Execution dir retention set to " + executionDirRetention + " ms");
 
@@ -170,7 +174,7 @@ public class FlowRunnerManager implements EventListener,
     executorService = createExecutorService(numThreads);
 
     // Create a flow preparer
-    flowPreparer = new FlowPreparer(projectLoader, executionDirectory, projectDirectory, installedProjects);
+    flowPreparer = new FlowPreparer(storageManager, executionDirectory, projectDirectory, installedProjects);
 
     this.executorLoader = executorLoader;
     this.projectLoader = projectLoader;
@@ -193,7 +197,7 @@ public class FlowRunnerManager implements EventListener,
         new JobTypeManager(props.getString(
             AzkabanExecutorServer.JOBTYPE_PLUGIN_DIR,
             JobTypeManager.DEFAULT_JOBTYPEPLUGINDIR), globalProps,
-            parentClassLoader);
+            getClass().getClassLoader());
   }
 
   private TrackingThreadPool createExecutorService(int nThreads) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -19,7 +19,7 @@ package azkaban.execapp;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.project.ProjectFileHandler;
-import azkaban.project.ProjectLoader;
+import azkaban.storage.StorageManager;
 import azkaban.utils.Pair;
 import java.io.File;
 import java.util.HashMap;
@@ -49,7 +49,6 @@ public class FlowPreparerTest {
     executionsDir.mkdirs();
     projectsDir.mkdirs();
 
-
     ClassLoader classLoader = getClass().getClassLoader();
     File file = new File(classLoader.getResource(SAMPLE_FLOW_01 + ".zip").getFile());
 
@@ -57,10 +56,10 @@ public class FlowPreparerTest {
     when(projectFileHandler.getFileType()).thenReturn("zip");
     when(projectFileHandler.getLocalFile()).thenReturn(file);
 
-    ProjectLoader projectLoader = mock(ProjectLoader.class);
-    when(projectLoader.getUploadedFile(12, 34)).thenReturn(projectFileHandler);
+    StorageManager storageManager = mock(StorageManager.class);
+    when(storageManager.getProjectFile(12, 34)).thenReturn(projectFileHandler);
 
-    instance = new FlowPreparer(projectLoader, executionsDir, projectsDir, installedProjects);
+    instance = new FlowPreparer(storageManager, executionsDir, projectsDir, installedProjects);
   }
 
   @After

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -1207,9 +1207,9 @@ public class AzkabanWebServer extends AzkabanServer {
     executorManager.shutdown();
     try {
       server.stop();
-    } catch (Throwable t) {
+    } catch (Exception e) {
       // Catch all while closing server
-      logger.error(t);
+      logger.error(e);
     }
     server.destroy();
   }


### PR DESCRIPTION
This changes delegates all get calls via the `StorageManager`. By `get` I mean the process of fetching a project file (blob) from storage. By default, this storage is the database. There are some hacks in the code which can be fixed later as we go.

There are some refactors in the executor codebase. This was done to easily fetch the `StorageManager` class via Guice.

The changes have been verified on solo server locally and also on executors separately.