### PR TITLE
Added a unit test for Exec server instantiation

### DIFF
--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -5,11 +5,13 @@ dependencies {
   compile('org.apache.kafka:kafka-log4j-appender:0.10.0.0')
   compile('com.googlecode.json-simple:json-simple:1.1.1')
 
+  runtime(project(':azkaban-hadoop-security-plugin'))
+  runtime('org.slf4j:slf4j-log4j12:1.7.18')
+
   testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
   testCompile(project(':azkaban-common').sourceSets.test.output)
 
-  runtime(project(':azkaban-hadoop-security-plugin'))
-  runtime('org.slf4j:slf4j-log4j12:1.7.18')
+  testRuntime "com.h2database:h2:1.4.193"
 }
 
 distributions {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
@@ -63,9 +63,6 @@ public class AzkabanExecutorServerTest {
     props.put("database.type", "h2");
     props.put("h2.path", "./h2");
 
-    props.put("hadoop.conf.dir.path", "/Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop");
-    props.put("azkaban.storage.hdfs.root.uri", "hdfs://localhost:9000/");
-
     AzkabanDatabaseUpdater.runDatabaseUpdater(props, sqlScriptsDir, true);
   }
 
@@ -79,7 +76,7 @@ public class AzkabanExecutorServerTest {
   }
 
   @Test
-  public void testInjections() throws Exception {
+  public void testInjection() throws Exception {
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_LOCAL_BASEDIR, AZKABAN_LOCAL_TEST_STORAGE);
 
     Injector injector = Guice.createInjector(

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban.execapp;
+
+import azkaban.AzkabanCommonModule;
+import azkaban.Constants;
+import azkaban.database.AzkabanDatabaseSetup;
+import azkaban.database.AzkabanDatabaseUpdater;
+import azkaban.utils.Props;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static java.util.Objects.*;
+import static org.apache.commons.io.FileUtils.*;
+import static org.junit.Assert.*;
+
+
+public class AzkabanExecutorServerTest {
+  public static final String AZKABAN_LOCAL_TEST_STORAGE = "AZKABAN_LOCAL_TEST_STORAGE";
+  public static final String AZKABAN_DB_SQL_PATH = "azkaban-db/src/main/sql";
+
+  private static final Props props = new Props();
+
+  private static String getSqlScriptsDir() throws IOException {
+    // Dummy because any resource file works.
+    URL resource = AzkabanExecutorServerTest.class.getClassLoader().getResource("test.file");
+    final String dummyResourcePath = requireNonNull(resource).getPath();
+    Path resources = Paths.get(dummyResourcePath).getParent();
+    Path azkabanRoot = resources.getParent().getParent().getParent().getParent();
+
+    File sqlScriptDir = Paths.get(azkabanRoot.toString(), AZKABAN_DB_SQL_PATH).toFile();
+    return props.getString(AzkabanDatabaseSetup.DATABASE_SQL_SCRIPT_DIR, sqlScriptDir.getCanonicalPath());
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    String sqlScriptsDir = getSqlScriptsDir();
+    props.put(AzkabanDatabaseSetup.DATABASE_SQL_SCRIPT_DIR, sqlScriptsDir);
+
+    props.put("database.type", "h2");
+    props.put("h2.path", "./h2");
+
+    props.put("hadoop.conf.dir.path", "/Users/spyne/hadoop/hadoop-2.6.1/etc/hadoop");
+    props.put("azkaban.storage.hdfs.root.uri", "hdfs://localhost:9000/");
+
+    AzkabanDatabaseUpdater.runDatabaseUpdater(props, sqlScriptsDir, true);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    deleteQuietly(new File("h2.mv.db"));
+    deleteQuietly(new File("h2.trace.db"));
+    deleteQuietly(new File("executor.port"));
+    deleteQuietly(new File("executions"));
+    deleteQuietly(new File("projects"));
+  }
+
+  @Test
+  public void testInjections() throws Exception {
+    props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_LOCAL_BASEDIR, AZKABAN_LOCAL_TEST_STORAGE);
+
+    Injector injector = Guice.createInjector(
+        new AzkabanCommonModule(props),
+        new AzkabanExecServerModule()
+    );
+
+    assertNotNull(injector.getInstance(AzkabanExecutorServer.class));
+  }
+}

--- a/azkaban-exec-server/src/test/resources/test.file
+++ b/azkaban-exec-server/src/test/resources/test.file
@@ -1,0 +1,1 @@
+This file is used by the test suite. Please do not remove.


### PR DESCRIPTION
This patch adds a basic instantiation test to AzkabanExecServer with Guice.
This ensures that injection doesn't break. Also the goal is to reduce 
overhead during object construction.