### PR TITLE
Synchronize ExecutableNode status accessors

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -120,7 +120,7 @@ public class ExecutableNode {
     this.id = id;
   }
 
-  public Status getStatus() {
+  public synchronized Status getStatus() {
     return status;
   }
 
@@ -132,7 +132,7 @@ public class ExecutableNode {
     this.type = type;
   }
 
-  public void setStatus(Status status) {
+  public synchronized void setStatus(Status status) {
     this.status = status;
   }
 


### PR DESCRIPTION
Needed at least in FlowRunnerTest, to be able to always get the right status when FlowRunner runs in another thread. Doesn't do any harm for production code, but synchronization might be also crucial there in some cases.

See also: https://github.com/azkaban/azkaban/pull/1115 (also https://github.com/juhoautio/azkaban/pull/2 where the test was failing quite often without this sync).