### PR TITLE
Don't timeout flows by default

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -296,7 +296,8 @@ public class FlowRunnerManager implements EventListener,
     private long lastOldProjectCleanTime = -1;
     private long lastRecentlyFinishedCleanTime = -1;
     private long lastLongRunningFlowCleanTime = -1;
-    private final long flowMaxRunningTimeInMins = azkabanProps.getInt(Constants.ConfigurationKeys.AZKABAN_MAX_FLOW_RUNNING_MINS, 60 * 24 * 10);
+    private final long flowMaxRunningTimeInMins = azkabanProps.getInt(
+        Constants.ConfigurationKeys.AZKABAN_MAX_FLOW_RUNNING_MINS, -1);
 
     public CleanerThread() {
       this.setName("FlowRunnerManager-Cleaner-Thread");


### PR DESCRIPTION
Only timeout if `azkaban.server.flow.max.running.minutes` is set greater than 0.

As discussed in https://github.com/azkaban/azkaban/pull/955 and requested by @ameyamk.

gh-pages counter-part: https://github.com/azkaban/azkaban/pull/1118