### PR TITLE
Fix killed job status update and FlowRunnerTest

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -161,6 +161,10 @@ public class PropsUtils {
     LinkedHashSet<String> visitedVariables = new LinkedHashSet<String>();
     for (String key : props.getKeySet()) {
       String value = props.get(key);
+      if (value == null) {
+        logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
+        value = "";
+      }
 
       visitedVariables.add(key);
       String replacedValue =

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -16,21 +16,18 @@
 
 package azkaban.executor;
 
-import azkaban.AzkabanCommonModule;
-import azkaban.ServiceProvider;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import azkaban.user.User;
@@ -196,7 +193,6 @@ public class ExecutorManagerTest {
     Assert.assertEquals(manager.isQueueProcessorThreadActive(), true);
   }
 
-  @Ignore("TODO MockExecutorLoader doesn't have the actual flow instance so this fails..")
   /* Test submit a non-dispatched flow */
   @Test
   public void testQueuedFlows() throws ExecutorManagerException, IOException {
@@ -211,21 +207,20 @@ public class ExecutorManagerTest {
     manager.submitExecutableFlow(flow1, testUser.getUserId());
     manager.submitExecutableFlow(flow2, testUser.getUserId());
 
-    List<ExecutableFlow> testFlows = new LinkedList<ExecutableFlow>();
-    testFlows.add(flow1);
-    testFlows.add(flow2);
+    List<Integer> testFlows = Arrays.asList(flow1.getExecutionId(), flow2.getExecutionId());
 
     List<Pair<ExecutionReference, ExecutableFlow>> queuedFlowsDB =
       loader.fetchQueuedFlows();
     Assert.assertEquals(queuedFlowsDB.size(), testFlows.size());
     // Verify things are correctly setup in db
     for (Pair<ExecutionReference, ExecutableFlow> pair : queuedFlowsDB) {
-      Assert.assertTrue(testFlows.contains(pair.getSecond()));
+      Assert.assertTrue(testFlows.contains(pair.getSecond().getExecutionId()));
     }
 
     // Verify running flows using old definition of "running" flows i.e. a
     // non-dispatched flow is also considered running
-    List<ExecutableFlow> managerActiveFlows = manager.getRunningFlows();
+    List<Integer> managerActiveFlows = manager.getRunningFlows()
+        .stream().map(ExecutableFlow::getExecutionId).collect(Collectors.toList());
     Assert.assertTrue(managerActiveFlows.containsAll(testFlows)
       && testFlows.containsAll(managerActiveFlows));
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import azkaban.user.User;
@@ -195,6 +196,7 @@ public class ExecutorManagerTest {
     Assert.assertEquals(manager.isQueueProcessorThreadActive(), true);
   }
 
+  @Ignore("TODO MockExecutorLoader doesn't have the actual flow instance so this fails..")
   /* Test submit a non-dispatched flow */
   @Test
   public void testQueuedFlows() throws ExecutorManagerException, IOException {

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -27,7 +27,7 @@ import azkaban.jobExecutor.AbstractProcessJob;
 import azkaban.utils.Props;
 
 public class InteractiveTestJob extends AbstractProcessJob {
-  private static ConcurrentHashMap<String, InteractiveTestJob> testJobs =
+  public static final ConcurrentHashMap<String, InteractiveTestJob> testJobs =
       new ConcurrentHashMap<String, InteractiveTestJob>();
   private Props generatedProperties = new Props();
   private boolean isWaiting = true;
@@ -56,6 +56,9 @@ public class InteractiveTestJob extends AbstractProcessJob {
       id = groupName + ":" + id;
     }
     testJobs.put(id, this);
+    synchronized (InteractiveTestJob.testJobs) {
+      testJobs.notifyAll();
+    }
 
     if (jobProps.getBoolean("fail", false)) {
       int passRetry = jobProps.getInt("passRetry", -1);

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -71,11 +71,14 @@ public class InteractiveTestJob extends AbstractProcessJob {
 
     while (isWaiting) {
       synchronized (this) {
-        try {
-          wait(jobProps.getInt("seconds", 30) * 1000);
-        } catch (InterruptedException e) {
+        int waitMillis = jobProps.getInt("seconds", 5) * 1000;
+        if (waitMillis > 0) {
+          try {
+            wait(waitMillis);
+          } catch (InterruptedException e) {
+          }
         }
-        if (jobProps.containsKey("seconds")) {
+        if (jobProps.containsKey("fail")) {
           succeedJob();
         }
 

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -34,7 +34,7 @@ import org.apache.log4j.Logger;
 public class MockExecutorLoader implements ExecutorLoader {
 
   private static final Logger logger = Logger
-          .getLogger(MockExecutorLoader.class);
+      .getLogger(MockExecutorLoader.class);
   HashMap<Integer, Integer> executionExecutorMapping =
       new HashMap<Integer, Integer>();
   HashMap<Integer, ExecutableFlow> flows =

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -27,9 +28,13 @@ import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
 
 public class MockExecutorLoader implements ExecutorLoader {
 
+  private static final Logger logger = Logger
+          .getLogger(MockExecutorLoader.class);
   HashMap<Integer, Integer> executionExecutorMapping =
       new HashMap<Integer, Integer>();
   HashMap<Integer, ExecutableFlow> flows =
@@ -97,7 +102,14 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public void uploadLogFile(int execId, String name, int attempt, File... files)
       throws ExecutorManagerException {
-
+    for (File file : files) {
+      try {
+        String logs = FileUtils.readFileToString(file, "UTF-8");
+        logger.info("Uploaded log for [" + name + "]:[" + execId + "]:\n" + logs);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -54,7 +54,8 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public void uploadExecutableFlow(ExecutableFlow flow)
       throws ExecutorManagerException {
-    flows.put(flow.getExecutionId(), flow);
+    ExecutableFlow exFlow = ExecutableFlow.createExecutableFlowFromObject(flow.toObject());
+    flows.put(flow.getExecutionId(), exFlow);
     flowUpdateCount++;
   }
 

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
@@ -19,9 +19,9 @@ package azkaban.jobExecutor;
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
-class AllJobExecutorTests {
+public class AllJobExecutorTests {
 
-  static Props setUpCommonProps(){
+  public static Props setUpCommonProps(){
 
     Props props = new Props();
     props.put("fullPath", ".");

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -76,13 +76,13 @@ public class AzkabanExecServerModule extends AbstractModule {
     for (Connector connector : server.getConnectors()) {
       connector.setStatsOn(isStatsOn);
       logger.info(String.format(
-              "Jetty connector name: %s, default header buffer size: %d",
-              connector.getName(), connector.getHeaderBufferSize()));
+          "Jetty connector name: %s, default header buffer size: %d",
+          connector.getName(), connector.getHeaderBufferSize()));
       connector.setHeaderBufferSize(props.getInt("jetty.headerBufferSize",
-              DEFAULT_HEADER_BUFFER_SIZE));
+          DEFAULT_HEADER_BUFFER_SIZE));
       logger.info(String.format(
-              "Jetty connector name: %s, (if) new header buffer size: %d",
-              connector.getName(), connector.getHeaderBufferSize()));
+          "Jetty connector name: %s, (if) new header buffer size: %d",
+          connector.getName(), connector.getHeaderBufferSize()));
     }
 
     return server;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -19,8 +19,19 @@ package azkaban.execapp;
 
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.JdbcExecutorLoader;
+import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import org.apache.log4j.Logger;
+import org.mortbay.jetty.Connector;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.Context;
+import org.mortbay.jetty.servlet.ServletHolder;
+import org.mortbay.thread.QueuedThreadPool;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 
 /**
@@ -29,12 +40,65 @@ import com.google.inject.Scopes;
  * structuring of Guice components.
  */
 public class AzkabanExecServerModule extends AbstractModule {
+
+  private static final int DEFAULT_THREAD_NUMBER = 50;
+  private static final int DEFAULT_HEADER_BUFFER_SIZE = 4096;
+  private static final int MAX_FORM_CONTENT_SIZE = 10 * 1024 * 1024;
+
+  private static final Logger logger = Logger.getLogger(AzkabanExecServerModule.class);
+
   @Override
   protected void configure() {
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class).in(Scopes.SINGLETON);
     bind(AzkabanExecutorServer.class).in(Scopes.SINGLETON);
     bind(TriggerManager.class).in(Scopes.SINGLETON);
     bind(FlowRunnerManager.class).in(Scopes.SINGLETON);
+  }
 
+  @Provides
+  @Named("ExecServer")
+  @Singleton
+  private Server createJettyServer(Props props) {
+    int maxThreads = props.getInt("executor.maxThreads", DEFAULT_THREAD_NUMBER);
+
+    /*
+     * Default to a port number 0 (zero)
+     * The Jetty server automatically finds an unused port when the port number is set to zero
+     * TODO: This is using a highly outdated version of jetty [year 2010]. needs to be updated.
+     */
+    Server server = new Server(props.getInt("executor.port", 0));
+    QueuedThreadPool httpThreadPool = new QueuedThreadPool(maxThreads);
+    server.setThreadPool(httpThreadPool);
+
+    boolean isStatsOn = props.getBoolean("executor.connector.stats", true);
+    logger.info("Setting up connector with stats on: " + isStatsOn);
+
+    for (Connector connector : server.getConnectors()) {
+      connector.setStatsOn(isStatsOn);
+      logger.info(String.format(
+              "Jetty connector name: %s, default header buffer size: %d",
+              connector.getName(), connector.getHeaderBufferSize()));
+      connector.setHeaderBufferSize(props.getInt("jetty.headerBufferSize",
+              DEFAULT_HEADER_BUFFER_SIZE));
+      logger.info(String.format(
+              "Jetty connector name: %s, (if) new header buffer size: %d",
+              connector.getName(), connector.getHeaderBufferSize()));
+    }
+
+    return server;
+  }
+
+  @Provides
+  @Named("root")
+  @Singleton
+  private Context createRootContext(Server server) {
+    Context root = new Context(server, "/", Context.SESSIONS);
+    root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
+
+    root.addServlet(new ServletHolder(new ExecutorServlet()), "/executor");
+    root.addServlet(new ServletHolder(new JMXHttpServlet()), "/jmx");
+    root.addServlet(new ServletHolder(new StatsServlet()), "/stats");
+    root.addServlet(new ServletHolder(new ServerStatisticsServlet()), "/serverStatistics");
+    return root;
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -94,6 +94,19 @@ public class AzkabanExecutorServer {
   private final ArrayList<ObjectName> registeredMBeans = new ArrayList<ObjectName>();
   private MBeanServer mbeanServer;
 
+  public static boolean testing = false;
+
+  public AzkabanExecutorServer(ExecutorLoader executionLoader, FlowRunnerManager runnerManager, Props props,
+                               Server server) {
+    if (!testing) {
+      throw new IllegalStateException("This constructor is only for testing");
+    }
+    this.executionLoader = executionLoader;
+    this.runnerManager = runnerManager;
+    this.props = props;
+    this.server = server;
+  }
+
   @Inject
   public AzkabanExecutorServer(Props props,
       ExecutorLoader executionLoader,
@@ -319,6 +332,10 @@ public class AzkabanExecutorServer {
    */
   public static AzkabanExecutorServer getApp() {
     return app;
+  }
+
+  public static void setApp(AzkabanExecutorServer app) {
+    AzkabanExecutorServer.app = app;
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -39,6 +39,7 @@ import azkaban.server.AzkabanServer;
 import azkaban.utils.Props;
 import azkaban.utils.StdOutErrRedirect;
 import azkaban.utils.Utils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -55,6 +56,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import javax.inject.Named;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -64,8 +66,6 @@ import org.joda.time.DateTimeZone;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
-import org.mortbay.jetty.servlet.ServletHolder;
-import org.mortbay.thread.QueuedThreadPool;
 
 import static azkaban.Constants.*;
 import static azkaban.ServiceProvider.*;
@@ -75,14 +75,11 @@ import static java.util.Objects.*;
 public class AzkabanExecutorServer {
   private static final String CUSTOM_JMX_ATTRIBUTE_PROCESSOR_PROPERTY = "jmx.attribute.processor.class";
   private static final Logger logger = Logger.getLogger(AzkabanExecutorServer.class);
-  private static final int MAX_FORM_CONTENT_SIZE = 10 * 1024 * 1024;
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
-  public static final int DEFAULT_HEADER_BUFFER_SIZE = 4096;
 
   private static final String DEFAULT_TIMEZONE_ID = "default.timezone.id";
-  private static final int DEFAULT_THREAD_NUMBER = 50;
 
   private static AzkabanExecutorServer app;
 
@@ -90,32 +87,26 @@ public class AzkabanExecutorServer {
   private final FlowRunnerManager runnerManager;
   private final Props props;
   private final Server server;
+  private final Context root;
 
   private final ArrayList<ObjectName> registeredMBeans = new ArrayList<ObjectName>();
   private MBeanServer mbeanServer;
 
-  public static boolean testing = false;
-
-  public AzkabanExecutorServer(ExecutorLoader executionLoader, FlowRunnerManager runnerManager, Props props,
-                               Server server) {
-    if (!testing) {
-      throw new IllegalStateException("This constructor is only for testing");
-    }
-    this.executionLoader = executionLoader;
-    this.runnerManager = runnerManager;
-    this.props = props;
-    this.server = server;
-  }
-
   @Inject
   public AzkabanExecutorServer(Props props,
       ExecutorLoader executionLoader,
-      FlowRunnerManager runnerManager) throws Exception {
+      FlowRunnerManager runnerManager,
+      @Named("ExecServer") Server server,
+      @Named("root") Context root) throws Exception {
     this.props = props;
     this.executionLoader = executionLoader;
     this.runnerManager = runnerManager;
+    this.server = server;
+    this.root = root;
+  }
 
-    server = createJettyServer(props);
+  private void start() throws Exception {
+    root.setAttribute(Constants.AZKABAN_SERVLET_CONTEXT_KEY, this);
 
     JmxJobMBeanManager.getInstance().initialize(props);
 
@@ -139,48 +130,9 @@ public class AzkabanExecutorServer {
 
     logger.info("Started Executor Server on " + getExecutorHostPort());
 
-    if (props.getBoolean(Constants.ConfigurationKeys.IS_METRICS_ENABLED, false)) {
+    if (props.getBoolean(ConfigurationKeys.IS_METRICS_ENABLED, false)) {
       startExecMetrics();
     }
-  }
-
-  private Server createJettyServer(Props props) {
-    int maxThreads = props.getInt("executor.maxThreads", DEFAULT_THREAD_NUMBER);
-
-    /*
-     * Default to a port number 0 (zero)
-     * The Jetty server automatically finds an unused port when the port number is set to zero
-     * TODO: This is using a highly outdated version of jetty [year 2010]. needs to be updated.
-     */
-    Server server = new Server(props.getInt("executor.port", 0));
-    QueuedThreadPool httpThreadPool = new QueuedThreadPool(maxThreads);
-    server.setThreadPool(httpThreadPool);
-
-    boolean isStatsOn = props.getBoolean("executor.connector.stats", true);
-    logger.info("Setting up connector with stats on: " + isStatsOn);
-
-    for (Connector connector : server.getConnectors()) {
-      connector.setStatsOn(isStatsOn);
-      logger.info(String.format(
-          "Jetty connector name: %s, default header buffer size: %d",
-          connector.getName(), connector.getHeaderBufferSize()));
-      connector.setHeaderBufferSize(props.getInt("jetty.headerBufferSize",
-          DEFAULT_HEADER_BUFFER_SIZE));
-      logger.info(String.format(
-          "Jetty connector name: %s, (if) new header buffer size: %d",
-          connector.getName(), connector.getHeaderBufferSize()));
-    }
-
-    Context root = new Context(server, "/", Context.SESSIONS);
-    root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
-
-    root.addServlet(new ServletHolder(new ExecutorServlet()), "/executor");
-    root.addServlet(new ServletHolder(new JMXHttpServlet()), "/jmx");
-    root.addServlet(new ServletHolder(new StatsServlet()), "/stats");
-    root.addServlet(new ServletHolder(new ServerStatisticsServlet()), "/serverStatistics");
-
-    root.setAttribute(Constants.AZKABAN_SERVLET_CONTEXT_KEY, this);
-    return server;
   }
 
   private void startExecMetrics() throws Exception {
@@ -334,6 +286,7 @@ public class AzkabanExecutorServer {
     return app;
   }
 
+  @VisibleForTesting
   public static void setApp(AzkabanExecutorServer app) {
     AzkabanExecutorServer.app = app;
   }
@@ -365,8 +318,9 @@ public class AzkabanExecutorServer {
   }
 
   public static void launch(AzkabanExecutorServer azkabanExecutorServer) throws Exception {
+    azkabanExecutorServer.start();
     setupTimeZone(azkabanExecutorServer.getAzkabanProps());
-    app = azkabanExecutorServer;
+    setApp(azkabanExecutorServer);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -623,9 +623,11 @@ public class FlowRunner extends EventHandler implements Runnable {
     long durationSec = (flow.getEndTime() - flow.getStartTime()) / 1000;
     switch (flow.getStatus()) {
     case FAILED_FINISHING:
-      logger.info("Setting flow '" + id + "' status to FAILED in "
-          + durationSec + " seconds");
-      flow.setStatus(Status.FAILED);
+      if (!isKilled()) {
+        logger.info("Setting flow '" + id + "' status to FAILED in "
+            + durationSec + " seconds");
+        flow.setStatus(Status.FAILED);
+      }
       break;
     case FAILED:
     case KILLED:

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -506,6 +506,15 @@ public class JobRunner extends EventHandler implements Runnable {
    */
   @Override
   public void run() {
+    try {
+      doRun();
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+  private void doRun() {
     Thread.currentThread().setName(
         "JobRunner-" + this.jobId + "-" + executionId);
 
@@ -696,8 +705,13 @@ public class JobRunner extends EventHandler implements Runnable {
         logError("Job run failed, but will treat it like success.");
         logError(e.getMessage() + " cause: " + e.getCause(), e);
       } else {
-        finalStatus = changeStatus(Status.FAILED);
-        logError("Job run failed!", e);
+        if (node.getStatus() == Status.KILLED) {
+          finalStatus = Status.KILLED;
+          logError("Job run killed!", e);
+        } else {
+          finalStatus = changeStatus(Status.FAILED);
+          logError("Job run failed!", e);
+        }
         logError(e.getMessage() + " cause: " + e.getCause());
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -708,7 +708,7 @@ public class JobRunner extends EventHandler implements Runnable {
         logError("Job run failed, but will treat it like success.");
         logError(e.getMessage() + " cause: " + e.getCause(), e);
       } else {
-        if (node.getStatus() == Status.KILLED) {
+        if (isKilled() || node.getStatus() == Status.KILLED) {
           finalStatus = Status.KILLED;
           logError("Job run killed!", e);
         } else {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -64,6 +64,9 @@ import azkaban.utils.PatternLayoutEscaped;
 public class JobRunner extends EventHandler implements Runnable {
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
+  private static final Logger serverLogger = Logger
+          .getLogger(JobRunner.class);
+
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
 
@@ -509,7 +512,7 @@ public class JobRunner extends EventHandler implements Runnable {
     try {
       doRun();
     } catch (Exception e) {
-      e.printStackTrace();
+      serverLogger.error("Unexpected exception", e);
       throw e;
     }
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -65,7 +65,7 @@ public class JobRunner extends EventHandler implements Runnable {
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
   private static final Logger serverLogger = Logger
-          .getLogger(JobRunner.class);
+      .getLogger(JobRunner.class);
 
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -78,7 +78,6 @@ public class FlowRunnerTest {
         new JobTypeManager(null, null, this.getClass().getClassLoader());
     JobTypePluginSet pluginSet = jobtypeManager.getJobTypePluginSet();
     pluginSet.setCommonPluginLoadProps(AllJobExecutorTests.setUpCommonProps());
-    pluginSet.addPluginClass("java", JavaJob.class);
     pluginSet.addPluginClass("test", InteractiveTestJob.class);
     fakeProjectLoader = new MockProjectLoader(workingDir);
     Utils.initServiceProvider();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -381,7 +381,7 @@ public class FlowRunnerTest {
 
   private void waitFlowFinished(FlowRunner runner) {
     for (int i = 0; i < 500; i++) {
-      if (runner.getExecutableFlow().isFlowFinished()) {
+      if (runner.getExecutableFlow().isFlowFinished() && !runner.isRunnerThreadAlive()) {
         return;
       }
       try {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -82,7 +82,6 @@ public class FlowRunnerTest {
     pluginSet.addPluginClass("test", InteractiveTestJob.class);
     fakeProjectLoader = new MockProjectLoader(workingDir);
     Utils.initServiceProvider();
-    AzkabanExecutorServer.testing = true;
     AzkabanExecutorServer.setApp(new FakeApp());
 
     InteractiveTestJob.clearTestJobs();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -16,7 +16,9 @@
 
 package azkaban.execapp;
 
-import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +41,6 @@ import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutionOptions.FailureAction;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.InteractiveTestJob;
-import azkaban.executor.MockExecutorLoader;
 import azkaban.executor.Status;
 import azkaban.flow.Flow;
 import azkaban.jobExecutor.AllJobExecutorTests;
@@ -50,11 +51,14 @@ import azkaban.project.ProjectLoader;
 import azkaban.project.MockProjectLoader;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class FlowRunnerTest {
   private File workingDir;
   private JobTypeManager jobtypeManager;
   private ProjectLoader fakeProjectLoader;
+  @Mock private ExecutorLoader loader;
 
   private static final File TEST_DIR = new File("../azkaban-test/src/test/resources/azkaban/test/executions/exectest1");
 
@@ -64,6 +68,8 @@ public class FlowRunnerTest {
 
   @Before
   public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(loader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
     System.out.println("Create temp dir");
     synchronized (this) {
       // clear interrupted status
@@ -99,9 +105,6 @@ public class FlowRunnerTest {
 
   @Test
   public void exec1Normal() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
-    // just making compile. may not work at all.
-
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -166,7 +169,6 @@ public class FlowRunnerTest {
 
   @Test
   public void exec1Disabled() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -215,7 +217,6 @@ public class FlowRunnerTest {
 
   @Test
   public void exec1Failed() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -256,7 +257,6 @@ public class FlowRunnerTest {
 
   @Test
   public void exec1FailedKillAll() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -297,7 +297,6 @@ public class FlowRunnerTest {
 
   @Test
   public void exec1FailedFinishRest() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -340,7 +339,6 @@ public class FlowRunnerTest {
 
   @Test
   public void execAndCancel() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
@@ -382,7 +380,6 @@ public class FlowRunnerTest {
 
   @Test
   public void execRetries() throws Exception {
-    MockExecutorLoader loader = new MockExecutorLoader();
     EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
@@ -1,0 +1,14 @@
+package azkaban.execapp.fake;
+
+import azkaban.execapp.AzkabanExecutorServer;
+import azkaban.execapp.jmx.JmxJobMBeanManager;
+import azkaban.utils.Props;
+
+public class FakeApp extends AzkabanExecutorServer {
+
+    public FakeApp() throws Exception {
+        super(null, null, new Props(), new FakeServer());
+        JmxJobMBeanManager.getInstance().initialize(new Props());
+    }
+
+}

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
@@ -6,9 +6,9 @@ import azkaban.utils.Props;
 
 public class FakeApp extends AzkabanExecutorServer {
 
-    public FakeApp() throws Exception {
-        super(new Props(), null, null, new FakeServer(), null);
-        JmxJobMBeanManager.getInstance().initialize(new Props());
-    }
+  public FakeApp() throws Exception {
+    super(new Props(), null, null, new FakeServer(), null);
+    JmxJobMBeanManager.getInstance().initialize(new Props());
+  }
 
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeApp.java
@@ -7,7 +7,7 @@ import azkaban.utils.Props;
 public class FakeApp extends AzkabanExecutorServer {
 
     public FakeApp() throws Exception {
-        super(null, null, new Props(), new FakeServer());
+        super(new Props(), null, null, new FakeServer(), null);
         JmxJobMBeanManager.getInstance().initialize(new Props());
     }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeServer.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeServer.java
@@ -6,9 +6,9 @@ import org.mortbay.jetty.bio.SocketConnector;
 
 public class FakeServer extends Server {
 
-    @Override
-    public Connector[] getConnectors() {
-        return new Connector[] {new SocketConnector()};
-    }
+  @Override
+  public Connector[] getConnectors() {
+    return new Connector[]{new SocketConnector()};
+  }
 
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeServer.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/fake/FakeServer.java
@@ -1,0 +1,14 @@
+package azkaban.execapp.fake;
+
+import org.mortbay.jetty.Connector;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.bio.SocketConnector;
+
+public class FakeServer extends Server {
+
+    @Override
+    public Connector[] getConnectors() {
+        return new Connector[] {new SocketConnector()};
+    }
+
+}

--- a/azkaban-exec-server/src/test/resources/log4j.properties
+++ b/azkaban-exec-server/src/test/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=INFO, Console
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%t] [%c{1}] %m%n

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
@@ -1,3 +1,3 @@
 type=test
-seconds=1
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
@@ -1,4 +1,4 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -1,5 +1,5 @@
 type=test
-seconds=1
+seconds=0
 fail=true
 passRetry=3
 retries=2

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 seconds=1
 fail=true
 passRetry=3

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -3,5 +3,5 @@ seconds=1
 fail=true
 passRetry=3
 retries=2
-retry.backoff=2000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 seconds=1
 fail=true
 passRetry=3

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -3,5 +3,5 @@ seconds=1
 fail=true
 passRetry=2
 retries=3
-retry.backoff=1000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 seconds=1
 fail=true
 passRetry=2

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -1,5 +1,5 @@
 type=test
-seconds=1
+seconds=0
 fail=true
 passRetry=2
 retries=3

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 seconds=1
 fail=true
 passRetry=2

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
@@ -1,3 +1,3 @@
 type=test
-seconds=1
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
@@ -1,4 +1,4 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job8,job9
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job8,job9
 seconds=5
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job8,job9
 seconds=5
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job1
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job1
 seconds=2
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job1
 seconds=2
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job1
-seconds=1
+seconds=0
 fail=true

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job1
 seconds=1
 fail=true

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job1
 seconds=1
 fail=true

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job2
-seconds=3
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job2
 seconds=3
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job2
 seconds=3
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job2
 seconds=8
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job2
-seconds=8
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job2
 seconds=8
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job3,job4
 seconds=5
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job3,job4
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job3,job4
 seconds=5
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job1
-seconds=4
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job1
 seconds=4
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job1
 seconds=4
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job5,job6
 seconds=2
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job5,job6
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job5,job6
 seconds=2
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job7
 seconds=3
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job7
-seconds=3
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job7
 seconds=3
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job7
-seconds=4
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.executor.SleepJavaJob
+type=test
 dependencies=job7
 seconds=4
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
@@ -1,5 +1,5 @@
 type=java
-job.class=azkaban.test.executor.SleepJavaJob
+job.class=azkaban.executor.SleepJavaJob
 dependencies=job7
 seconds=4
 fail=false


### PR DESCRIPTION
Main fixes:

1. Fix setting job status in `JobRunner`.
    - It was setting status like this: `RUNNING -> KILLED -> FAILED -> KILLED`.
    - Now it's only `RUNNING -> KILLED`, as it should.
1. Make the `FlowRunnerTest` pass again.
    - Fixed file paths, cleaning up thread state etc. to make the test pass consistently.
    - However the test is so slow that I'm leaving the whole test class with `@Ignore`.

----

Changes required to make `FlowRunnerTest` run:
1. `PropsUtils` to tolerate null values in the property map. That shouldn't normally ever happen, but this makes testing easier when you don't need to insert every property that would be provided on a full-blown flow execution.
1. Allow creating an instance of `AzkabanExecutorServer` for testing without starting jetty server etc.

----

Changes to improve debugging test/job failures:
1. Log job logs in `MockExecutorLoader` instead of discarding them, so that it's possible to debug failures in tests.
1. `JobRunner` to print strackrace if an exception is thrown – otherwise it was impossible to see the failure anywhere when a job run failed like this.