### PR TITLE
Fix build warning : enums should be immutable

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/AbstractJdbcLoader.java
+++ b/azkaban-common/src/main/java/azkaban/database/AbstractJdbcLoader.java
@@ -33,7 +33,7 @@ public abstract class AbstractJdbcLoader {
   public enum EncodingType {
     PLAIN(1), GZIP(2);
 
-    private int numVal;
+    private final int numVal;
 
     EncodingType(int numVal) {
       this.numVal = numVal;

--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -36,7 +36,7 @@ public class DataSourceUtils {
   public static enum PropertyType {
     DB(1);
 
-    private int numVal;
+    private final int numVal;
 
     PropertyType(int numVal) {
       this.numVal = numVal;

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -31,7 +31,7 @@ public enum Status {
   FAILED_SUCCEEDED(120),
   CANCELLED(130);
 
-  private int numVal;
+  private final int numVal;
 
   Status(int numVal) {
     this.numVal = numVal;

--- a/azkaban-common/src/main/java/azkaban/user/Permission.java
+++ b/azkaban-common/src/main/java/azkaban/user/Permission.java
@@ -33,7 +33,7 @@ public class Permission {
     CREATEPROJECTS(0x40000000), // Only used for roles
     ADMIN(0x8000000);
 
-    private int numVal;
+    private final int numVal;
 
     Type(int numVal) {
       this.numVal = numVal;


### PR DESCRIPTION
e.g.

azkaban/azkaban-common/src/main/java/azkaban/executor/Status.java:34: warning: [ImmutableEnumChecker] enums should be immutable, and cannot have non-final fields
  private int numVal;
              ^
    (see http://errorprone.info/bugpattern/ImmutableEnumChecker)
  Did you mean 'private final int numVal;'?