### PR TITLE
Implement HDFS Storage for Azkaban

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -35,6 +35,11 @@ configurations {
   testCompileOnly.extendsFrom(compileOnly)
 }
 dependencies {
+  compileOnly "org.apache.hadoop:hadoop-auth:$hadoopVersion"
+  compileOnly "org.apache.hadoop:hadoop-annotations:$hadoopVersion"
+  compileOnly "org.apache.hadoop:hadoop-common:$hadoopVersion"
+  compileOnly "org.apache.hadoop:hadoop-hdfs:$hadoopVersion"
+
   compile project(':azkaban-spi')
   compile project(':azkaban-db')
 

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -32,8 +32,13 @@ model {
 }
 
 configurations {
-  testCompileOnly.extendsFrom(compileOnly)
+  /*
+   * We need to explicitly import compileOnly dependencies in test. Else, they are not available in the test compile
+   * and runtime classpaths.
+   */
+  testCompile.extendsFrom(compileOnly)
 }
+
 dependencies {
   compileOnly "org.apache.hadoop:hadoop-auth:$hadoopVersion"
   compileOnly "org.apache.hadoop:hadoop-annotations:$hadoopVersion"
@@ -80,4 +85,10 @@ dependencies {
 
 tasks.withType(JavaCompile) {
   options.encoding = "UTF-8"
+}
+
+task printClasspath {
+  doLast {
+    configurations.testRuntime.each { println it }
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
@@ -24,7 +24,6 @@ import azkaban.storage.StorageImplementationType;
 import azkaban.utils.Props;
 import com.google.inject.Inject;
 import java.net.URI;
-import java.net.URISyntaxException;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.log4j.Logger;
 
@@ -47,17 +46,16 @@ public class AzkabanCommonModuleConfig {
    *
    */
   private String storageImplementation = DATABASE.name();
-  private String localStorageBaseDirPath = "AZKABAN_STORAGE";
-  private URI hdfsBaseUri = uri("hdfs://localhost:50070/path/to/base/");
+  private String localStorageBaseDirPath = "LOCAL_STORAGE";
+  private URI hdfsRootUri;
 
   @Inject
   public AzkabanCommonModuleConfig(Props props) {
     this.props = props;
 
-    storageImplementation = props.getString(Constants.ConfigurationKeys.AZKABAN_STORAGE_TYPE,
-        storageImplementation);
+    storageImplementation = props.getString(AZKABAN_STORAGE_TYPE, storageImplementation);
     localStorageBaseDirPath = props.getString(AZKABAN_STORAGE_LOCAL_BASEDIR, localStorageBaseDirPath);
-    hdfsBaseUri = props.getUri(AZKABAN_STORAGE_HDFS_BASEURI, hdfsBaseUri);
+    hdfsRootUri = props.get(AZKABAN_STORAGE_HDFS_ROOT_URI) != null ? props.getUri(AZKABAN_STORAGE_HDFS_ROOT_URI) : null;
   }
 
   public Props getProps() {
@@ -70,6 +68,10 @@ public class AzkabanCommonModuleConfig {
 
   public String getLocalStorageBaseDirPath() {
     return localStorageBaseDirPath;
+  }
+
+  public URI getHdfsRootUri() {
+    return hdfsRootUri;
   }
 
   // todo kunkun-tang: the below method should moved out to azkaban-db module eventually.
@@ -96,18 +98,5 @@ public class AzkabanCommonModuleConfig {
 
   public QueryRunner getQueryRunner() {
     return new QueryRunner(getDataSource());
-  }
-
-  public URI getHdfsBaseUri() {
-    return hdfsBaseUri;
-  }
-
-  private static URI uri(String uri){
-    try {
-      return new URI(uri);
-    } catch (URISyntaxException e) {
-      log.error(e);
-    }
-    return null;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -90,7 +90,8 @@ public class Constants {
 
     public static final String AZKABAN_STORAGE_TYPE = "azkaban.storage.type";
     public static final String AZKABAN_STORAGE_LOCAL_BASEDIR = "azkaban.storage.local.basedir";
-    public static final String AZKABAN_STORAGE_HDFS_BASEURI = "azkaban.storage.hdfs.baseuri";
+    public static final String HADOOP_CONF_DIR_PATH = "hadoop.conf.dir.path";
+    public static final String AZKABAN_STORAGE_HDFS_ROOT_URI = "azkaban.storage.hdfs.root.uri";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -142,10 +142,11 @@ public interface ProjectLoader {
    * @param version
    * @param localFile
    * @param uploader
+   * @param md5
    * @param resourceId
    * @throws ProjectManagerException
    */
-  void addProjectVersion(int projectId, int version, File localFile, String uploader, String resourceId)
+  void addProjectVersion(int projectId, int version, File localFile, String uploader, byte[] md5, String resourceId)
       throws ProjectManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -17,28 +17,72 @@
 
 package azkaban.storage;
 
+import azkaban.AzkabanCommonModuleConfig;
 import azkaban.spi.Storage;
+import azkaban.spi.StorageException;
 import azkaban.spi.StorageMetadata;
+import com.google.common.io.Files;
 import com.google.inject.Inject;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import static com.google.common.base.Preconditions.*;
+import static java.util.Objects.*;
 
 
 public class HdfsStorage implements Storage {
+  private static final Logger log = Logger.getLogger(HdfsStorage.class);
+  private static final String HDFS_SCHEME = "hdfs";
+
+  private final URI rootUri;
+  private final FileSystem hdfs;
 
   @Inject
-  public HdfsStorage() {
-
+  public HdfsStorage(FileSystem hdfs, AzkabanCommonModuleConfig config) {
+    this.rootUri = config.getHdfsRootUri();
+    requireNonNull(rootUri.getAuthority(), "URI must have host:port mentioned.");
+    checkArgument(HDFS_SCHEME.equals(rootUri.getScheme()));
+    this.hdfs = hdfs;
   }
 
   @Override
-  public InputStream get(String key) {
-    throw new UnsupportedOperationException("Method not implemented");
+  public InputStream get(String key) throws IOException {
+    // TODO spyne: relative uri vs absolute uri
+    return hdfs.open(new Path(rootUri.toString(), key));
   }
 
   @Override
   public String put(StorageMetadata metadata, File localFile) {
-    throw new UnsupportedOperationException("Method not implemented");
+    final Path projectsPath = new Path(rootUri.getPath(), String.valueOf(metadata.getProjectId()));
+    try {
+      if (hdfs.mkdirs(projectsPath)) {
+        log.info("Created project dir: " + projectsPath);
+      }
+      final Path targetPath = createTargetPath(metadata, localFile, projectsPath);
+      if ( hdfs.exists( targetPath )) {
+        throw new StorageException(String.format(
+            "Error: Target file already exists. targetFile: %s, Metadata: %s",
+            targetPath, metadata));
+      }
+      hdfs.copyFromLocalFile(new Path(localFile.getAbsolutePath()), targetPath);
+      return URI.create(rootUri.getPath()).relativize(targetPath.toUri()).getPath();
+    } catch (IOException e) {
+      log.error("error in put(): Metadata: " + metadata);
+      throw new StorageException(e);
+    }
+  }
+
+  private Path createTargetPath(StorageMetadata metadata, File localFile, Path projectsPath) {
+    return new Path(projectsPath, String.format("%s-%s.%s",
+        String.valueOf(metadata.getProjectId()),
+        new String(metadata.getHash()),
+        Files.getFileExtension(localFile.getName())
+    ));
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
+++ b/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
@@ -20,6 +20,7 @@ package azkaban;
 import azkaban.project.JdbcProjectLoader;
 import azkaban.spi.Storage;
 import azkaban.storage.DatabaseStorage;
+import azkaban.storage.HdfsStorage;
 import azkaban.storage.LocalStorage;
 import azkaban.storage.StorageManager;
 import azkaban.utils.Props;
@@ -48,19 +49,22 @@ public class ServiceProviderTest {
     Props props = new Props();
     props.put("database.type", "h2");
     props.put("h2.path", "h2");
+
+    props.put("hadoop.conf.dir.path", "/Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop");
+    props.put("azkaban.storage.hdfs.root.uri", "hdfs://localhost:9000/");
+
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_LOCAL_BASEDIR, AZKABAN_LOCAL_TEST_STORAGE);
 
 
     Injector injector = Guice.createInjector(
         new AzkabanCommonModule(props)
     );
-    SERVICE_PROVIDER.unsetInjector();
-    SERVICE_PROVIDER.setInjector(injector);
 
-    assertNotNull(SERVICE_PROVIDER.getInstance(JdbcProjectLoader.class));
-    assertNotNull(SERVICE_PROVIDER.getInstance(StorageManager.class));
-    assertNotNull(SERVICE_PROVIDER.getInstance(DatabaseStorage.class));
-    assertNotNull(SERVICE_PROVIDER.getInstance(LocalStorage.class));
-    assertNotNull(SERVICE_PROVIDER.getInstance(Storage.class));
+    assertNotNull(injector.getInstance(JdbcProjectLoader.class));
+    assertNotNull(injector.getInstance(StorageManager.class));
+    assertNotNull(injector.getInstance(DatabaseStorage.class));
+    assertNotNull(injector.getInstance(LocalStorage.class));
+    assertNotNull(injector.getInstance(HdfsStorage.class));
+    assertNotNull(injector.getInstance(Storage.class));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
+++ b/azkaban-common/src/test/java/azkaban/project/MockProjectLoader.java
@@ -123,7 +123,7 @@ public class MockProjectLoader implements ProjectLoader {
   }
 
   @Override
-  public void addProjectVersion(int projectId, int version, File localFile, String uploader, String resourceId)
+  public void addProjectVersion(int projectId, int version, File localFile, String uploader, byte[] md5, String resourceId)
       throws ProjectManagerException {
 
   }

--- a/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
@@ -22,7 +22,6 @@ import azkaban.spi.StorageMetadata;
 import java.io.File;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 
@@ -36,7 +35,7 @@ public class DatabaseStorageTest {
     int projectId = 1234;
     int version = 1;
     String uploader = "testuser";
-    final StorageMetadata metadata = new StorageMetadata(projectId, version, uploader);
+    final StorageMetadata metadata = new StorageMetadata(projectId, version, uploader, null);
     databaseStorage.put(metadata, file);
     verify(projectLoader).uploadProjectFile(projectId, version, file, uploader);
   }

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban.storage;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+public class HdfsStorageTest {
+  private static final Logger log = Logger.getLogger(HdfsStorageTest.class);
+
+  public static void main(String[] args) throws IOException {
+    Configuration conf = new Configuration(false);
+    conf.addResource(new Path("file:///Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop/core-site.xml"));
+    conf.addResource(new Path("file:///Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop/hdfs-site.xml"));
+
+    System.out.println(conf);
+    conf.set("fs.hdfs.impl", org.apache.hadoop.hdfs.DistributedFileSystem.class.getName());
+    Path pt=new Path("hdfs://localhost:9000/test.file");
+    FileSystem fs = FileSystem.get(conf);
+    BufferedReader br=new BufferedReader(new InputStreamReader(fs.open(pt)));
+    String line;
+    line=br.readLine();
+    while (line != null){
+      System.out.println(line);
+      line=br.readLine();
+    }
+  }
+}

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -5,11 +5,17 @@ dependencies {
   compile('org.apache.kafka:kafka-log4j-appender:0.10.0.0')
   compile('com.googlecode.json-simple:json-simple:1.1.1')
 
-  testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
-  testCompile(project(':azkaban-common').sourceSets.test.output)
-
   runtime(project(':azkaban-hadoop-security-plugin'))
   runtime('org.slf4j:slf4j-log4j12:1.7.18')
+
+  testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
+  testCompile(project(':azkaban-common').sourceSets.test.output)
+  testCompile "org.apache.hadoop:hadoop-auth:$hadoopVersion"
+  testCompile "org.apache.hadoop:hadoop-annotations:$hadoopVersion"
+  testCompile "org.apache.hadoop:hadoop-common:$hadoopVersion"
+  testCompile "org.apache.hadoop:hadoop-hdfs:$hadoopVersion"
+
+  testRuntime "com.h2database:h2:1.4.193"
 }
 
 distributions {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -326,7 +326,7 @@ public class AzkabanExecutorServer {
    * @param args
    * @throws IOException
    */
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
     // Redirect all std out and err messages into log4j
     StdOutErrRedirect.redirectOutAndErrToLog();
 
@@ -346,7 +346,13 @@ public class AzkabanExecutorServer {
         new AzkabanExecServerModule()
     ));
 
-    launch(props);
+    try {
+      launch(props);
+      logger.info("Azkaban Exec Server started...");
+    } catch (Exception e) {
+      logger.error("Exec Server start failed. Exiting...", e);
+      System.exit(1);
+    }
   }
 
   public static void launch(Props azkabanSettings) throws Exception {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban.execapp;
+
+import azkaban.AzkabanCommonModule;
+import azkaban.Constants;
+import azkaban.database.AzkabanDatabaseSetup;
+import azkaban.database.AzkabanDatabaseUpdater;
+import azkaban.utils.Props;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static java.util.Objects.*;
+import static org.apache.commons.io.FileUtils.*;
+import static org.junit.Assert.*;
+
+
+public class AzkabanExecutorServerTest {
+  public static final String AZKABAN_LOCAL_TEST_STORAGE = "AZKABAN_LOCAL_TEST_STORAGE";
+  public static final String AZKABAN_DB_SQL_PATH = "azkaban-db/src/main/sql";
+
+  private static final Props props = new Props();
+
+  private static String getSqlScriptsDir() throws IOException {
+    // Dummy because any resource file works.
+    URL resource = AzkabanExecutorServerTest.class.getClassLoader().getResource("test.file");
+    final String dummyResourcePath = requireNonNull(resource).getPath();
+    Path resources = Paths.get(dummyResourcePath).getParent();
+    Path azkabanRoot = resources.getParent().getParent().getParent().getParent();
+
+    File sqlScriptDir = Paths.get(azkabanRoot.toString(), AZKABAN_DB_SQL_PATH).toFile();
+    return props.getString(AzkabanDatabaseSetup.DATABASE_SQL_SCRIPT_DIR, sqlScriptDir.getCanonicalPath());
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    String sqlScriptsDir = getSqlScriptsDir();
+    props.put(AzkabanDatabaseSetup.DATABASE_SQL_SCRIPT_DIR, sqlScriptsDir);
+
+    props.put("database.type", "h2");
+    props.put("h2.path", "./h2");
+
+    props.put("hadoop.conf.dir.path", "/Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop");
+    props.put("azkaban.storage.hdfs.root.uri", "hdfs://localhost:9000/");
+
+    AzkabanDatabaseUpdater.runDatabaseUpdater(props, sqlScriptsDir, true);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    deleteQuietly(new File("h2.mv.db"));
+    deleteQuietly(new File("h2.trace.db"));
+    deleteQuietly(new File("executor.port"));
+    deleteQuietly(new File("executions"));
+    deleteQuietly(new File("projects"));
+  }
+
+  @Test
+  public void testInjections() throws Exception {
+    props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_LOCAL_BASEDIR, AZKABAN_LOCAL_TEST_STORAGE);
+
+    Injector injector = Guice.createInjector(
+        new AzkabanCommonModule(props),
+        new AzkabanExecServerModule()
+    );
+
+    assertNotNull(injector.getInstance(AzkabanExecutorServer.class));
+  }
+}

--- a/azkaban-exec-server/src/test/resources/test.file
+++ b/azkaban-exec-server/src/test/resources/test.file
@@ -1,0 +1,1 @@
+This file is used by the test suite. Please do not remove.

--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -26,6 +26,9 @@ distributions {
       from ('src/main/resources/conf') {
         into 'conf'
       }
+      from ('src/main/resources/log4j.properties') {
+        into 'conf'
+      }
       from ('src/main/resources/commonprivate.properties') {
         into 'plugins/jobtypes'
       }

--- a/azkaban-solo-server/src/main/bash/azkaban-solo-start.sh
+++ b/azkaban-solo-server/src/main/bash/azkaban-solo-start.sh
@@ -48,7 +48,7 @@ executorport=$(grep executor.port "${conf}/azkaban.properties" | cut -d = -f 2)
 serverpath=$(pwd)
 
 AZKABAN_OPTS=" -Xmx512M -server -Djava.io.tmpdir=$tmpdir -Dexecutorport=${executorport} \
-    -Dserverpath=${serverpath} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+    -Dserverpath=${serverpath} -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
 
 if [[ -f "${conf}/log4j.properties" ]]; then
   # Set the log4j configuration file

--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -14,6 +14,19 @@ user.manager.xml.file=conf/azkaban-users.xml
 executor.global.properties=conf/global.properties
 azkaban.project.dir=projects
 
+#--------------------------------------
+# Azkaban Storage Config
+#--------------------------------------
+# Available options DATABASE (default), LOCAL, HDFS
+azkaban.storage.type=LOCAL
+#
+# For Local Storage
+# azkaban.storage.local.basedir=LOCAL_STORAGE
+#
+# For HDFS Storage
+hadoop.conf.dir.path=/Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop
+azkaban.storage.hdfs.root.uri=hdfs://localhost:9000/
+
 database.type=h2
 h2.path=./h2
 h2.create.tables=true

--- a/azkaban-solo-server/src/main/resources/log4j.properties
+++ b/azkaban-solo-server/src/main/resources/log4j.properties
@@ -1,13 +1,5 @@
-log4j.rootLogger=INFO, Console
-log4j.logger.azkaban=INFO, server
-
-log4j.appender.server=org.apache.log4j.RollingFileAppender
-log4j.appender.server.layout=org.apache.log4j.PatternLayout
-log4j.appender.server.File=azkaban-webserver.log
-log4j.appender.server.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] [Azkaban] %m%n
-log4j.appender.server.MaxFileSize=102400MB
-log4j.appender.server.MaxBackupIndex=2
+log4j.rootLogger=DEBUG, Console
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] [Azkaban] %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n

--- a/azkaban-spi/src/main/java/azkaban/spi/Storage.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/Storage.java
@@ -18,6 +18,7 @@
 package azkaban.spi;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 
 
@@ -39,7 +40,7 @@ public interface Storage {
    * @return InputStream for fetching the blob. null if the key is not found.
    *
    */
-  InputStream get(String key);
+  InputStream get(String key) throws IOException;
 
   /**
    * Put an object and return a key.

--- a/azkaban-spi/src/main/java/azkaban/spi/StorageMetadata.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/StorageMetadata.java
@@ -26,11 +26,13 @@ public class StorageMetadata {
   private final int projectId;
   private final int version;
   private final String uploader;
+  private byte[] hash;
 
-  public StorageMetadata(int projectId, int version, String uploader) {
+  public StorageMetadata(int projectId, int version, String uploader, byte[] hash) {
     this.projectId = projectId;
     this.version = version;
     this.uploader = requireNonNull(uploader);
+    this.hash = hash;
   }
 
   @Override
@@ -48,6 +50,10 @@ public class StorageMetadata {
 
   public String getUploader() {
     return uploader;
+  }
+
+  public byte[] getHash() {
+    return hash;
   }
 
   @Override

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -670,7 +670,7 @@ public class AzkabanWebServer extends AzkabanServer {
    *
    * @param args
    */
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
     // Redirect all std out and err messages into log4j
     StdOutErrRedirect.redirectOutAndErrToLog();
 
@@ -688,7 +688,13 @@ public class AzkabanWebServer extends AzkabanServer {
         new AzkabanWebServerModule()
     ));
 
-    launch(props);
+    try {
+      launch(props);
+      logger.info("Azkaban Web Server started...");
+    } catch (Exception e) {
+      logger.error("Web Server start failed. Exiting...", e);
+      System.exit(1);
+    }
   }
 
   public static void launch(Props azkabanSettings) throws Exception {


### PR DESCRIPTION
This patch implements HDFS storage for Azkaban.

Config parameters introduced:
```
# URI root for HDFS storage.
azkaban.storage.hdfs.root.uri=hdfs://localhost:9000/path/to/foo

# Hadoop conf dir
hadoop.conf.dir.path=/path/to/hadoop/etc/hadoop
```

Local and HDFS example project filepath: `<project_id>/<project_id>_<md5_hash>.zip`