### PR TITLE
Removing 'ClassCanBeStatic' warnings.  For example:

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/HistoryServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/HistoryServlet.java
@@ -200,7 +200,7 @@ public class HistoryServlet extends LoginAbstractAzkabanServlet {
       HttpServletResponse resp, Session session) {
   }
 
-  public class PageSelection {
+  public static class PageSelection {
     private int page;
     private int size;
     private boolean disabled;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1806,7 +1806,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
   }
 
-  public class PageSelection {
+  public static class PageSelection {
     private String page;
     private int size;
     private boolean disabled;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
@@ -85,7 +85,7 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
    * ProjectServlet class now handles ajax requests. It returns a
    * @SimplifiedProject object: information regarding projects, and information
    * regarding user and project association
-   * 
+   *
    * @param req
    * @param resp
    * @param session
@@ -119,7 +119,7 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
    * If user provides an empty user name, the user defaults to the session user<br>
    * If user does not provide the user param, the user also defaults to the
    * session user<br>
-   * 
+   *
    * @param req
    * @param session
    * @param manager
@@ -151,7 +151,7 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
 
   /**
    * A simple helper method that converts a List<Project> to List<SimplifiedProject>
-   * 
+   *
    * @param projects
    * @return
    */
@@ -169,7 +169,7 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
 
   /**
    * Renders the user homepage that users see when they log in
-   * 
+   *
    * @param req
    * @param resp
    * @param session
@@ -260,11 +260,11 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
    * to end users via REST API. This is done in consideration that the API
    * caller only wants certain project level information regarding a project,
    * but does not want every flow and every job inside that project.
-   * 
+   *
    * @author jyu
    *
    */
-  private class SimplifiedProject {
+  private static class SimplifiedProject {
     private int projectId;
     private String projectName;
     private String createdBy;


### PR DESCRIPTION
  Did you mean 'PrintWriter out = new PrintWriter(new BufferedWriter(new
  OutputStreamWriter(new FileOutputStream(_output), UTF_8)));' or
  'PrintWriter out = new PrintWriter(new BufferedWriter(new
  OutputStreamWriter(new FileOutputStream(_output),
  Charset.defaultCharset())));'?
  /Users/afaris/work/public/li-afaris_azkaban/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java:1809:
  warning: [ClassCanBeStatic] Inner class is non-static but does not
  reference enclosing class
    public class PageSelection {
               ^
                   (see
                   http://errorprone.info/bugpattern/ClassCanBeStatic)