### PR TITLE
[DO NOT MERGE] Migration Tool for transferring project file data from Database to Local Storage

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -15,6 +15,10 @@
  *
  */
 
+plugins {
+  id "com.github.johnrengelman.shadow" version "1.2.4"
+}
+
 apply plugin: 'c'
 model {
   components {
@@ -76,4 +80,15 @@ dependencies {
 
 tasks.withType(JavaCompile) {
   options.encoding = "UTF-8"
+}
+
+shadowJar {
+  baseName = 'migrateSql2Local'
+  classifier = null
+  version = null
+  manifest {
+    attributes(
+            'Main-Class': 'azkaban.MigrateSqlToLocal'
+    )
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -64,9 +64,10 @@ public class MigrateSqlToLocal {
     List<JdbcProjectLoader.Result> allActiveProjects = jdbcProjectLoader
         .fetchProjectsForMigration();
     System.out.println("fetched all migratable projects. #: " + allActiveProjects.size());
-    for (JdbcProjectLoader.Result r : allActiveProjects) {
+    for (int i = 0; i < allActiveProjects.size(); i++) {
+      Result r = allActiveProjects.get(i);
       System.out.println("--------------------------------------------------------------------");
-      System.out.println("Migrating :: " + r);
+      System.out.printf("Migrating (%d of %d) :: %s%n", i + 1, allActiveProjects.size(), r);
 
       try {
         migrateProject(r);

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban;
+
+import azkaban.project.JdbcProjectLoader;
+import azkaban.project.ProjectFileHandler;
+import azkaban.spi.AzkabanException;
+import azkaban.spi.StorageMetadata;
+import azkaban.storage.DatabaseStorage;
+import azkaban.storage.LocalStorage;
+import azkaban.utils.Props;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.codec.binary.Hex;
+
+
+public class MigrateSqlToLocal {
+  public static final String MIGRATE_PROPERTIES = "migrate.properties";
+  final Props props;
+  final JdbcProjectLoader jdbcProjectLoader;
+  final DatabaseStorage databaseStorage;
+  final LocalStorage localStorage;
+
+  @Inject
+  public MigrateSqlToLocal(Props props, JdbcProjectLoader jdbcProjectLoader, DatabaseStorage databaseStorage,
+      LocalStorage localStorage) {
+    this.props = props;
+    this.jdbcProjectLoader = jdbcProjectLoader;
+    this.databaseStorage = databaseStorage;
+    this.localStorage = localStorage;
+  }
+
+  private void migrate() {
+    List<JdbcProjectLoader.Result> allActiveProjects = jdbcProjectLoader.fetchProjectsForMigration();
+    System.out.println("fetched all migratable projects");
+    for (JdbcProjectLoader.Result r : allActiveProjects) {
+      final String key = String.format("%s/%s-%s.zip", r.id, r.id, new String(Hex.encodeHex(r.md5)));
+      if (!localStorage.contains(key)) {
+        System.out.println("Adding storage for " + r);
+        final ProjectFileHandler pfh = jdbcProjectLoader.getUploadedFile(r.id, r.version);
+        System.out.println("Received file: " + pfh.getLocalFile().getAbsolutePath());
+
+        StorageMetadata metadata = new StorageMetadata(r.id, r.version, "", r.md5);
+        System.out.println("Metadata: " + metadata);
+        final String resourceId = localStorage.put(metadata, pfh.getLocalFile());
+        System.out.printf("ResourceId: %s\n", resourceId);
+        jdbcProjectLoader.updateResourceId(r.id, r.version, resourceId);
+        System.out.println("Migration complete for r: " + r);
+      } else {
+        System.out.println("No key for: " + r);
+      }
+    }
+  }
+
+  public static void main(String[] args) {
+    try {
+      final File propsFile = new File(MigrateSqlToLocal.class.getClassLoader().getResource(MIGRATE_PROPERTIES).getFile());
+      final Injector injector = Guice.createInjector(new AzkabanCommonModule(new Props(null, propsFile)));
+      injector.getInstance(MigrateSqlToLocal.class).migrate();
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new AzkabanException(e);
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -79,6 +79,9 @@ public class MigrateSqlToLocal {
     }
 
     printFailed();
+    System.out.println("=====================================================");
+    System.out.println(" Migration complete.");
+    System.out.println("=====================================================");
   }
 
   private void printFailed() {

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -121,8 +121,10 @@ public class MigrateSqlToLocal {
       System.out.println("File already present: " + r);
     }
 
-    System.out.printf("ResourceId: %s\n", key);
-    jdbcProjectLoader.updateResourceId(r.id, r.version, key);
+    if (!key.equals(r.resourceId)) {
+      System.out.printf("Updated ResourceId from: %s to %s%n", r.resourceId, key);
+      jdbcProjectLoader.updateResourceId(r.id, r.version, key);
+    }
     System.out.println("Migration complete for r: " + r);
   }
 

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -18,6 +18,7 @@
 package azkaban;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 import azkaban.project.JdbcProjectLoader;
 import azkaban.project.ProjectFileHandler;
@@ -68,12 +69,14 @@ public class MigrateSqlToLocal {
         StorageMetadata metadata = new StorageMetadata(r.id, r.version, "", r.md5);
         System.out.println("Metadata: " + metadata);
         final String resourceId = localStorage.put(metadata, pfh.getLocalFile());
-        System.out.printf("ResourceId: %s\n", resourceId);
-        jdbcProjectLoader.updateResourceId(r.id, r.version, resourceId);
-        System.out.println("Migration complete for r: " + r);
+        checkState(key.equals(resourceId));
       } else {
-        System.out.println("Already present: " + r);
+        System.out.println("File already present: " + r);
       }
+
+      System.out.printf("ResourceId: %s\n", key);
+      jdbcProjectLoader.updateResourceId(r.id, r.version, key);
+      System.out.println("Migration complete for r: " + r);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
+++ b/azkaban-common/src/main/java/azkaban/MigrateSqlToLocal.java
@@ -21,17 +21,22 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import azkaban.project.JdbcProjectLoader;
+import azkaban.project.JdbcProjectLoader.Result;
 import azkaban.project.ProjectFileHandler;
 import azkaban.spi.AzkabanException;
 import azkaban.spi.StorageMetadata;
 import azkaban.storage.DatabaseStorage;
 import azkaban.storage.LocalStorage;
+import azkaban.utils.Md5Hasher;
 import azkaban.utils.Props;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.codec.binary.Hex;
 
@@ -42,6 +47,8 @@ public class MigrateSqlToLocal {
   final JdbcProjectLoader jdbcProjectLoader;
   final DatabaseStorage databaseStorage;
   final LocalStorage localStorage;
+
+  final List<Result> failed = new ArrayList<>();
 
   @Inject
   public MigrateSqlToLocal(Props props, JdbcProjectLoader jdbcProjectLoader,
@@ -58,26 +65,69 @@ public class MigrateSqlToLocal {
         .fetchProjectsForMigration();
     System.out.println("fetched all migratable projects. #: " + allActiveProjects.size());
     for (JdbcProjectLoader.Result r : allActiveProjects) {
-      final String key = String
-          .format("%s/%s-%s.zip", r.id, r.id, new String(Hex.encodeHex(r.md5)));
       System.out.println("--------------------------------------------------------------------");
-      System.out.println("Adding storage for " + r);
-      if (!localStorage.contains(key)) {
-        final ProjectFileHandler pfh = jdbcProjectLoader.getUploadedFile(r.id, r.version);
-        System.out.println("Received file: " + pfh.getLocalFile().getAbsolutePath());
+      System.out.println("Migrating :: " + r);
 
-        StorageMetadata metadata = new StorageMetadata(r.id, r.version, "", r.md5);
-        System.out.println("Metadata: " + metadata);
-        final String resourceId = localStorage.put(metadata, pfh.getLocalFile());
-        checkState(key.equals(resourceId));
-      } else {
-        System.out.println("File already present: " + r);
+      try {
+        migrateProject(r);
+      } catch (Exception e) {
+        e.printStackTrace();
+        System.err.println("Migration failed for r: " + r);
+        failed.add(r);
       }
-
-      System.out.printf("ResourceId: %s\n", key);
-      jdbcProjectLoader.updateResourceId(r.id, r.version, key);
-      System.out.println("Migration complete for r: " + r);
     }
+
+    printFailed();
+  }
+
+  private void printFailed() {
+    if (failed.size() > 0) {
+      System.err.println("Migration Failed for ::");
+      for (Result r : failed) {
+        System.err.println(r);
+      }
+    }
+  }
+
+  private void migrateProject(Result r) throws IOException {
+    final String key = String.format("%s/%s-%s.zip", r.id, r.id, string(r.md5));
+
+    if (!localStorage.contains(key)) {
+      long start = System.currentTimeMillis();
+      final ProjectFileHandler pfh = jdbcProjectLoader.getUploadedFile(r.id, r.version);
+      System.out.printf("Received file: %s [ %d KB] in %d sec%n",
+          pfh.getLocalFile().getAbsolutePath(),
+          pfh.getLocalFile().length() / 1024,
+          (System.currentTimeMillis() - start) / 1000
+      );
+
+      StorageMetadata metadata = new StorageMetadata(r.id, r.version, "", r.md5);
+      System.out.println("Metadata: " + metadata);
+
+      start = System.currentTimeMillis();
+      final String resourceId = localStorage.put(metadata, pfh.getLocalFile());
+      System.out.printf("Stored file in %d sec%n",
+          (System.currentTimeMillis() - start) / 1000
+      );
+
+      checkState(key.equals(resourceId));
+
+      final InputStream inputStream = localStorage.get(key);
+      final byte[] actual = Md5Hasher.md5Hash(inputStream);
+      checkState(Arrays.equals(actual, r.md5), String
+          .format("Hash Mismatch error for %s Found: %s, Expected: %s", r, string(actual),
+              string(r.md5)));
+    } else {
+      System.out.println("File already present: " + r);
+    }
+
+    System.out.printf("ResourceId: %s\n", key);
+    jdbcProjectLoader.updateResourceId(r.id, r.version, key);
+    System.out.println("Migration complete for r: " + r);
+  }
+
+  private static String string(byte[] bytes) {
+    return new String(Hex.encodeHex(bytes));
   }
 
   public static void main(String[] args) {

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
@@ -54,6 +55,10 @@ public class LocalStorage implements Storage {
     return new FileInputStream(new File(rootDirectory, key));
   }
 
+  public boolean contains(String key) {
+    return new File(rootDirectory, key).exists();
+  }
+
   @Override
   public String put(StorageMetadata metadata, File localFile) {
     final File projectDir = new File(rootDirectory, String.valueOf(metadata.getProjectId()));
@@ -63,8 +68,8 @@ public class LocalStorage implements Storage {
 
     final File targetFile = new File(projectDir, String.format("%s-%s.%s",
         String.valueOf(metadata.getProjectId()),
-        new String(metadata.getHash()),
-        Files.getFileExtension(localFile.getName())));
+        new String(Hex.encodeHex(metadata.getHash())),
+        "zip"));
 
     if (targetFile.exists()) {
       log.info(String.format("Duplicate found: meta: %s, targetFile: %s, ", metadata,

--- a/azkaban-common/src/main/java/azkaban/utils/Md5Hasher.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Md5Hasher.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 LinkedIn Corp.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -20,6 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -29,7 +30,7 @@ import java.security.NoSuchAlgorithmException;
  */
 public class Md5Hasher {
 
-  private static final int BYTE_BUFFER_SIZE = 1024;
+  public static final int BYTE_BUFFER_SIZE = 1024;
 
   public static MessageDigest getMd5Digest() {
     MessageDigest digest = null;
@@ -43,10 +44,15 @@ public class Md5Hasher {
   }
 
   public static byte[] md5Hash(File file) throws IOException {
-    MessageDigest digest = getMd5Digest();
 
     FileInputStream fStream = new FileInputStream(file);
+    return md5Hash(fStream);
+  }
+
+  public static byte[] md5Hash(InputStream fStream) throws IOException {
     BufferedInputStream bStream = new BufferedInputStream(fStream);
+
+    MessageDigest digest = getMd5Digest();
     DigestInputStream blobStream = new DigestInputStream(bStream, digest);
 
     byte[] buffer = new byte[BYTE_BUFFER_SIZE];
@@ -60,5 +66,4 @@ public class Md5Hasher {
 
     return digest.digest();
   }
-
 }

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -22,6 +22,7 @@ import azkaban.spi.StorageMetadata;
 import azkaban.utils.Md5Hasher;
 import java.io.File;
 import java.io.InputStream;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.After;
@@ -71,7 +72,7 @@ public class LocalStorageTest {
         .append(File.separator)
         .append(metadata.getProjectId())
         .append("-")
-        .append(new String(metadata.getHash()))
+        .append(new String(Hex.encodeHex(metadata.getHash())))
         .append(".zip")
         .toString()
     );


### PR DESCRIPTION
This PR implements a tool to transfer existing projects in Azkaban DB to Local Storage. A similar approach can be taken to transfer projects to HDFS. Or one can simply copy the local storage directory to HDFS to make it work.

Usage:
```
# migration command
java -jar migrateSql2Local.jar migrate.properties
```

Example migrate.properties
```
# mysql
database.type=mysql
mysql.port=3306
mysql.password=
mysql.user=azkaban
mysql.numconnections=100
mysql.host=
mysql.database=

#local storage
azkaban.storage.local.basedir=/data/azkaban/
```
