### PR TITLE
Fix bug in MockExecutorLoader

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -16,18 +16,15 @@
 
 package azkaban.executor;
 
-import azkaban.AzkabanCommonModule;
-import azkaban.ServiceProvider;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -210,21 +207,20 @@ public class ExecutorManagerTest {
     manager.submitExecutableFlow(flow1, testUser.getUserId());
     manager.submitExecutableFlow(flow2, testUser.getUserId());
 
-    List<ExecutableFlow> testFlows = new LinkedList<ExecutableFlow>();
-    testFlows.add(flow1);
-    testFlows.add(flow2);
+    List<Integer> testFlows = Arrays.asList(flow1.getExecutionId(), flow2.getExecutionId());
 
     List<Pair<ExecutionReference, ExecutableFlow>> queuedFlowsDB =
       loader.fetchQueuedFlows();
     Assert.assertEquals(queuedFlowsDB.size(), testFlows.size());
     // Verify things are correctly setup in db
     for (Pair<ExecutionReference, ExecutableFlow> pair : queuedFlowsDB) {
-      Assert.assertTrue(testFlows.contains(pair.getSecond()));
+      Assert.assertTrue(testFlows.contains(pair.getSecond().getExecutionId()));
     }
 
     // Verify running flows using old definition of "running" flows i.e. a
     // non-dispatched flow is also considered running
-    List<ExecutableFlow> managerActiveFlows = manager.getRunningFlows();
+    List<Integer> managerActiveFlows = manager.getRunningFlows()
+        .stream().map(ExecutableFlow::getExecutionId).collect(Collectors.toList());
     Assert.assertTrue(managerActiveFlows.containsAll(testFlows)
       && testFlows.containsAll(managerActiveFlows));
 


### PR DESCRIPTION
Fix concurrency bug in MockExecutorLoader: it shouldn't modify the state of actual flows, so make a clone of the flows, too.

Also log job logs in `MockExecutorLoader` instead of discarding them, so that it's possible to debug failures in tests.

----

The problem was this (originally revealed when `FlowRunnerTest` still used this mock class instead of a Mockito mock):
- MockExecutorLoader kept a handle to the actual ExecutableFlow instance
- MockExecutorLoader.updateExecutableFlow set the job statuses based on the current flow status, which is not synchronized with the job runner threads
- So this wrote an old job status over the newer one in ExecutableNode

Stacktrace for that:

job4: setStatus SUCCEEDED -> QUEUED
	at azkaban.executor.ExecutableNode.setStatus(ExecutableNode.java:141)
	at azkaban.executor.ExecutableNode.applyUpdateObject(ExecutableNode.java:398)
	at azkaban.executor.ExecutableFlowBase.applyUpdateObject(ExecutableFlowBase.java:352)
	at azkaban.executor.ExecutableFlowBase.applyUpdateObject(ExecutableFlowBase.java:369)
	at azkaban.executor.MockExecutorLoader.updateExecutableFlow(MockExecutorLoader.java:120)
	at azkaban.execapp.FlowRunner.updateFlow(FlowRunner.java:322)
	at azkaban.execapp.FlowRunner.updateFlow(FlowRunner.java:316)
	at azkaban.execapp.FlowRunner.progressGraph(FlowRunner.java:552)
	at azkaban.execapp.FlowRunner.runFlow(FlowRunner.java:413)
	at azkaban.execapp.FlowRunner.doRun(FlowRunner.java:238)
	at azkaban.execapp.FlowRunner.run(FlowRunner.java:215)

Overlapping updates by 2 different threads could look something like this:

2017/05/24 12:20:54.695 +0300 INFO [JobRunner-job3-1] [ExecutableNode] job4: applyUpdateObject: RUNNING-> QUEUED
2017/05/24 12:20:55.700 +0300 INFO [JobRunner-job4-1] [JobRunner] job4: changeStatus: QUEUED -> SUCCEEDED
2017/05/24 12:20:55.701 +0300 INFO [FlowRunner-exec-1] [ExecutableNode] job4: applyUpdateObject: SUCCEEDED-> QUEUED

----

Background discussion at https://github.com/azkaban/azkaban/pull/1105.