### PR TITLE
Cleaning up warnings generated during build process

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -624,6 +624,7 @@ public class ExecutorManager extends EventHandler implements
     }
   }
 
+  @Override
   public List<ExecutableFlow> getRecentlyFinishedFlows() {
     return new ArrayList<ExecutableFlow>(recentlyFinished.values());
   }
@@ -1225,6 +1226,7 @@ public class ExecutorManager extends EventHandler implements
       shutdown = true;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public void run() {
       while (!shutdown) {
@@ -1677,6 +1679,7 @@ public class ExecutorManager extends EventHandler implements
       this.interrupt();
     }
 
+    @Override
     public void run() {
       while (!shutdown) {
         synchronized (this) {
@@ -1778,6 +1781,7 @@ public class ExecutorManager extends EventHandler implements
       this.interrupt();
     }
 
+    @Override
     public void run() {
       // Loops till QueueProcessorThread is shutdown
       while (!shutdown) {

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
@@ -38,10 +38,12 @@ public abstract class AbstractJob implements Job {
     _progress = 0.0;
   }
 
+  @Override
   public String getId() {
     return _id;
   }
 
+  @Override
   public double getProgress() throws Exception {
     return _progress;
   }
@@ -50,6 +52,7 @@ public abstract class AbstractJob implements Job {
     this._progress = progress;
   }
 
+  @Override
   public void cancel() throws Exception {
     throw new RuntimeException("Job " + _id + " does not support cancellation!");
   }
@@ -90,12 +93,15 @@ public abstract class AbstractJob implements Job {
     this._log.error(message, t);
   }
 
+  @Override
   public Props getJobGeneratedProperties() {
     return new Props();
   }
 
+  @Override
   public abstract void run() throws Exception;
 
+  @Override
   public boolean isCanceled() {
     return false;
   }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
@@ -152,6 +152,7 @@ public class JavaProcessJob extends ProcessJob {
     return "";
   }
 
+  @Override
   protected Pair<Long, Long> getProcMemoryRequirement() throws Exception {
     String strXms = getInitialMemorySize();
     String strXmx = getMaxMemorySize();

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/LongArgJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/LongArgJob.java
@@ -53,6 +53,7 @@ public abstract class LongArgJob extends AbstractProcessJob {
     appendProps(suppressedKeys);
   }
 
+  @Override
   public void run() throws Exception {
     try {
       resolveProps();

--- a/azkaban-common/src/main/java/azkaban/metric/AbstractMetric.java
+++ b/azkaban-common/src/main/java/azkaban/metric/AbstractMetric.java
@@ -46,6 +46,7 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable{
    * {@inheritDoc}
    * @see azkaban.metric.IMetric#getName()
    */
+  @Override
   public String getName() {
     return name;
   }
@@ -54,6 +55,7 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable{
    * {@inheritDoc}
    * @see azkaban.metric.IMetric#getValueType()
    */
+  @Override
   public String getValueType() {
     return type;
   }
@@ -71,6 +73,7 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable{
    * @throws CloneNotSupportedException
    * @see azkaban.metric.IMetric#getSnapshot()
    */
+  @Override
   @SuppressWarnings("unchecked")
   public IMetric<T> getSnapshot() throws CloneNotSupportedException{
     return (IMetric<T>) this.clone();
@@ -80,6 +83,7 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable{
    * {@inheritDoc}
    * @see azkaban.metric.IMetric#getValue()
    */
+  @Override
   public T getValue() {
     return value;
   }
@@ -91,6 +95,7 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable{
    * {@inheritDoc}
    * @see azkaban.metric.IMetric#notifyManager()
    */
+  @Override
   public void notifyManager() {
     logger.debug(String.format("Notifying Manager for %s", this.getClass().getName()));
     try {

--- a/azkaban-common/src/main/java/azkaban/metric/MetricReportManager.java
+++ b/azkaban-common/src/main/java/azkaban/metric/MetricReportManager.java
@@ -222,6 +222,7 @@ public class MetricReportManager {
    * {@inheritDoc}
    * @see java.lang.Object#finalize()
    */
+  @Override
   protected void finalize() {
     executorService.shutdown();
   }

--- a/azkaban-common/src/main/java/azkaban/project/validator/ValidatorClassLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/validator/ValidatorClassLoader.java
@@ -28,6 +28,7 @@ public class ValidatorClassLoader extends URLClassLoader {
     super(urls);
   }
 
+  @Override
   public void close() throws ValidatorManagerException {
     setJarFileNames2Close.clear();
     closeClassLoader(this);

--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -123,6 +123,7 @@ public class Schedule {
     return projectName + "." + flowName + " (" + projectId + ")";
   }
 
+  @Override
   public String toString() {
 
     String underlying = projectName + "." + flowName + " (" + projectId + ")" + " to be run at (starting) " + new DateTime(

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -104,6 +104,7 @@ public class ScheduleManager implements TriggerAgent {
    * Shutdowns the scheduler thread. After shutdown, it may not be safe to use
    * it again.
    */
+  @Override
   public void shutdown() {
 
   }

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -217,6 +217,7 @@ public class TriggerManager extends EventHandler implements
       triggers.remove(t);
     }
 
+    @Override
     public void run() {
       while (!shutdown) {
         synchronized (syncObj) {

--- a/azkaban-common/src/main/java/azkaban/user/Permission.java
+++ b/azkaban-common/src/main/java/azkaban/user/Permission.java
@@ -162,6 +162,7 @@ public class Permission {
     return list.toArray(new String[count]);
   }
 
+  @Override
   public String toString() {
     return Utils.flattenToString(permissions, ",");
   }

--- a/azkaban-common/src/main/java/azkaban/user/Role.java
+++ b/azkaban-common/src/main/java/azkaban/user/Role.java
@@ -33,6 +33,7 @@ public class Role {
     return name;
   }
 
+  @Override
   public String toString() {
     return "Role " + name;
   }

--- a/azkaban-common/src/main/java/azkaban/user/User.java
+++ b/azkaban-common/src/main/java/azkaban/user/User.java
@@ -94,6 +94,7 @@ public class User {
     return properties.get(name);
   }
 
+  @Override
   public String toString() {
     String groupStr = "[";
     for (String group : groups) {

--- a/azkaban-common/src/main/java/azkaban/utils/CircularBuffer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/CircularBuffer.java
@@ -55,6 +55,7 @@ public class CircularBuffer<T> implements Iterable<T> {
     return "[" + Joiner.on(", ").join(lines) + "]";
   }
 
+  @Override
   public Iterator<T> iterator() {
     if (start == 0)
       return lines.iterator();

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -204,6 +204,7 @@ public class FileIOUtils {
       inputReader = new BufferedReader(new InputStreamReader(stream));
     }
 
+    @Override
     public void run() {
       try {
         while (!Thread.currentThread().isInterrupted()) {

--- a/azkaban-common/src/test/java/azkaban/executor/JavaJobRunnerMain.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JavaJobRunnerMain.java
@@ -70,6 +70,7 @@ public class JavaJobRunnerMain {
 
   public JavaJobRunnerMain() throws Exception {
     Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
       public void run() {
         cancelJob();
       }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
@@ -49,6 +49,7 @@ public class WordCountLocal extends AbstractJob {
     _output = prop.getString("output");
   }
 
+  @Override
   public void run() throws Exception {
 
     if (_input == null)

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -204,6 +204,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     return execDir;
   }
 
+  @Override
   public void run() {
     try {
       if (this.executorService == null) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -308,6 +308,7 @@ public class FlowRunnerManager implements EventListener,
       return nonFinishingStatusAfterFlowStarts.contains(flow.getStatus()) && flow.getStartTime() > 0 && TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis()-flow.getStartTime()) >= flowMaxRunningTimeInMins;
     }
 
+    @Override
     public void run() {
       while (!shutdown) {
         synchronized (this) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -57,6 +57,7 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
     return HttpRequestUtils.getParam(request, name);
   }
 
+  @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
     Map<String, Object> ret = new HashMap<String, Object>();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -52,6 +52,7 @@ public class ServerStatisticsServlet extends HttpServlet {
    * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
    *      javax.servlet.http.HttpServletResponse)
    */
+  @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 
     boolean noCache = null != req && Boolean.valueOf(req.getParameter(noCacheParamName));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
@@ -76,6 +76,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
    * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
    *      javax.servlet.http.HttpServletResponse)
    */
+  @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
     Map<String, Object> ret = new HashMap<String, Object>();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/BlockingStatusTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/BlockingStatusTest.java
@@ -32,6 +32,7 @@ public class BlockingStatusTest {
       this.status = status;
     }
 
+    @Override
     public void run() {
       long startTime = System.currentTimeMillis();
       status.blockOnFinishedStatus();

--- a/azkaban-web-server/package.json
+++ b/azkaban-web-server/package.json
@@ -21,5 +21,6 @@
   "bugs": {
     "url": "https://github.com/azkaban/azkaban/issues"
   },
-  "homepage": "https://azkaban.github.io/"
+  "homepage": "https://azkaban.github.io/",
+  "license": "Apache-2.0"
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -657,6 +657,7 @@ public class AzkabanWebServer extends AzkabanServer {
    *
    * @return
    */
+  @Override
   public Props getServerProps() {
     return props;
   }
@@ -696,6 +697,7 @@ public class AzkabanWebServer extends AzkabanServer {
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
 
+      @Override
       public void run() {
         try {
           logTopMemoryConsumers();


### PR DESCRIPTION
This is to address the build warnings in issue#1025.

I focused on two areas related to build warnings.  
1) NPM
2) Override annotations.

#### NPM
While I was able to fix a licensing issue with NPM, there's still a version dependency issue with eonasdan-bootstrap-datetimepicker.  Instead of passing in a 0.4.x version of  moment-timezone, we are giving it a 0.5.x version which causes the dependency check to fail.  

#### Override
I got most of the override warnings but didn’t feel comfortable with blindly putting @Override everywhere the warning occurred.  Hence, there are still a remainder of Override warnings. 
