### PR TITLE
EndDate Expiring Schedule Introduction

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -46,6 +46,7 @@ public class Schedule {
   private String projectName;
   private String flowName;
   private long firstSchedTime;
+  private long endSchedTime;
   private DateTimeZone timezone;
   private long lastModifyTime;
   private ReadablePeriod period;
@@ -60,37 +61,28 @@ public class Schedule {
   private ExecutionOptions executionOptions;
   private List<SlaOption> slaOptions;
 
-  public Schedule(int scheduleId, int projectId, String projectName,
-      String flowName, String status, long firstSchedTime,
-      DateTimeZone timezone, ReadablePeriod period, long lastModifyTime,
-      long nextExecTime, long submitTime, String submitUser) {
-
-    this(scheduleId, projectId, projectName, flowName, status, firstSchedTime,
-        timezone, period, lastModifyTime, nextExecTime, submitTime, submitUser,
-        null, null, null);
-  }
-
-  public Schedule(int scheduleId, int projectId, String projectName,
-      String flowName, String status, long firstSchedTime, String timezoneId,
-      String period, long lastModifyTime, long nextExecTime, long submitTime,
-      String submitUser, ExecutionOptions executionOptions,
-      List<SlaOption> slaOptions) {
-    this(scheduleId, projectId, projectName, flowName, status, firstSchedTime,
-        DateTimeZone.forID(timezoneId), parsePeriodString(period),
-        lastModifyTime, nextExecTime, submitTime, submitUser, executionOptions,
-        slaOptions, null);
-  }
-
-  public Schedule(int scheduleId, int projectId, String projectName,
-      String flowName, String status, long firstSchedTime,
-      DateTimeZone timezone, ReadablePeriod period, long lastModifyTime,
-      long nextExecTime, long submitTime, String submitUser,
-      ExecutionOptions executionOptions, List<SlaOption> slaOptions, String cronExpression) {
+  public Schedule(int scheduleId,
+                  int projectId,
+                  String projectName,
+                  String flowName,
+                  String status,
+                  long firstSchedTime,
+                  long endSchedTime,
+                  DateTimeZone timezone,
+                  ReadablePeriod period,
+                  long lastModifyTime,
+                  long nextExecTime,
+                  long submitTime,
+                  String submitUser,
+                  ExecutionOptions executionOptions,
+                  List<SlaOption> slaOptions,
+                  String cronExpression) {
     this.scheduleId = scheduleId;
     this.projectId = projectId;
     this.projectName = projectName;
     this.flowName = flowName;
     this.firstSchedTime = firstSchedTime;
+    this.endSchedTime = endSchedTime;
     this.timezone = timezone;
     this.lastModifyTime = lastModifyTime;
     this.period = period;
@@ -386,4 +378,7 @@ public class Schedule {
     return skipPastOccurrences;
   }
 
+  public long getEndSchedTime() {
+    return endSchedTime;
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -157,6 +157,7 @@ public class ScheduleManager implements TriggerAgent {
                                final String flowName,
                                final String status,
                                final long firstSchedTime,
+                               final long endSchedTime,
                                final DateTimeZone timezone,
                                final ReadablePeriod period,
                                final long lastModifyTime,
@@ -165,10 +166,9 @@ public class ScheduleManager implements TriggerAgent {
                                final String submitUser,
                                ExecutionOptions execOptions,
                                List<SlaOption> slaOptions) {
-    Schedule sched =
-        new Schedule(scheduleId, projectId, projectName, flowName, status,
-            firstSchedTime, timezone, period, lastModifyTime, nextExecTime,
-            submitTime, submitUser, execOptions, slaOptions, null);
+    Schedule sched = new Schedule(scheduleId, projectId, projectName, flowName, status,
+        firstSchedTime, endSchedTime, timezone, period, lastModifyTime, nextExecTime,
+        submitTime, submitUser, execOptions, slaOptions, null);
     logger
         .info("Scheduling flow '" + sched.getScheduleName() + "' for "
             + _dateFormat.print(firstSchedTime) + " with a period of " + (period == null ? "(non-recurring)"
@@ -178,15 +178,24 @@ public class ScheduleManager implements TriggerAgent {
     return sched;
   }
 
-  public Schedule cronScheduleFlow(final int scheduleId, final int projectId,
-      final String projectName, final String flowName, final String status,
-      final long firstSchedTime, final DateTimeZone timezone,
-      final long lastModifyTime,
-      final long nextExecTime, final long submitTime, final String submitUser,
-      ExecutionOptions execOptions, List<SlaOption> slaOptions, String cronExpression) {
+  public Schedule cronScheduleFlow(final int scheduleId,
+                                   final int projectId,
+                                   final String projectName,
+                                   final String flowName,
+                                   final String status,
+                                   final long firstSchedTime,
+                                   final long endSchedTime,
+                                   final DateTimeZone timezone,
+                                   final long lastModifyTime,
+                                   final long nextExecTime,
+                                   final long submitTime,
+                                   final String submitUser,
+                                   ExecutionOptions execOptions,
+                                   List<SlaOption> slaOptions,
+                                   String cronExpression) {
     Schedule sched =
         new Schedule(scheduleId, projectId, projectName, flowName, status,
-            firstSchedTime, timezone, null, lastModifyTime, nextExecTime,
+            firstSchedTime, endSchedTime, timezone, null, lastModifyTime, nextExecTime,
             submitTime, submitUser, execOptions, slaOptions, cronExpression);
     logger
         .info("Scheduling flow '" + sched.getScheduleName() + "' for "

--- a/azkaban-common/src/main/java/azkaban/trigger/Condition.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Condition.java
@@ -35,7 +35,7 @@ public class Condition {
   private static CheckerTypeLoader checkerLoader = null;
   private Expression expression;
   private Map<String, ConditionChecker> checkers =
-      new HashMap<String, ConditionChecker>();
+      new HashMap<>();
   private MapContext context = new MapContext();
   private Long nextCheckTime = -1L;
 
@@ -52,22 +52,8 @@ public class Condition {
     this.expression = jexl.createExpression(expr);
   }
 
-  public synchronized static void setJexlEngine(JexlEngine jexl) {
-    Condition.jexl = jexl;
-  }
-
   public synchronized static void setCheckerLoader(CheckerTypeLoader loader) {
     Condition.checkerLoader = loader;
-  }
-
-  protected static CheckerTypeLoader getCheckerLoader() {
-    return checkerLoader;
-  }
-
-  protected void registerChecker(ConditionChecker checker) {
-    checkers.put(checker.getId(), checker);
-    context.set(checker.getId(), checker);
-    updateNextCheckTime();
   }
 
   public long getNextCheckTime() {
@@ -78,18 +64,12 @@ public class Condition {
     return this.checkers;
   }
 
-  public void setCheckers(Map<String, ConditionChecker> checkers) {
+  private void setCheckers(Map<String, ConditionChecker> checkers) {
     this.checkers = checkers;
     for (ConditionChecker checker : checkers.values()) {
       this.context.set(checker.getId(), checker);
     }
     updateNextCheckTime();
-  }
-
-  public void updateCheckTime(Long ct) {
-    if (nextCheckTime < ct) {
-      nextCheckTime = ct;
-    }
   }
 
   private void updateNextCheckTime() {
@@ -125,12 +105,12 @@ public class Condition {
   }
 
   public Object toJson() {
-    Map<String, Object> jsonObj = new HashMap<String, Object>();
+    Map<String, Object> jsonObj = new HashMap<>();
     jsonObj.put("expression", expression.getExpression());
 
-    List<Object> checkersJson = new ArrayList<Object>();
+    List<Object> checkersJson = new ArrayList<>();
     for (ConditionChecker checker : checkers.values()) {
-      Map<String, Object> oneChecker = new HashMap<String, Object>();
+      Map<String, Object> oneChecker = new HashMap<>();
       oneChecker.put("type", checker.getType());
       oneChecker.put("checkerJson", checker.toJson());
       checkersJson.add(oneChecker);
@@ -152,7 +132,7 @@ public class Condition {
 
     try {
       Map<String, ConditionChecker> checkers =
-          new HashMap<String, ConditionChecker>();
+          new HashMap<>();
       List<Object> checkersJson = (List<Object>) jsonObj.get("checkers");
       for (Object oneCheckerJson : checkersJson) {
         Map<String, Object> oneChecker =

--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -62,8 +62,7 @@ public class Trigger {
   }
 
   public void updateNextCheckTime() {
-    this.nextCheckTime =
-        Math.min(triggerCondition.getNextCheckTime(),
+    this.nextCheckTime = Math.min(triggerCondition.getNextCheckTime(),
             expireCondition.getNextCheckTime());
   }
 

--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -336,8 +336,7 @@ public class Trigger {
     Trigger trigger = null;
     try {
       logger.info("Decoding for " + JSONUtils.toJSON(obj));
-      Condition triggerCond =
-          Condition.fromJson(jsonObj.get("triggerCondition"));
+      Condition triggerCond = Condition.fromJson(jsonObj.get("triggerCondition"));
       Condition expireCond = Condition.fromJson(jsonObj.get("expireCondition"));
       List<TriggerAction> actions = new ArrayList<TriggerAction>();
       List<Object> actionsJson = (List<Object>) jsonObj.get("actions");

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -63,8 +63,6 @@ public class TriggerManager extends EventHandler implements
 
   private String scannerStage = "";
 
-  // TODO kunkun-tang: Before apply guice to this class, we should make
-  // ExecutorManager guiceable.
   @Inject
   public TriggerManager(Props props, TriggerLoader triggerLoader,
       ExecutorManager executorManager) throws TriggerManagerException {
@@ -263,10 +261,11 @@ public class TriggerManager extends EventHandler implements
             /**
              * TODO kunkun-tang: rewrite checking expiration logics here.
              *
-             * Before this change, expiration condition should be never really leveraged though
-             * we have some related code here. Previously, expireCondition uses the same BasicTimeChecker
-             * as triggerCondition do, such that we can not expire it directly in this code.
-             * The workaround here is to check if we meet expire condition only when the trigger
+             * Prior to this change, expiration condition should never be called though
+             * we have some related code here. ExpireCondition used the same BasicTimeChecker
+             * as triggerCondition do. As a consequence, we need to figure out a way to distinguish
+             * the previous ExpireCondition and this commit's ExpireCondition.
+             * The workaround here is to check if we expire a trigger only when the ExpireCondition
              * has {@link azkaban.trigger.builtin.EndTimeChecker}.
              */
             if (t.getExpireCondition().getExpression().contains("EndTimeChecker")
@@ -298,6 +297,8 @@ public class TriggerManager extends EventHandler implements
           logger.error("Failed to do action " + action.getDescription() + " for " + t, th);
         }
       }
+      // Todo kunkun-tang: Today, when one trigger is triggered, we reset expireCondition. This
+      // should be not right. Need to do evaluations and adjust the logics here.
       if (t.isResetOnTrigger()) {
         t.resetTriggerConditions();
         t.resetExpireCondition();

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -257,10 +257,21 @@ public class TriggerManager extends EventHandler implements
           scannerStage = "Checking for trigger " + t.getTriggerId();
 
           if (t.getStatus().equals(TriggerStatus.READY)) {
-            if (t.expireConditionMet()) {
-              onTriggerPause(t);
-            } else if (t.triggerConditionMet()) {
+            if (t.triggerConditionMet()) {
               onTriggerTrigger(t);
+            }
+            /**
+             * TODO kunkun-tang: rewrite checking expiration logics here.
+             *
+             * Before this change, expiration condition should be never really leveraged though
+             * we have some related code here. Previously, expireCondition uses the same BasicTimeChecker
+             * as triggerCondition do, such that we can not expire it directly in this code.
+             * The workaround here is to check if we meet expire condition only when the trigger
+             * has {@link azkaban.trigger.builtin.EndTimeChecker}.
+             */
+            if (t.getExpireCondition().getExpression().contains("EndTimeChecker")
+                  && t.expireConditionMet()) {
+              onTriggerPause(t);
             }
           }
           if (t.getStatus().equals(TriggerStatus.EXPIRED) && t.getSource().equals("azkaban")) {

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -65,11 +65,11 @@ public class TriggerManager extends EventHandler implements
 
   // TODO kunkun-tang: Before apply guice to this class, we should make
   // ExecutorManager guiceable.
+  @Inject
   public TriggerManager(Props props, TriggerLoader triggerLoader,
       ExecutorManager executorManager) throws TriggerManagerException {
 
-    // TODO kunkun-tang: Doing hack here to allow calling new azkaban-db code. Should fix in future.
-    this.triggerLoader = ServiceProvider.SERVICE_PROVIDER.getInstance(TriggerLoader.class);
+    this.triggerLoader = triggerLoader;
 
     long scannerInterval =
         props.getLong("trigger.scan.interval", DEFAULT_SCANNER_INTERVAL_MS);

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
-import org.apache.log4j.Logger;
 
 import org.quartz.CronExpression;
 
@@ -31,7 +30,6 @@ import azkaban.trigger.ConditionChecker;
 import azkaban.utils.Utils;
 
 public class BasicTimeChecker implements ConditionChecker {
-
 
   public static final String type = "BasicTimeChecker";
 

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/EndTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/EndTimeChecker.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.trigger.builtin;
+
+import azkaban.trigger.ConditionChecker;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class EndTimeChecker implements ConditionChecker {
+
+  public static final String type = "EndTimeChecker";
+
+  private long endCheckTime;
+  private final String id;
+
+  public EndTimeChecker(String id) {
+    this(id, -1);
+  }
+
+  public EndTimeChecker(String id, long endCheckTime) {
+    this.id = id;
+    this.endCheckTime = endCheckTime;
+  }
+
+  public long getEndCheckTime() {
+    return endCheckTime;
+  }
+
+  @Override
+  public Boolean eval() {
+    /*
+     * Expire condition must satisfy two criteria:
+     * 1). endCheckTime > 0 (the trigger has expire condition);
+     * 2). current time passed endCheckTime.
+     */
+    return endCheckTime > 0 && endCheckTime < System.currentTimeMillis();
+  }
+
+  @Override
+  public void reset() {
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static EndTimeChecker createFromJson(Object obj) throws Exception {
+    return createFromJson((HashMap<String, Object>) obj);
+  }
+
+  public static EndTimeChecker createFromJson(HashMap<String, Object> obj)
+      throws Exception {
+    Map<String, Object> jsonObj = (HashMap<String, Object>) obj;
+    if (!jsonObj.get("type").equals(type)) {
+      throw new Exception("Cannot create checker of " + type + " from "
+          + jsonObj.get("type"));
+    }
+    Long firstCheckTime = Long.valueOf((String) jsonObj.get("endCheckTime"));
+    String id = (String) jsonObj.get("id");
+    return new EndTimeChecker(id, firstCheckTime);
+  }
+
+  @Override
+  public EndTimeChecker fromJson(Object obj) throws Exception {
+    return createFromJson(obj);
+  }
+
+  @Override
+  public Object getNum() {
+    return null;
+  }
+
+  @Override
+  public Object toJson() {
+    Map<String, Object> jsonObj = new HashMap<String, Object>();
+    jsonObj.put("type", type);
+    jsonObj.put("endCheckTime", String.valueOf(endCheckTime));
+    jsonObj.put("id", id);
+    return jsonObj;
+  }
+
+  @Override
+  public void stopChecker() {
+    this.endCheckTime = -1;
+  }
+
+  @Override
+  public void setContext(Map<String, Object> context) {
+  }
+
+  @Override
+  public long getNextCheckTime() {
+    return 0;
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/trigger/EndTimeCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/EndTimeCheckerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.trigger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import azkaban.trigger.builtin.EndTimeChecker;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class EndTimeCheckerTest {
+
+  private Condition getCondition(EndTimeChecker timeChecker){
+    Map<String, ConditionChecker> checkers =
+        new HashMap<String, ConditionChecker>();
+    checkers.put(timeChecker.getId(), timeChecker);
+    String expr = timeChecker.getId() + ".eval()";
+
+    return new Condition(checkers, expr);
+  }
+
+  @Test
+  public void expireTest() {
+
+    long nowPlus5seconds = System.currentTimeMillis() + 2000L;
+    EndTimeChecker timeChecker = new EndTimeChecker("expire", nowPlus5seconds);
+    Condition cond = getCondition(timeChecker);
+
+    assertFalse(cond.isMet());
+    // sleep for 4s
+    try {
+      Thread.sleep(4000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertTrue(cond.isMet());
+    timeChecker.stopChecker();
+    assertFalse(cond.isMet());
+  }
+
+  @Test
+  public void neverExpireTest() {
+
+    EndTimeChecker timeChecker = new EndTimeChecker("expire", -1);
+    Condition cond = getCondition(timeChecker);
+
+    assertFalse(cond.isMet());
+    // sleep for 1s
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    assertFalse(cond.isMet());
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/trigger/EndTimeCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/EndTimeCheckerTest.java
@@ -38,14 +38,14 @@ public class EndTimeCheckerTest {
   @Test
   public void expireTest() {
 
-    long nowPlus5seconds = System.currentTimeMillis() + 2000L;
+    long nowPlus5seconds = System.currentTimeMillis() + 200L;
     EndTimeChecker timeChecker = new EndTimeChecker("expire", nowPlus5seconds);
     Condition cond = getCondition(timeChecker);
 
     assertFalse(cond.isMet());
     // sleep for 4s
     try {
-      Thread.sleep(4000);
+      Thread.sleep(400);
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
@@ -63,7 +63,7 @@ public class EndTimeCheckerTest {
     assertFalse(cond.isMet());
     // sleep for 1s
     try {
-      Thread.sleep(1000);
+      Thread.sleep(100);
     } catch (InterruptedException e) {
       e.printStackTrace();
     }

--- a/azkaban-common/src/test/java/azkaban/trigger/ThresholdChecker.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/ThresholdChecker.java
@@ -86,31 +86,25 @@ public class ThresholdChecker implements ConditionChecker {
 
   @Override
   public Object getNum() {
-    // TODO Auto-generated method stub
     return null;
   }
 
   @Override
   public Object toJson() {
-    // TODO Auto-generated method stub
     return null;
   }
 
   @Override
   public void stopChecker() {
     return;
-
   }
 
   @Override
   public void setContext(Map<String, Object> context) {
-    // TODO Auto-generated method stub
-
   }
 
   @Override
   public long getNextCheckTime() {
-    // TODO Auto-generated method stub
     return 0;
   }
 

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
@@ -16,51 +16,63 @@
 
 package azkaban.trigger;
 
+import azkaban.executor.ExecutorManager;
+
+import azkaban.trigger.builtin.BasicTimeChecker;
+import azkaban.trigger.builtin.EndTimeChecker;
+import azkaban.utils.Utils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 import azkaban.utils.Props;
 
+import static org.mockito.Mockito.*;
+
 public class TriggerManagerTest {
 
-  private TriggerLoader triggerLoader;
+  private static TriggerLoader triggerLoader;
+  private static ExecutorManager executorManager;
+  private TriggerManager triggerManager;
+
+  @BeforeClass
+  public static void prepare() {
+    triggerLoader = new MockTriggerLoader();
+    executorManager = mock(ExecutorManager.class);
+    doNothing().when(executorManager).addListener(anyObject());
+  }
 
   @Before
   public void setup() throws TriggerException, TriggerManagerException {
-    triggerLoader = new MockTriggerLoader();
-
-  }
-
-  @After
-  public void tearDown() {
-
-  }
-
-  @Ignore @Test
-  public void triggerManagerSimpleTest() throws TriggerManagerException {
     Props props = new Props();
-    props.put("trigger.scan.interval", 4000);
-    TriggerManager triggerManager =
-        new TriggerManager(props, triggerLoader, null);
-
+    props.put("trigger.scan.interval", 300);
+    triggerManager = new TriggerManager(props, triggerLoader, executorManager);
     triggerManager.registerCheckerType(ThresholdChecker.type,
         ThresholdChecker.class);
     triggerManager.registerActionType(DummyTriggerAction.type,
         DummyTriggerAction.class);
+    triggerManager.start();
+  }
 
-    ThresholdChecker.setVal(1);
+  @After
+  public void tearDown() {
+    triggerManager.shutdown();
+  }
+
+  @Test
+  public void triggerManagerSimpleTest() throws TriggerManagerException {
 
     triggerManager.insertTrigger(
-        createDummyTrigger("test1", "triggerLoader", 10), "testUser");
+        createDummyTrigger("triggerLoader", 10), "testUser");
     List<Trigger> triggers = triggerManager.getTriggers();
     assertTrue(triggers.size() == 1);
     Trigger t1 = triggers.get(0);
@@ -72,57 +84,93 @@ public class TriggerManagerTest {
     assertTrue(t1.getSource().equals("triggerLoader"));
 
     Trigger t2 =
-        createDummyTrigger("test2: add new trigger", "addNewTriggerTest", 20);
+        createDummyTrigger("addNewTriggerTest", 20);
     triggerManager.insertTrigger(t2, "testUser");
     ThresholdChecker checker2 =
         (ThresholdChecker) t2.getTriggerCondition().getCheckers().values()
             .toArray()[0];
 
-    ThresholdChecker.setVal(15);
-    try {
-      Thread.sleep(2000);
-    } catch (InterruptedException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-
+    ThresholdChecker.setVal(1);
     assertTrue(checker1.isCheckerMet() == false);
     assertTrue(checker2.isCheckerMet() == false);
     assertTrue(checker1.isCheckerReset() == false);
     assertTrue(checker2.isCheckerReset() == false);
 
-    try {
-      Thread.sleep(2000);
-    } catch (InterruptedException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-
+    ThresholdChecker.setVal(15);
+    sleep(300);
     assertTrue(checker1.isCheckerMet() == true);
     assertTrue(checker2.isCheckerMet() == false);
     assertTrue(checker1.isCheckerReset() == false);
     assertTrue(checker2.isCheckerReset() == false);
 
     ThresholdChecker.setVal(25);
-    try {
-      Thread.sleep(4000);
-    } catch (InterruptedException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-
+    sleep(300);
     assertTrue(checker1.isCheckerMet() == true);
+    //When reset trigger, ThreSholdChecker reset checkerMet to false.
+    assertTrue(checker2.isCheckerMet() == false);
     assertTrue(checker1.isCheckerReset() == false);
     assertTrue(checker2.isCheckerReset() == true);
 
-    triggers = triggerManager.getTriggers();
+    triggerManager.removeTrigger(1);
     assertTrue(triggers.size() == 1);
-
   }
 
-  public static class MockTriggerLoader implements TriggerLoader {
+  @Test
+  public void neverExpireTriggerTest() throws TriggerManagerException {
 
-    private Map<Integer, Trigger> triggers = new HashMap<Integer, Trigger>();
+    Trigger t1 = createNeverExpireTrigger("triggerLoader", 10);
+    triggerManager.insertTrigger(t1);
+    t1.setResetOnTrigger(false);
+    ThresholdChecker triggerChecker =
+        (ThresholdChecker) t1.getTriggerCondition().getCheckers().values()
+            .toArray()[0];
+
+    EndTimeChecker expireChecker =
+        (EndTimeChecker) t1.getExpireCondition().getCheckers().values()
+            .toArray()[0];
+
+    ThresholdChecker.setVal(15);
+    sleep(300);
+    assertTrue(triggerChecker.isCheckerMet() == true);
+    assertTrue(expireChecker.eval() == false);
+
+    ThresholdChecker.setVal(25);
+    sleep(300);
+    assertTrue(triggerChecker.isCheckerMet() == true);
+    assertTrue(expireChecker.eval() == false);
+  }
+
+
+  @Test
+  public void timeCheckerAndExpireTriggerTest() throws TriggerManagerException {
+
+    long curr = System.currentTimeMillis();
+    Trigger t1 = createPeriodAndEndCheckerTrigger(curr);
+    triggerManager.insertTrigger(t1);
+    t1.setResetOnTrigger(true);
+    EndTimeChecker expireChecker =
+        (EndTimeChecker) t1.getExpireCondition().getCheckers().values()
+            .toArray()[0];
+
+    sleep(1000);
+
+    assertTrue(expireChecker.eval() == false);
+    assertTrue(t1.getStatus() == TriggerStatus.READY);
+
+    sleep(1000);
+    sleep(1000);
+    sleep(1000);
+    assertTrue(expireChecker.eval() == true);
+    assertTrue(t1.getStatus() == TriggerStatus.PAUSED);
+
+    sleep(1000);
+    assertTrue(expireChecker.eval() == true);
+    assertTrue(t1.getStatus() == TriggerStatus.PAUSED);
+  }
+
+
+  public static class MockTriggerLoader implements TriggerLoader {
+    private Map<Integer, Trigger> triggers = new HashMap<>();
     private int idIndex = 0;
 
     @Override
@@ -144,7 +192,7 @@ public class TriggerManagerTest {
 
     @Override
     public List<Trigger> loadTriggers() {
-      return new ArrayList<Trigger>(triggers.values());
+      return new ArrayList<>(triggers.values());
     }
 
     @Override
@@ -159,21 +207,21 @@ public class TriggerManagerTest {
       // TODO Auto-generated method stub
       return null;
     }
-
   }
 
-  private Trigger createDummyTrigger(String message, String source,
-      int threshold) {
+  private void sleep (long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
 
-    Map<String, ConditionChecker> checkers =
-        new HashMap<String, ConditionChecker>();
-    ConditionChecker checker =
-        new ThresholdChecker(ThresholdChecker.type, threshold);
+  private Trigger createDummyTrigger(String source, int threshold) {
+
+    Map<String, ConditionChecker> checkers = new HashMap<>();
+    ConditionChecker checker = new ThresholdChecker(ThresholdChecker.type, threshold);
     checkers.put(checker.getId(), checker);
-
-    List<TriggerAction> actions = new ArrayList<TriggerAction>();
-    TriggerAction act = new DummyTriggerAction(message);
-    actions.add(act);
 
     String expr = checker.getId() + ".eval()";
 
@@ -184,7 +232,7 @@ public class TriggerManagerTest {
         source,
         triggerCond,
         expireCond,
-        actions).build();
+        getTriggerActions()).build();
 
     fakeTrigger.setResetOnTrigger(true);
     fakeTrigger.setResetOnExpire(true);
@@ -192,19 +240,68 @@ public class TriggerManagerTest {
     return fakeTrigger;
   }
 
-  // public class MockCheckerLoader extends CheckerTypeLoader{
-  //
-  // @Override
-  // public void init(Props props) {
-  // checkerToClass.put(ThresholdChecker.type, ThresholdChecker.class);
-  // }
-  // }
-  //
-  // public class MockActionLoader extends ActionTypeLoader {
-  // @Override
-  // public void init(Props props) {
-  // actionToClass.put(DummyTriggerAction.type, DummyTriggerAction.class);
-  // }
-  // }
 
+  private Trigger createNeverExpireTrigger(String source, int threshold) {
+    Map<String, ConditionChecker> triggerCheckers = new HashMap<>();
+    Map<String, ConditionChecker> expireCheckers = new HashMap<>();
+    ConditionChecker triggerChecker = new ThresholdChecker(ThresholdChecker.type, threshold);
+    ConditionChecker endTimeChecker = new EndTimeChecker("id");
+    triggerCheckers.put(triggerChecker.getId(), triggerChecker);
+    expireCheckers.put(endTimeChecker.getId(), endTimeChecker);
+
+    String triggerExpr = triggerChecker.getId() + ".eval()";
+    String expireExpr = endTimeChecker.getId() + ".eval()";
+
+    Condition triggerCond = new Condition(triggerCheckers, triggerExpr);
+    Condition expireCond = new Condition(expireCheckers, expireExpr);
+
+    Trigger fakeTrigger = new Trigger.TriggerBuilder("azkaban",
+        source,
+        triggerCond,
+        expireCond,
+        getTriggerActions()).build();
+
+    fakeTrigger.setResetOnTrigger(false);
+    fakeTrigger.setResetOnExpire(true);
+    return fakeTrigger;
+  }
+
+  private Trigger createPeriodAndEndCheckerTrigger(long currMillis) {
+    Map<String, ConditionChecker> triggerCheckers = new HashMap<>();
+    Map<String, ConditionChecker> expireCheckers = new HashMap<>();
+
+    // TODO kunkun-tang: 1 second is the minimum unit for {@link org.joda.time.ReadablePeriod}.
+    // In future, we should use some smaller alternative.
+    ConditionChecker triggerChecker = new BasicTimeChecker("BasicTimeChecker_1",
+        currMillis, DateTimeZone.UTC, true, true,
+        Utils.parsePeriodString("1s"), null);
+
+    // End time is 3 seconds past now.
+    ConditionChecker endTimeChecker = new EndTimeChecker("EndTimeChecker_1", currMillis + 3000L);
+    triggerCheckers.put(triggerChecker.getId(), triggerChecker);
+    expireCheckers.put(endTimeChecker.getId(), endTimeChecker);
+
+    String triggerExpr = triggerChecker.getId() + ".eval()";
+    String expireExpr = endTimeChecker.getId() + ".eval()";
+
+    Condition triggerCond = new Condition(triggerCheckers, triggerExpr);
+    Condition expireCond = new Condition(expireCheckers, expireExpr);
+
+    Trigger timeTrigger = new Trigger.TriggerBuilder("azkaban",
+        "",
+        triggerCond,
+        expireCond,
+        getTriggerActions()).build();
+
+    timeTrigger.setResetOnTrigger(false);
+    timeTrigger.setResetOnExpire(true);
+    return timeTrigger;
+  }
+
+  private List<TriggerAction> getTriggerActions() {
+    List<TriggerAction> actions = new ArrayList<>();
+    TriggerAction act = new DummyTriggerAction("");
+    actions.add(act);
+    return actions;
+  }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -18,6 +18,7 @@ package azkaban.webapp;
 
 import azkaban.AzkabanCommonModule;
 import azkaban.executor.AlerterHolder;
+import azkaban.trigger.builtin.EndTimeChecker;
 import com.codahale.metrics.MetricRegistry;
 
 import com.google.inject.Guice;
@@ -297,6 +298,7 @@ public class AzkabanWebServer extends AzkabanServer {
     ExecutionChecker.setExecutorManager(executorManager);
 
     triggerManager.registerCheckerType(BasicTimeChecker.type, BasicTimeChecker.class);
+    triggerManager.registerCheckerType(EndTimeChecker.type, EndTimeChecker.class);
     triggerManager.registerCheckerType(SlaChecker.type, SlaChecker.class);
     triggerManager.registerCheckerType(ExecutionChecker.type, ExecutionChecker.class);
     triggerManager.registerActionType(ExecuteFlowAction.type, ExecuteFlowAction.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -669,6 +669,14 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
+    long endSchedTime = getLongParam(req, "endSchedTime", -1L);
+    try {
+      // Todo kunkun-tang: Need to verify if passed end time is valid.
+    } catch (Exception e) {
+      ret.put("error", "Invalid date and time: " + endSchedTime);
+      return;
+    }
+
     ReadablePeriod thePeriod = null;
     try {
       if (hasParam(req, "is_recurring")
@@ -691,7 +699,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
     Schedule schedule =
         scheduleManager.scheduleFlow(-1, projectId, projectName, flowName,
-            "ready", firstSchedTime.getMillis(), firstSchedTime.getZone(),
+            "ready", firstSchedTime.getMillis(), endSchedTime, firstSchedTime.getZone(),
             thePeriod, DateTime.now().getMillis(), firstSchedTime.getMillis(),
             firstSchedTime.getMillis(), user.getUserId(), flowOptions,
             slaOptions);
@@ -759,6 +767,14 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
       ret.put("error", e.getMessage());
     }
 
+    long endSchedTime = getLongParam(req, "endSchedTime", -1L);
+    try {
+      // Todo kunkun-tang: Need to verify if passed end time is valid.
+    } catch (Exception e) {
+      ret.put("error", "Invalid date and time: " + endSchedTime);
+      return;
+    }
+
     ExecutionOptions flowOptions = null;
     try {
       flowOptions = HttpRequestUtils.parseFlowOptions(req);
@@ -771,7 +787,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
     // Because either cronExpression or recurrence exists, we build schedule in the below way.
     Schedule schedule = scheduleManager.cronScheduleFlow(-1, projectId, projectName, flowName,
-            "ready", firstSchedTime.getMillis(), firstSchedTime.getZone(),
+            "ready", firstSchedTime.getMillis(), endSchedTime, firstSchedTime.getZone(),
             DateTime.now().getMillis(), firstSchedTime.getMillis(),
             firstSchedTime.getMillis(), user.getUserId(), flowOptions,
             slaOptions, cronExpression);


### PR DESCRIPTION
Today, when we specify a flow schedule in Azkaban, the flow will run infinitely without termination as per the schedule. As #721 proposes, should schedule have an end date, the flow will have more flexibilities to be managed. In this PR, I implement the end date feature to allow users to specify the expiration date given a schedule. UI has not been changed yet in this patch (will not be implemented in near future), but people will be able to call API to leverage the new feature.

The API command sample:
`curl -k -d ajax=scheduleCronFlow -d projectName=wtwt -d flow=azkaban -d endSchedTime=14XXXXXXXXXX --data-urlencode cronExpression="0 * * ? * 6" -b "azkaban.browser.session.id=XXXXXXXXXXXXXX" http://localhost:8081/schedule`

Similar to what @inoviavenkat implemented, I add an EndTimeChecker, as part of Expire Condition checker. Also, Added one parameter `endSchedTime` to schedule API. If the users don't specify this parameter, Azkaban would use the default value `-1`, and the schedule will be still running infinitely. Besides, I add Unit tests as much as possible to guarantee that this change will not break out. 

Furthermore, I made comprehensive manual tests and am glad to share:
* We have flow1, flow2, flow3, flow4, corresponding schedule1, schedule2, schedule3, schedule4. Every schedule runs flow every minute. The 4 flows keep undispatched at this stage.
* Ignoring this PR, I started a web server running on 3.24.0. Triggering schedule1. it is working fine.
* Apply the patch, started web server having end date feature. 
  * Triggered regular schedule2 without specifying endDate. Both sche1 and sche2 were running fine.
  * Triggered schedule3 by specifying endtime (5 minutes later). schedule3 was initially running. was able to observe schedule3 expire then.
  * Triggered schedule4 by specifying endtime (15 minutes later). Shutdown Webserver before schedule4 expires.

* restarted web server with end date implementation. Schedule3 never run. Both schedule1 and schedule2 and schdule4 were running well. Schedule4 expires at correct time.

* I also try rolling back web server to 3.24.0 (without this PR). Schedule 2 , 3 and 4 were not loaded due to lacking EndTimeChecker, but schedule1 was running good. Even though rolled back web server can not identify those latest schedules, the exceptions don't break and web server keeps working.

Though this PR looks big, but more than 80% code is related to testing and refactoring
