### PR TITLE
Fix killed job status update and FlowRunnerTest

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -161,6 +161,10 @@ public class PropsUtils {
     LinkedHashSet<String> visitedVariables = new LinkedHashSet<String>();
     for (String key : props.getKeySet()) {
       String value = props.get(key);
+      if (value == null) {
+        logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
+        value = "";
+      }
 
       visitedVariables.add(key);
       String replacedValue =

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
@@ -19,9 +19,9 @@ package azkaban.jobExecutor;
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
-class AllJobExecutorTests {
+public class AllJobExecutorTests {
 
-  static Props setUpCommonProps(){
+  public static Props setUpCommonProps(){
 
     Props props = new Props();
     props.put("fullPath", ".");

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -278,6 +278,7 @@ public class FlowRunner extends EventHandler implements Runnable {
       this.watcher.setLogger(logger);
     }
 
+    // Avoid NPE in unit tests when the static app instance is not set
     if (AzkabanExecutorServer.getApp() != null) {
       logger.info("Assigned executor : " + AzkabanExecutorServer.getApp().getExecutorHostPort());
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -278,7 +278,9 @@ public class FlowRunner extends EventHandler implements Runnable {
       this.watcher.setLogger(logger);
     }
 
-    logger.info("Assigned executor : " + AzkabanExecutorServer.getApp().getExecutorHostPort());
+    if (AzkabanExecutorServer.getApp() != null) {
+      logger.info("Assigned executor : " + AzkabanExecutorServer.getApp().getExecutorHostPort());
+    }
     logger.info("Running execid:" + execId + " flow:" + flowId + " project:"
         + projectId + " version:" + version);
     if (pipelineExecId != null) {
@@ -623,9 +625,10 @@ public class FlowRunner extends EventHandler implements Runnable {
     long durationSec = (flow.getEndTime() - flow.getStartTime()) / 1000;
     switch (flow.getStatus()) {
     case FAILED_FINISHING:
-      logger.info("Setting flow '" + id + "' status to FAILED in "
-          + durationSec + " seconds");
-      flow.setStatus(Status.FAILED);
+      if (!isKilled()) {
+        logger.info("Setting flow '" + id + "' status to FAILED in " + durationSec + " seconds");
+        flow.setStatus(Status.FAILED);
+      }
       break;
     case FAILED:
     case KILLED:

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -626,10 +626,9 @@ public class FlowRunner extends EventHandler implements Runnable {
     long durationSec = (flow.getEndTime() - flow.getStartTime()) / 1000;
     switch (flow.getStatus()) {
     case FAILED_FINISHING:
-      if (!isKilled()) {
-        logger.info("Setting flow '" + id + "' status to FAILED in " + durationSec + " seconds");
-        flow.setStatus(Status.FAILED);
-      }
+      logger.info("Setting flow '" + id + "' status to FAILED in "
+          + durationSec + " seconds");
+      flow.setStatus(Status.FAILED);
       break;
     case FAILED:
     case KILLED:

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -64,6 +64,8 @@ import azkaban.utils.PatternLayoutEscaped;
 public class JobRunner extends EventHandler implements Runnable {
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
+  private static final Logger serverLogger = Logger.getLogger(JobRunner.class);
+
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
 
@@ -506,6 +508,15 @@ public class JobRunner extends EventHandler implements Runnable {
    */
   @Override
   public void run() {
+    try {
+      doRun();
+    } catch (Exception e) {
+      serverLogger.error("Unexpected exception", e);
+      throw e;
+    }
+  }
+
+  private void doRun() {
     Thread.currentThread().setName(
         "JobRunner-" + this.jobId + "-" + executionId);
 
@@ -696,8 +707,13 @@ public class JobRunner extends EventHandler implements Runnable {
         logError("Job run failed, but will treat it like success.");
         logError(e.getMessage() + " cause: " + e.getCause(), e);
       } else {
-        finalStatus = changeStatus(Status.FAILED);
-        logError("Job run failed!", e);
+        if (isKilled() || node.getStatus() == Status.KILLED) {
+          finalStatus = Status.KILLED;
+          logError("Job run killed!", e);
+        } else {
+          finalStatus = changeStatus(Status.FAILED);
+          logError("Job run failed!", e);
+        }
         logError(e.getMessage() + " cause: " + e.getCause());
       }
     }

--- a/azkaban-exec-server/src/test/resources/log4j.properties
+++ b/azkaban-exec-server/src/test/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=INFO, Console
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%t] [%c{1}] %m%n

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -1,8 +1,7 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=true
 passRetry=3
 retries=2
-retry.backoff=2000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -1,8 +1,7 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=true
 passRetry=2
 retries=3
-retry.backoff=1000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job8,job9
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=1
+seconds=0
 fail=true

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job2
-seconds=3
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job2
-seconds=8
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job3,job4
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=4
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job5,job6
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job7
-seconds=3
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job7
-seconds=4
+seconds=0
 fail=false


### PR DESCRIPTION
This is the minimal change to make it happen. Background discussion at https://github.com/azkaban/azkaban/pull/1105.

----

1. Fix setting job status in `JobRunner`.
    - It was setting status like this: `RUNNING -> KILLED -> FAILED -> KILLED`.
    - Now it's only `RUNNING -> KILLED`, as it should.
1. Make the `FlowRunnerTest` pass again.
    - Fixed file paths, cleaning up thread state etc. to make the test pass consistently.
    - Remove `@Ignore`.

----

Changes required to make `FlowRunnerTest` run:
1. `PropsUtils` to tolerate null values in the property map. That shouldn't normally ever happen, but this makes testing easier when you don't need to insert every property that would be provided on a full-blown flow execution.
1. Others: see the diff.

----

Changes to improve debugging test/job failures:
1. `JobRunner` to print strackrace if an exception is thrown – otherwise it was impossible to see the failure anywhere when a job run failed like this.