### PR TITLE
Remove runningFlows cache in ExecutorManager. Added unit tests for Ex…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -35,6 +35,9 @@ public interface ExecutorLoader {
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException;
 
+  Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+      throws ExecutorManagerException;
+
   List<ExecutableFlow> fetchFlowHistory(int skip, int num)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -93,14 +93,12 @@ public class ExecutorManager extends EventHandler implements
 
   private CleanerThread cleanerThread;
 
-  private ConcurrentHashMap<Integer, Pair<ExecutionReference, ExecutableFlow>> runningFlows =
-      new ConcurrentHashMap<Integer, Pair<ExecutionReference, ExecutableFlow>>();
   private ConcurrentHashMap<Integer, ExecutableFlow> recentlyFinished =
-      new ConcurrentHashMap<Integer, ExecutableFlow>();
+      new ConcurrentHashMap<>();
 
   QueuedExecutions queuedFlows;
 
-  final private Set<Executor> activeExecutors = new HashSet<Executor>();
+  final private Set<Executor> activeExecutors = new HashSet<>();
   private QueueProcessorThread queueProcessor;
   private volatile Pair<ExecutionReference, ExecutableFlow> runningCandidate = null;
 
@@ -129,7 +127,6 @@ public class ExecutorManager extends EventHandler implements
     this.azkProps = azkProps;
     this.executorLoader = loader;
     this.setupExecutors();
-    this.loadRunningFlows();
 
     queuedFlows =
         new QueuedExecutions(azkProps.getLong(AZKABAN_WEBSERVER_QUEUE_SIZE, 100000));
@@ -420,21 +417,21 @@ public class ExecutorManager extends EventHandler implements
   @Override
   public Set<String> getAllActiveExecutorServerHosts() {
     // Includes non primary server/hosts
-    HashSet<String> ports = new HashSet<String>();
+    HashSet<String> ports = new HashSet<>();
     for (Executor executor : activeExecutors) {
       ports.add(executor.getHost() + ":" + executor.getPort());
     }
-    // include executor which were initially active and still has flows running
-    for (Pair<ExecutionReference, ExecutableFlow> running : runningFlows
-      .values()) {
-      ExecutionReference ref = running.getFirst();
-      ports.add(ref.getHost() + ":" + ref.getPort());
+    try {
+      // include executor which were initially active and still has flows running
+      for (Pair<ExecutionReference, ExecutableFlow> running :
+          executorLoader.fetchActiveFlows().values()) {
+        ExecutionReference ref = running.getFirst();
+        ports.add(ref.getHost() + ":" + ref.getPort());
+      }
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
     }
     return ports;
-  }
-
-  private void loadRunningFlows() throws ExecutorManagerException {
-    runningFlows.putAll(executorLoader.fetchActiveFlows());
   }
 
   /*
@@ -469,8 +466,12 @@ public class ExecutorManager extends EventHandler implements
     if (runningCandidate != null) {
       executionIds.addAll(getRunningFlowsHelper(projectId, flowId, Lists.newArrayList(runningCandidate)));
     }
-    executionIds.addAll(getRunningFlowsHelper(projectId, flowId,
-      runningFlows.values()));
+    try {
+      executionIds.addAll(getRunningFlowsHelper(projectId, flowId,
+          executorLoader.fetchActiveFlows().values()));
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
+    }
     Collections.sort(executionIds);
     return executionIds;
   }
@@ -497,10 +498,13 @@ public class ExecutorManager extends EventHandler implements
   @Override
   public List<Pair<ExecutableFlow, Executor>> getActiveFlowsWithExecutor()
     throws IOException {
-    List<Pair<ExecutableFlow, Executor>> flows =
-      new ArrayList<Pair<ExecutableFlow, Executor>>();
+    List<Pair<ExecutableFlow, Executor>> flows = new ArrayList<>();
     getActiveFlowsWithExecutorHelper(flows, queuedFlows.getAllEntries());
-    getActiveFlowsWithExecutorHelper(flows, runningFlows.values());
+    try {
+      getActiveFlowsWithExecutorHelper(flows, executorLoader.fetchActiveFlows().values());
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
+    }
     return flows;
   }
 
@@ -527,9 +531,12 @@ public class ExecutorManager extends EventHandler implements
     isRunning =
       isRunning
         || isFlowRunningHelper(projectId, flowId, queuedFlows.getAllEntries());
-    isRunning =
-      isRunning
-        || isFlowRunningHelper(projectId, flowId, runningFlows.values());
+    try {
+      isRunning = isRunning || isFlowRunningHelper(projectId, flowId,
+          executorLoader.fetchActiveFlows().values());
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
+    }
     return isRunning;
   }
 
@@ -565,9 +572,13 @@ public class ExecutorManager extends EventHandler implements
    */
   @Override
   public List<ExecutableFlow> getRunningFlows() {
-    ArrayList<ExecutableFlow> flows = new ArrayList<ExecutableFlow>();
+    ArrayList<ExecutableFlow> flows = new ArrayList<>();
     getActiveFlowHelper(flows, queuedFlows.getAllEntries());
-    getActiveFlowHelper(flows, runningFlows.values());
+    try {
+      getActiveFlowHelper(flows, executorLoader.fetchActiveFlows().values());
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
+    }
     return flows;
   }
 
@@ -590,9 +601,13 @@ public class ExecutorManager extends EventHandler implements
    * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows()
    */
   public String getRunningFlowIds() {
-    List<Integer> allIds = new ArrayList<Integer>();
+    List<Integer> allIds = new ArrayList<>();
     getRunningFlowsIdsHelper(allIds, queuedFlows.getAllEntries());
-    getRunningFlowsIdsHelper(allIds, runningFlows.values());
+    try {
+      getRunningFlowsIdsHelper(allIds, executorLoader.fetchActiveFlows().values());
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
+    }
     Collections.sort(allIds);
     return allIds.toString();
   }
@@ -686,7 +701,7 @@ public class ExecutorManager extends EventHandler implements
   public LogData getExecutableFlowLog(ExecutableFlow exFlow, int offset,
       int length) throws ExecutorManagerException {
     Pair<ExecutionReference, ExecutableFlow> pair =
-        runningFlows.get(exFlow.getExecutionId());
+        executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
     if (pair != null) {
       Pair<String, String> typeParam = new Pair<String, String>("type", "flow");
       Pair<String, String> offsetParam =
@@ -711,7 +726,7 @@ public class ExecutorManager extends EventHandler implements
   public LogData getExecutionJobLog(ExecutableFlow exFlow, String jobId,
       int offset, int length, int attempt) throws ExecutorManagerException {
     Pair<ExecutionReference, ExecutableFlow> pair =
-        runningFlows.get(exFlow.getExecutionId());
+        executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
     if (pair != null) {
       Pair<String, String> typeParam = new Pair<String, String>("type", "job");
       Pair<String, String> jobIdParam =
@@ -740,7 +755,7 @@ public class ExecutorManager extends EventHandler implements
   public List<Object> getExecutionJobStats(ExecutableFlow exFlow, String jobId,
       int attempt) throws ExecutorManagerException {
     Pair<ExecutionReference, ExecutableFlow> pair =
-        runningFlows.get(exFlow.getExecutionId());
+        executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
     if (pair == null) {
       return executorLoader.fetchAttachments(exFlow.getExecutionId(), jobId,
           attempt);
@@ -765,9 +780,9 @@ public class ExecutorManager extends EventHandler implements
   public JobMetaData getExecutionJobMetaData(ExecutableFlow exFlow,
       String jobId, int offset, int length, int attempt)
       throws ExecutorManagerException {
-    Pair<ExecutionReference, ExecutableFlow> pair =
-        runningFlows.get(exFlow.getExecutionId());
-    if (pair != null) {
+    Pair<ExecutionReference, ExecutableFlow> activeFlow =
+        executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
+    if (activeFlow != null) {
 
       Pair<String, String> typeParam = new Pair<String, String>("type", "job");
       Pair<String, String> jobIdParam =
@@ -781,7 +796,7 @@ public class ExecutorManager extends EventHandler implements
 
       @SuppressWarnings("unchecked")
       Map<String, Object> result =
-          callExecutorServer(pair.getFirst(), ConnectorParams.METADATA_ACTION,
+          callExecutorServer(activeFlow.getFirst(), ConnectorParams.METADATA_ACTION,
               typeParam, jobIdParam, offsetParam, lengthParam, attemptParam);
       return JobMetaData.createJobMetaDataFromObject(result);
     } else {
@@ -800,10 +815,10 @@ public class ExecutorManager extends EventHandler implements
   public void cancelFlow(ExecutableFlow exFlow, String userId)
     throws ExecutorManagerException {
     synchronized (exFlow) {
-      if (runningFlows.containsKey(exFlow.getExecutionId())) {
-        Pair<ExecutionReference, ExecutableFlow> pair =
-          runningFlows.get(exFlow.getExecutionId());
-        callExecutorServer(pair.getFirst(), ConnectorParams.CANCEL_ACTION,
+      Pair<ExecutionReference, ExecutableFlow> activeFlow =
+          executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
+      if(activeFlow != null) {
+        callExecutorServer(activeFlow.getFirst(), ConnectorParams.CANCEL_ACTION,
           userId);
       } else if (queuedFlows.hasExecution(exFlow.getExecutionId())) {
         queuedFlows.dequeue(exFlow.getExecutionId());
@@ -820,14 +835,14 @@ public class ExecutorManager extends EventHandler implements
   public void resumeFlow(ExecutableFlow exFlow, String userId)
       throws ExecutorManagerException {
     synchronized (exFlow) {
-      Pair<ExecutionReference, ExecutableFlow> pair =
-          runningFlows.get(exFlow.getExecutionId());
-      if (pair == null) {
+      Pair<ExecutionReference, ExecutableFlow> activeFlow =
+          executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
+      if (activeFlow == null) {
         throw new ExecutorManagerException("Execution "
             + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId()
             + " isn't running.");
       }
-      callExecutorServer(pair.getFirst(), ConnectorParams.RESUME_ACTION, userId);
+      callExecutorServer(activeFlow.getFirst(), ConnectorParams.RESUME_ACTION, userId);
     }
   }
 
@@ -835,14 +850,14 @@ public class ExecutorManager extends EventHandler implements
   public void pauseFlow(ExecutableFlow exFlow, String userId)
       throws ExecutorManagerException {
     synchronized (exFlow) {
-      Pair<ExecutionReference, ExecutableFlow> pair =
-          runningFlows.get(exFlow.getExecutionId());
-      if (pair == null) {
+      Pair<ExecutionReference, ExecutableFlow> activeFlow =
+          executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
+      if (activeFlow == null) {
         throw new ExecutorManagerException("Execution "
             + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId()
             + " isn't running.");
       }
-      callExecutorServer(pair.getFirst(), ConnectorParams.PAUSE_ACTION, userId);
+      callExecutorServer(activeFlow.getFirst(), ConnectorParams.PAUSE_ACTION, userId);
     }
   }
 
@@ -900,7 +915,7 @@ public class ExecutorManager extends EventHandler implements
       throws ExecutorManagerException {
     synchronized (exFlow) {
       Pair<ExecutionReference, ExecutableFlow> pair =
-          runningFlows.get(exFlow.getExecutionId());
+          executorLoader.fetchActiveFlowByExecId(exFlow.getExecutionId());
       if (pair == null) {
         throw new ExecutorManagerException("Execution "
             + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId()
@@ -1141,6 +1156,7 @@ public class ExecutorManager extends EventHandler implements
       paramList = new ArrayList<Pair<String, String>>();
     }
 
+    // TODO: refactor using Guice, inject ExecutorApiClient in ExecutorManager
     ExecutorApiClient apiclient = ExecutorApiClient.getInstance();
     @SuppressWarnings("unchecked")
     URI uri =
@@ -1238,6 +1254,8 @@ public class ExecutorManager extends EventHandler implements
               new ArrayList<ExecutableFlow>();
           ArrayList<ExecutableFlow> finalizeFlows =
               new ArrayList<ExecutableFlow>();
+          Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows =
+              executorLoader.fetchActiveFlows();
 
           if (exFlowMap.size() > 0) {
             for (Map.Entry<Executor, List<ExecutableFlow>> entry : exFlowMap
@@ -1273,15 +1291,15 @@ public class ExecutorManager extends EventHandler implements
               } catch (IOException e) {
                 logger.error(e);
                 for (ExecutableFlow flow : entry.getValue()) {
-                  Pair<ExecutionReference, ExecutableFlow> pair =
-                      runningFlows.get(flow.getExecutionId());
+                  Pair<ExecutionReference, ExecutableFlow> activeFlow =
+                      activeFlows.get(flow.getExecutionId());
 
                   updaterStage =
                       "Failed to get update. Doing some clean up for flow "
-                          + pair.getSecond().getExecutionId();
+                          + flow.getExecutionId();
 
-                  if (pair != null) {
-                    ExecutionReference ref = pair.getFirst();
+                  if (activeFlow != null) {
+                    ExecutionReference ref = activeFlow.getFirst();
                     int numErrors = ref.getNumErrors();
                     if (ref.getNumErrors() < this.numErrors) {
                       ref.setNextCheckTime(System.currentTimeMillis()
@@ -1291,7 +1309,7 @@ public class ExecutorManager extends EventHandler implements
                       logger.error("Evicting flow " + flow.getExecutionId()
                           + ". The executor is unresponsive.");
                       // TODO should send out an unresponsive email here.
-                      finalizeFlows.add(pair.getSecond());
+                      finalizeFlows.add(activeFlow.getSecond());
                     }
                   }
                 }
@@ -1352,7 +1370,7 @@ public class ExecutorManager extends EventHandler implements
 
           synchronized (this) {
             try {
-              if (runningFlows.size() > 0) {
+              if (activeFlows.size() > 0) {
                 this.wait(waitTimeMs);
               } else {
                 this.wait(waitTimeIdleMs);
@@ -1400,7 +1418,6 @@ public class ExecutorManager extends EventHandler implements
       executorLoader.removeActiveExecutableReference(execId);
 
       updaterStage = "finalizing flow " + execId + " cleaning from memory";
-      runningFlows.remove(execId);
       fireEventListeners(Event.create(dsFlow, Type.FLOW_FINISHED, new EventData(dsFlow.getStatus())));
       recentlyFinished.put(execId, dsFlow);
 
@@ -1528,15 +1545,15 @@ public class ExecutorManager extends EventHandler implements
           "Response is malformed. Need exec id to update.");
     }
 
-    Pair<ExecutionReference, ExecutableFlow> refPair =
-        this.runningFlows.get(execId);
-    if (refPair == null) {
+    Pair<ExecutionReference, ExecutableFlow> activeFlow =
+        executorLoader.fetchActiveFlowByExecId(execId);
+    if (activeFlow == null) {
       throw new ExecutorManagerException(
           "No running flow found with the execution id. Removing " + execId);
     }
 
-    ExecutionReference ref = refPair.getFirst();
-    ExecutableFlow flow = refPair.getSecond();
+    ExecutionReference ref = activeFlow.getFirst();
+    ExecutableFlow flow = activeFlow.getSecond();
     if (updateData.containsKey("error")) {
       // The flow should be finished here.
       throw new ExecutorManagerException((String) updateData.get("error"), flow);
@@ -1608,27 +1625,31 @@ public class ExecutorManager extends EventHandler implements
   /* Group Executable flow by Executors to reduce number of REST calls */
   private Map<Executor, List<ExecutableFlow>> getFlowToExecutorMap() {
     HashMap<Executor, List<ExecutableFlow>> exFlowMap =
-      new HashMap<Executor, List<ExecutableFlow>>();
+      new HashMap<>();
 
-    for (Pair<ExecutionReference, ExecutableFlow> runningFlow : runningFlows
-      .values()) {
-      ExecutionReference ref = runningFlow.getFirst();
-      ExecutableFlow flow = runningFlow.getSecond();
-      Executor executor = ref.getExecutor();
+    try {
+      for (Pair<ExecutionReference, ExecutableFlow> runningFlow :
+          executorLoader.fetchActiveFlows().values()) {
+        ExecutionReference ref = runningFlow.getFirst();
+        ExecutableFlow flow = runningFlow.getSecond();
+        Executor executor = ref.getExecutor();
 
-      // We can set the next check time to prevent the checking of certain
-      // flows.
-      if (ref.getNextCheckTime() >= System.currentTimeMillis()) {
-        continue;
+        // We can set the next check time to prevent the checking of certain
+        // flows.
+        if (ref.getNextCheckTime() >= System.currentTimeMillis()) {
+          continue;
+        }
+
+        List<ExecutableFlow> flows = exFlowMap.get(executor);
+        if (flows == null) {
+          flows = new ArrayList<>();
+          exFlowMap.put(executor, flows);
+        }
+
+        flows.add(flow);
       }
-
-      List<ExecutableFlow> flows = exFlowMap.get(executor);
-      if (flows == null) {
-        flows = new ArrayList<ExecutableFlow>();
-        exFlowMap.put(executor, flows);
-      }
-
-      flows.add(flow);
+    } catch(ExecutorManagerException e) {
+      logger.error(e);
     }
 
     return exFlowMap;
@@ -1728,10 +1749,6 @@ public class ExecutorManager extends EventHandler implements
       throw new ExecutorManagerException(ex);
     }
     reference.setExecutor(choosenExecutor);
-
-    // move from flow to running flows
-    runningFlows.put(exflow.getExecutionId(),
-      new Pair<ExecutionReference, ExecutableFlow>(reference, exflow));
 
     logger.info(String.format(
       "Successfully dispatched exec %d with error count %d",

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -218,6 +218,27 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
   }
 
   @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+      throws ExecutorManagerException {
+    QueryRunner runner = createQueryRunner();
+    FetchActiveExecutableFlowByExecId flowHandler = new FetchActiveExecutableFlowByExecId();
+
+    try {
+      List<Pair<ExecutionReference, ExecutableFlow>> flows =
+          runner.query(FetchActiveExecutableFlowByExecId.FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID,
+              flowHandler, execId);
+      if(flows.isEmpty()) {
+        return null;
+      }
+      else {
+        return flows.get(0);
+      }
+    } catch (SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows by exec id", e);
+    }
+  }
+
+  @Override
   public int fetchNumExecutableFlows() throws ExecutorManagerException {
     QueryRunner runner = createQueryRunner();
 
@@ -1156,7 +1177,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
         "SELECT exec_id, project_id, version, flow_id, job_id, "
             + "start_time, end_time, status, attempt "
             + "FROM execution_jobs WHERE exec_id=? "
-            + "AND job_id=? AND attempt_id=?";
+            + "AND job_id=? AND attempt=?";
     private static String FETCH_EXECUTABLE_NODE_ATTEMPTS =
         "SELECT exec_id, project_id, version, flow_id, job_id, "
             + "start_time, end_time, status, attempt FROM execution_jobs "
@@ -1363,7 +1384,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
       }
 
       Map<Integer, Pair<ExecutionReference, ExecutableFlow>> execFlows =
-          new HashMap<Integer, Pair<ExecutionReference, ExecutableFlow>>();
+          new HashMap<>();
       do {
         int id = rs.getInt(1);
         int encodingType = rs.getInt(2);
@@ -1399,6 +1420,68 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
 
             execFlows.put(id, new Pair<ExecutionReference, ExecutableFlow>(ref,
                 exFlow));
+          } catch (IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  private static class FetchActiveExecutableFlowByExecId implements
+      ResultSetHandler<List<Pair<ExecutionReference, ExecutableFlow>>> {
+    private static String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, ax.update_time axUpdateTime, et.id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " INNER JOIN "
+            + " active_executing_flows ax ON ex.exec_id = ax.exec_id"
+            + " INNER JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " WHERE ax.exec_id = ?";
+
+    @Override
+    public List<Pair<ExecutionReference, ExecutableFlow>> handle(ResultSet rs)
+        throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyList();
+      }
+
+      List<Pair<ExecutionReference, ExecutableFlow>> execFlows =
+          new ArrayList<>();
+      do {
+        int id = rs.getInt(1);
+        int encodingType = rs.getInt(2);
+        byte[] data = rs.getBytes(3);
+        String host = rs.getString(4);
+        int port = rs.getInt(5);
+        long updateTime = rs.getLong(6);
+        int executorId = rs.getInt(7);
+        boolean executorStatus = rs.getBoolean(8);
+
+        if (data == null) {
+          logger.error("Found a flow with empty data blob exec_id: " + id);
+        } else {
+          EncodingType encType = EncodingType.fromInteger(encodingType);
+          Object flowObj;
+          try {
+            if (encType == EncodingType.GZIP) {
+              String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+            Executor executor = new Executor(executorId, host, port, executorStatus);
+            ExecutionReference ref = new ExecutionReference(id, executor);
+            ref.setUpdateTime(updateTime);
+
+            execFlows.add(new Pair<>(ref, exFlow));
           } catch (IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);
           }

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -67,6 +67,12 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+      throws ExecutorManagerException {
+    return activeFlows.get(execId);
+  }
+
+  @Override
   public List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
       int skip, int num) throws ExecutorManagerException {
     return null;

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/exec2.flow
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/exec2.flow
@@ -1,7 +1,7 @@
 {
   "project.id":1,
   "version":2,
-  "id" : "derived-member-data",
+  "id" : "derived-member-data-2",
   "success.email" : [],
   "edges" : [ {
     "source" : "job1",


### PR DESCRIPTION
Tested the changes in solo server and local mysql database. Fixed some bugs in existing test cases for ExecutorManger and JdbcExecutorLoader.

TODO: 
1. Remove queuedFlows cache and refactor the unit tests for ExecutorManager. Need to remove QueueProcessorThread as well. 
2. Refactor executorManager, inject ExecutorApiClient using Guice. This will help mock http calls to executors in unit tests. 
3. When a running flow is canceled, it takes some time for the job/flow log to show up. Need to fix this issue. 
4. Refactor JdbcExecutorLoaderTest. Consider using in-memory database.
