### PR TITLE
Fixing cosmetic storage bug

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -24,7 +24,6 @@ import azkaban.AzkabanCommonModuleConfig;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageException;
 import azkaban.spi.StorageMetadata;
-import com.google.common.io.Files;
 import com.google.inject.Inject;
 import java.io.File;
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class HdfsStorage implements Storage {
       if (hdfs.mkdirs(projectsPath)) {
         log.info("Created project dir: " + projectsPath);
       }
-      final Path targetPath = createTargetPath(metadata, localFile, projectsPath);
+      final Path targetPath = createTargetPath(metadata, projectsPath);
       if (hdfs.exists(targetPath)) {
         log.info(
             String.format("Duplicate Found: meta: %s path: %s", metadata, targetPath));
@@ -90,11 +89,10 @@ public class HdfsStorage implements Storage {
     return URI.create(rootUri.getPath()).relativize(targetPath.toUri()).getPath();
   }
 
-  private Path createTargetPath(StorageMetadata metadata, File localFile, Path projectsPath) {
-    return new Path(projectsPath, String.format("%s-%s.%s",
+  private Path createTargetPath(StorageMetadata metadata, Path projectsPath) {
+    return new Path(projectsPath, String.format("%s-%s.zip",
         String.valueOf(metadata.getProjectId()),
-        new String(Hex.encodeHex(metadata.getHash())),
-        Files.getFileExtension(localFile.getName())
+        new String(Hex.encodeHex(metadata.getHash()))
     ));
   }
 

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -61,10 +61,9 @@ public class LocalStorage implements Storage {
       log.info("Created project dir: " + projectDir.getAbsolutePath());
     }
 
-    final File targetFile = new File(projectDir, String.format("%s-%s.%s",
+    final File targetFile = new File(projectDir, String.format("%s-%s.zip",
         String.valueOf(metadata.getProjectId()),
-        new String(metadata.getHash()),
-        Files.getFileExtension(localFile.getName())));
+        new String(metadata.getHash())));
 
     if (targetFile.exists()) {
       log.info(String.format("Duplicate found: meta: %s, targetFile: %s, ", metadata,


### PR DESCRIPTION
Changing the file extension to be hardcoded to zip. The reason is because of the way the
temp file is created, the file extension is 'zip1234761982374'. There are a whole bunch
 of random characters added at the end which becomes the target file extension which is
 unintended. Since we strictly enforce .zip extensions only I have hardcoded the extension.