### PR TITLE
Storage schema changes and implementation. Working Local Storage.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -393,6 +393,7 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
       String uri) throws ProjectManagerException {
     try (Connection connection = getConnection()) {
       addProjectToProjectVersions(connection, projectId, version, localFile, uploader, uri);
+      connection.commit();
     } catch (SQLException e) {
       logger.error(e);
       throw new ProjectManagerException(String.format("Add ProjectVersion failed. project id: %d version: %d",

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java
@@ -420,8 +420,12 @@ public class JdbcProjectLoader extends AbstractJdbcLoader implements
    * When we upload a new project zip in day2, new file in day 2 will use the new version (proj_v + 1).
    * When file uploading completes, AZ will clean all old chunks in DB afterward.
    */
-  private void addProjectToProjectVersions(Connection connection, int projectId, int version, File localFile,
-      String uploader, String uri) throws ProjectManagerException {
+  private void addProjectToProjectVersions(Connection connection,
+      int projectId,
+      int version,
+      File localFile,
+      String uploader,
+      String uri) throws ProjectManagerException {
     final long updateTime = System.currentTimeMillis();
     QueryRunner runner = new QueryRunner();
     logger.info("Creating message digest for upload " + localFile.getName());

--- a/azkaban-common/src/main/java/azkaban/project/ProjectFileHandler.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectFileHandler.java
@@ -22,24 +22,34 @@ public class ProjectFileHandler {
   private final int projectId;
   private final int version;
   private final long uploadTime;
-  private String fileType;
-  private String fileName;
-  private String uploader;
-  private byte[] md5Hash;
-  private int numChunks;
+  private final String fileType;
+  private final String fileName;
+  private final String uploader;
+  private final byte[] md5Hash;
+  private final int numChunks;
+  private final String uri;
+
   private File localFile = null;
 
-  public ProjectFileHandler(int projectId, int version, long uploadTime,
-      String uploader, String fileType, String fileName, int numChunks,
-      byte[] md5Hash) {
+  public ProjectFileHandler(
+      int projectId,
+      int version,
+      long uploadTime,
+      String uploader,
+      String fileType,
+      String fileName,
+      int numChunks,
+      byte[] md5Hash,
+      String uri) {
     this.projectId = projectId;
     this.version = version;
     this.uploadTime = uploadTime;
-    this.setUploader(uploader);
-    this.setFileType(fileType);
-    this.setFileName(fileName);
-    this.setMd5Hash(md5Hash);
-    this.setNumChunks(numChunks);
+    this.uploader = uploader;
+    this.fileType = fileType;
+    this.fileName = fileName;
+    this.md5Hash = md5Hash;
+    this.numChunks = numChunks;
+    this.uri = uri;
   }
 
   public int getProjectId() {
@@ -58,24 +68,12 @@ public class ProjectFileHandler {
     return fileType;
   }
 
-  public void setFileType(String fileType) {
-    this.fileType = fileType;
-  }
-
   public String getFileName() {
     return fileName;
   }
 
-  public void setFileName(String fileName) {
-    this.fileName = fileName;
-  }
-
   public byte[] getMd5Hash() {
     return md5Hash;
-  }
-
-  public void setMd5Hash(byte[] md5Hash) {
-    this.md5Hash = md5Hash;
   }
 
   public File getLocalFile() {
@@ -87,9 +85,7 @@ public class ProjectFileHandler {
   }
 
   public synchronized void deleteLocalFile() {
-    if (localFile == null) {
-      return;
-    } else {
+    if (localFile != null) {
       localFile.delete();
       localFile = null;
     }
@@ -99,16 +95,11 @@ public class ProjectFileHandler {
     return uploader;
   }
 
-  public void setUploader(String uploader) {
-    this.uploader = uploader;
-  }
-
   public int getNumChunks() {
     return numChunks;
   }
 
-  public void setNumChunks(int numChunks) {
-    this.numChunks = numChunks;
+  public String getUri() {
+    return uri;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -135,6 +135,20 @@ public interface ProjectLoader {
       throws ProjectManagerException;
 
   /**
+   * Add project and version info to the project_versions table. This current maintains the metadata for each uploaded
+   * version of the project
+   *
+   * @param projectId
+   * @param version
+   * @param localFile
+   * @param uploader
+   * @param uri
+   * @throws ProjectManagerException
+   */
+  void addProjectVersion(int projectId, int version, File localFile, String uploader, String uri)
+      throws ProjectManagerException;
+
+  /**
    * Fetch project metadata from project_versions table
    *
    * @param projectId project ID

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -135,6 +135,15 @@ public interface ProjectLoader {
       throws ProjectManagerException;
 
   /**
+   * Fetch project metadata from project_versions table
+   *
+   * @param projectId project ID
+   * @param version version
+   * @return ProjectFileHandler object containing the metadata
+   */
+  ProjectFileHandler fetchProjectMetaData(int projectId, int version);
+
+  /**
    * Get file that's uploaded.
    *
    * @return

--- a/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
@@ -34,14 +34,10 @@ import javax.inject.Inject;
  * behavior of Azkaban.
  */
 public class DatabaseStorage implements Storage {
-  public static final String PROJECT_ID = "projectId";
-  public static final String VERSION = "version";
-
   private final ProjectLoader projectLoader;
 
   @Inject
   public DatabaseStorage(ProjectLoader projectLoader) {
-
     this.projectLoader = projectLoader;
   }
 

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -90,7 +90,23 @@ public class StorageManager {
     );
     log.info(String.format("Adding archive to storage. Meta:%s File: %s[%d bytes]",
         metadata, localFile.getName(), localFile.length()));
-    storage.put(metadata, localFile);
+
+    /* upload to storage */
+    URI uri = storage.put(metadata, localFile);
+
+    /* Add metadata to db */
+    // TODO spyne: remove hack. Database storage should go through the same flow
+    if (!(storage instanceof DatabaseStorage)) {
+      projectLoader.addProjectVersion(
+          project.getId(),
+          version,
+          localFile,
+          uploader.getUserId(),
+          uri.toString()
+      );
+      log.info(String.format("Added project metadata to DB. Meta:%s File: %s[%d bytes] URI: %s",
+          metadata, localFile.getName(), localFile.length(), uri));
+    }
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
+++ b/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
@@ -123,6 +123,11 @@ public class MockProjectLoader implements ProjectLoader {
   }
 
   @Override
+  public ProjectFileHandler fetchProjectMetaData(int projectId, int version) {
+    return null;
+  }
+
+  @Override
   public ProjectFileHandler getUploadedFile(int projectId, int version)
       throws ProjectManagerException {
     // TODO Auto-generated method stub

--- a/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
+++ b/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
@@ -123,6 +123,12 @@ public class MockProjectLoader implements ProjectLoader {
   }
 
   @Override
+  public void addProjectVersion(int projectId, int version, File localFile, String uploader, String uri)
+      throws ProjectManagerException {
+
+  }
+
+  @Override
   public ProjectFileHandler fetchProjectMetaData(int projectId, int version) {
     return null;
   }

--- a/azkaban-sql/src/sql/create.project_versions.sql
+++ b/azkaban-sql/src/sql/create.project_versions.sql
@@ -7,6 +7,7 @@ CREATE TABLE project_versions (
 	file_name VARCHAR(128),
 	md5 BINARY(16),
 	num_chunks INT,
+	uri VARCHAR(512) DEFAULT NULL,
 	PRIMARY KEY (project_id, version)
 );
 


### PR DESCRIPTION
The `project_versions` table currently stores all metadata corresponding to every upload of a project zip. The newly introduced storage layer in azkaban requires the persistence of an additional field in the `project_versions` table `uri`.
```
CREATE TABLE project_versions (
...
	uri VARCHAR(512) DEFAULT NULL,
...
);
```

The changes integrate `uri` in the query APIs in `ProjectLoader` and modify the interfaces in a *backward incompatible* manner. The solo server SQL scripts have been updated accordingly and have been tested to work.

Existing installations of Azkaban *will* require a simple DB migration: `uri` field addition to `project_versions`.

This completes the implementation for `LOCAL` and `DATABASE` storage types. By default, the storage will continue to be `DATABASE`. (DB migration will still be required)

To change to `LOCAL` storage. Add this to `conf/azkaban.properties`
```
azkaban.storage.type=LOCAL
```

This has been tested to work on solo server and also tested on dev clusters