### PR TITLE
Fix build warning DefaultCharset in test Utils class

### DIFF
--- a/azkaban-common/src/test/java/azkaban/jobExecutor/PythonJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/PythonJobTest.java
@@ -78,7 +78,7 @@ public class PythonJobTest {
   }
 
   @AfterClass
-  public static void cleanup() {
+  public static void cleanup() throws IOException {
     // remove the input file and error input file
     Utils.removeFile(scriptFile);
   }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/Utils.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/Utils.java
@@ -16,24 +16,24 @@
 
 package azkaban.jobExecutor;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 
 public class Utils {
   private Utils() {
   }
 
-  public static void dumpFile(String filename, String filecontent)
-      throws IOException {
-    PrintWriter writer = new PrintWriter(new FileWriter(filename));
-    writer.print(filecontent);
-    writer.close();
+  static void dumpFile(String filename, String fileContent) throws IOException {
+    try (PrintWriter writer = new PrintWriter(filename, StandardCharsets.UTF_8.toString())) {
+      writer.print(fileContent);
+    }
   }
 
-  public static void removeFile(String filename) {
-    File file = new File(filename);
-    file.delete();
+  static void removeFile(String filename) throws IOException {
+    Files.delete(Paths.get(filename));
   }
 }


### PR DESCRIPTION
Warning:
azkaban/azkaban-common/src/test/java/azkaban/jobExecutor/Utils.java:30: warning: [DefaultCharset] Implicit use of the platform default charset, which can result in e.g. non-ASCII characters being silently replaced with '?' in many environments
    PrintWriter writer = new PrintWriter(new FileWriter(filename));
                                         ^
    (see http://errorprone.info/bugpattern/DefaultCharset)
  Did you mean 'PrintWriter writer = new PrintWriter(Files.newBufferedWriter(Paths.get(filename), UTF_8));' or 'PrintWriter writer = new PrintWriter(Files.newBufferedWriter(Paths.get(filename), Charset.defaultCharset()));'?

Also:
 * refactored it to use try with resource.
 * refactored the delete method to simplify it and check results.
 * removed all intellij warnings

Testing:
All tests passed.