### PR TITLE
Refactor AzkabanExecutorServer

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -20,7 +20,12 @@ package azkaban.execapp;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.JdbcExecutorLoader;
 import com.google.inject.AbstractModule;
+import com.google.inject.Key;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
+import org.apache.log4j.Logger;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.Context;
 
 
 /**
@@ -29,12 +34,19 @@ import com.google.inject.Scopes;
  * structuring of Guice components.
  */
 public class AzkabanExecServerModule extends AbstractModule {
+
+  private static final Logger logger = Logger.getLogger(AzkabanExecServerModule.class);
+
   @Override
   protected void configure() {
+    bind(Key.get(Server.class, Names.named("ExecServer"))).toProvider(ExecServerProvider.class)
+        .in(Scopes.SINGLETON);
+    bind(Key.get(Context.class, Names.named("root"))).toProvider(RootContextProvider.class)
+        .in(Scopes.SINGLETON);
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class).in(Scopes.SINGLETON);
     bind(AzkabanExecutorServer.class).in(Scopes.SINGLETON);
     bind(TriggerManager.class).in(Scopes.SINGLETON);
     bind(FlowRunnerManager.class).in(Scopes.SINGLETON);
-
   }
+
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecServerProvider.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecServerProvider.java
@@ -1,0 +1,52 @@
+package azkaban.execapp;
+
+import azkaban.utils.Props;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.apache.log4j.Logger;
+import org.mortbay.jetty.Connector;
+import org.mortbay.jetty.Server;
+import org.mortbay.thread.QueuedThreadPool;
+
+public class ExecServerProvider implements Provider<Server> {
+
+  private static final int DEFAULT_THREAD_NUMBER = 50;
+  private static final int DEFAULT_HEADER_BUFFER_SIZE = 4096;
+
+  private static final Logger logger = Logger.getLogger(ExecServerProvider.class);
+
+  @Inject
+  private Props props;
+
+  @Override
+  public Server get() {
+    int maxThreads = props.getInt("executor.maxThreads", DEFAULT_THREAD_NUMBER);
+
+    /*
+     * Default to a port number 0 (zero)
+     * The Jetty server automatically finds an unused port when the port number is set to zero
+     * TODO: This is using a highly outdated version of jetty [year 2010]. needs to be updated.
+     */
+    Server server = new Server(props.getInt("executor.port", 0));
+    QueuedThreadPool httpThreadPool = new QueuedThreadPool(maxThreads);
+    server.setThreadPool(httpThreadPool);
+
+    boolean isStatsOn = props.getBoolean("executor.connector.stats", true);
+    logger.info("Setting up connector with stats on: " + isStatsOn);
+
+    for (Connector connector : server.getConnectors()) {
+      connector.setStatsOn(isStatsOn);
+      logger.info(String.format(
+          "Jetty connector name: %s, default header buffer size: %d",
+          connector.getName(), connector.getHeaderBufferSize()));
+      connector.setHeaderBufferSize(props.getInt("jetty.headerBufferSize",
+          DEFAULT_HEADER_BUFFER_SIZE));
+      logger.info(String.format(
+          "Jetty connector name: %s, (if) new header buffer size: %d",
+          connector.getName(), connector.getHeaderBufferSize()));
+    }
+
+    return server;
+  }
+
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/RootContextProvider.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/RootContextProvider.java
@@ -1,0 +1,30 @@
+package azkaban.execapp;
+
+import com.google.inject.Provider;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.Context;
+import org.mortbay.jetty.servlet.ServletHolder;
+
+public class RootContextProvider implements Provider<Context> {
+
+  private static final int MAX_FORM_CONTENT_SIZE = 10 * 1024 * 1024;
+
+  @Inject
+  @Named("ExecServer")
+  private Server server;
+
+  @Override
+  public Context get() {
+    Context root = new Context(server, "/", Context.SESSIONS);
+    root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
+
+    root.addServlet(new ServletHolder(new ExecutorServlet()), "/executor");
+    root.addServlet(new ServletHolder(new JMXHttpServlet()), "/jmx");
+    root.addServlet(new ServletHolder(new StatsServlet()), "/stats");
+    root.addServlet(new ServletHolder(new ServerStatisticsServlet()), "/serverStatistics");
+    return root;
+  }
+
+}


### PR DESCRIPTION
As requested by @HappyRay on https://github.com/azkaban/azkaban/pull/1105, this part as a separate PR.

Extract some parts into providers and inject them to `AzkabanExecutorServer`, instead of `AzkabanExecutorServer` creating them.

I hope you agree that https://github.com/azkaban/azkaban/pull/1113 is the better way to do this.