### PR TITLE
Add org.slf4j:slf4j-log4j12 run time dependency to select modules

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -70,6 +70,7 @@ dependencies {
   testCompile(project(':azkaban-test').sourceSets.test.output)
 
   testRuntime('com.h2database:h2:1.4.193')
+  testRuntime('org.slf4j:slf4j-log4j12:1.7.18')
 }
 
 tasks.withType(JavaCompile) {

--- a/azkaban-common/src/test/resources/log4j.properties
+++ b/azkaban-common/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, Console
+
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n

--- a/azkaban-db/src/test/resources/log4j.properties
+++ b/azkaban-db/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=INFO, Console
+
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n
+
+log4j.category.velocity=INFO

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   testCompile(project(':azkaban-common').sourceSets.test.output)
 
   runtime(project(':azkaban-hadoop-security-plugin'))
+  runtime('org.slf4j:slf4j-log4j12:1.7.18')
 }
 
 distributions {

--- a/azkaban-exec-server/src/test/resources/log4j.properties
+++ b/azkaban-exec-server/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, Console
+
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n

--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -54,6 +54,8 @@ dependencies {
   compile('com.linkedin.pegasus:restli-server:' + pegasusVersion)
   compile('org.apache.velocity:velocity-tools:2.0')
 
+  runtime('org.slf4j:slf4j-log4j12:1.7.18')
+
   testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
   testCompile('commons-collections:commons-collections:3.2.2')
   testCompile('org.hamcrest:hamcrest-all:1.3')


### PR DESCRIPTION
This allows loggers that use slf4j to log properly.

Also added log4j.properties files to test resources to log to console
in tests by default.

Symptom:
example warning when running tests:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
log4j:WARN No appenders could be found for logger (azkaban.jobExecutor.JavaProcessJob).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.


Testing:
Here is the console output from running a test

2017/05/03 08:35:08.586 -0700 ERROR [DatabaseOperatorImpl] query failed
java.sql.SQLException