### PR TITLE
Fix killed job status update and FlowRunner tests

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -16,6 +16,10 @@
 
 package azkaban.utils;
 
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.flow.CommonJobProperties;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -27,33 +31,28 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.apache.commons.jexl2.Expression;
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.MapContext;
 import org.apache.commons.lang.StringUtils;
-
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
-
-import com.google.common.collect.Maps;
-import com.google.common.collect.MapDifference;
-
-import azkaban.executor.ExecutableFlowBase;
-import azkaban.flow.CommonJobProperties;
 
 public class PropsUtils {
 
   private static final Logger logger = Logger.getLogger(PropsUtils.class);
+  private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
+      .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
+
   /**
-   * Load job schedules from the given directories ] * @param dir The directory
-   * to look in
+   * Load job schedules from the given directories
    *
+   * @param dir The directory to look in
    * @param suffixes File suffixes to load
    * @return The loaded set of schedules
    */
-  public static Props loadPropsInDir(File dir, String... suffixes) {
+  public static Props loadPropsInDir(final File dir, final String... suffixes) {
     return loadPropsInDir(null, dir, suffixes);
   }
 
@@ -65,35 +64,35 @@ public class PropsUtils {
    * @param suffixes File suffixes to load
    * @return The loaded set of schedules
    */
-  public static Props loadPropsInDir(Props parent, File dir, String... suffixes) {
+  public static Props loadPropsInDir(final Props parent, final File dir, final String... suffixes) {
     try {
-      Props props = new Props(parent);
-      File[] files = dir.listFiles();
+      final Props props = new Props(parent);
+      final File[] files = dir.listFiles();
       Arrays.sort(files);
       if (files != null) {
-        for (File f : files) {
+        for (final File f : files) {
           if (f.isFile() && endsWith(f, suffixes)) {
             props.putAll(new Props(null, f.getAbsolutePath()));
           }
         }
       }
       return props;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException("Error loading properties.", e);
     }
   }
 
-  public static Props loadProps(Props parent, File... propFiles) {
+  public static Props loadProps(final Props parent, final File... propFiles) {
     try {
       Props props = new Props(parent);
-      for (File f : propFiles) {
+      for (final File f : propFiles) {
         if (f.isFile()) {
           props = new Props(props, f);
         }
       }
 
       return props;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException("Error loading properties.", e);
     }
   }
@@ -105,9 +104,9 @@ public class PropsUtils {
    * @param suffixes The suffixes to load
    * @return The properties
    */
-  public static Props loadPropsInDirs(List<File> dirs, String... suffixes) {
-    Props props = new Props();
-    for (File dir : dirs) {
+  public static Props loadPropsInDirs(final List<File> dirs, final String... suffixes) {
+    final Props props = new Props();
+    for (final File dir : dirs) {
       props.putLocal(loadPropsInDir(dir, suffixes));
     }
     return props;
@@ -120,46 +119,47 @@ public class PropsUtils {
    * @param props The parent properties for loaded properties
    * @param suffixes The suffixes of files to load
    */
-  public static void loadPropsBySuffix(File jobPath, Props props,
-      String... suffixes) {
+  public static void loadPropsBySuffix(final File jobPath, final Props props,
+      final String... suffixes) {
     try {
       if (jobPath.isDirectory()) {
-        File[] files = jobPath.listFiles();
+        final File[] files = jobPath.listFiles();
         if (files != null) {
-          for (File file : files)
+          for (final File file : files) {
             loadPropsBySuffix(file, props, suffixes);
+          }
         }
       } else if (endsWith(jobPath, suffixes)) {
         props.putAll(new Props(null, jobPath.getAbsolutePath()));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException("Error loading schedule properties.", e);
     }
   }
 
-  public static boolean endsWith(File file, String... suffixes) {
-    for (String suffix : suffixes)
-      if (file.getName().endsWith(suffix))
+  public static boolean endsWith(final File file, final String... suffixes) {
+    for (final String suffix : suffixes) {
+      if (file.getName().endsWith(suffix)) {
         return true;
+      }
+    }
     return false;
   }
 
-  private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
-      .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
-
-  public static boolean isVarialbeReplacementPattern(String str) {
-    Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(str);
+  public static boolean isVarialbeReplacementPattern(final String str) {
+    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(str);
     return matcher.matches();
   }
 
-  public static Props resolveProps(Props props) {
-    if (props == null)
+  public static Props resolveProps(final Props props) {
+    if (props == null) {
       return null;
+    }
 
-    Props resolvedProps = new Props();
+    final Props resolvedProps = new Props();
 
-    LinkedHashSet<String> visitedVariables = new LinkedHashSet<String>();
-    for (String key : props.getKeySet()) {
+    final LinkedHashSet<String> visitedVariables = new LinkedHashSet<>();
+    for (final String key : props.getKeySet()) {
       String value = props.get(key);
       if (value == null) {
         logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
@@ -167,35 +167,35 @@ public class PropsUtils {
       }
 
       visitedVariables.add(key);
-      String replacedValue =
+      final String replacedValue =
           resolveVariableReplacement(value, props, visitedVariables);
       visitedVariables.clear();
 
       resolvedProps.put(key, replacedValue);
     }
 
-    for (String key : resolvedProps.getKeySet()) {
-      String value = resolvedProps.get(key);
-      String expressedValue = resolveVariableExpression(value);
+    for (final String key : resolvedProps.getKeySet()) {
+      final String value = resolvedProps.get(key);
+      final String expressedValue = resolveVariableExpression(value);
       resolvedProps.put(key, expressedValue);
     }
 
     return resolvedProps;
-  };
+  }
 
-  private static String resolveVariableReplacement(String value, Props props,
-      LinkedHashSet<String> visitedVariables) {
-    StringBuffer buffer = new StringBuffer();
+  private static String resolveVariableReplacement(final String value, final Props props,
+      final LinkedHashSet<String> visitedVariables) {
+    final StringBuffer buffer = new StringBuffer();
     int startIndex = 0;
 
-    Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
+    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
     while (matcher.find(startIndex)) {
       if (startIndex < matcher.start()) {
         // Copy everything up front to the buffer
         buffer.append(value.substring(startIndex, matcher.start()));
       }
 
-      String subVariable = matcher.group(1);
+      final String subVariable = matcher.group(1);
       // Detected a cycle
       if (visitedVariables.contains(subVariable)) {
         throw new IllegalArgumentException(String.format(
@@ -203,7 +203,7 @@ public class PropsUtils {
             StringUtils.join(visitedVariables, "->"), subVariable));
       } else {
         // Add substitute variable and recurse.
-        String replacement = props.get(subVariable);
+        final String replacement = props.get(subVariable);
         visitedVariables.add(subVariable);
 
         if (replacement == null) {
@@ -227,23 +227,18 @@ public class PropsUtils {
     return buffer.toString();
   }
 
-  private static String resolveVariableExpression(String value) {
-    JexlEngine jexl = new JexlEngine();
+  private static String resolveVariableExpression(final String value) {
+    final JexlEngine jexl = new JexlEngine();
     return resolveVariableExpression(value, value.length(), jexl);
   }
 
   /**
-   * Function that looks for expressions to parse. It parses backwards to
-   * capture embedded expressions
-   *
-   * @param value
-   * @param last
-   * @param jexl
-   * @return
+   * Function that looks for expressions to parse. It parses backwards to capture embedded
+   * expressions
    */
-  private static String resolveVariableExpression(String value, int last,
-      JexlEngine jexl) {
-    int lastIndex = value.lastIndexOf("$(", last);
+  private static String resolveVariableExpression(final String value, final int last,
+      final JexlEngine jexl) {
+    final int lastIndex = value.lastIndexOf("$(", last);
     if (lastIndex == -1) {
       return value;
     }
@@ -268,12 +263,12 @@ public class PropsUtils {
           + " not well formed.");
     }
 
-    String innerExpression = value.substring(lastIndex + 2, nextClosed);
+    final String innerExpression = value.substring(lastIndex + 2, nextClosed);
     Object result = null;
     try {
-      Expression e = jexl.createExpression(innerExpression);
+      final Expression e = jexl.createExpression(innerExpression);
       result = e.evaluate(new MapContext());
-    } catch (JexlException e) {
+    } catch (final JexlException e) {
       throw new IllegalArgumentException("Expression " + value
           + " not well formed. " + e.getMessage(), e);
     }
@@ -283,15 +278,15 @@ public class PropsUtils {
       return value;
     }
 
-    String newValue =
+    final String newValue =
         value.substring(0, lastIndex) + result.toString()
             + value.substring(nextClosed + 1);
     return resolveVariableExpression(newValue, lastIndex, jexl);
   }
 
-  public static Props addCommonFlowProperties(Props parentProps,
+  public static Props addCommonFlowProperties(final Props parentProps,
       final ExecutableFlowBase flow) {
-    Props props = new Props(parentProps);
+    final Props props = new Props(parentProps);
 
     props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
     props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
@@ -303,7 +298,7 @@ public class PropsUtils {
     props.put(CommonJobProperties.PROJECT_LAST_CHANGED_DATE, flow.getLastModifiedTimestamp());
     props.put(CommonJobProperties.SUBMIT_USER, flow.getExecutableFlow().getSubmitUser());
 
-    DateTime loadTime = new DateTime();
+    final DateTime loadTime = new DateTime();
 
     props.put(CommonJobProperties.FLOW_START_TIMESTAMP, loadTime.toString());
     props.put(CommonJobProperties.FLOW_START_YEAR, loadTime.toString("yyyy"));
@@ -320,49 +315,48 @@ public class PropsUtils {
     return props;
   }
 
-  public static String toJSONString(Props props, boolean localOnly) {
-    Map<String, String> map = toStringMap(props, localOnly);
+  public static String toJSONString(final Props props, final boolean localOnly) {
+    final Map<String, String> map = toStringMap(props, localOnly);
     return JSONUtils.toJSON(map);
   }
 
-  public static Map<String, String> toStringMap(Props props, boolean localOnly) {
-    HashMap<String, String> map = new HashMap<String, String>();
-    Set<String> keyset = localOnly ? props.localKeySet() : props.getKeySet();
+  public static Map<String, String> toStringMap(final Props props, final boolean localOnly) {
+    final HashMap<String, String> map = new HashMap<>();
+    final Set<String> keyset = localOnly ? props.localKeySet() : props.getKeySet();
 
-    for (String key : keyset) {
-      String value = props.get(key);
+    for (final String key : keyset) {
+      final String value = props.get(key);
       map.put(key, value);
     }
 
     return map;
   }
 
-  public static Props fromJSONString(String json) throws IOException {
-    Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
-    Props props = new Props(null, obj);
+  public static Props fromJSONString(final String json) throws IOException {
+    final Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
+    final Props props = new Props(null, obj);
     return props;
   }
 
-  @SuppressWarnings("unchecked")
-  public static Props fromHierarchicalMap(Map<String, Object> propsMap) {
+  public static Props fromHierarchicalMap(final Map<String, Object> propsMap) {
     if (propsMap == null) {
       return null;
     }
 
-    String source = (String) propsMap.get("source");
-    Map<String, String> propsParams =
+    final String source = (String) propsMap.get("source");
+    final Map<String, String> propsParams =
         (Map<String, String>) propsMap.get("props");
 
-    Map<String, Object> parent = (Map<String, Object>) propsMap.get("parent");
-    Props parentProps = fromHierarchicalMap(parent);
+    final Map<String, Object> parent = (Map<String, Object>) propsMap.get("parent");
+    final Props parentProps = fromHierarchicalMap(parent);
 
-    Props props = new Props(parentProps, propsParams);
+    final Props props = new Props(parentProps, propsParams);
     props.setSource(source);
     return props;
   }
 
-  public static Map<String, Object> toHierarchicalMap(Props props) {
-    Map<String, Object> propsMap = new HashMap<String, Object>();
+  public static Map<String, Object> toHierarchicalMap(final Props props) {
+    final Map<String, Object> propsMap = new HashMap<>();
     propsMap.put("source", props.getSource());
     propsMap.put("props", toStringMap(props, true));
 
@@ -374,13 +368,11 @@ public class PropsUtils {
   }
 
   /**
-   * @param oldProps
-   * @param newProps
    * @return the difference between oldProps and newProps.
    */
   public static String getPropertyDiff(Props oldProps, Props newProps) {
 
-    StringBuilder builder = new StringBuilder("");
+    final StringBuilder builder = new StringBuilder("");
 
     // oldProps can not be null during the below comparison process.
     if (oldProps == null) {
@@ -391,10 +383,10 @@ public class PropsUtils {
       newProps = new Props();
     }
 
-    MapDifference<String, String> md =
+    final MapDifference<String, String> md =
         Maps.difference(toStringMap(oldProps, false), toStringMap(newProps, false));
 
-    Map<String, String> newlyCreatedProperty = md.entriesOnlyOnRight();
+    final Map<String, String> newlyCreatedProperty = md.entriesOnlyOnRight();
     if (newlyCreatedProperty != null && newlyCreatedProperty.size() > 0) {
       builder.append("Newly created Properties: ");
       newlyCreatedProperty.forEach((k, v) -> {
@@ -403,7 +395,7 @@ public class PropsUtils {
       builder.append("\n");
     }
 
-    Map<String, String> deletedProperty = md.entriesOnlyOnLeft();
+    final Map<String, String> deletedProperty = md.entriesOnlyOnLeft();
     if (deletedProperty != null && deletedProperty.size() > 0) {
       builder.append("Deleted Properties: ");
       deletedProperty.forEach((k, v) -> {
@@ -412,7 +404,7 @@ public class PropsUtils {
       builder.append("\n");
     }
 
-    Map<String, MapDifference.ValueDifference<String>> diffProperties = md.entriesDiffering();
+    final Map<String, MapDifference.ValueDifference<String>> diffProperties = md.entriesDiffering();
     if (diffProperties != null && diffProperties.size() > 0) {
       builder.append("Modified Properties: ");
       diffProperties.forEach((k, v) -> {

--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -16,10 +16,6 @@
 
 package azkaban.utils;
 
-import azkaban.executor.ExecutableFlowBase;
-import azkaban.flow.CommonJobProperties;
-import com.google.common.collect.MapDifference;
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -31,20 +27,25 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.apache.commons.jexl2.Expression;
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.MapContext;
 import org.apache.commons.lang.StringUtils;
+
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.MapDifference;
+
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.flow.CommonJobProperties;
 
 public class PropsUtils {
 
   private static final Logger logger = Logger.getLogger(PropsUtils.class);
-  private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
-      .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
-
   /**
    * Load job schedules from the given directories ] * @param dir The directory
    * to look in
@@ -52,7 +53,7 @@ public class PropsUtils {
    * @param suffixes File suffixes to load
    * @return The loaded set of schedules
    */
-  public static Props loadPropsInDir(final File dir, final String... suffixes) {
+  public static Props loadPropsInDir(File dir, String... suffixes) {
     return loadPropsInDir(null, dir, suffixes);
   }
 
@@ -64,35 +65,35 @@ public class PropsUtils {
    * @param suffixes File suffixes to load
    * @return The loaded set of schedules
    */
-  public static Props loadPropsInDir(final Props parent, final File dir, final String... suffixes) {
+  public static Props loadPropsInDir(Props parent, File dir, String... suffixes) {
     try {
-      final Props props = new Props(parent);
-      final File[] files = dir.listFiles();
+      Props props = new Props(parent);
+      File[] files = dir.listFiles();
       Arrays.sort(files);
       if (files != null) {
-        for (final File f : files) {
+        for (File f : files) {
           if (f.isFile() && endsWith(f, suffixes)) {
             props.putAll(new Props(null, f.getAbsolutePath()));
           }
         }
       }
       return props;
-    } catch (final IOException e) {
+    } catch (IOException e) {
       throw new RuntimeException("Error loading properties.", e);
     }
   }
 
-  public static Props loadProps(final Props parent, final File... propFiles) {
+  public static Props loadProps(Props parent, File... propFiles) {
     try {
       Props props = new Props(parent);
-      for (final File f : propFiles) {
+      for (File f : propFiles) {
         if (f.isFile()) {
           props = new Props(props, f);
         }
       }
 
       return props;
-    } catch (final IOException e) {
+    } catch (IOException e) {
       throw new RuntimeException("Error loading properties.", e);
     }
   }
@@ -104,9 +105,9 @@ public class PropsUtils {
    * @param suffixes The suffixes to load
    * @return The properties
    */
-  public static Props loadPropsInDirs(final List<File> dirs, final String... suffixes) {
-    final Props props = new Props();
-    for (final File dir : dirs) {
+  public static Props loadPropsInDirs(List<File> dirs, String... suffixes) {
+    Props props = new Props();
+    for (File dir : dirs) {
       props.putLocal(loadPropsInDir(dir, suffixes));
     }
     return props;
@@ -119,79 +120,82 @@ public class PropsUtils {
    * @param props The parent properties for loaded properties
    * @param suffixes The suffixes of files to load
    */
-  public static void loadPropsBySuffix(final File jobPath, final Props props,
-      final String... suffixes) {
+  public static void loadPropsBySuffix(File jobPath, Props props,
+      String... suffixes) {
     try {
       if (jobPath.isDirectory()) {
-        final File[] files = jobPath.listFiles();
+        File[] files = jobPath.listFiles();
         if (files != null) {
-          for (final File file : files) {
+          for (File file : files)
             loadPropsBySuffix(file, props, suffixes);
-          }
         }
       } else if (endsWith(jobPath, suffixes)) {
         props.putAll(new Props(null, jobPath.getAbsolutePath()));
       }
-    } catch (final IOException e) {
+    } catch (IOException e) {
       throw new RuntimeException("Error loading schedule properties.", e);
     }
   }
 
-  public static boolean endsWith(final File file, final String... suffixes) {
-    for (final String suffix : suffixes) {
-      if (file.getName().endsWith(suffix)) {
+  public static boolean endsWith(File file, String... suffixes) {
+    for (String suffix : suffixes)
+      if (file.getName().endsWith(suffix))
         return true;
-      }
-    }
     return false;
   }
 
-  public static boolean isVarialbeReplacementPattern(final String str) {
-    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(str);
+  private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
+      .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
+
+  public static boolean isVarialbeReplacementPattern(String str) {
+    Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(str);
     return matcher.matches();
   }
 
-  public static Props resolveProps(final Props props) {
-    if (props == null) {
+  public static Props resolveProps(Props props) {
+    if (props == null)
       return null;
-    }
 
-    final Props resolvedProps = new Props();
+    Props resolvedProps = new Props();
 
-    final LinkedHashSet<String> visitedVariables = new LinkedHashSet<>();
-    for (final String key : props.getKeySet()) {
-      final String value = props.get(key);
+    LinkedHashSet<String> visitedVariables = new LinkedHashSet<String>();
+    for (String key : props.getKeySet()) {
+      String value = props.get(key);
+      if (value == null) {
+        logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
+        value = "";
+      }
 
       visitedVariables.add(key);
-      final String replacedValue =
+      String replacedValue =
           resolveVariableReplacement(value, props, visitedVariables);
       visitedVariables.clear();
 
       resolvedProps.put(key, replacedValue);
     }
 
-    for (final String key : resolvedProps.getKeySet()) {
-      final String value = resolvedProps.get(key);
-      final String expressedValue = resolveVariableExpression(value);
+    for (String key : resolvedProps.getKeySet()) {
+      String value = resolvedProps.get(key);
+      String expressedValue = resolveVariableExpression(value);
       resolvedProps.put(key, expressedValue);
     }
 
     return resolvedProps;
-  }
+  };
 
-  private static String resolveVariableReplacement(final String value, final Props props,
-      final LinkedHashSet<String> visitedVariables) {
-    final StringBuffer buffer = new StringBuffer();
+  private static String resolveVariableReplacement(String value, Props props,
+      LinkedHashSet<String> visitedVariables) {
+    StringBuffer buffer = new StringBuffer();
     int startIndex = 0;
 
-    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
+    Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
     while (matcher.find(startIndex)) {
       if (startIndex < matcher.start()) {
         // Copy everything up front to the buffer
         buffer.append(value.substring(startIndex, matcher.start()));
       }
 
-      final String subVariable = matcher.group(1);
+      String subVariable = matcher.group(1);
       // Detected a cycle
       if (visitedVariables.contains(subVariable)) {
         throw new IllegalArgumentException(String.format(
@@ -199,7 +203,7 @@ public class PropsUtils {
             StringUtils.join(visitedVariables, "->"), subVariable));
       } else {
         // Add substitute variable and recurse.
-        final String replacement = props.get(subVariable);
+        String replacement = props.get(subVariable);
         visitedVariables.add(subVariable);
 
         if (replacement == null) {
@@ -223,18 +227,23 @@ public class PropsUtils {
     return buffer.toString();
   }
 
-  private static String resolveVariableExpression(final String value) {
-    final JexlEngine jexl = new JexlEngine();
+  private static String resolveVariableExpression(String value) {
+    JexlEngine jexl = new JexlEngine();
     return resolveVariableExpression(value, value.length(), jexl);
   }
 
   /**
    * Function that looks for expressions to parse. It parses backwards to
    * capture embedded expressions
+   *
+   * @param value
+   * @param last
+   * @param jexl
+   * @return
    */
-  private static String resolveVariableExpression(final String value, final int last,
-      final JexlEngine jexl) {
-    final int lastIndex = value.lastIndexOf("$(", last);
+  private static String resolveVariableExpression(String value, int last,
+      JexlEngine jexl) {
+    int lastIndex = value.lastIndexOf("$(", last);
     if (lastIndex == -1) {
       return value;
     }
@@ -259,12 +268,12 @@ public class PropsUtils {
           + " not well formed.");
     }
 
-    final String innerExpression = value.substring(lastIndex + 2, nextClosed);
+    String innerExpression = value.substring(lastIndex + 2, nextClosed);
     Object result = null;
     try {
-      final Expression e = jexl.createExpression(innerExpression);
+      Expression e = jexl.createExpression(innerExpression);
       result = e.evaluate(new MapContext());
-    } catch (final JexlException e) {
+    } catch (JexlException e) {
       throw new IllegalArgumentException("Expression " + value
           + " not well formed. " + e.getMessage(), e);
     }
@@ -274,15 +283,15 @@ public class PropsUtils {
       return value;
     }
 
-    final String newValue =
+    String newValue =
         value.substring(0, lastIndex) + result.toString()
             + value.substring(nextClosed + 1);
     return resolveVariableExpression(newValue, lastIndex, jexl);
   }
 
-  public static Props addCommonFlowProperties(final Props parentProps,
+  public static Props addCommonFlowProperties(Props parentProps,
       final ExecutableFlowBase flow) {
-    final Props props = new Props(parentProps);
+    Props props = new Props(parentProps);
 
     props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
     props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
@@ -294,7 +303,7 @@ public class PropsUtils {
     props.put(CommonJobProperties.PROJECT_LAST_CHANGED_DATE, flow.getLastModifiedTimestamp());
     props.put(CommonJobProperties.SUBMIT_USER, flow.getExecutableFlow().getSubmitUser());
 
-    final DateTime loadTime = new DateTime();
+    DateTime loadTime = new DateTime();
 
     props.put(CommonJobProperties.FLOW_START_TIMESTAMP, loadTime.toString());
     props.put(CommonJobProperties.FLOW_START_YEAR, loadTime.toString("yyyy"));
@@ -311,48 +320,49 @@ public class PropsUtils {
     return props;
   }
 
-  public static String toJSONString(final Props props, final boolean localOnly) {
-    final Map<String, String> map = toStringMap(props, localOnly);
+  public static String toJSONString(Props props, boolean localOnly) {
+    Map<String, String> map = toStringMap(props, localOnly);
     return JSONUtils.toJSON(map);
   }
 
-  public static Map<String, String> toStringMap(final Props props, final boolean localOnly) {
-    final HashMap<String, String> map = new HashMap<>();
-    final Set<String> keyset = localOnly ? props.localKeySet() : props.getKeySet();
+  public static Map<String, String> toStringMap(Props props, boolean localOnly) {
+    HashMap<String, String> map = new HashMap<String, String>();
+    Set<String> keyset = localOnly ? props.localKeySet() : props.getKeySet();
 
-    for (final String key : keyset) {
-      final String value = props.get(key);
+    for (String key : keyset) {
+      String value = props.get(key);
       map.put(key, value);
     }
 
     return map;
   }
 
-  public static Props fromJSONString(final String json) throws IOException {
-    final Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
-    final Props props = new Props(null, obj);
+  public static Props fromJSONString(String json) throws IOException {
+    Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
+    Props props = new Props(null, obj);
     return props;
   }
 
-  public static Props fromHierarchicalMap(final Map<String, Object> propsMap) {
+  @SuppressWarnings("unchecked")
+  public static Props fromHierarchicalMap(Map<String, Object> propsMap) {
     if (propsMap == null) {
       return null;
     }
 
-    final String source = (String) propsMap.get("source");
-    final Map<String, String> propsParams =
+    String source = (String) propsMap.get("source");
+    Map<String, String> propsParams =
         (Map<String, String>) propsMap.get("props");
 
-    final Map<String, Object> parent = (Map<String, Object>) propsMap.get("parent");
-    final Props parentProps = fromHierarchicalMap(parent);
+    Map<String, Object> parent = (Map<String, Object>) propsMap.get("parent");
+    Props parentProps = fromHierarchicalMap(parent);
 
-    final Props props = new Props(parentProps, propsParams);
+    Props props = new Props(parentProps, propsParams);
     props.setSource(source);
     return props;
   }
 
-  public static Map<String, Object> toHierarchicalMap(final Props props) {
-    final Map<String, Object> propsMap = new HashMap<>();
+  public static Map<String, Object> toHierarchicalMap(Props props) {
+    Map<String, Object> propsMap = new HashMap<String, Object>();
     propsMap.put("source", props.getSource());
     propsMap.put("props", toStringMap(props, true));
 
@@ -364,11 +374,13 @@ public class PropsUtils {
   }
 
   /**
+   * @param oldProps
+   * @param newProps
    * @return the difference between oldProps and newProps.
    */
   public static String getPropertyDiff(Props oldProps, Props newProps) {
 
-    final StringBuilder builder = new StringBuilder("");
+    StringBuilder builder = new StringBuilder("");
 
     // oldProps can not be null during the below comparison process.
     if (oldProps == null) {
@@ -379,10 +391,10 @@ public class PropsUtils {
       newProps = new Props();
     }
 
-    final MapDifference<String, String> md =
+    MapDifference<String, String> md =
         Maps.difference(toStringMap(oldProps, false), toStringMap(newProps, false));
 
-    final Map<String, String> newlyCreatedProperty = md.entriesOnlyOnRight();
+    Map<String, String> newlyCreatedProperty = md.entriesOnlyOnRight();
     if (newlyCreatedProperty != null && newlyCreatedProperty.size() > 0) {
       builder.append("Newly created Properties: ");
       newlyCreatedProperty.forEach((k, v) -> {
@@ -391,7 +403,7 @@ public class PropsUtils {
       builder.append("\n");
     }
 
-    final Map<String, String> deletedProperty = md.entriesOnlyOnLeft();
+    Map<String, String> deletedProperty = md.entriesOnlyOnLeft();
     if (deletedProperty != null && deletedProperty.size() > 0) {
       builder.append("Deleted Properties: ");
       deletedProperty.forEach((k, v) -> {
@@ -400,7 +412,7 @@ public class PropsUtils {
       builder.append("\n");
     }
 
-    final Map<String, MapDifference.ValueDifference<String>> diffProperties = md.entriesDiffering();
+    Map<String, MapDifference.ValueDifference<String>> diffProperties = md.entriesDiffering();
     if (diffProperties != null && diffProperties.size() > 0) {
       builder.append("Modified Properties: ");
       diffProperties.forEach((k, v) -> {

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -18,22 +18,26 @@ package azkaban.executor;
 
 import static azkaban.flow.CommonJobProperties.JOB_ATTEMPT;
 
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.apache.log4j.Logger;
-
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.AbstractProcessJob;
 import azkaban.utils.Props;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.log4j.Logger;
 
 public class InteractiveTestJob extends AbstractProcessJob {
+
   public static final ConcurrentHashMap<String, InteractiveTestJob> testJobs =
-      new ConcurrentHashMap<String, InteractiveTestJob>();
+      new ConcurrentHashMap<>();
   private Props generatedProperties = new Props();
   private boolean isWaiting = true;
   private boolean succeed = true;
 
-  public static InteractiveTestJob getTestJob(String name) {
+  public InteractiveTestJob(final String jobId, final Props sysProps, final Props jobProps,
+      final Logger log) {
+    super(jobId, sysProps, jobProps, log);
+  }
+
+  public static InteractiveTestJob getTestJob(final String name) {
     for (int i = 0; i < 100; i++) {
       if (testJobs.containsKey(name)) {
         return testJobs.get(name);
@@ -41,7 +45,7 @@ public class InteractiveTestJob extends AbstractProcessJob {
       synchronized (testJobs) {
         try {
           InteractiveTestJob.testJobs.wait(10L);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
         }
       }
     }
@@ -52,16 +56,11 @@ public class InteractiveTestJob extends AbstractProcessJob {
     testJobs.clear();
   }
 
-  public InteractiveTestJob(String jobId, Props sysProps, Props jobProps,
-      Logger log) {
-    super(jobId, sysProps, jobProps, log);
-  }
-
   @Override
   public void run() throws Exception {
-    String nestedFlowPath =
+    final String nestedFlowPath =
         this.getJobProps().get(CommonJobProperties.NESTED_FLOW_PATH);
-    String groupName = this.getJobProps().getString("group", null);
+    final String groupName = this.getJobProps().getString("group", null);
     String id = nestedFlowPath == null ? this.getId() : nestedFlowPath;
     if (groupName != null) {
       id = groupName + ":" + id;
@@ -71,33 +70,33 @@ public class InteractiveTestJob extends AbstractProcessJob {
       testJobs.notifyAll();
     }
 
-    if (jobProps.getBoolean("fail", false)) {
-      int passRetry = jobProps.getInt("passRetry", -1);
-      if (passRetry > 0 && passRetry < jobProps.getInt(JOB_ATTEMPT)) {
+    if (this.jobProps.getBoolean("fail", false)) {
+      final int passRetry = this.jobProps.getInt("passRetry", -1);
+      if (passRetry > 0 && passRetry < this.jobProps.getInt(JOB_ATTEMPT)) {
         succeedJob();
       } else {
         failJob();
       }
     }
-    if (!succeed) {
+    if (!this.succeed) {
       throw new RuntimeException("Forced failure of " + getId());
     }
 
-    while (isWaiting) {
+    while (this.isWaiting) {
       synchronized (this) {
-        int waitMillis = jobProps.getInt("seconds", 5) * 1000;
+        final int waitMillis = this.jobProps.getInt("seconds", 5) * 1000;
         if (waitMillis > 0) {
           try {
             wait(waitMillis);
-          } catch (InterruptedException e) {
+          } catch (final InterruptedException e) {
           }
         }
-        if (jobProps.containsKey("fail")) {
+        if (this.jobProps.containsKey("fail")) {
           succeedJob();
         }
 
-        if (!isWaiting) {
-          if (!succeed) {
+        if (!this.isWaiting) {
+          if (!this.succeed) {
             throw new RuntimeException("Forced failure of " + getId());
           } else {
             info("Job " + getId() + " succeeded.");
@@ -109,32 +108,32 @@ public class InteractiveTestJob extends AbstractProcessJob {
 
   public void failJob() {
     synchronized (this) {
-      succeed = false;
-      isWaiting = false;
+      this.succeed = false;
+      this.isWaiting = false;
       this.notify();
     }
   }
 
   public void succeedJob() {
     synchronized (this) {
-      succeed = true;
-      isWaiting = false;
+      this.succeed = true;
+      this.isWaiting = false;
       this.notify();
     }
   }
 
-  public void succeedJob(Props generatedProperties) {
+  public void succeedJob(final Props generatedProperties) {
     synchronized (this) {
       this.generatedProperties = generatedProperties;
-      succeed = true;
-      isWaiting = false;
+      this.succeed = true;
+      this.isWaiting = false;
       this.notify();
     }
   }
 
   @Override
   public Props getJobGeneratedProperties() {
-    return generatedProperties;
+    return this.generatedProperties;
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -23,27 +23,22 @@ import azkaban.utils.Props;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MockExecutorLoader implements ExecutorLoader {
 
-  HashMap<Integer, Integer> executionExecutorMapping =
-      new HashMap<>();
-  HashMap<Integer, ExecutableFlow> flows =
-      new HashMap<>();
-  HashMap<String, ExecutableNode> nodes = new HashMap<>();
-  HashMap<Integer, ExecutionReference> refs =
-      new HashMap<>();
+  Map<Integer, Integer> executionExecutorMapping = new ConcurrentHashMap<>();
+  Map<Integer, ExecutableFlow> flows = new ConcurrentHashMap<>();
+  Map<String, ExecutableNode> nodes = new ConcurrentHashMap<>();
+  Map<Integer, ExecutionReference> refs = new ConcurrentHashMap<>();
   int flowUpdateCount = 0;
-  HashMap<String, Integer> jobUpdateCount = new HashMap<>();
-  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows =
-      new HashMap<>();
+  Map<String, Integer> jobUpdateCount = new ConcurrentHashMap<>();
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows = new ConcurrentHashMap<>();
   List<Executor> executors = new ArrayList<>();
   int executorIdCounter = 0;
-  Map<Integer, ArrayList<ExecutorLogEvent>> executorEvents =
-      new HashMap<>();
+  Map<Integer, ArrayList<ExecutorLogEvent>> executorEvents = new ConcurrentHashMap<>();
 
   @Override
   public void uploadExecutableFlow(final ExecutableFlow flow)
@@ -122,9 +117,6 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public void updateExecutableNode(final ExecutableNode node)
       throws ExecutorManagerException {
-    if (!this.nodes.containsKey(node.getId())) {
-      uploadExecutableNode(node, new Props());
-    }
     final ExecutableNode foundNode = this.nodes.get(node.getId());
     foundNode.setEndTime(node.getEndTime());
     foundNode.setStartTime(node.getStartTime());

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -16,6 +16,10 @@
 
 package azkaban.executor;
 
+import azkaban.executor.ExecutorLogEvent.EventType;
+import azkaban.utils.FileIOUtils.LogData;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -23,126 +27,122 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import azkaban.executor.ExecutorLogEvent.EventType;
-import azkaban.utils.FileIOUtils.LogData;
-import azkaban.utils.Pair;
-import azkaban.utils.Props;
-
 public class MockExecutorLoader implements ExecutorLoader {
 
   HashMap<Integer, Integer> executionExecutorMapping =
-      new HashMap<Integer, Integer>();
+      new HashMap<>();
   HashMap<Integer, ExecutableFlow> flows =
-      new HashMap<Integer, ExecutableFlow>();
-  HashMap<String, ExecutableNode> nodes = new HashMap<String, ExecutableNode>();
+      new HashMap<>();
+  HashMap<String, ExecutableNode> nodes = new HashMap<>();
   HashMap<Integer, ExecutionReference> refs =
-      new HashMap<Integer, ExecutionReference>();
+      new HashMap<>();
   int flowUpdateCount = 0;
-  HashMap<String, Integer> jobUpdateCount = new HashMap<String, Integer>();
+  HashMap<String, Integer> jobUpdateCount = new HashMap<>();
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows =
-      new HashMap<Integer, Pair<ExecutionReference, ExecutableFlow>>();
-  List<Executor> executors = new ArrayList<Executor>();
+      new HashMap<>();
+  List<Executor> executors = new ArrayList<>();
   int executorIdCounter = 0;
   Map<Integer, ArrayList<ExecutorLogEvent>> executorEvents =
-    new HashMap<Integer, ArrayList<ExecutorLogEvent>>();
+      new HashMap<>();
 
   @Override
-  public void uploadExecutableFlow(ExecutableFlow flow)
+  public void uploadExecutableFlow(final ExecutableFlow flow)
       throws ExecutorManagerException {
-    flows.put(flow.getExecutionId(), flow);
-    flowUpdateCount++;
+    this.flows.put(flow.getExecutionId(), flow);
+    this.flowUpdateCount++;
   }
 
   @Override
-  public ExecutableFlow fetchExecutableFlow(int execId)
+  public ExecutableFlow fetchExecutableFlow(final int execId)
       throws ExecutorManagerException {
-    ExecutableFlow flow = flows.get(execId);
+    final ExecutableFlow flow = this.flows.get(execId);
     return ExecutableFlow.createExecutableFlowFromObject(flow.toObject());
   }
 
   @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
-    return activeFlows;
+    return this.activeFlows;
   }
 
   @Override
-  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
       throws ExecutorManagerException {
-    return activeFlows.get(execId);
+    return this.activeFlows.get(execId);
   }
 
   @Override
-  public List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
-      int skip, int num) throws ExecutorManagerException {
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+      final int skip, final int num) throws ExecutorManagerException {
     return null;
   }
 
   @Override
-  public void addActiveExecutableReference(ExecutionReference ref)
+  public void addActiveExecutableReference(final ExecutionReference ref)
       throws ExecutorManagerException {
-    refs.put(ref.getExecId(), ref);
+    this.refs.put(ref.getExecId(), ref);
   }
 
   @Override
-  public void removeActiveExecutableReference(int execId)
+  public void removeActiveExecutableReference(final int execId)
       throws ExecutorManagerException {
-    refs.remove(execId);
+    this.refs.remove(execId);
   }
 
-  public boolean hasActiveExecutableReference(int execId) {
-    return refs.containsKey(execId);
-  }
-
-  @Override
-  public void uploadLogFile(int execId, String name, int attempt, File... files)
-      throws ExecutorManagerException {
-
+  public boolean hasActiveExecutableReference(final int execId) {
+    return this.refs.containsKey(execId);
   }
 
   @Override
-  public void updateExecutableFlow(ExecutableFlow flow)
+  public void uploadLogFile(final int execId, final String name, final int attempt,
+      final File... files)
       throws ExecutorManagerException {
-    ExecutableFlow toUpdate = flows.get(flow.getExecutionId());
+
+  }
+
+  @Override
+  public void updateExecutableFlow(final ExecutableFlow flow)
+      throws ExecutorManagerException {
+    final ExecutableFlow toUpdate = this.flows.get(flow.getExecutionId());
 
     toUpdate.applyUpdateObject((Map<String, Object>) flow.toUpdateObject(0));
-    flowUpdateCount++;
+    this.flowUpdateCount++;
   }
 
   @Override
-  public void uploadExecutableNode(ExecutableNode node, Props inputParams)
+  public void uploadExecutableNode(final ExecutableNode node, final Props inputParams)
       throws ExecutorManagerException {
-    ExecutableNode exNode = new ExecutableNode();
+    final ExecutableNode exNode = new ExecutableNode();
     exNode.fillExecutableFromMapObject(node.toObject());
 
-    nodes.put(node.getId(), exNode);
-    jobUpdateCount.put(node.getId(), 1);
+    this.nodes.put(node.getId(), exNode);
+    this.jobUpdateCount.put(node.getId(), 1);
   }
 
   @Override
-  public void updateExecutableNode(ExecutableNode node)
+  public void updateExecutableNode(final ExecutableNode node)
       throws ExecutorManagerException {
-    if (!nodes.containsKey(node.getId())) {
+    if (!this.nodes.containsKey(node.getId())) {
       uploadExecutableNode(node, new Props());
     }
-    ExecutableNode foundNode = nodes.get(node.getId());
+    final ExecutableNode foundNode = this.nodes.get(node.getId());
     foundNode.setEndTime(node.getEndTime());
     foundNode.setStartTime(node.getStartTime());
     foundNode.setStatus(node.getStatus());
     foundNode.setUpdateTime(node.getUpdateTime());
 
-    Integer value = jobUpdateCount.get(node.getId());
+    Integer value = this.jobUpdateCount.get(node.getId());
     if (value == null) {
       throw new ExecutorManagerException("The node has not been uploaded");
     } else {
-      jobUpdateCount.put(node.getId(), ++value);
+      this.jobUpdateCount.put(node.getId(), ++value);
     }
 
-    flowUpdateCount++;
+    this.flowUpdateCount++;
   }
 
   @Override
-  public int fetchNumExecutableFlows(int projectId, String flowId)
+  public int fetchNumExecutableFlows(final int projectId, final String flowId)
       throws ExecutorManagerException {
     return 0;
   }
@@ -154,114 +154,116 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   public int getFlowUpdateCount() {
-    return flowUpdateCount;
+    return this.flowUpdateCount;
   }
 
-  public Integer getNodeUpdateCount(String jobId) {
-    return jobUpdateCount.get(jobId);
+  public Integer getNodeUpdateCount(final String jobId) {
+    return this.jobUpdateCount.get(jobId);
   }
 
   @Override
-  public ExecutableJobInfo fetchJobInfo(int execId, String jobId, int attempt)
+  public ExecutableJobInfo fetchJobInfo(final int execId, final String jobId, final int attempt)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public boolean updateExecutableReference(int execId, long updateTime)
+  public boolean updateExecutableReference(final int execId, final long updateTime)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return true;
   }
 
   @Override
-  public LogData fetchLogs(int execId, String name, int attempt, int startByte,
-      int endByte) throws ExecutorManagerException {
+  public LogData fetchLogs(final int execId, final String name, final int attempt,
+      final int startByte,
+      final int endByte) throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<ExecutableFlow> fetchFlowHistory(int skip, int num)
+  public List<ExecutableFlow> fetchFlowHistory(final int skip, final int num)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<ExecutableFlow> fetchFlowHistory(String projectContains,
-      String flowContains, String userNameContains, int status, long startData,
-      long endData, int skip, int num) throws ExecutorManagerException {
+  public List<ExecutableFlow> fetchFlowHistory(final String projectContains,
+      final String flowContains, final String userNameContains, final int status,
+      final long startData,
+      final long endData, final int skip, final int num) throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<ExecutableJobInfo> fetchJobHistory(int projectId, String jobId,
-      int skip, int size) throws ExecutorManagerException {
+  public List<ExecutableJobInfo> fetchJobHistory(final int projectId, final String jobId,
+      final int skip, final int size) throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public int fetchNumExecutableNodes(int projectId, String jobId)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return 0;
-  }
-
-  @Override
-  public Props fetchExecutionJobInputProps(int execId, String jobId)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public Props fetchExecutionJobOutputProps(int execId, String jobId)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public Pair<Props, Props> fetchExecutionJobProps(int execId, String jobId)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public List<ExecutableJobInfo> fetchJobInfoAttempts(int execId, String jobId)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public int removeExecutionLogsByTime(long millis)
+  public int fetchNumExecutableNodes(final int projectId, final String jobId)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return 0;
   }
 
   @Override
-  public List<ExecutableFlow> fetchFlowHistory(int projectId, String flowId,
-      int skip, int num, Status status) throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public List<Object> fetchAttachments(int execId, String name, int attempt)
+  public Props fetchExecutionJobInputProps(final int execId, final String jobId)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }
 
   @Override
-  public void uploadAttachmentFile(ExecutableNode node, File file)
+  public Props fetchExecutionJobOutputProps(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Pair<Props, Props> fetchExecutionJobProps(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public List<ExecutableJobInfo> fetchJobInfoAttempts(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int removeExecutionLogsByTime(final long millis)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+      final int skip, final int num, final Status status) throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public List<Object> fetchAttachments(final int execId, final String name, final int attempt)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void uploadAttachmentFile(final ExecutableNode node, final File file)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
 
@@ -269,8 +271,8 @@ public class MockExecutorLoader implements ExecutorLoader {
 
   @Override
   public List<Executor> fetchActiveExecutors() throws ExecutorManagerException {
-    List<Executor> activeExecutors = new ArrayList<Executor>();
-    for (Executor executor : executors) {
+    final List<Executor> activeExecutors = new ArrayList<>();
+    for (final Executor executor : this.executors) {
       if (executor.isActive()) {
         activeExecutors.add(executor);
       }
@@ -279,9 +281,9 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor fetchExecutor(String host, int port)
-    throws ExecutorManagerException {
-    for (Executor executor : executors) {
+  public Executor fetchExecutor(final String host, final int port)
+      throws ExecutorManagerException {
+    for (final Executor executor : this.executors) {
       if (executor.getHost().equals(host) && executor.getPort() == port) {
         return executor;
       }
@@ -290,8 +292,8 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor fetchExecutor(int executorId) throws ExecutorManagerException {
-    for (Executor executor : executors) {
+  public Executor fetchExecutor(final int executorId) throws ExecutorManagerException {
+    for (final Executor executor : this.executors) {
       if (executor.getId() == executorId) {
         return executor;
       }
@@ -300,95 +302,95 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor addExecutor(String host, int port)
-    throws ExecutorManagerException {
+  public Executor addExecutor(final String host, final int port)
+      throws ExecutorManagerException {
     Executor executor = null;
     if (fetchExecutor(host, port) == null) {
-      executorIdCounter++;
-      executor = new Executor(executorIdCounter, host, port, true);
-      executors.add(executor);
+      this.executorIdCounter++;
+      executor = new Executor(this.executorIdCounter, host, port, true);
+      this.executors.add(executor);
     }
     return executor;
   }
 
   @Override
-  public void removeExecutor(String host, int port) throws ExecutorManagerException {
-    Executor executor = fetchExecutor(host, port);
+  public void removeExecutor(final String host, final int port) throws ExecutorManagerException {
+    final Executor executor = fetchExecutor(host, port);
     if (executor != null) {
-        executorIdCounter--;
-        executors.remove(executor);
+      this.executorIdCounter--;
+      this.executors.remove(executor);
     }
   }
 
   @Override
-  public void postExecutorEvent(Executor executor, EventType type, String user,
-    String message) throws ExecutorManagerException {
-    ExecutorLogEvent event =
-      new ExecutorLogEvent(executor.getId(), user, new Date(), type, message);
+  public void postExecutorEvent(final Executor executor, final EventType type, final String user,
+      final String message) throws ExecutorManagerException {
+    final ExecutorLogEvent event =
+        new ExecutorLogEvent(executor.getId(), user, new Date(), type, message);
 
-    if (!executorEvents.containsKey(executor.getId())) {
-      executorEvents.put(executor.getId(), new ArrayList<ExecutorLogEvent>());
+    if (!this.executorEvents.containsKey(executor.getId())) {
+      this.executorEvents.put(executor.getId(), new ArrayList<>());
     }
 
-    executorEvents.get(executor.getId()).add(event);
+    this.executorEvents.get(executor.getId()).add(event);
   }
 
   @Override
-  public List<ExecutorLogEvent> getExecutorEvents(Executor executor, int num,
-    int skip) throws ExecutorManagerException {
-    if (!executorEvents.containsKey(executor.getId())) {
-      List<ExecutorLogEvent> events = executorEvents.get(executor.getId());
+  public List<ExecutorLogEvent> getExecutorEvents(final Executor executor, final int num,
+      final int skip) throws ExecutorManagerException {
+    if (!this.executorEvents.containsKey(executor.getId())) {
+      final List<ExecutorLogEvent> events = this.executorEvents.get(executor.getId());
       return events.subList(skip, Math.min(num + skip - 1, events.size() - 1));
     }
     return null;
   }
 
   @Override
-  public void updateExecutor(Executor executor) throws ExecutorManagerException {
-    Executor oldExecutor = fetchExecutor(executor.getId());
-    executors.remove(oldExecutor);
-    executors.add(executor);
+  public void updateExecutor(final Executor executor) throws ExecutorManagerException {
+    final Executor oldExecutor = fetchExecutor(executor.getId());
+    this.executors.remove(oldExecutor);
+    this.executors.add(executor);
   }
 
   @Override
   public List<Executor> fetchAllExecutors() throws ExecutorManagerException {
-    return executors;
+    return this.executors;
   }
 
   @Override
-  public void assignExecutor(int executorId, int execId)
-    throws ExecutorManagerException {
-    ExecutionReference ref = refs.get(execId);
+  public void assignExecutor(final int executorId, final int execId)
+      throws ExecutorManagerException {
+    final ExecutionReference ref = this.refs.get(execId);
     ref.setExecutor(fetchExecutor(executorId));
-    executionExecutorMapping.put(execId, executorId);
+    this.executionExecutorMapping.put(execId, executorId);
   }
 
   @Override
-  public Executor fetchExecutorByExecutionId(int execId) throws ExecutorManagerException {
-    if (executionExecutorMapping.containsKey(execId)) {
-      return fetchExecutor(executionExecutorMapping.get(execId));
+  public Executor fetchExecutorByExecutionId(final int execId) throws ExecutorManagerException {
+    if (this.executionExecutorMapping.containsKey(execId)) {
+      return fetchExecutor(this.executionExecutorMapping.get(execId));
     } else {
       throw new ExecutorManagerException(
-        "Failed to find executor with execution : " + execId);
+          "Failed to find executor with execution : " + execId);
     }
   }
 
   @Override
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
-    throws ExecutorManagerException {
-    List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows =
-      new ArrayList<Pair<ExecutionReference, ExecutableFlow>>();
-    for (int execId : refs.keySet()) {
-      if (!executionExecutorMapping.containsKey(execId)) {
-        queuedFlows.add(new Pair<ExecutionReference, ExecutableFlow>(refs
-          .get(execId), flows.get(execId)));
+      throws ExecutorManagerException {
+    final List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows =
+        new ArrayList<>();
+    for (final int execId : this.refs.keySet()) {
+      if (!this.executionExecutorMapping.containsKey(execId)) {
+        queuedFlows.add(new Pair<>(this.refs
+            .get(execId), this.flows.get(execId)));
       }
     }
     return queuedFlows;
   }
 
   @Override
-  public void unassignExecutor(int executionId) throws ExecutorManagerException {
-    executionExecutorMapping.remove(executionId);
+  public void unassignExecutor(final int executionId) throws ExecutorManagerException {
+    this.executionExecutorMapping.remove(executionId);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -122,6 +122,9 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public void updateExecutableNode(ExecutableNode node)
       throws ExecutorManagerException {
+    if (!nodes.containsKey(node.getId())) {
+      uploadExecutableNode(node, new Props());
+    }
     ExecutableNode foundNode = nodes.get(node.getId());
     foundNode.setEndTime(node.getEndTime());
     foundNode.setStartTime(node.getStartTime());

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/AllJobExecutorTests.java
@@ -19,9 +19,9 @@ package azkaban.jobExecutor;
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
-class AllJobExecutorTests {
+public class AllJobExecutorTests {
 
-  static Props setUpCommonProps() {
+  public static Props setUpCommonProps() {
 
     final Props props = new Props();
     props.put("fullPath", ".");

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -131,8 +131,7 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   /**
-   * Constructor. If executorService is null, then it will create it's own for
-   * thread pools.
+   * Constructor. If executorService is null, then it will create it's own for thread pools.
    */
   public FlowRunner(final ExecutableFlow flow, final ExecutorLoader executorLoader,
       final ProjectLoader projectLoader, final JobTypeManager jobtypeManager,
@@ -257,7 +256,11 @@ public class FlowRunner extends EventHandler implements Runnable {
       this.watcher.setLogger(this.logger);
     }
 
-    this.logger.info("Assigned executor : " + AzkabanExecutorServer.getApp().getExecutorHostPort());
+    // Avoid NPE in unit tests when the static app instance is not set
+    if (AzkabanExecutorServer.getApp() != null) {
+      this.logger
+          .info("Assigned executor : " + AzkabanExecutorServer.getApp().getExecutorHostPort());
+    }
     this.logger.info("Running execid:" + this.execId + " flow:" + flowId + " project:"
         + projectId + " version:" + version);
     if (this.pipelineExecId != null) {
@@ -730,8 +733,8 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   /**
-   * Determines what the state of the next node should be. Returns null if the
-   * node should not be run.
+   * Determines what the state of the next node should be. Returns null if the node should not be
+   * run.
    */
   public Status getImpliedStatus(final ExecutableNode node) {
     // If it's running or finished with 'SUCCEEDED', than don't even

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -17,27 +17,6 @@
 package azkaban.execapp;
 
 import azkaban.Constants;
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Optional;
-
-import org.apache.log4j.Appender;
-import org.apache.log4j.EnhancedPatternLayout;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Layout;
-import org.apache.log4j.Logger;
-import org.apache.log4j.RollingFileAppender;
-
-import org.apache.kafka.log4jappender.KafkaLog4jAppender;
-
-import org.json.simple.JSONObject;
-
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
 import azkaban.event.EventData;
@@ -56,48 +35,57 @@ import azkaban.jobExecutor.Job;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypeManagerException;
 import azkaban.utils.ExternalLinkUtils;
+import azkaban.utils.PatternLayoutEscaped;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import azkaban.utils.UndefinedPropertyException;
-import azkaban.utils.PatternLayoutEscaped;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.log4jappender.KafkaLog4jAppender;
+import org.apache.log4j.Appender;
+import org.apache.log4j.EnhancedPatternLayout;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Logger;
+import org.apache.log4j.RollingFileAppender;
+import org.json.simple.JSONObject;
 
 public class JobRunner extends EventHandler implements Runnable {
+
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
   private static final Logger serverLogger = Logger.getLogger(JobRunner.class);
-
+  private static final Object logCreatorLock = new Object();
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
-
-  private ExecutorLoader loader;
-  private Props props;
-  private Props azkabanProps;
-  private ExecutableNode node;
-  private File workingDir;
-
+  private final Object syncObject = new Object();
+  private final JobTypeManager jobtypeManager;
+  private final ExecutorLoader loader;
+  private final Props props;
+  private final Props azkabanProps;
+  private final ExecutableNode node;
+  private final File workingDir;
+  private final Layout loggerLayout = this.DEFAULT_LAYOUT;
+  private final String jobId;
+  private final Set<String> pipelineJobs = new HashSet<>();
   private Logger logger = null;
-  private Layout loggerLayout = DEFAULT_LAYOUT;
   private Logger flowLogger = null;
-
   private Appender jobAppender = null;
   private Optional<Appender> kafkaAppender = Optional.empty();
   private File logFile;
   private String attachmentFileName;
-
   private Job job;
   private int executionId = -1;
-  private String jobId;
-
-  private static final Object logCreatorLock = new Object();
-  private final Object syncObject = new Object();
-
-  private final JobTypeManager jobtypeManager;
-
   // Used by the job to watch and block against another flow
   private Integer pipelineLevel = null;
   private FlowWatcher watcher = null;
-  private Set<String> pipelineJobs = new HashSet<String>();
-
   private Set<String> proxyUsers = null;
 
   private String jobLogChunkSize;
@@ -107,8 +95,8 @@ public class JobRunner extends EventHandler implements Runnable {
   private boolean killed = false;
   private BlockingStatus currentBlockStatus = null;
 
-  public JobRunner(ExecutableNode node, File workingDir, ExecutorLoader loader,
-      JobTypeManager jobtypeManager, Props azkabanProps) {
+  public JobRunner(final ExecutableNode node, final File workingDir, final ExecutorLoader loader,
+      final JobTypeManager jobtypeManager, final Props azkabanProps) {
     this.props = node.getInputProps();
     this.node = node;
     this.workingDir = workingDir;
@@ -120,69 +108,117 @@ public class JobRunner extends EventHandler implements Runnable {
     this.azkabanProps = azkabanProps;
   }
 
-  public void setValidatedProxyUsers(Set<String> proxyUsers) {
+  public static String createLogFileName(final ExecutableNode node, final int attempt) {
+    final int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".log" : "_job." + executionId + "." + jobId + ".log";
+  }
+
+  public static String createLogFileName(final ExecutableNode node) {
+    return JobRunner.createLogFileName(node, node.getAttempt());
+  }
+
+  public static String createMetaDataFileName(final ExecutableNode node, final int attempt) {
+    final int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".meta" : "_job." + executionId + "." + jobId + ".meta";
+  }
+
+  public static String createMetaDataFileName(final ExecutableNode node) {
+    return JobRunner.createMetaDataFileName(node, node.getAttempt());
+  }
+
+  public static String createAttachmentFileName(final ExecutableNode node) {
+
+    return JobRunner.createAttachmentFileName(node, node.getAttempt());
+  }
+
+  public static String createAttachmentFileName(final ExecutableNode node, final int attempt) {
+    final int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".attach" : "_job." + executionId + "." + jobId + ".attach";
+  }
+
+  public void setValidatedProxyUsers(final Set<String> proxyUsers) {
     this.proxyUsers = proxyUsers;
   }
 
-  public void setLogSettings(Logger flowLogger, String logFileChuckSize,
-      int numLogBackup) {
+  public void setLogSettings(final Logger flowLogger, final String logFileChuckSize,
+      final int numLogBackup) {
     this.flowLogger = flowLogger;
     this.jobLogChunkSize = logFileChuckSize;
     this.jobLogBackupIndex = numLogBackup;
   }
 
   public Props getProps() {
-    return props;
+    return this.props;
   }
 
-  public void setPipeline(FlowWatcher watcher, int pipelineLevel) {
+  public void setPipeline(final FlowWatcher watcher, final int pipelineLevel) {
     this.watcher = watcher;
     this.pipelineLevel = pipelineLevel;
 
     if (this.pipelineLevel == 1) {
-      pipelineJobs.add(node.getNestedId());
+      this.pipelineJobs.add(this.node.getNestedId());
     } else if (this.pipelineLevel == 2) {
-      pipelineJobs.add(node.getNestedId());
-      ExecutableFlowBase parentFlow = node.getParentFlow();
+      this.pipelineJobs.add(this.node.getNestedId());
+      final ExecutableFlowBase parentFlow = this.node.getParentFlow();
 
-      if (parentFlow.getEndNodes().contains(node.getId())) {
+      if (parentFlow.getEndNodes().contains(this.node.getId())) {
         if (!parentFlow.getOutNodes().isEmpty()) {
-          ExecutableFlowBase grandParentFlow = parentFlow.getParentFlow();
-          for (String outNode : parentFlow.getOutNodes()) {
-            ExecutableNode nextNode =
+          final ExecutableFlowBase grandParentFlow = parentFlow.getParentFlow();
+          for (final String outNode : parentFlow.getOutNodes()) {
+            final ExecutableNode nextNode =
                 grandParentFlow.getExecutableNode(outNode);
 
             // If the next node is a nested flow, then we add the nested
             // starting nodes
             if (nextNode instanceof ExecutableFlowBase) {
-              ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
-              findAllStartingNodes(nextFlow, pipelineJobs);
+              final ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
+              findAllStartingNodes(nextFlow, this.pipelineJobs);
             } else {
-              pipelineJobs.add(nextNode.getNestedId());
+              this.pipelineJobs.add(nextNode.getNestedId());
             }
           }
         }
       } else {
-        for (String outNode : node.getOutNodes()) {
-          ExecutableNode nextNode = parentFlow.getExecutableNode(outNode);
+        for (final String outNode : this.node.getOutNodes()) {
+          final ExecutableNode nextNode = parentFlow.getExecutableNode(outNode);
 
           // If the next node is a nested flow, then we add the nested starting
           // nodes
           if (nextNode instanceof ExecutableFlowBase) {
-            ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
-            findAllStartingNodes(nextFlow, pipelineJobs);
+            final ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
+            findAllStartingNodes(nextFlow, this.pipelineJobs);
           } else {
-            pipelineJobs.add(nextNode.getNestedId());
+            this.pipelineJobs.add(nextNode.getNestedId());
           }
         }
       }
     }
   }
 
-  private void findAllStartingNodes(ExecutableFlowBase flow,
-      Set<String> pipelineJobs) {
-    for (String startingNode : flow.getStartNodes()) {
-      ExecutableNode node = flow.getExecutableNode(startingNode);
+  private void findAllStartingNodes(final ExecutableFlowBase flow,
+      final Set<String> pipelineJobs) {
+    for (final String startingNode : flow.getStartNodes()) {
+      final ExecutableNode node = flow.getExecutableNode(startingNode);
       if (node instanceof ExecutableFlowBase) {
         findAllStartingNodes((ExecutableFlowBase) node, pipelineJobs);
       } else {
@@ -192,178 +228,185 @@ public class JobRunner extends EventHandler implements Runnable {
   }
 
   /**
-   * Returns a list of jobs that this JobRunner will wait upon to finish before
-   * starting. It is only relevant if pipeline is turned on.
-   *
-   * @return
+   * Returns a list of jobs that this JobRunner will wait upon to finish before starting. It is only
+   * relevant if pipeline is turned on.
    */
   public Set<String> getPipelineWatchedJobs() {
-    return pipelineJobs;
-  }
-
-  public void setDelayStart(long delayMS) {
-    delayStartMs = delayMS;
+    return this.pipelineJobs;
   }
 
   public long getDelayStart() {
-    return delayStartMs;
+    return this.delayStartMs;
+  }
+
+  public void setDelayStart(final long delayMS) {
+    this.delayStartMs = delayMS;
   }
 
   public ExecutableNode getNode() {
-    return node;
+    return this.node;
   }
 
   public String getLogFilePath() {
-    return logFile == null ? null : logFile.getPath();
+    return this.logFile == null ? null : this.logFile.getPath();
   }
 
   private void createLogger() {
     // Create logger
     synchronized (logCreatorLock) {
-      String loggerName =
+      final String loggerName =
           System.currentTimeMillis() + "." + this.executionId + "."
               + this.jobId;
-      logger = Logger.getLogger(loggerName);
+      this.logger = Logger.getLogger(loggerName);
 
       try {
         attachFileAppender(createFileAppender());
-      } catch (IOException e) {
-        removeAppender(jobAppender);
-        flowLogger.error("Could not open log file in " + workingDir
+      } catch (final IOException e) {
+        removeAppender(this.jobAppender);
+        this.flowLogger.error("Could not open log file in " + this.workingDir
             + " for job " + this.jobId, e);
       }
 
-      if (props.getBoolean(Constants.JobProperties.AZKABAN_JOB_LOGGING_KAFKA_ENABLE, false)) {
+      if (this.props.getBoolean(Constants.JobProperties.AZKABAN_JOB_LOGGING_KAFKA_ENABLE, false)) {
         // Only attempt appender construction if required properties are present
-        if (azkabanProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST)
-            && azkabanProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC)) {
+        if (this.azkabanProps
+            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST)
+            && this.azkabanProps
+            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC)) {
           try {
             attachKafkaAppender(createKafkaAppender());
-          } catch (Exception e) {
-            removeAppender(kafkaAppender);
-            flowLogger.error("Failed to create Kafka appender for job " + this.jobId, e);
+          } catch (final Exception e) {
+            removeAppender(this.kafkaAppender);
+            this.flowLogger.error("Failed to create Kafka appender for job " + this.jobId, e);
           }
         } else {
-          flowLogger.info("Kafka appender not created as brokerlist or topic not provided by executor server");
+          this.flowLogger.info(
+              "Kafka appender not created as brokerlist or topic not provided by executor server");
         }
       }
     }
 
-    String externalViewer = ExternalLinkUtils.getExternalLogViewer(azkabanProps, this.jobId, props);
+    final String externalViewer = ExternalLinkUtils
+        .getExternalLogViewer(this.azkabanProps, this.jobId,
+            this.props);
     if (!externalViewer.isEmpty()) {
-      logger.info("See logs at: " + externalViewer);
+      this.logger.info("See logs at: " + externalViewer);
     }
   }
 
-  private void attachFileAppender(FileAppender appender) {
+  private void attachFileAppender(final FileAppender appender) {
     // If present, remove the existing file appender
-    assert(jobAppender == null);
+    assert (this.jobAppender == null);
 
-    jobAppender = appender;
-    logger.addAppender(jobAppender);
-    logger.setAdditivity(false);
-    flowLogger.info("Attached file appender for job " + this.jobId);
+    this.jobAppender = appender;
+    this.logger.addAppender(this.jobAppender);
+    this.logger.setAdditivity(false);
+    this.flowLogger.info("Attached file appender for job " + this.jobId);
   }
 
   private FileAppender createFileAppender() throws IOException {
     // Set up log files
-    String logName = createLogFileName(node);
-    logFile = new File(workingDir, logName);
-    String absolutePath = logFile.getAbsolutePath();
+    final String logName = createLogFileName(this.node);
+    this.logFile = new File(this.workingDir, logName);
+    final String absolutePath = this.logFile.getAbsolutePath();
 
     // Attempt to create FileAppender
-    RollingFileAppender fileAppender =
-        new RollingFileAppender(loggerLayout, absolutePath, true);
-    fileAppender.setMaxBackupIndex(jobLogBackupIndex);
-    fileAppender.setMaxFileSize(jobLogChunkSize);
+    final RollingFileAppender fileAppender =
+        new RollingFileAppender(this.loggerLayout, absolutePath, true);
+    fileAppender.setMaxBackupIndex(this.jobLogBackupIndex);
+    fileAppender.setMaxFileSize(this.jobLogChunkSize);
 
-    flowLogger.info("Created file appender for job " + this.jobId);
+    this.flowLogger.info("Created file appender for job " + this.jobId);
     return fileAppender;
   }
 
   private void createAttachmentFile() {
-    String fileName = createAttachmentFileName(node);
-    File file = new File(workingDir, fileName);
-    attachmentFileName = file.getAbsolutePath();
+    final String fileName = createAttachmentFileName(this.node);
+    final File file = new File(this.workingDir, fileName);
+    this.attachmentFileName = file.getAbsolutePath();
   }
 
-  private void attachKafkaAppender(KafkaLog4jAppender appender) {
+  private void attachKafkaAppender(final KafkaLog4jAppender appender) {
     // This should only be called once
-    assert(!kafkaAppender.isPresent());
+    assert (!this.kafkaAppender.isPresent());
 
-    kafkaAppender = Optional.of(appender);
-    logger.addAppender(kafkaAppender.get());
-    logger.setAdditivity(false);
-    flowLogger.info("Attached new Kafka appender for job " + this.jobId);
+    this.kafkaAppender = Optional.of(appender);
+    this.logger.addAppender(this.kafkaAppender.get());
+    this.logger.setAdditivity(false);
+    this.flowLogger.info("Attached new Kafka appender for job " + this.jobId);
   }
 
   private KafkaLog4jAppender createKafkaAppender() throws UndefinedPropertyException {
-    KafkaLog4jAppender kafkaProducer = new KafkaLog4jAppender();
+    final KafkaLog4jAppender kafkaProducer = new KafkaLog4jAppender();
     kafkaProducer.setSyncSend(false);
-    kafkaProducer.setBrokerList(azkabanProps.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST));
-    kafkaProducer.setTopic(azkabanProps.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
+    kafkaProducer.setBrokerList(this.azkabanProps
+        .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST));
+    kafkaProducer.setTopic(
+        this.azkabanProps
+            .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
 
-    JSONObject layout = new JSONObject();
+    final JSONObject layout = new JSONObject();
     layout.put("category", "%c{1}");
     layout.put("level", "%p");
     layout.put("message", "%m");
-    layout.put("projectname", props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_NAME));
-    layout.put("flowid", props.getString(Constants.FlowProperties.AZKABAN_FLOW_FLOW_ID));
+    layout.put("projectname",
+        this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_NAME));
+    layout.put("flowid", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_FLOW_ID));
     layout.put("jobid", this.jobId);
-    layout.put("submituser", props.getString(Constants.FlowProperties.AZKABAN_FLOW_SUBMIT_USER));
-    layout.put("execid", props.getString(Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID));
-    layout.put("projectversion", props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_VERSION));
+    layout
+        .put("submituser", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_SUBMIT_USER));
+    layout.put("execid", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID));
+    layout.put("projectversion",
+        this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_VERSION));
     layout.put("logsource", "userJob");
 
     kafkaProducer.setLayout(new PatternLayoutEscaped(layout.toString()));
     kafkaProducer.activateOptions();
 
-    flowLogger.info("Created kafka appender for " + this.jobId);
+    this.flowLogger.info("Created kafka appender for " + this.jobId);
     return kafkaProducer;
   }
 
-  private void removeAppender(Optional<Appender> appender) {
+  private void removeAppender(final Optional<Appender> appender) {
     if (appender.isPresent()) {
       removeAppender(appender.get());
     }
   }
 
-  private void removeAppender(Appender appender) {
+  private void removeAppender(final Appender appender) {
     if (appender != null) {
-      logger.removeAppender(appender);
+      this.logger.removeAppender(appender);
       appender.close();
     }
   }
 
   private void closeLogger() {
-    if (jobAppender != null) {
-      removeAppender(jobAppender);
+    if (this.jobAppender != null) {
+      removeAppender(this.jobAppender);
     }
-    if (kafkaAppender.isPresent()) {
-      removeAppender(kafkaAppender);
+    if (this.kafkaAppender.isPresent()) {
+      removeAppender(this.kafkaAppender);
     }
   }
 
   private void writeStatus() {
     try {
-      node.setUpdateTime(System.currentTimeMillis());
-      loader.updateExecutableNode(node);
-    } catch (ExecutorManagerException e) {
-      flowLogger.error("Could not update job properties in db for "
+      this.node.setUpdateTime(System.currentTimeMillis());
+      this.loader.updateExecutableNode(this.node);
+    } catch (final ExecutorManagerException e) {
+      this.flowLogger.error("Could not update job properties in db for "
           + this.jobId, e);
     }
   }
 
   /**
-   * Used to handle non-ready and special status's (i.e. KILLED). Returns true
-   * if they handled anything.
-   *
-   * @return
+   * Used to handle non-ready and special status's (i.e. KILLED). Returns true if they handled
+   * anything.
    */
   private boolean handleNonReadyStatus() {
-    Status nodeStatus = node.getStatus();
+    Status nodeStatus = this.node.getStatus();
     boolean quickFinish = false;
-    long time = System.currentTimeMillis();
+    final long time = System.currentTimeMillis();
 
     if (Status.isStatusFinished(nodeStatus)) {
       quickFinish = true;
@@ -376,10 +419,13 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     if (quickFinish) {
-      node.setStartTime(time);
-      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(nodeStatus, node.getNestedId())));
-      node.setEndTime(time);
-      fireEvent(Event.create(this, Type.JOB_FINISHED, new EventData(nodeStatus, node.getNestedId())));
+      this.node.setStartTime(time);
+      fireEvent(
+          Event.create(this, Type.JOB_STARTED, new EventData(nodeStatus, this.node.getNestedId())));
+      this.node.setEndTime(time);
+      fireEvent(
+          Event
+              .create(this, Type.JOB_FINISHED, new EventData(nodeStatus, this.node.getNestedId())));
       return true;
     }
 
@@ -395,37 +441,37 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     // For pipelining of jobs. Will watch other jobs.
-    if (!pipelineJobs.isEmpty()) {
+    if (!this.pipelineJobs.isEmpty()) {
       String blockedList = "";
-      ArrayList<BlockingStatus> blockingStatus =
-          new ArrayList<BlockingStatus>();
-      for (String waitingJobId : pipelineJobs) {
-        Status status = watcher.peekStatus(waitingJobId);
+      final ArrayList<BlockingStatus> blockingStatus =
+          new ArrayList<>();
+      for (final String waitingJobId : this.pipelineJobs) {
+        final Status status = this.watcher.peekStatus(waitingJobId);
         if (status != null && !Status.isStatusFinished(status)) {
-          BlockingStatus block = watcher.getBlockingStatus(waitingJobId);
+          final BlockingStatus block = this.watcher.getBlockingStatus(waitingJobId);
           blockingStatus.add(block);
           blockedList += waitingJobId + ",";
         }
       }
       if (!blockingStatus.isEmpty()) {
-        logger.info("Pipeline job " + this.jobId + " waiting on " + blockedList
-            + " in execution " + watcher.getExecId());
+        this.logger.info("Pipeline job " + this.jobId + " waiting on " + blockedList
+            + " in execution " + this.watcher.getExecId());
 
-        for (BlockingStatus bStatus : blockingStatus) {
-          logger.info("Waiting on pipelined job " + bStatus.getJobId());
-          currentBlockStatus = bStatus;
+        for (final BlockingStatus bStatus : blockingStatus) {
+          this.logger.info("Waiting on pipelined job " + bStatus.getJobId());
+          this.currentBlockStatus = bStatus;
           bStatus.blockOnFinishedStatus();
           if (this.isKilled()) {
-            logger.info("Job was killed while waiting on pipeline. Quiting.");
+            this.logger.info("Job was killed while waiting on pipeline. Quiting.");
             return true;
           } else {
-            logger.info("Pipelined job " + bStatus.getJobId() + " finished.");
+            this.logger.info("Pipelined job " + bStatus.getJobId() + " finished.");
           }
         }
       }
     }
 
-    currentBlockStatus = null;
+    this.currentBlockStatus = null;
     return false;
   }
 
@@ -434,24 +480,24 @@ public class JobRunner extends EventHandler implements Runnable {
       return true;
     }
 
-    long currentTime = System.currentTimeMillis();
-    if (delayStartMs > 0) {
-      logger.info("Delaying start of execution for " + delayStartMs
+    final long currentTime = System.currentTimeMillis();
+    if (this.delayStartMs > 0) {
+      this.logger.info("Delaying start of execution for " + this.delayStartMs
           + " milliseconds.");
       synchronized (this) {
         try {
-          this.wait(delayStartMs);
-          logger.info("Execution has been delayed for " + delayStartMs
+          this.wait(this.delayStartMs);
+          this.logger.info("Execution has been delayed for " + this.delayStartMs
               + " ms. Continuing with execution.");
-        } catch (InterruptedException e) {
-          logger.error("Job " + this.jobId + " was to be delayed for "
-              + delayStartMs + ". Interrupted after "
+        } catch (final InterruptedException e) {
+          this.logger.error("Job " + this.jobId + " was to be delayed for "
+              + this.delayStartMs + ". Interrupted after "
               + (System.currentTimeMillis() - currentTime));
         }
       }
 
       if (this.isKilled()) {
-        logger.info("Job was killed while in delay. Quiting.");
+        this.logger.info("Job was killed while in delay. Quiting.");
         return true;
       }
     }
@@ -459,46 +505,46 @@ public class JobRunner extends EventHandler implements Runnable {
     return false;
   }
 
-  private void finalizeLogFile(int attemptNo) {
+  private void finalizeLogFile(final int attemptNo) {
     closeLogger();
-    if (logFile == null) {
-      flowLogger.info("Log file for job " + this.jobId + " is null");
+    if (this.logFile == null) {
+      this.flowLogger.info("Log file for job " + this.jobId + " is null");
       return;
     }
 
     try {
-      File[] files = logFile.getParentFile().listFiles(new FilenameFilter() {
+      final File[] files = this.logFile.getParentFile().listFiles(new FilenameFilter() {
         @Override
-        public boolean accept(File dir, String name) {
-          return name.startsWith(logFile.getName());
+        public boolean accept(final File dir, final String name) {
+          return name.startsWith(JobRunner.this.logFile.getName());
         }
       });
       Arrays.sort(files, Collections.reverseOrder());
 
-      loader.uploadLogFile(executionId, this.node.getNestedId(), attemptNo,
+      this.loader.uploadLogFile(this.executionId, this.node.getNestedId(), attemptNo,
           files);
-    } catch (ExecutorManagerException e) {
-      flowLogger.error(
+    } catch (final ExecutorManagerException e) {
+      this.flowLogger.error(
           "Error writing out logs for job " + this.node.getNestedId(), e);
     }
   }
 
   private void finalizeAttachmentFile() {
-    if (attachmentFileName == null) {
-      flowLogger.info("Attachment file for job " + this.jobId + " is null");
+    if (this.attachmentFileName == null) {
+      this.flowLogger.info("Attachment file for job " + this.jobId + " is null");
       return;
     }
 
     try {
-      File file = new File(attachmentFileName);
+      final File file = new File(this.attachmentFileName);
       if (!file.exists()) {
-        flowLogger.info("No attachment file for job " + this.jobId
+        this.flowLogger.info("No attachment file for job " + this.jobId
             + " written.");
         return;
       }
-      loader.uploadAttachmentFile(node, file);
-    } catch (ExecutorManagerException e) {
-      flowLogger.error(
+      this.loader.uploadAttachmentFile(this.node, file);
+    } catch (final ExecutorManagerException e) {
+      this.flowLogger.error(
           "Error writing out attachment for job " + this.node.getNestedId(), e);
     }
   }
@@ -510,7 +556,7 @@ public class JobRunner extends EventHandler implements Runnable {
   public void run() {
     try {
       doRun();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       serverLogger.error("Unexpected exception", e);
       throw e;
     }
@@ -518,7 +564,7 @@ public class JobRunner extends EventHandler implements Runnable {
 
   private void doRun() {
     Thread.currentThread().setName(
-        "JobRunner-" + this.jobId + "-" + executionId);
+        "JobRunner-" + this.jobId + "-" + this.executionId);
 
     // If the job is cancelled, disabled, killed. No log is created in this case
     if (handleNonReadyStatus()) {
@@ -536,29 +582,29 @@ public class JobRunner extends EventHandler implements Runnable {
     errorFound |= blockOnPipeLine();
 
     // Start the node.
-    node.setStartTime(System.currentTimeMillis());
-    Status finalStatus = node.getStatus();
+    this.node.setStartTime(System.currentTimeMillis());
+    Status finalStatus = this.node.getStatus();
     if (!errorFound && !isKilled()) {
-      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(node)));
+      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(this.node)));
       try {
-        loader.uploadExecutableNode(node, props);
-      } catch (ExecutorManagerException e1) {
-        logger.error("Error writing initial node properties");
+        this.loader.uploadExecutableNode(this.node, this.props);
+      } catch (final ExecutorManagerException e1) {
+        this.logger.error("Error writing initial node properties");
       }
 
-      Status prepareStatus = prepareJob();
+      final Status prepareStatus = prepareJob();
       if (prepareStatus != null) {
         // Writes status to the db
         writeStatus();
         fireEvent(Event.create(this, Type.JOB_STATUS_CHANGED,
-            new EventData(prepareStatus, node.getNestedId())));
+            new EventData(prepareStatus, this.node.getNestedId())));
         finalStatus = runJob();
       } else {
         finalStatus = changeStatus(Status.FAILED);
         logError("Job run failed preparing the job.");
       }
     }
-    node.setEndTime(System.currentTimeMillis());
+    this.node.setEndTime(System.currentTimeMillis());
 
     if (isKilled()) {
       // even if it's killed, there is a chance that the job failed is marked as
@@ -569,12 +615,12 @@ public class JobRunner extends EventHandler implements Runnable {
       finalStatus = changeStatus(Status.KILLED);
     }
 
-    int attemptNo = node.getAttempt();
+    final int attemptNo = this.node.getAttempt();
     logInfo("Finishing job " + this.jobId + " attempt: " + attemptNo + " at "
-        + node.getEndTime() + " with status " + node.getStatus());
+        + this.node.getEndTime() + " with status " + this.node.getStatus());
 
     fireEvent(Event.create(this, Type.JOB_FINISHED,
-        new EventData(finalStatus, node.getNestedId())), false);
+        new EventData(finalStatus, this.node.getNestedId())), false);
     finalizeLogFile(attemptNo);
     finalizeAttachmentFile();
     writeStatus();
@@ -582,59 +628,59 @@ public class JobRunner extends EventHandler implements Runnable {
 
   private Status prepareJob() throws RuntimeException {
     // Check pre conditions
-    if (props == null || this.isKilled()) {
+    if (this.props == null || this.isKilled()) {
       logError("Failing job. The job properties don't exist");
       return null;
     }
 
-    Status finalStatus;
-    synchronized (syncObject) {
-      if (node.getStatus() == Status.FAILED || this.isKilled()) {
+    final Status finalStatus;
+    synchronized (this.syncObject) {
+      if (this.node.getStatus() == Status.FAILED || this.isKilled()) {
         return null;
       }
 
-      if (node.getAttempt() > 0) {
-        logInfo("Starting job " + this.jobId + " attempt " + node.getAttempt()
-            + " at " + node.getStartTime());
+      if (this.node.getAttempt() > 0) {
+        logInfo("Starting job " + this.jobId + " attempt " + this.node.getAttempt()
+            + " at " + this.node.getStartTime());
       } else {
-        logInfo("Starting job " + this.jobId + " at " + node.getStartTime());
+        logInfo("Starting job " + this.jobId + " at " + this.node.getStartTime());
       }
 
       // If it's an embedded flow, we'll add the nested flow info to the job
       // conf
-      if (node.getExecutableFlow() != node.getParentFlow()) {
-        String subFlow = node.getPrintableId(":");
-        props.put(CommonJobProperties.NESTED_FLOW_PATH, subFlow);
+      if (this.node.getExecutableFlow() != this.node.getParentFlow()) {
+        final String subFlow = this.node.getPrintableId(":");
+        this.props.put(CommonJobProperties.NESTED_FLOW_PATH, subFlow);
       }
 
       insertJobMetadata();
       insertJVMAargs();
 
-      props.put(CommonJobProperties.JOB_ID, this.jobId);
-      props.put(CommonJobProperties.JOB_ATTEMPT, node.getAttempt());
-      props.put(CommonJobProperties.JOB_METADATA_FILE,
-          createMetaDataFileName(node));
-      props.put(CommonJobProperties.JOB_ATTACHMENT_FILE, attachmentFileName);
+      this.props.put(CommonJobProperties.JOB_ID, this.jobId);
+      this.props.put(CommonJobProperties.JOB_ATTEMPT, this.node.getAttempt());
+      this.props.put(CommonJobProperties.JOB_METADATA_FILE,
+          createMetaDataFileName(this.node));
+      this.props.put(CommonJobProperties.JOB_ATTACHMENT_FILE, this.attachmentFileName);
       finalStatus = changeStatus(Status.RUNNING);
 
       // Ability to specify working directory
-      if (!props.containsKey(AbstractProcessJob.WORKING_DIR)) {
-        props.put(AbstractProcessJob.WORKING_DIR, workingDir.getAbsolutePath());
+      if (!this.props.containsKey(AbstractProcessJob.WORKING_DIR)) {
+        this.props.put(AbstractProcessJob.WORKING_DIR, this.workingDir.getAbsolutePath());
       }
 
-      if (props.containsKey("user.to.proxy")) {
-        String jobProxyUser = props.getString("user.to.proxy");
-        if (proxyUsers != null && !proxyUsers.contains(jobProxyUser)) {
-          logger.error("User " + jobProxyUser
+      if (this.props.containsKey("user.to.proxy")) {
+        final String jobProxyUser = this.props.getString("user.to.proxy");
+        if (this.proxyUsers != null && !this.proxyUsers.contains(jobProxyUser)) {
+          this.logger.error("User " + jobProxyUser
               + " has no permission to execute this job " + this.jobId + "!");
           return null;
         }
       }
 
       try {
-        job = jobtypeManager.buildJobExecutor(this.jobId, props, logger);
-      } catch (JobTypeManagerException e) {
-        logger.error("Failed to build job type", e);
+        this.job = this.jobtypeManager.buildJobExecutor(this.jobId, this.props, this.logger);
+      } catch (final JobTypeManagerException e) {
+        this.logger.error("Failed to build job type", e);
         return null;
       }
     }
@@ -643,73 +689,73 @@ public class JobRunner extends EventHandler implements Runnable {
   }
 
   /**
-   * Add useful JVM arguments so it is easier to map a running Java process to a
-   * flow, execution id and job
+   * Add useful JVM arguments so it is easier to map a running Java process to a flow, execution id
+   * and job
    */
   private void insertJVMAargs() {
-    String flowName = node.getParentFlow().getFlowId();
-    String jobId = node.getId();
+    final String flowName = this.node.getParentFlow().getFlowId();
+    final String jobId = this.node.getId();
 
     String jobJVMArgs =
         String.format(
             "-Dazkaban.flowid=%s -Dazkaban.execid=%s -Dazkaban.jobid=%s",
-            flowName, executionId, jobId);
+            flowName, this.executionId, jobId);
 
-    String previousJVMArgs = props.get(JavaProcessJob.JVM_PARAMS);
+    final String previousJVMArgs = this.props.get(JavaProcessJob.JVM_PARAMS);
     jobJVMArgs += (previousJVMArgs == null) ? "" : " " + previousJVMArgs;
 
-    logger.info("job JVM args: " + jobJVMArgs);
-    props.put(JavaProcessJob.JVM_PARAMS, jobJVMArgs);
+    this.logger.info("job JVM args: " + jobJVMArgs);
+    this.props.put(JavaProcessJob.JVM_PARAMS, jobJVMArgs);
   }
 
   /**
-   * Add relevant links to the job properties so that downstream consumers may
-   * know what executions initiated their execution.
+   * Add relevant links to the job properties so that downstream consumers may know what executions
+   * initiated their execution.
    */
   private void insertJobMetadata() {
-    String baseURL = azkabanProps.get(AZKABAN_WEBSERVER_URL);
+    final String baseURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);
     if (baseURL != null) {
-      String flowName = node.getParentFlow().getFlowId();
-      String projectName = node.getParentFlow().getProjectName();
+      final String flowName = this.node.getParentFlow().getFlowId();
+      final String projectName = this.node.getParentFlow().getProjectName();
 
-      props.put(CommonJobProperties.AZKABAN_URL, baseURL);
-      props.put(CommonJobProperties.EXECUTION_LINK,
-          String.format("%s/executor?execid=%d", baseURL, executionId));
-      props.put(CommonJobProperties.JOBEXEC_LINK, String.format(
-          "%s/executor?execid=%d&job=%s", baseURL, executionId, jobId));
-      props.put(CommonJobProperties.ATTEMPT_LINK, String.format(
-          "%s/executor?execid=%d&job=%s&attempt=%d", baseURL, executionId,
-          jobId, node.getAttempt()));
-      props.put(CommonJobProperties.WORKFLOW_LINK, String.format(
+      this.props.put(CommonJobProperties.AZKABAN_URL, baseURL);
+      this.props.put(CommonJobProperties.EXECUTION_LINK,
+          String.format("%s/executor?execid=%d", baseURL, this.executionId));
+      this.props.put(CommonJobProperties.JOBEXEC_LINK, String.format(
+          "%s/executor?execid=%d&job=%s", baseURL, this.executionId, this.jobId));
+      this.props.put(CommonJobProperties.ATTEMPT_LINK, String.format(
+          "%s/executor?execid=%d&job=%s&attempt=%d", baseURL, this.executionId,
+          this.jobId, this.node.getAttempt()));
+      this.props.put(CommonJobProperties.WORKFLOW_LINK, String.format(
           "%s/manager?project=%s&flow=%s", baseURL, projectName, flowName));
-      props.put(CommonJobProperties.JOB_LINK, String.format(
+      this.props.put(CommonJobProperties.JOB_LINK, String.format(
           "%s/manager?project=%s&flow=%s&job=%s", baseURL, projectName,
-          flowName, jobId));
+          flowName, this.jobId));
     } else {
-      if (logger != null) {
-        logger.info(AZKABAN_WEBSERVER_URL + " property was not set");
+      if (this.logger != null) {
+        this.logger.info(AZKABAN_WEBSERVER_URL + " property was not set");
       }
     }
     // out nodes
-    props.put(CommonJobProperties.OUT_NODES,
-        StringUtils.join2(node.getOutNodes(), ","));
+    this.props.put(CommonJobProperties.OUT_NODES,
+        StringUtils.join2(this.node.getOutNodes(), ","));
 
     // in nodes
-    props.put(CommonJobProperties.IN_NODES,
-        StringUtils.join2(node.getInNodes(), ","));
+    this.props.put(CommonJobProperties.IN_NODES,
+        StringUtils.join2(this.node.getInNodes(), ","));
   }
 
   private Status runJob() {
-    Status finalStatus = node.getStatus();
+    Status finalStatus = this.node.getStatus();
     try {
-      job.run();
-    } catch (Throwable e) {
-      if (props.getBoolean("job.succeed.on.failure", false)) {
+      this.job.run();
+    } catch (final Throwable e) {
+      if (this.props.getBoolean("job.succeed.on.failure", false)) {
         finalStatus = changeStatus(Status.FAILED_SUCCEEDED);
         logError("Job run failed, but will treat it like success.");
         logError(e.getMessage() + " cause: " + e.getCause(), e);
       } else {
-        if (isKilled() || node.getStatus() == Status.KILLED) {
+        if (isKilled() || this.node.getStatus() == Status.KILLED) {
           finalStatus = Status.KILLED;
           logError("Job run killed!", e);
         } else {
@@ -720,8 +766,8 @@ public class JobRunner extends EventHandler implements Runnable {
       }
     }
 
-    if (job != null) {
-      node.setOutputProps(job.getJobGeneratedProperties());
+    if (this.job != null) {
+      this.node.setOutputProps(this.job.getJobGeneratedProperties());
     }
 
     // If the job is still running, set the status to Success.
@@ -731,43 +777,43 @@ public class JobRunner extends EventHandler implements Runnable {
     return finalStatus;
   }
 
-  private Status changeStatus(Status status) {
+  private Status changeStatus(final Status status) {
     changeStatus(status, System.currentTimeMillis());
     return status;
   }
 
-  private Status changeStatus(Status status, long time) {
-    node.setStatus(status);
-    node.setUpdateTime(time);
+  private Status changeStatus(final Status status, final long time) {
+    this.node.setStatus(status);
+    this.node.setUpdateTime(time);
     return status;
   }
 
-  private void fireEvent(Event event) {
+  private void fireEvent(final Event event) {
     fireEvent(event, true);
   }
 
-  private void fireEvent(Event event, boolean updateTime) {
+  private void fireEvent(final Event event, final boolean updateTime) {
     if (updateTime) {
-      node.setUpdateTime(System.currentTimeMillis());
+      this.node.setUpdateTime(System.currentTimeMillis());
     }
     this.fireEventListeners(event);
   }
 
   public void kill() {
-    synchronized (syncObject) {
-      if (Status.isStatusFinished(node.getStatus())) {
+    synchronized (this.syncObject) {
+      if (Status.isStatusFinished(this.node.getStatus())) {
         return;
       }
       logError("Kill has been called.");
       this.killed = true;
 
-      BlockingStatus status = currentBlockStatus;
+      final BlockingStatus status = this.currentBlockStatus;
       if (status != null) {
         status.unblock();
       }
 
       // Cancel code here
-      if (job == null) {
+      if (this.job == null) {
         logError("Job hasn't started yet.");
         // Just in case we're waiting on the delay
         synchronized (this) {
@@ -777,10 +823,11 @@ public class JobRunner extends EventHandler implements Runnable {
       }
 
       try {
-        job.cancel();
-      } catch (Exception e) {
+        this.job.cancel();
+      } catch (final Exception e) {
         logError(e.getMessage());
-        logError("Failed trying to cancel job. Maybe it hasn't started running yet or just finished.");
+        logError(
+            "Failed trying to cancel job. Maybe it hasn't started running yet or just finished.");
       }
 
       this.changeStatus(Status.KILLED);
@@ -788,84 +835,36 @@ public class JobRunner extends EventHandler implements Runnable {
   }
 
   public boolean isKilled() {
-    return killed;
+    return this.killed;
   }
 
   public Status getStatus() {
-    return node.getStatus();
+    return this.node.getStatus();
   }
 
-  private void logError(String message) {
-    if (logger != null) {
-      logger.error(message);
+  private void logError(final String message) {
+    if (this.logger != null) {
+      this.logger.error(message);
     }
   }
 
-  private void logError(String message, Throwable t) {
-    if (logger != null) {
-      logger.error(message, t);
+  private void logError(final String message, final Throwable t) {
+    if (this.logger != null) {
+      this.logger.error(message, t);
     }
   }
 
-  private void logInfo(String message) {
-    if (logger != null) {
-      logger.info(message);
+  private void logInfo(final String message) {
+    if (this.logger != null) {
+      this.logger.info(message);
     }
   }
 
   public File getLogFile() {
-    return logFile;
+    return this.logFile;
   }
 
   public Logger getLogger() {
-    return logger;
-  }
-
-  public static String createLogFileName(ExecutableNode node, int attempt) {
-    int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".log" : "_job." + executionId + "." + jobId + ".log";
-  }
-
-  public static String createLogFileName(ExecutableNode node) {
-    return JobRunner.createLogFileName(node, node.getAttempt());
-  }
-
-  public static String createMetaDataFileName(ExecutableNode node, int attempt) {
-    int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".meta" : "_job." + executionId + "." + jobId + ".meta";
-  }
-
-  public static String createMetaDataFileName(ExecutableNode node) {
-    return JobRunner.createMetaDataFileName(node, node.getAttempt());
-  }
-
-  public static String createAttachmentFileName(ExecutableNode node) {
-
-    return JobRunner.createAttachmentFileName(node, node.getAttempt());
-  }
-
-  public static String createAttachmentFileName(ExecutableNode node, int attempt) {
-    int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".attach" : "_job." + executionId + "." + jobId + ".attach";
+    return this.logger;
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -17,6 +17,27 @@
 package azkaban.execapp;
 
 import azkaban.Constants;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Optional;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.EnhancedPatternLayout;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Logger;
+import org.apache.log4j.RollingFileAppender;
+
+import org.apache.kafka.log4jappender.KafkaLog4jAppender;
+
+import org.json.simple.JSONObject;
+
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
 import azkaban.event.EventData;
@@ -35,55 +56,48 @@ import azkaban.jobExecutor.Job;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypeManagerException;
 import azkaban.utils.ExternalLinkUtils;
-import azkaban.utils.PatternLayoutEscaped;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import azkaban.utils.UndefinedPropertyException;
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import org.apache.kafka.log4jappender.KafkaLog4jAppender;
-import org.apache.log4j.Appender;
-import org.apache.log4j.EnhancedPatternLayout;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Layout;
-import org.apache.log4j.Logger;
-import org.apache.log4j.RollingFileAppender;
-import org.json.simple.JSONObject;
+import azkaban.utils.PatternLayoutEscaped;
 
 public class JobRunner extends EventHandler implements Runnable {
-
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
-  private static final Object logCreatorLock = new Object();
+
+  private static final Logger serverLogger = Logger.getLogger(JobRunner.class);
+
   private final Layout DEFAULT_LAYOUT = new EnhancedPatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
-  private final Object syncObject = new Object();
-  private final JobTypeManager jobtypeManager;
-  private final ExecutorLoader loader;
-  private final Props props;
-  private final Props azkabanProps;
-  private final ExecutableNode node;
-  private final File workingDir;
-  private final Layout loggerLayout = this.DEFAULT_LAYOUT;
-  private final String jobId;
-  private final Set<String> pipelineJobs = new HashSet<>();
+
+  private ExecutorLoader loader;
+  private Props props;
+  private Props azkabanProps;
+  private ExecutableNode node;
+  private File workingDir;
+
   private Logger logger = null;
+  private Layout loggerLayout = DEFAULT_LAYOUT;
   private Logger flowLogger = null;
+
   private Appender jobAppender = null;
   private Optional<Appender> kafkaAppender = Optional.empty();
   private File logFile;
   private String attachmentFileName;
+
   private Job job;
   private int executionId = -1;
+  private String jobId;
+
+  private static final Object logCreatorLock = new Object();
+  private final Object syncObject = new Object();
+
+  private final JobTypeManager jobtypeManager;
+
   // Used by the job to watch and block against another flow
   private Integer pipelineLevel = null;
   private FlowWatcher watcher = null;
+  private Set<String> pipelineJobs = new HashSet<String>();
+
   private Set<String> proxyUsers = null;
 
   private String jobLogChunkSize;
@@ -93,8 +107,8 @@ public class JobRunner extends EventHandler implements Runnable {
   private boolean killed = false;
   private BlockingStatus currentBlockStatus = null;
 
-  public JobRunner(final ExecutableNode node, final File workingDir, final ExecutorLoader loader,
-      final JobTypeManager jobtypeManager, final Props azkabanProps) {
+  public JobRunner(ExecutableNode node, File workingDir, ExecutorLoader loader,
+      JobTypeManager jobtypeManager, Props azkabanProps) {
     this.props = node.getInputProps();
     this.node = node;
     this.workingDir = workingDir;
@@ -106,117 +120,69 @@ public class JobRunner extends EventHandler implements Runnable {
     this.azkabanProps = azkabanProps;
   }
 
-  public static String createLogFileName(final ExecutableNode node, final int attempt) {
-    final int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".log" : "_job." + executionId + "." + jobId + ".log";
-  }
-
-  public static String createLogFileName(final ExecutableNode node) {
-    return JobRunner.createLogFileName(node, node.getAttempt());
-  }
-
-  public static String createMetaDataFileName(final ExecutableNode node, final int attempt) {
-    final int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".meta" : "_job." + executionId + "." + jobId + ".meta";
-  }
-
-  public static String createMetaDataFileName(final ExecutableNode node) {
-    return JobRunner.createMetaDataFileName(node, node.getAttempt());
-  }
-
-  public static String createAttachmentFileName(final ExecutableNode node) {
-
-    return JobRunner.createAttachmentFileName(node, node.getAttempt());
-  }
-
-  public static String createAttachmentFileName(final ExecutableNode node, final int attempt) {
-    final int executionId = node.getExecutableFlow().getExecutionId();
-    String jobId = node.getId();
-    if (node.getExecutableFlow() != node.getParentFlow()) {
-      // Posix safe file delimiter
-      jobId = node.getPrintableId("._.");
-    }
-
-    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
-        + ".attach" : "_job." + executionId + "." + jobId + ".attach";
-  }
-
-  public void setValidatedProxyUsers(final Set<String> proxyUsers) {
+  public void setValidatedProxyUsers(Set<String> proxyUsers) {
     this.proxyUsers = proxyUsers;
   }
 
-  public void setLogSettings(final Logger flowLogger, final String logFileChuckSize,
-      final int numLogBackup) {
+  public void setLogSettings(Logger flowLogger, String logFileChuckSize,
+      int numLogBackup) {
     this.flowLogger = flowLogger;
     this.jobLogChunkSize = logFileChuckSize;
     this.jobLogBackupIndex = numLogBackup;
   }
 
   public Props getProps() {
-    return this.props;
+    return props;
   }
 
-  public void setPipeline(final FlowWatcher watcher, final int pipelineLevel) {
+  public void setPipeline(FlowWatcher watcher, int pipelineLevel) {
     this.watcher = watcher;
     this.pipelineLevel = pipelineLevel;
 
     if (this.pipelineLevel == 1) {
-      this.pipelineJobs.add(this.node.getNestedId());
+      pipelineJobs.add(node.getNestedId());
     } else if (this.pipelineLevel == 2) {
-      this.pipelineJobs.add(this.node.getNestedId());
-      final ExecutableFlowBase parentFlow = this.node.getParentFlow();
+      pipelineJobs.add(node.getNestedId());
+      ExecutableFlowBase parentFlow = node.getParentFlow();
 
-      if (parentFlow.getEndNodes().contains(this.node.getId())) {
+      if (parentFlow.getEndNodes().contains(node.getId())) {
         if (!parentFlow.getOutNodes().isEmpty()) {
-          final ExecutableFlowBase grandParentFlow = parentFlow.getParentFlow();
-          for (final String outNode : parentFlow.getOutNodes()) {
-            final ExecutableNode nextNode =
+          ExecutableFlowBase grandParentFlow = parentFlow.getParentFlow();
+          for (String outNode : parentFlow.getOutNodes()) {
+            ExecutableNode nextNode =
                 grandParentFlow.getExecutableNode(outNode);
 
             // If the next node is a nested flow, then we add the nested
             // starting nodes
             if (nextNode instanceof ExecutableFlowBase) {
-              final ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
-              findAllStartingNodes(nextFlow, this.pipelineJobs);
+              ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
+              findAllStartingNodes(nextFlow, pipelineJobs);
             } else {
-              this.pipelineJobs.add(nextNode.getNestedId());
+              pipelineJobs.add(nextNode.getNestedId());
             }
           }
         }
       } else {
-        for (final String outNode : this.node.getOutNodes()) {
-          final ExecutableNode nextNode = parentFlow.getExecutableNode(outNode);
+        for (String outNode : node.getOutNodes()) {
+          ExecutableNode nextNode = parentFlow.getExecutableNode(outNode);
 
           // If the next node is a nested flow, then we add the nested starting
           // nodes
           if (nextNode instanceof ExecutableFlowBase) {
-            final ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
-            findAllStartingNodes(nextFlow, this.pipelineJobs);
+            ExecutableFlowBase nextFlow = (ExecutableFlowBase) nextNode;
+            findAllStartingNodes(nextFlow, pipelineJobs);
           } else {
-            this.pipelineJobs.add(nextNode.getNestedId());
+            pipelineJobs.add(nextNode.getNestedId());
           }
         }
       }
     }
   }
 
-  private void findAllStartingNodes(final ExecutableFlowBase flow,
-      final Set<String> pipelineJobs) {
-    for (final String startingNode : flow.getStartNodes()) {
-      final ExecutableNode node = flow.getExecutableNode(startingNode);
+  private void findAllStartingNodes(ExecutableFlowBase flow,
+      Set<String> pipelineJobs) {
+    for (String startingNode : flow.getStartNodes()) {
+      ExecutableNode node = flow.getExecutableNode(startingNode);
       if (node instanceof ExecutableFlowBase) {
         findAllStartingNodes((ExecutableFlowBase) node, pipelineJobs);
       } else {
@@ -228,171 +194,162 @@ public class JobRunner extends EventHandler implements Runnable {
   /**
    * Returns a list of jobs that this JobRunner will wait upon to finish before
    * starting. It is only relevant if pipeline is turned on.
+   *
+   * @return
    */
   public Set<String> getPipelineWatchedJobs() {
-    return this.pipelineJobs;
+    return pipelineJobs;
+  }
+
+  public void setDelayStart(long delayMS) {
+    delayStartMs = delayMS;
   }
 
   public long getDelayStart() {
-    return this.delayStartMs;
-  }
-
-  public void setDelayStart(final long delayMS) {
-    this.delayStartMs = delayMS;
+    return delayStartMs;
   }
 
   public ExecutableNode getNode() {
-    return this.node;
+    return node;
   }
 
   public String getLogFilePath() {
-    return this.logFile == null ? null : this.logFile.getPath();
+    return logFile == null ? null : logFile.getPath();
   }
 
   private void createLogger() {
     // Create logger
     synchronized (logCreatorLock) {
-      final String loggerName =
+      String loggerName =
           System.currentTimeMillis() + "." + this.executionId + "."
               + this.jobId;
-      this.logger = Logger.getLogger(loggerName);
+      logger = Logger.getLogger(loggerName);
 
       try {
         attachFileAppender(createFileAppender());
-      } catch (final IOException e) {
-        removeAppender(this.jobAppender);
-        this.flowLogger.error("Could not open log file in " + this.workingDir
+      } catch (IOException e) {
+        removeAppender(jobAppender);
+        flowLogger.error("Could not open log file in " + workingDir
             + " for job " + this.jobId, e);
       }
 
-      if (this.props.getBoolean(Constants.JobProperties.AZKABAN_JOB_LOGGING_KAFKA_ENABLE, false)) {
+      if (props.getBoolean(Constants.JobProperties.AZKABAN_JOB_LOGGING_KAFKA_ENABLE, false)) {
         // Only attempt appender construction if required properties are present
-        if (this.azkabanProps
-            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST)
-            && this.azkabanProps
-            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC)) {
+        if (azkabanProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST)
+            && azkabanProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC)) {
           try {
             attachKafkaAppender(createKafkaAppender());
-          } catch (final Exception e) {
-            removeAppender(this.kafkaAppender);
-            this.flowLogger.error("Failed to create Kafka appender for job " + this.jobId, e);
+          } catch (Exception e) {
+            removeAppender(kafkaAppender);
+            flowLogger.error("Failed to create Kafka appender for job " + this.jobId, e);
           }
         } else {
-          this.flowLogger.info(
-              "Kafka appender not created as brokerlist or topic not provided by executor server");
+          flowLogger.info("Kafka appender not created as brokerlist or topic not provided by executor server");
         }
       }
     }
 
-    final String externalViewer = ExternalLinkUtils
-        .getExternalLogViewer(this.azkabanProps, this.jobId,
-            this.props);
+    String externalViewer = ExternalLinkUtils.getExternalLogViewer(azkabanProps, this.jobId, props);
     if (!externalViewer.isEmpty()) {
-      this.logger.info("See logs at: " + externalViewer);
+      logger.info("See logs at: " + externalViewer);
     }
   }
 
-  private void attachFileAppender(final FileAppender appender) {
+  private void attachFileAppender(FileAppender appender) {
     // If present, remove the existing file appender
-    assert (this.jobAppender == null);
+    assert(jobAppender == null);
 
-    this.jobAppender = appender;
-    this.logger.addAppender(this.jobAppender);
-    this.logger.setAdditivity(false);
-    this.flowLogger.info("Attached file appender for job " + this.jobId);
+    jobAppender = appender;
+    logger.addAppender(jobAppender);
+    logger.setAdditivity(false);
+    flowLogger.info("Attached file appender for job " + this.jobId);
   }
 
   private FileAppender createFileAppender() throws IOException {
     // Set up log files
-    final String logName = createLogFileName(this.node);
-    this.logFile = new File(this.workingDir, logName);
-    final String absolutePath = this.logFile.getAbsolutePath();
+    String logName = createLogFileName(node);
+    logFile = new File(workingDir, logName);
+    String absolutePath = logFile.getAbsolutePath();
 
     // Attempt to create FileAppender
-    final RollingFileAppender fileAppender =
-        new RollingFileAppender(this.loggerLayout, absolutePath, true);
-    fileAppender.setMaxBackupIndex(this.jobLogBackupIndex);
-    fileAppender.setMaxFileSize(this.jobLogChunkSize);
+    RollingFileAppender fileAppender =
+        new RollingFileAppender(loggerLayout, absolutePath, true);
+    fileAppender.setMaxBackupIndex(jobLogBackupIndex);
+    fileAppender.setMaxFileSize(jobLogChunkSize);
 
-    this.flowLogger.info("Created file appender for job " + this.jobId);
+    flowLogger.info("Created file appender for job " + this.jobId);
     return fileAppender;
   }
 
   private void createAttachmentFile() {
-    final String fileName = createAttachmentFileName(this.node);
-    final File file = new File(this.workingDir, fileName);
-    this.attachmentFileName = file.getAbsolutePath();
+    String fileName = createAttachmentFileName(node);
+    File file = new File(workingDir, fileName);
+    attachmentFileName = file.getAbsolutePath();
   }
 
-  private void attachKafkaAppender(final KafkaLog4jAppender appender) {
+  private void attachKafkaAppender(KafkaLog4jAppender appender) {
     // This should only be called once
-    assert (!this.kafkaAppender.isPresent());
+    assert(!kafkaAppender.isPresent());
 
-    this.kafkaAppender = Optional.of(appender);
-    this.logger.addAppender(this.kafkaAppender.get());
-    this.logger.setAdditivity(false);
-    this.flowLogger.info("Attached new Kafka appender for job " + this.jobId);
+    kafkaAppender = Optional.of(appender);
+    logger.addAppender(kafkaAppender.get());
+    logger.setAdditivity(false);
+    flowLogger.info("Attached new Kafka appender for job " + this.jobId);
   }
 
   private KafkaLog4jAppender createKafkaAppender() throws UndefinedPropertyException {
-    final KafkaLog4jAppender kafkaProducer = new KafkaLog4jAppender();
+    KafkaLog4jAppender kafkaProducer = new KafkaLog4jAppender();
     kafkaProducer.setSyncSend(false);
-    kafkaProducer.setBrokerList(this.azkabanProps
-        .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST));
-    kafkaProducer.setTopic(
-        this.azkabanProps
-            .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
+    kafkaProducer.setBrokerList(azkabanProps.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST));
+    kafkaProducer.setTopic(azkabanProps.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
 
-    final JSONObject layout = new JSONObject();
+    JSONObject layout = new JSONObject();
     layout.put("category", "%c{1}");
     layout.put("level", "%p");
     layout.put("message", "%m");
-    layout.put("projectname",
-        this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_NAME));
-    layout.put("flowid", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_FLOW_ID));
+    layout.put("projectname", props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_NAME));
+    layout.put("flowid", props.getString(Constants.FlowProperties.AZKABAN_FLOW_FLOW_ID));
     layout.put("jobid", this.jobId);
-    layout
-        .put("submituser", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_SUBMIT_USER));
-    layout.put("execid", this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID));
-    layout.put("projectversion",
-        this.props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_VERSION));
+    layout.put("submituser", props.getString(Constants.FlowProperties.AZKABAN_FLOW_SUBMIT_USER));
+    layout.put("execid", props.getString(Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID));
+    layout.put("projectversion", props.getString(Constants.FlowProperties.AZKABAN_FLOW_PROJECT_VERSION));
     layout.put("logsource", "userJob");
 
     kafkaProducer.setLayout(new PatternLayoutEscaped(layout.toString()));
     kafkaProducer.activateOptions();
 
-    this.flowLogger.info("Created kafka appender for " + this.jobId);
+    flowLogger.info("Created kafka appender for " + this.jobId);
     return kafkaProducer;
   }
 
-  private void removeAppender(final Optional<Appender> appender) {
+  private void removeAppender(Optional<Appender> appender) {
     if (appender.isPresent()) {
       removeAppender(appender.get());
     }
   }
 
-  private void removeAppender(final Appender appender) {
+  private void removeAppender(Appender appender) {
     if (appender != null) {
-      this.logger.removeAppender(appender);
+      logger.removeAppender(appender);
       appender.close();
     }
   }
 
   private void closeLogger() {
-    if (this.jobAppender != null) {
-      removeAppender(this.jobAppender);
+    if (jobAppender != null) {
+      removeAppender(jobAppender);
     }
-    if (this.kafkaAppender.isPresent()) {
-      removeAppender(this.kafkaAppender);
+    if (kafkaAppender.isPresent()) {
+      removeAppender(kafkaAppender);
     }
   }
 
   private void writeStatus() {
     try {
-      this.node.setUpdateTime(System.currentTimeMillis());
-      this.loader.updateExecutableNode(this.node);
-    } catch (final ExecutorManagerException e) {
-      this.flowLogger.error("Could not update job properties in db for "
+      node.setUpdateTime(System.currentTimeMillis());
+      loader.updateExecutableNode(node);
+    } catch (ExecutorManagerException e) {
+      flowLogger.error("Could not update job properties in db for "
           + this.jobId, e);
     }
   }
@@ -400,11 +357,13 @@ public class JobRunner extends EventHandler implements Runnable {
   /**
    * Used to handle non-ready and special status's (i.e. KILLED). Returns true
    * if they handled anything.
+   *
+   * @return
    */
   private boolean handleNonReadyStatus() {
-    Status nodeStatus = this.node.getStatus();
+    Status nodeStatus = node.getStatus();
     boolean quickFinish = false;
-    final long time = System.currentTimeMillis();
+    long time = System.currentTimeMillis();
 
     if (Status.isStatusFinished(nodeStatus)) {
       quickFinish = true;
@@ -417,13 +376,10 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     if (quickFinish) {
-      this.node.setStartTime(time);
-      fireEvent(
-          Event.create(this, Type.JOB_STARTED, new EventData(nodeStatus, this.node.getNestedId())));
-      this.node.setEndTime(time);
-      fireEvent(
-          Event
-              .create(this, Type.JOB_FINISHED, new EventData(nodeStatus, this.node.getNestedId())));
+      node.setStartTime(time);
+      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(nodeStatus, node.getNestedId())));
+      node.setEndTime(time);
+      fireEvent(Event.create(this, Type.JOB_FINISHED, new EventData(nodeStatus, node.getNestedId())));
       return true;
     }
 
@@ -439,37 +395,37 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     // For pipelining of jobs. Will watch other jobs.
-    if (!this.pipelineJobs.isEmpty()) {
+    if (!pipelineJobs.isEmpty()) {
       String blockedList = "";
-      final ArrayList<BlockingStatus> blockingStatus =
-          new ArrayList<>();
-      for (final String waitingJobId : this.pipelineJobs) {
-        final Status status = this.watcher.peekStatus(waitingJobId);
+      ArrayList<BlockingStatus> blockingStatus =
+          new ArrayList<BlockingStatus>();
+      for (String waitingJobId : pipelineJobs) {
+        Status status = watcher.peekStatus(waitingJobId);
         if (status != null && !Status.isStatusFinished(status)) {
-          final BlockingStatus block = this.watcher.getBlockingStatus(waitingJobId);
+          BlockingStatus block = watcher.getBlockingStatus(waitingJobId);
           blockingStatus.add(block);
           blockedList += waitingJobId + ",";
         }
       }
       if (!blockingStatus.isEmpty()) {
-        this.logger.info("Pipeline job " + this.jobId + " waiting on " + blockedList
-            + " in execution " + this.watcher.getExecId());
+        logger.info("Pipeline job " + this.jobId + " waiting on " + blockedList
+            + " in execution " + watcher.getExecId());
 
-        for (final BlockingStatus bStatus : blockingStatus) {
-          this.logger.info("Waiting on pipelined job " + bStatus.getJobId());
-          this.currentBlockStatus = bStatus;
+        for (BlockingStatus bStatus : blockingStatus) {
+          logger.info("Waiting on pipelined job " + bStatus.getJobId());
+          currentBlockStatus = bStatus;
           bStatus.blockOnFinishedStatus();
           if (this.isKilled()) {
-            this.logger.info("Job was killed while waiting on pipeline. Quiting.");
+            logger.info("Job was killed while waiting on pipeline. Quiting.");
             return true;
           } else {
-            this.logger.info("Pipelined job " + bStatus.getJobId() + " finished.");
+            logger.info("Pipelined job " + bStatus.getJobId() + " finished.");
           }
         }
       }
     }
 
-    this.currentBlockStatus = null;
+    currentBlockStatus = null;
     return false;
   }
 
@@ -478,24 +434,24 @@ public class JobRunner extends EventHandler implements Runnable {
       return true;
     }
 
-    final long currentTime = System.currentTimeMillis();
-    if (this.delayStartMs > 0) {
-      this.logger.info("Delaying start of execution for " + this.delayStartMs
+    long currentTime = System.currentTimeMillis();
+    if (delayStartMs > 0) {
+      logger.info("Delaying start of execution for " + delayStartMs
           + " milliseconds.");
       synchronized (this) {
         try {
-          this.wait(this.delayStartMs);
-          this.logger.info("Execution has been delayed for " + this.delayStartMs
+          this.wait(delayStartMs);
+          logger.info("Execution has been delayed for " + delayStartMs
               + " ms. Continuing with execution.");
-        } catch (final InterruptedException e) {
-          this.logger.error("Job " + this.jobId + " was to be delayed for "
-              + this.delayStartMs + ". Interrupted after "
+        } catch (InterruptedException e) {
+          logger.error("Job " + this.jobId + " was to be delayed for "
+              + delayStartMs + ". Interrupted after "
               + (System.currentTimeMillis() - currentTime));
         }
       }
 
       if (this.isKilled()) {
-        this.logger.info("Job was killed while in delay. Quiting.");
+        logger.info("Job was killed while in delay. Quiting.");
         return true;
       }
     }
@@ -503,46 +459,46 @@ public class JobRunner extends EventHandler implements Runnable {
     return false;
   }
 
-  private void finalizeLogFile(final int attemptNo) {
+  private void finalizeLogFile(int attemptNo) {
     closeLogger();
-    if (this.logFile == null) {
-      this.flowLogger.info("Log file for job " + this.jobId + " is null");
+    if (logFile == null) {
+      flowLogger.info("Log file for job " + this.jobId + " is null");
       return;
     }
 
     try {
-      final File[] files = this.logFile.getParentFile().listFiles(new FilenameFilter() {
+      File[] files = logFile.getParentFile().listFiles(new FilenameFilter() {
         @Override
-        public boolean accept(final File dir, final String name) {
-          return name.startsWith(JobRunner.this.logFile.getName());
+        public boolean accept(File dir, String name) {
+          return name.startsWith(logFile.getName());
         }
       });
       Arrays.sort(files, Collections.reverseOrder());
 
-      this.loader.uploadLogFile(this.executionId, this.node.getNestedId(), attemptNo,
+      loader.uploadLogFile(executionId, this.node.getNestedId(), attemptNo,
           files);
-    } catch (final ExecutorManagerException e) {
-      this.flowLogger.error(
+    } catch (ExecutorManagerException e) {
+      flowLogger.error(
           "Error writing out logs for job " + this.node.getNestedId(), e);
     }
   }
 
   private void finalizeAttachmentFile() {
-    if (this.attachmentFileName == null) {
-      this.flowLogger.info("Attachment file for job " + this.jobId + " is null");
+    if (attachmentFileName == null) {
+      flowLogger.info("Attachment file for job " + this.jobId + " is null");
       return;
     }
 
     try {
-      final File file = new File(this.attachmentFileName);
+      File file = new File(attachmentFileName);
       if (!file.exists()) {
-        this.flowLogger.info("No attachment file for job " + this.jobId
+        flowLogger.info("No attachment file for job " + this.jobId
             + " written.");
         return;
       }
-      this.loader.uploadAttachmentFile(this.node, file);
-    } catch (final ExecutorManagerException e) {
-      this.flowLogger.error(
+      loader.uploadAttachmentFile(node, file);
+    } catch (ExecutorManagerException e) {
+      flowLogger.error(
           "Error writing out attachment for job " + this.node.getNestedId(), e);
     }
   }
@@ -552,8 +508,17 @@ public class JobRunner extends EventHandler implements Runnable {
    */
   @Override
   public void run() {
+    try {
+      doRun();
+    } catch (Exception e) {
+      serverLogger.error("Unexpected exception", e);
+      throw e;
+    }
+  }
+
+  private void doRun() {
     Thread.currentThread().setName(
-        "JobRunner-" + this.jobId + "-" + this.executionId);
+        "JobRunner-" + this.jobId + "-" + executionId);
 
     // If the job is cancelled, disabled, killed. No log is created in this case
     if (handleNonReadyStatus()) {
@@ -571,29 +536,29 @@ public class JobRunner extends EventHandler implements Runnable {
     errorFound |= blockOnPipeLine();
 
     // Start the node.
-    this.node.setStartTime(System.currentTimeMillis());
-    Status finalStatus = this.node.getStatus();
+    node.setStartTime(System.currentTimeMillis());
+    Status finalStatus = node.getStatus();
     if (!errorFound && !isKilled()) {
-      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(this.node)));
+      fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(node)));
       try {
-        this.loader.uploadExecutableNode(this.node, this.props);
-      } catch (final ExecutorManagerException e1) {
-        this.logger.error("Error writing initial node properties");
+        loader.uploadExecutableNode(node, props);
+      } catch (ExecutorManagerException e1) {
+        logger.error("Error writing initial node properties");
       }
 
-      final Status prepareStatus = prepareJob();
+      Status prepareStatus = prepareJob();
       if (prepareStatus != null) {
         // Writes status to the db
         writeStatus();
         fireEvent(Event.create(this, Type.JOB_STATUS_CHANGED,
-            new EventData(prepareStatus, this.node.getNestedId())));
+            new EventData(prepareStatus, node.getNestedId())));
         finalStatus = runJob();
       } else {
         finalStatus = changeStatus(Status.FAILED);
         logError("Job run failed preparing the job.");
       }
     }
-    this.node.setEndTime(System.currentTimeMillis());
+    node.setEndTime(System.currentTimeMillis());
 
     if (isKilled()) {
       // even if it's killed, there is a chance that the job failed is marked as
@@ -604,12 +569,12 @@ public class JobRunner extends EventHandler implements Runnable {
       finalStatus = changeStatus(Status.KILLED);
     }
 
-    final int attemptNo = this.node.getAttempt();
+    int attemptNo = node.getAttempt();
     logInfo("Finishing job " + this.jobId + " attempt: " + attemptNo + " at "
-        + this.node.getEndTime() + " with status " + this.node.getStatus());
+        + node.getEndTime() + " with status " + node.getStatus());
 
     fireEvent(Event.create(this, Type.JOB_FINISHED,
-        new EventData(finalStatus, this.node.getNestedId())), false);
+        new EventData(finalStatus, node.getNestedId())), false);
     finalizeLogFile(attemptNo);
     finalizeAttachmentFile();
     writeStatus();
@@ -617,59 +582,59 @@ public class JobRunner extends EventHandler implements Runnable {
 
   private Status prepareJob() throws RuntimeException {
     // Check pre conditions
-    if (this.props == null || this.isKilled()) {
+    if (props == null || this.isKilled()) {
       logError("Failing job. The job properties don't exist");
       return null;
     }
 
-    final Status finalStatus;
-    synchronized (this.syncObject) {
-      if (this.node.getStatus() == Status.FAILED || this.isKilled()) {
+    Status finalStatus;
+    synchronized (syncObject) {
+      if (node.getStatus() == Status.FAILED || this.isKilled()) {
         return null;
       }
 
-      if (this.node.getAttempt() > 0) {
-        logInfo("Starting job " + this.jobId + " attempt " + this.node.getAttempt()
-            + " at " + this.node.getStartTime());
+      if (node.getAttempt() > 0) {
+        logInfo("Starting job " + this.jobId + " attempt " + node.getAttempt()
+            + " at " + node.getStartTime());
       } else {
-        logInfo("Starting job " + this.jobId + " at " + this.node.getStartTime());
+        logInfo("Starting job " + this.jobId + " at " + node.getStartTime());
       }
 
       // If it's an embedded flow, we'll add the nested flow info to the job
       // conf
-      if (this.node.getExecutableFlow() != this.node.getParentFlow()) {
-        final String subFlow = this.node.getPrintableId(":");
-        this.props.put(CommonJobProperties.NESTED_FLOW_PATH, subFlow);
+      if (node.getExecutableFlow() != node.getParentFlow()) {
+        String subFlow = node.getPrintableId(":");
+        props.put(CommonJobProperties.NESTED_FLOW_PATH, subFlow);
       }
 
       insertJobMetadata();
       insertJVMAargs();
 
-      this.props.put(CommonJobProperties.JOB_ID, this.jobId);
-      this.props.put(CommonJobProperties.JOB_ATTEMPT, this.node.getAttempt());
-      this.props.put(CommonJobProperties.JOB_METADATA_FILE,
-          createMetaDataFileName(this.node));
-      this.props.put(CommonJobProperties.JOB_ATTACHMENT_FILE, this.attachmentFileName);
+      props.put(CommonJobProperties.JOB_ID, this.jobId);
+      props.put(CommonJobProperties.JOB_ATTEMPT, node.getAttempt());
+      props.put(CommonJobProperties.JOB_METADATA_FILE,
+          createMetaDataFileName(node));
+      props.put(CommonJobProperties.JOB_ATTACHMENT_FILE, attachmentFileName);
       finalStatus = changeStatus(Status.RUNNING);
 
       // Ability to specify working directory
-      if (!this.props.containsKey(AbstractProcessJob.WORKING_DIR)) {
-        this.props.put(AbstractProcessJob.WORKING_DIR, this.workingDir.getAbsolutePath());
+      if (!props.containsKey(AbstractProcessJob.WORKING_DIR)) {
+        props.put(AbstractProcessJob.WORKING_DIR, workingDir.getAbsolutePath());
       }
 
-      if (this.props.containsKey("user.to.proxy")) {
-        final String jobProxyUser = this.props.getString("user.to.proxy");
-        if (this.proxyUsers != null && !this.proxyUsers.contains(jobProxyUser)) {
-          this.logger.error("User " + jobProxyUser
+      if (props.containsKey("user.to.proxy")) {
+        String jobProxyUser = props.getString("user.to.proxy");
+        if (proxyUsers != null && !proxyUsers.contains(jobProxyUser)) {
+          logger.error("User " + jobProxyUser
               + " has no permission to execute this job " + this.jobId + "!");
           return null;
         }
       }
 
       try {
-        this.job = this.jobtypeManager.buildJobExecutor(this.jobId, this.props, this.logger);
-      } catch (final JobTypeManagerException e) {
-        this.logger.error("Failed to build job type", e);
+        job = jobtypeManager.buildJobExecutor(this.jobId, props, logger);
+      } catch (JobTypeManagerException e) {
+        logger.error("Failed to build job type", e);
         return null;
       }
     }
@@ -682,19 +647,19 @@ public class JobRunner extends EventHandler implements Runnable {
    * flow, execution id and job
    */
   private void insertJVMAargs() {
-    final String flowName = this.node.getParentFlow().getFlowId();
-    final String jobId = this.node.getId();
+    String flowName = node.getParentFlow().getFlowId();
+    String jobId = node.getId();
 
     String jobJVMArgs =
         String.format(
             "-Dazkaban.flowid=%s -Dazkaban.execid=%s -Dazkaban.jobid=%s",
-            flowName, this.executionId, jobId);
+            flowName, executionId, jobId);
 
-    final String previousJVMArgs = this.props.get(JavaProcessJob.JVM_PARAMS);
+    String previousJVMArgs = props.get(JavaProcessJob.JVM_PARAMS);
     jobJVMArgs += (previousJVMArgs == null) ? "" : " " + previousJVMArgs;
 
-    this.logger.info("job JVM args: " + jobJVMArgs);
-    this.props.put(JavaProcessJob.JVM_PARAMS, jobJVMArgs);
+    logger.info("job JVM args: " + jobJVMArgs);
+    props.put(JavaProcessJob.JVM_PARAMS, jobJVMArgs);
   }
 
   /**
@@ -702,56 +667,61 @@ public class JobRunner extends EventHandler implements Runnable {
    * know what executions initiated their execution.
    */
   private void insertJobMetadata() {
-    final String baseURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);
+    String baseURL = azkabanProps.get(AZKABAN_WEBSERVER_URL);
     if (baseURL != null) {
-      final String flowName = this.node.getParentFlow().getFlowId();
-      final String projectName = this.node.getParentFlow().getProjectName();
+      String flowName = node.getParentFlow().getFlowId();
+      String projectName = node.getParentFlow().getProjectName();
 
-      this.props.put(CommonJobProperties.AZKABAN_URL, baseURL);
-      this.props.put(CommonJobProperties.EXECUTION_LINK,
-          String.format("%s/executor?execid=%d", baseURL, this.executionId));
-      this.props.put(CommonJobProperties.JOBEXEC_LINK, String.format(
-          "%s/executor?execid=%d&job=%s", baseURL, this.executionId, this.jobId));
-      this.props.put(CommonJobProperties.ATTEMPT_LINK, String.format(
-          "%s/executor?execid=%d&job=%s&attempt=%d", baseURL, this.executionId,
-          this.jobId, this.node.getAttempt()));
-      this.props.put(CommonJobProperties.WORKFLOW_LINK, String.format(
+      props.put(CommonJobProperties.AZKABAN_URL, baseURL);
+      props.put(CommonJobProperties.EXECUTION_LINK,
+          String.format("%s/executor?execid=%d", baseURL, executionId));
+      props.put(CommonJobProperties.JOBEXEC_LINK, String.format(
+          "%s/executor?execid=%d&job=%s", baseURL, executionId, jobId));
+      props.put(CommonJobProperties.ATTEMPT_LINK, String.format(
+          "%s/executor?execid=%d&job=%s&attempt=%d", baseURL, executionId,
+          jobId, node.getAttempt()));
+      props.put(CommonJobProperties.WORKFLOW_LINK, String.format(
           "%s/manager?project=%s&flow=%s", baseURL, projectName, flowName));
-      this.props.put(CommonJobProperties.JOB_LINK, String.format(
+      props.put(CommonJobProperties.JOB_LINK, String.format(
           "%s/manager?project=%s&flow=%s&job=%s", baseURL, projectName,
-          flowName, this.jobId));
+          flowName, jobId));
     } else {
-      if (this.logger != null) {
-        this.logger.info(AZKABAN_WEBSERVER_URL + " property was not set");
+      if (logger != null) {
+        logger.info(AZKABAN_WEBSERVER_URL + " property was not set");
       }
     }
     // out nodes
-    this.props.put(CommonJobProperties.OUT_NODES,
-        StringUtils.join2(this.node.getOutNodes(), ","));
+    props.put(CommonJobProperties.OUT_NODES,
+        StringUtils.join2(node.getOutNodes(), ","));
 
     // in nodes
-    this.props.put(CommonJobProperties.IN_NODES,
-        StringUtils.join2(this.node.getInNodes(), ","));
+    props.put(CommonJobProperties.IN_NODES,
+        StringUtils.join2(node.getInNodes(), ","));
   }
 
   private Status runJob() {
-    Status finalStatus = this.node.getStatus();
+    Status finalStatus = node.getStatus();
     try {
-      this.job.run();
-    } catch (final Throwable e) {
-      if (this.props.getBoolean("job.succeed.on.failure", false)) {
+      job.run();
+    } catch (Throwable e) {
+      if (props.getBoolean("job.succeed.on.failure", false)) {
         finalStatus = changeStatus(Status.FAILED_SUCCEEDED);
         logError("Job run failed, but will treat it like success.");
         logError(e.getMessage() + " cause: " + e.getCause(), e);
       } else {
-        finalStatus = changeStatus(Status.FAILED);
-        logError("Job run failed!", e);
+        if (isKilled() || node.getStatus() == Status.KILLED) {
+          finalStatus = Status.KILLED;
+          logError("Job run killed!", e);
+        } else {
+          finalStatus = changeStatus(Status.FAILED);
+          logError("Job run failed!", e);
+        }
         logError(e.getMessage() + " cause: " + e.getCause());
       }
     }
 
-    if (this.job != null) {
-      this.node.setOutputProps(this.job.getJobGeneratedProperties());
+    if (job != null) {
+      node.setOutputProps(job.getJobGeneratedProperties());
     }
 
     // If the job is still running, set the status to Success.
@@ -761,43 +731,43 @@ public class JobRunner extends EventHandler implements Runnable {
     return finalStatus;
   }
 
-  private Status changeStatus(final Status status) {
+  private Status changeStatus(Status status) {
     changeStatus(status, System.currentTimeMillis());
     return status;
   }
 
-  private Status changeStatus(final Status status, final long time) {
-    this.node.setStatus(status);
-    this.node.setUpdateTime(time);
+  private Status changeStatus(Status status, long time) {
+    node.setStatus(status);
+    node.setUpdateTime(time);
     return status;
   }
 
-  private void fireEvent(final Event event) {
+  private void fireEvent(Event event) {
     fireEvent(event, true);
   }
 
-  private void fireEvent(final Event event, final boolean updateTime) {
+  private void fireEvent(Event event, boolean updateTime) {
     if (updateTime) {
-      this.node.setUpdateTime(System.currentTimeMillis());
+      node.setUpdateTime(System.currentTimeMillis());
     }
     this.fireEventListeners(event);
   }
 
   public void kill() {
-    synchronized (this.syncObject) {
-      if (Status.isStatusFinished(this.node.getStatus())) {
+    synchronized (syncObject) {
+      if (Status.isStatusFinished(node.getStatus())) {
         return;
       }
       logError("Kill has been called.");
       this.killed = true;
 
-      final BlockingStatus status = this.currentBlockStatus;
+      BlockingStatus status = currentBlockStatus;
       if (status != null) {
         status.unblock();
       }
 
       // Cancel code here
-      if (this.job == null) {
+      if (job == null) {
         logError("Job hasn't started yet.");
         // Just in case we're waiting on the delay
         synchronized (this) {
@@ -807,11 +777,10 @@ public class JobRunner extends EventHandler implements Runnable {
       }
 
       try {
-        this.job.cancel();
-      } catch (final Exception e) {
+        job.cancel();
+      } catch (Exception e) {
         logError(e.getMessage());
-        logError(
-            "Failed trying to cancel job. Maybe it hasn't started running yet or just finished.");
+        logError("Failed trying to cancel job. Maybe it hasn't started running yet or just finished.");
       }
 
       this.changeStatus(Status.KILLED);
@@ -819,36 +788,84 @@ public class JobRunner extends EventHandler implements Runnable {
   }
 
   public boolean isKilled() {
-    return this.killed;
+    return killed;
   }
 
   public Status getStatus() {
-    return this.node.getStatus();
+    return node.getStatus();
   }
 
-  private void logError(final String message) {
-    if (this.logger != null) {
-      this.logger.error(message);
+  private void logError(String message) {
+    if (logger != null) {
+      logger.error(message);
     }
   }
 
-  private void logError(final String message, final Throwable t) {
-    if (this.logger != null) {
-      this.logger.error(message, t);
+  private void logError(String message, Throwable t) {
+    if (logger != null) {
+      logger.error(message, t);
     }
   }
 
-  private void logInfo(final String message) {
-    if (this.logger != null) {
-      this.logger.info(message);
+  private void logInfo(String message) {
+    if (logger != null) {
+      logger.info(message);
     }
   }
 
   public File getLogFile() {
-    return this.logFile;
+    return logFile;
   }
 
   public Logger getLogger() {
-    return this.logger;
+    return logger;
+  }
+
+  public static String createLogFileName(ExecutableNode node, int attempt) {
+    int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".log" : "_job." + executionId + "." + jobId + ".log";
+  }
+
+  public static String createLogFileName(ExecutableNode node) {
+    return JobRunner.createLogFileName(node, node.getAttempt());
+  }
+
+  public static String createMetaDataFileName(ExecutableNode node, int attempt) {
+    int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".meta" : "_job." + executionId + "." + jobId + ".meta";
+  }
+
+  public static String createMetaDataFileName(ExecutableNode node) {
+    return JobRunner.createMetaDataFileName(node, node.getAttempt());
+  }
+
+  public static String createAttachmentFileName(ExecutableNode node) {
+
+    return JobRunner.createAttachmentFileName(node, node.getAttempt());
+  }
+
+  public static String createAttachmentFileName(ExecutableNode node, int attempt) {
+    int executionId = node.getExecutableFlow().getExecutionId();
+    String jobId = node.getId();
+    if (node.getExecutableFlow() != node.getParentFlow()) {
+      // Posix safe file delimiter
+      jobId = node.getPrintableId("._.");
+    }
+
+    return attempt > 0 ? "_job." + executionId + "." + attempt + "." + jobId
+        + ".attach" : "_job." + executionId + "." + jobId + ".attach";
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
@@ -19,7 +19,6 @@ package azkaban.execapp;
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
 import azkaban.event.EventListener;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -28,8 +27,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class EventCollectorListener implements EventListener {
 
   public static final Object handleEvent = new Object();
-  private final ArrayList<Event> eventList = new ArrayList<>();
-  private final HashSet<Event.Type> filterOutTypes = new HashSet<>();
   // CopyOnWriteArrayList allows concurrent iteration and modification
   private final List<Event> eventList = new CopyOnWriteArrayList<>();
   private final HashSet<Event.Type> filterOutTypes = new HashSet<>();
@@ -37,7 +34,7 @@ public class EventCollectorListener implements EventListener {
   public void setEventFilterOut(final Event.Type... types) {
     this.filterOutTypes.addAll(Arrays.asList(types));
   }
-
+  
   @Override
   public void handleEvent(final Event event) {
     synchronized (handleEvent) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -65,13 +65,11 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     MockitoAnnotations.initMocks(this);
     when(this.loader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
     System.out.println("Create temp dir");
-    synchronized (this) {
-      this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
-      if (this.workingDir.exists()) {
-        FileUtils.deleteDirectory(this.workingDir);
-      }
-      this.workingDir.mkdirs();
+    this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
+    if (this.workingDir.exists()) {
+      FileUtils.deleteDirectory(this.workingDir);
     }
+    this.workingDir.mkdirs();
     this.jobtypeManager =
         new JobTypeManager(null, null, this.getClass().getClassLoader());
     final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -16,22 +16,27 @@
 
 package azkaban.execapp;
 
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
+
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
+import azkaban.execapp.jmx.JmxJobMBeanManager;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutionOptions.FailureAction;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.InteractiveTestJob;
-import azkaban.executor.JavaJob;
-import azkaban.executor.MockExecutorLoader;
 import azkaban.executor.Status;
 import azkaban.flow.Flow;
+import azkaban.jobExecutor.AllJobExecutorTests;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
+import azkaban.test.Utils;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 import java.io.File;
@@ -41,24 +46,29 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
-public class FlowRunnerTest {
+public class FlowRunnerTest extends FlowRunnerTestBase {
 
+  private static final File TEST_DIR = new File(
+      "../azkaban-test/src/test/resources/azkaban/test/executions/exectest1");
   private File workingDir;
   private JobTypeManager jobtypeManager;
   private ProjectLoader fakeProjectLoader;
-
-  public FlowRunnerTest() {
-
-  }
+  @Mock
+  private ExecutorLoader loader;
 
   @Before
   public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(this.loader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
     System.out.println("Create temp dir");
     synchronized (this) {
-      this.workingDir = new File("_AzkabanTestDir_" + System.currentTimeMillis());
+      // clear interrupted status
+      Thread.interrupted();
+      this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
       if (this.workingDir.exists()) {
         FileUtils.deleteDirectory(this.workingDir);
       }
@@ -67,9 +77,11 @@ public class FlowRunnerTest {
     this.jobtypeManager =
         new JobTypeManager(null, null, this.getClass().getClassLoader());
     final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();
-    pluginSet.addPluginClass("java", JavaJob.class);
+    pluginSet.setCommonPluginLoadProps(AllJobExecutorTests.setUpCommonProps());
     pluginSet.addPluginClass("test", InteractiveTestJob.class);
     this.fakeProjectLoader = new MockProjectLoader(this.workingDir);
+    Utils.initServiceProvider();
+    JmxJobMBeanManager.getInstance().initialize(new Props());
 
     InteractiveTestJob.clearTestJobs();
   }
@@ -85,32 +97,29 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void exec1Normal() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
-    // just making compile. may not work at all.
-
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final FlowRunner runner = createFlowRunner(loader, eventCollector, "exec1");
+    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
 
-    Assert.assertTrue(!runner.isKilled());
-    runner.run();
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
-    Assert.assertTrue(exFlow.getStatus() == Status.SUCCEEDED);
-    compareFinishedRuntime(runner);
+    startThread(this.runner);
+    succeedJobs("job3", "job4", "job6");
 
-    testStatus(exFlow, "job1", Status.SUCCEEDED);
-    testStatus(exFlow, "job2", Status.SUCCEEDED);
-    testStatus(exFlow, "job3", Status.SUCCEEDED);
-    testStatus(exFlow, "job4", Status.SUCCEEDED);
-    testStatus(exFlow, "job5", Status.SUCCEEDED);
-    testStatus(exFlow, "job6", Status.SUCCEEDED);
-    testStatus(exFlow, "job7", Status.SUCCEEDED);
-    testStatus(exFlow, "job8", Status.SUCCEEDED);
-    testStatus(exFlow, "job10", Status.SUCCEEDED);
+    assertFlowStatus(Status.SUCCEEDED);
+    assertThreadShutDown();
+    compareFinishedRuntime(this.runner);
+
+    assertStatus("job1", Status.SUCCEEDED);
+    assertStatus("job2", Status.SUCCEEDED);
+    assertStatus("job3", Status.SUCCEEDED);
+    assertStatus("job4", Status.SUCCEEDED);
+    assertStatus("job5", Status.SUCCEEDED);
+    assertStatus("job6", Status.SUCCEEDED);
+    assertStatus("job7", Status.SUCCEEDED);
+    assertStatus("job8", Status.SUCCEEDED);
+    assertStatus("job10", Status.SUCCEEDED);
 
     try {
       eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
@@ -122,15 +131,12 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void exec1Disabled() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final File testDir = new File("unit/executions/exectest1");
-    ExecutableFlow exFlow = prepareExecDir(testDir, "exec1", 1);
+    final ExecutableFlow exFlow = prepareExecDir(TEST_DIR, "exec1", 1);
 
     // Disable couple in the middle and at the end.
     exFlow.getExecutableNode("job1").setStatus(Status.DISABLED);
@@ -138,26 +144,28 @@ public class FlowRunnerTest {
     exFlow.getExecutableNode("job5").setStatus(Status.DISABLED);
     exFlow.getExecutableNode("job10").setStatus(Status.DISABLED);
 
-    final FlowRunner runner = createFlowRunner(exFlow, loader, eventCollector);
+    this.runner = createFlowRunner(exFlow, this.loader, eventCollector);
 
-    Assert.assertTrue(!runner.isKilled());
-    Assert.assertTrue(exFlow.getStatus() == Status.READY);
-    runner.run();
+    Assert.assertTrue(!this.runner.isKilled());
+    assertFlowStatus(Status.READY);
 
-    exFlow = runner.getExecutableFlow();
-    compareFinishedRuntime(runner);
+    startThread(this.runner);
+    succeedJobs("job3", "job4");
 
-    Assert.assertTrue(exFlow.getStatus() == Status.SUCCEEDED);
+    assertThreadShutDown();
+    compareFinishedRuntime(this.runner);
 
-    testStatus(exFlow, "job1", Status.SKIPPED);
-    testStatus(exFlow, "job2", Status.SUCCEEDED);
-    testStatus(exFlow, "job3", Status.SUCCEEDED);
-    testStatus(exFlow, "job4", Status.SUCCEEDED);
-    testStatus(exFlow, "job5", Status.SKIPPED);
-    testStatus(exFlow, "job6", Status.SKIPPED);
-    testStatus(exFlow, "job7", Status.SUCCEEDED);
-    testStatus(exFlow, "job8", Status.SUCCEEDED);
-    testStatus(exFlow, "job10", Status.SKIPPED);
+    assertFlowStatus(Status.SUCCEEDED);
+
+    assertStatus("job1", Status.SKIPPED);
+    assertStatus("job2", Status.SUCCEEDED);
+    assertStatus("job3", Status.SUCCEEDED);
+    assertStatus("job4", Status.SUCCEEDED);
+    assertStatus("job5", Status.SKIPPED);
+    assertStatus("job6", Status.SKIPPED);
+    assertStatus("job7", Status.SUCCEEDED);
+    assertStatus("job8", Status.SUCCEEDED);
+    assertStatus("job10", Status.SKIPPED);
 
     try {
       eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
@@ -169,34 +177,32 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void exec1Failed() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final File testDir = new File("unit/executions/exectest1");
-    final ExecutableFlow flow = prepareExecDir(testDir, "exec2", 1);
+    final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec2", 1);
 
-    final FlowRunner runner = createFlowRunner(flow, loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, eventCollector);
 
-    runner.run();
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
-    Assert.assertTrue(!runner.isKilled());
-    Assert.assertTrue("Flow status " + exFlow.getStatus(),
-        exFlow.getStatus() == Status.FAILED);
+    startThread(this.runner);
+    succeedJobs("job6");
 
-    testStatus(exFlow, "job1", Status.SUCCEEDED);
-    testStatus(exFlow, "job2d", Status.FAILED);
-    testStatus(exFlow, "job3", Status.CANCELLED);
-    testStatus(exFlow, "job4", Status.CANCELLED);
-    testStatus(exFlow, "job5", Status.CANCELLED);
-    testStatus(exFlow, "job6", Status.SUCCEEDED);
-    testStatus(exFlow, "job7", Status.CANCELLED);
-    testStatus(exFlow, "job8", Status.CANCELLED);
-    testStatus(exFlow, "job9", Status.CANCELLED);
-    testStatus(exFlow, "job10", Status.CANCELLED);
+    Assert.assertTrue(!this.runner.isKilled());
+    assertFlowStatus(Status.FAILED);
+
+    assertStatus("job1", Status.SUCCEEDED);
+    assertStatus("job2d", Status.FAILED);
+    assertStatus("job3", Status.CANCELLED);
+    assertStatus("job4", Status.CANCELLED);
+    assertStatus("job5", Status.CANCELLED);
+    assertStatus("job6", Status.SUCCEEDED);
+    assertStatus("job7", Status.CANCELLED);
+    assertStatus("job8", Status.CANCELLED);
+    assertStatus("job9", Status.CANCELLED);
+    assertStatus("job10", Status.CANCELLED);
+    assertThreadShutDown();
 
     try {
       eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
@@ -208,43 +214,32 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void exec1FailedKillAll() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final File testDir = new File("unit/executions/exectest1");
-    final ExecutableFlow flow = prepareExecDir(testDir, "exec2", 1);
+    final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec2", 1);
     flow.getExecutionOptions().setFailureAction(FailureAction.CANCEL_ALL);
 
-    final FlowRunner runner = createFlowRunner(flow, loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, eventCollector);
 
-    runner.run();
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
+    this.runner.run();
 
-    Assert.assertTrue(runner.isKilled());
+    Assert.assertTrue(this.runner.isKilled());
 
-    Assert.assertTrue(
-        "Expected flow " + Status.FAILED + " instead " + exFlow.getStatus(),
-        exFlow.getStatus() == Status.FAILED);
+    assertFlowStatus(Status.KILLED);
 
-    try {
-      Thread.sleep(500);
-    } catch (final InterruptedException e) {
-    }
-
-    testStatus(exFlow, "job1", Status.SUCCEEDED);
-    testStatus(exFlow, "job2d", Status.FAILED);
-    testStatus(exFlow, "job3", Status.CANCELLED);
-    testStatus(exFlow, "job4", Status.CANCELLED);
-    testStatus(exFlow, "job5", Status.CANCELLED);
-    testStatus(exFlow, "job6", Status.KILLED);
-    testStatus(exFlow, "job7", Status.CANCELLED);
-    testStatus(exFlow, "job8", Status.CANCELLED);
-    testStatus(exFlow, "job9", Status.CANCELLED);
-    testStatus(exFlow, "job10", Status.CANCELLED);
+    assertStatus("job1", Status.SUCCEEDED);
+    assertStatus("job2d", Status.FAILED);
+    assertStatus("job3", Status.CANCELLED);
+    assertStatus("job4", Status.CANCELLED);
+    assertStatus("job5", Status.CANCELLED);
+    assertStatus("job6", Status.KILLED);
+    assertStatus("job7", Status.CANCELLED);
+    assertStatus("job8", Status.CANCELLED);
+    assertStatus("job9", Status.CANCELLED);
+    assertStatus("job10", Status.CANCELLED);
 
     try {
       eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
@@ -256,40 +251,32 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void exec1FailedFinishRest() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final File testDir = new File("unit/executions/exectest1");
-    final ExecutableFlow flow = prepareExecDir(testDir, "exec3", 1);
+    final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec3", 1);
     flow.getExecutionOptions().setFailureAction(
         FailureAction.FINISH_ALL_POSSIBLE);
-    final FlowRunner runner = createFlowRunner(flow, loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, eventCollector);
 
-    runner.run();
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
-    Assert.assertTrue(
-        "Expected flow " + Status.FAILED + " instead " + exFlow.getStatus(),
-        exFlow.getStatus() == Status.FAILED);
+    startThread(this.runner);
+    succeedJobs("job3");
 
-    try {
-      Thread.sleep(500);
-    } catch (final InterruptedException e) {
-    }
+    assertFlowStatus(Status.FAILED);
 
-    testStatus(exFlow, "job1", Status.SUCCEEDED);
-    testStatus(exFlow, "job2d", Status.FAILED);
-    testStatus(exFlow, "job3", Status.SUCCEEDED);
-    testStatus(exFlow, "job4", Status.CANCELLED);
-    testStatus(exFlow, "job5", Status.CANCELLED);
-    testStatus(exFlow, "job6", Status.CANCELLED);
-    testStatus(exFlow, "job7", Status.SUCCEEDED);
-    testStatus(exFlow, "job8", Status.SUCCEEDED);
-    testStatus(exFlow, "job9", Status.SUCCEEDED);
-    testStatus(exFlow, "job10", Status.CANCELLED);
+    assertStatus("job1", Status.SUCCEEDED);
+    assertStatus("job2d", Status.FAILED);
+    assertStatus("job3", Status.SUCCEEDED);
+    assertStatus("job4", Status.CANCELLED);
+    assertStatus("job5", Status.CANCELLED);
+    assertStatus("job6", Status.CANCELLED);
+    assertStatus("job7", Status.SUCCEEDED);
+    assertStatus("job8", Status.SUCCEEDED);
+    assertStatus("job9", Status.SUCCEEDED);
+    assertStatus("job10", Status.CANCELLED);
+    assertThreadShutDown();
 
     try {
       eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
@@ -301,97 +288,70 @@ public class FlowRunnerTest {
     }
   }
 
-  @Ignore
   @Test
   public void execAndCancel() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final FlowRunner runner = createFlowRunner(loader, eventCollector, "exec1");
+    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
 
+    startThread(this.runner);
+
+    assertStatus("job1", Status.SUCCEEDED);
+    assertStatus("job2", Status.SUCCEEDED);
+    waitJobsStarted(this.runner, "job3", "job4", "job6");
+
+    this.runner.kill("me");
+    Assert.assertTrue(this.runner.isKilled());
+
+    assertStatus("job5", Status.CANCELLED);
+    assertStatus("job7", Status.CANCELLED);
+    assertStatus("job8", Status.CANCELLED);
+    assertStatus("job10", Status.CANCELLED);
+    assertStatus("job3", Status.KILLED);
+    assertStatus("job4", Status.KILLED);
+    assertStatus("job6", Status.KILLED);
+    assertThreadShutDown();
+
+    assertFlowStatus(Status.KILLED);
+
+    try {
+      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
+          Type.FLOW_FINISHED});
+    } catch (final Exception e) {
+      System.out.println(e.getMessage());
+      eventCollector.writeAllEvents();
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void execRetries() throws Exception {
+    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+        Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
+    this.runner = createFlowRunner(this.loader, eventCollector, "exec4-retry");
+
+    this.runner.run();
+
+    assertStatus("job-retry", Status.SUCCEEDED);
+    assertStatus("job-pass", Status.SUCCEEDED);
+    assertStatus("job-retry-fail", Status.FAILED);
+    assertAttempts("job-retry", 3);
+    assertAttempts("job-pass", 0);
+    assertAttempts("job-retry-fail", 2);
+
+    assertFlowStatus(Status.FAILED);
+  }
+
+  private void startThread(final FlowRunner runner) {
     Assert.assertTrue(!runner.isKilled());
     final Thread thread = new Thread(runner);
     thread.start();
-
-    try {
-      Thread.sleep(5000);
-    } catch (final InterruptedException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-
-    runner.kill("me");
-    Assert.assertTrue(runner.isKilled());
-
-    try {
-      Thread.sleep(2000);
-    } catch (final InterruptedException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
-    testStatus(exFlow, "job1", Status.SUCCEEDED);
-    testStatus(exFlow, "job2", Status.SUCCEEDED);
-    testStatus(exFlow, "job5", Status.CANCELLED);
-    testStatus(exFlow, "job7", Status.CANCELLED);
-    testStatus(exFlow, "job8", Status.CANCELLED);
-    testStatus(exFlow, "job10", Status.CANCELLED);
-    testStatus(exFlow, "job3", Status.KILLED);
-    testStatus(exFlow, "job4", Status.KILLED);
-    testStatus(exFlow, "job6", Status.KILLED);
-
-    Assert.assertTrue(
-        "Expected FAILED status instead got " + exFlow.getStatus(),
-        exFlow.getStatus() == Status.KILLED);
-
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-      eventCollector.writeAllEvents();
-      Assert.fail(e.getMessage());
-    }
   }
 
-  @Ignore
-  @Test
-  public void execRetries() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
-        Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    final FlowRunner runner = createFlowRunner(loader, eventCollector, "exec4-retry");
-
-    runner.run();
-
-    final ExecutableFlow exFlow = runner.getExecutableFlow();
-    testStatus(exFlow, "job-retry", Status.SUCCEEDED);
-    testStatus(exFlow, "job-pass", Status.SUCCEEDED);
-    testStatus(exFlow, "job-retry-fail", Status.FAILED);
-    testAttempts(exFlow, "job-retry", 3);
-    testAttempts(exFlow, "job-pass", 0);
-    testAttempts(exFlow, "job-retry-fail", 2);
-
-    Assert.assertTrue(
-        "Expected FAILED status instead got " + exFlow.getStatus(),
-        exFlow.getStatus() == Status.FAILED);
-  }
-
-  private void testStatus(final ExecutableFlow flow, final String name, final Status status) {
-    final ExecutableNode node = flow.getExecutableNode(name);
-
-    if (node.getStatus() != status) {
-      Assert.fail("Status of job " + node.getId() + " is " + node.getStatus()
-          + " not " + status + " as expected.");
-    }
-  }
-
-  private void testAttempts(final ExecutableFlow flow, final String name, final int attempt) {
-    final ExecutableNode node = flow.getExecutableNode(name);
-
+  private void assertAttempts(final String name, final int attempt) {
+    final ExecutableNode node = this.runner.getExecutableFlow().getExecutableNode(name);
     if (node.getAttempt() != attempt) {
       Assert.fail("Expected " + attempt + " got " + node.getAttempt()
           + " attempts " + name);
@@ -437,8 +397,6 @@ public class FlowRunnerTest {
       return;
     }
 
-    // System.out.println("Node " + node.getJobId() + " start:" + startTime +
-    // " end:" + endTime + " previous:" + previousEndTime);
     Assert.assertTrue("Checking start and end times", startTime > 0
         && endTime >= startTime);
     Assert.assertTrue("Start time for " + node.getId() + " is " + startTime
@@ -459,9 +417,6 @@ public class FlowRunnerTest {
       final ExecutorLoader loader, final EventCollectorListener eventCollector,
       final Props azkabanProps)
       throws Exception {
-    // File testDir = new File("unit/executions/exectest1");
-    // MockProjectLoader projectLoader = new MockProjectLoader(new
-    // File(flow.getExecutionPath()));
 
     loader.uploadExecutableFlow(flow);
     final FlowRunner runner =
@@ -480,10 +435,7 @@ public class FlowRunnerTest {
   private FlowRunner createFlowRunner(final ExecutorLoader loader,
       final EventCollectorListener eventCollector, final String flowName, final Props azkabanProps)
       throws Exception {
-    final File testDir = new File("unit/executions/exectest1");
-    final ExecutableFlow exFlow = prepareExecDir(testDir, flowName, 1);
-    // MockProjectLoader projectLoader = new MockProjectLoader(new
-    // File(exFlow.getExecutionPath()));
+    final ExecutableFlow exFlow = prepareExecDir(TEST_DIR, flowName, 1);
 
     loader.uploadExecutableFlow(exFlow);
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -66,8 +66,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     when(this.loader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
     System.out.println("Create temp dir");
     synchronized (this) {
-      // clear interrupted status
-      Thread.interrupted();
       this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
       if (this.workingDir.exists()) {
         FileUtils.deleteDirectory(this.workingDir);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -106,15 +106,11 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
   @Before
   public void setUp() throws Exception {
     System.out.println("Create temp dir");
-    synchronized (this) {
-      // clear interrupted status
-      Thread.interrupted();
-      this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
-      if (this.workingDir.exists()) {
-        FileUtils.deleteDirectory(this.workingDir);
-      }
-      this.workingDir.mkdirs();
+    this.workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
+    if (this.workingDir.exists()) {
+      FileUtils.deleteDirectory(this.workingDir);
     }
+    this.workingDir.mkdirs();
     this.jobtypeManager = new JobTypeManager(null, null,
         this.getClass().getClassLoader());
     final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -16,6 +16,23 @@
 
 package azkaban.execapp;
 
+import static org.junit.Assert.assertEquals;
+
+import azkaban.execapp.jmx.JmxJobMBeanManager;
+import azkaban.jobExecutor.AllJobExecutorTests;
+import azkaban.test.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
@@ -29,22 +46,11 @@ import azkaban.flow.Flow;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
 import azkaban.project.DirectoryFlowLoader;
-import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManagerException;
+import azkaban.project.MockProjectLoader;
 import azkaban.utils.Props;
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  * Test the flow run, especially with embedded flows.
@@ -56,73 +62,77 @@ import org.junit.Test;
  * Flow jobf looks like the following:
  *
  *
- * joba       joba1
- * /  |  \      |
- * /   |   \     |
- * jobb  jobd jobc  |
- * \   |   /    /
- * \  |  /    /
- * jobe    /
- * |     /
- * |    /
- * jobf
+ *       joba       joba1
+ *      /  |  \      |
+ *     /   |   \     |
+ *  jobb  jobd jobc  |
+ *     \   |   /    /
+ *      \  |  /    /
+ *        jobe    /
+ *         |     /
+ *         |    /
+ *        jobf
  *
- * The job 'jobb' is an embedded flow:
+ *  The job 'jobb' is an embedded flow:
  *
- * jobb:innerFlow
+ *  jobb:innerFlow
  *
- * innerJobA
- * /       \
- * innerJobB   innerJobC
- * \       /
- * innerFlow
+ *        innerJobA
+ *        /       \
+ *   innerJobB   innerJobC
+ *        \       /
+ *        innerFlow
  *
  *
- * The job 'jobd' is a simple embedded flow:
+ *  The job 'jobd' is a simple embedded flow:
  *
- * jobd:innerFlow2
+ *  jobd:innerFlow2
  *
- * innerJobA
- * |
- * innerFlow2
+ *       innerJobA
+ *           |
+ *       innerFlow2
  *
- * The following tests checks each stage of the flow run by forcing jobs to
- * succeed or fail.
+ *  The following tests checks each stage of the flow run by forcing jobs to
+ *  succeed or fail.
  */
-public class FlowRunnerTest2 {
-
-  private static int id = 101;
-  private final Logger logger = Logger.getLogger(FlowRunnerTest2.class);
+public class FlowRunnerTest2 extends FlowRunnerTestBase {
   private File workingDir;
   private JobTypeManager jobtypeManager;
   private ProjectLoader fakeProjectLoader;
   private ExecutorLoader fakeExecutorLoader;
+  private Logger logger = Logger.getLogger(FlowRunnerTest2.class);
   private Project project;
   private Map<String, Flow> flowMap;
+  private static int id=101;
 
-  public FlowRunnerTest2() {
-  }
+  private static final File TEST_DIR = new File("../azkaban-test/src/test/resources/azkaban/test/executions/embedded2");
 
   @Before
   public void setUp() throws Exception {
     System.out.println("Create temp dir");
-    this.workingDir = new File("_AzkabanTestDir_" + System.currentTimeMillis());
-    if (this.workingDir.exists()) {
-      FileUtils.deleteDirectory(this.workingDir);
+    synchronized (this) {
+      // clear interrupted status
+      Thread.interrupted();
+      workingDir = new File("build/tmp/_AzkabanTestDir_" + System.currentTimeMillis());
+      if (workingDir.exists()) {
+        FileUtils.deleteDirectory(workingDir);
+      }
+      workingDir.mkdirs();
     }
-    this.workingDir.mkdirs();
-    this.jobtypeManager = new JobTypeManager(null, null,
+    jobtypeManager = new JobTypeManager(null, null,
         this.getClass().getClassLoader());
-    final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();
+    JobTypePluginSet pluginSet = jobtypeManager.getJobTypePluginSet();
 
+    pluginSet.setCommonPluginLoadProps(AllJobExecutorTests.setUpCommonProps());
     pluginSet.addPluginClass("java", JavaJob.class);
     pluginSet.addPluginClass("test", InteractiveTestJob.class);
-    this.fakeProjectLoader = new MockProjectLoader(this.workingDir);
-    this.fakeExecutorLoader = new MockExecutorLoader();
-    this.project = new Project(1, "testProject");
+    fakeProjectLoader = new MockProjectLoader(workingDir);
+    fakeExecutorLoader = new MockExecutorLoader();
+    project = new Project(1, "testProject");
+    Utils.initServiceProvider();
+    JmxJobMBeanManager.getInstance().initialize(new Props());
 
-    final File dir = new File("unit/executions/embedded2");
-    prepareProject(this.project, dir);
+    prepareProject(project, TEST_DIR);
 
     InteractiveTestJob.clearTestJobs();
   }
@@ -130,427 +140,350 @@ public class FlowRunnerTest2 {
   @After
   public void tearDown() throws IOException {
     System.out.println("Teardown temp dir");
-    if (this.workingDir != null) {
-      FileUtils.deleteDirectory(this.workingDir);
-      this.workingDir = null;
+    if (workingDir != null) {
+      FileUtils.deleteDirectory(workingDir);
+      workingDir = null;
     }
   }
 
   /**
    * Tests the basic successful flow run, and also tests all output variables
    * from each job.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testBasicRun() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
-    compareStates(expectedStateMap, nodeMap);
-    final Props joba = nodeMap.get("joba").getInputProps();
-    Assert.assertEquals("joba.1", joba.get("param1"));
-    Assert.assertEquals("test1.2", joba.get("param2"));
-    Assert.assertEquals("test1.3", joba.get("param3"));
-    Assert.assertEquals("override.4", joba.get("param4"));
-    Assert.assertEquals("test2.5", joba.get("param5"));
-    Assert.assertEquals("test2.6", joba.get("param6"));
-    Assert.assertEquals("test2.7", joba.get("param7"));
-    Assert.assertEquals("test2.8", joba.get("param8"));
+    Props joba = runner.getExecutableFlow().getExecutableNodePath("joba").getInputProps();
+    assertEquals("joba.1", joba.get("param1"));
+    assertEquals("test1.2", joba.get("param2"));
+    assertEquals("test1.3", joba.get("param3"));
+    assertEquals("override.4", joba.get("param4"));
+    assertEquals("test2.5", joba.get("param5"));
+    assertEquals("test2.6", joba.get("param6"));
+    assertEquals("test2.7", joba.get("param7"));
+    assertEquals("test2.8", joba.get("param8"));
 
-    final Props joba1 = nodeMap.get("joba1").getInputProps();
-    Assert.assertEquals("test1.1", joba1.get("param1"));
-    Assert.assertEquals("test1.2", joba1.get("param2"));
-    Assert.assertEquals("test1.3", joba1.get("param3"));
-    Assert.assertEquals("override.4", joba1.get("param4"));
-    Assert.assertEquals("test2.5", joba1.get("param5"));
-    Assert.assertEquals("test2.6", joba1.get("param6"));
-    Assert.assertEquals("test2.7", joba1.get("param7"));
-    Assert.assertEquals("test2.8", joba1.get("param8"));
+    Props joba1 = runner.getExecutableFlow().getExecutableNodePath("joba1").getInputProps();
+    assertEquals("test1.1", joba1.get("param1"));
+    assertEquals("test1.2", joba1.get("param2"));
+    assertEquals("test1.3", joba1.get("param3"));
+    assertEquals("override.4", joba1.get("param4"));
+    assertEquals("test2.5", joba1.get("param5"));
+    assertEquals("test2.6", joba1.get("param6"));
+    assertEquals("test2.7", joba1.get("param7"));
+    assertEquals("test2.8", joba1.get("param8"));
 
     // 2. JOB A COMPLETES SUCCESSFULLY
     InteractiveTestJob.getTestJob("joba").succeedJob(
         Props.of("output.joba", "joba", "output.override", "joba"));
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
-    final ExecutableNode node = nodeMap.get("jobb");
-    Assert.assertEquals(Status.RUNNING, node.getStatus());
-    final Props jobb = node.getInputProps();
-    Assert.assertEquals("override.4", jobb.get("param4"));
+    ExecutableNode node = runner.getExecutableFlow().getExecutableNodePath("jobb");
+    assertEquals(Status.RUNNING, node.getStatus());
+    Props jobb = node.getInputProps();
+    assertEquals("override.4", jobb.get("param4"));
     // Test that jobb properties overwrites the output properties
-    Assert.assertEquals("moo", jobb.get("testprops"));
-    Assert.assertEquals("jobb", jobb.get("output.override"));
-    Assert.assertEquals("joba", jobb.get("output.joba"));
+    assertEquals("moo", jobb.get("testprops"));
+    assertEquals("jobb", jobb.get("output.override"));
+    assertEquals("joba", jobb.get("output.joba"));
 
-    final Props jobbInnerJobA = nodeMap.get("jobb:innerJobA").getInputProps();
-    Assert.assertEquals("test1.1", jobbInnerJobA.get("param1"));
-    Assert.assertEquals("test1.2", jobbInnerJobA.get("param2"));
-    Assert.assertEquals("test1.3", jobbInnerJobA.get("param3"));
-    Assert.assertEquals("override.4", jobbInnerJobA.get("param4"));
-    Assert.assertEquals("test2.5", jobbInnerJobA.get("param5"));
-    Assert.assertEquals("test2.6", jobbInnerJobA.get("param6"));
-    Assert.assertEquals("test2.7", jobbInnerJobA.get("param7"));
-    Assert.assertEquals("test2.8", jobbInnerJobA.get("param8"));
-    Assert.assertEquals("joba", jobbInnerJobA.get("output.joba"));
+    Props jobbInnerJobA = runner.getExecutableFlow().getExecutableNodePath("jobb:innerJobA").getInputProps();
+    assertEquals("test1.1", jobbInnerJobA.get("param1"));
+    assertEquals("test1.2", jobbInnerJobA.get("param2"));
+    assertEquals("test1.3", jobbInnerJobA.get("param3"));
+    assertEquals("override.4", jobbInnerJobA.get("param4"));
+    assertEquals("test2.5", jobbInnerJobA.get("param5"));
+    assertEquals("test2.6", jobbInnerJobA.get("param6"));
+    assertEquals("test2.7", jobbInnerJobA.get("param7"));
+    assertEquals("test2.8", jobbInnerJobA.get("param8"));
+    assertEquals("joba", jobbInnerJobA.get("output.joba"));
 
     // 3. jobb:Inner completes
     /// innerJobA completes
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob(
         Props.of("output.jobb.innerJobA", "jobb.innerJobA"));
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
-    final Props jobbInnerJobB = nodeMap.get("jobb:innerJobB").getInputProps();
-    Assert.assertEquals("test1.1", jobbInnerJobB.get("param1"));
-    Assert.assertEquals("override.4", jobbInnerJobB.get("param4"));
-    Assert.assertEquals("jobb.innerJobA",
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
+    Props jobbInnerJobB = runner.getExecutableFlow().getExecutableNodePath("jobb:innerJobB").getInputProps();
+    assertEquals("test1.1", jobbInnerJobB.get("param1"));
+    assertEquals("override.4", jobbInnerJobB.get("param4"));
+    assertEquals("jobb.innerJobA",
         jobbInnerJobB.get("output.jobb.innerJobA"));
-    Assert.assertEquals("moo", jobbInnerJobB.get("testprops"));
+    assertEquals("moo", jobbInnerJobB.get("testprops"));
     /// innerJobB, C completes
     InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob(
         Props.of("output.jobb.innerJobB", "jobb.innerJobB"));
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob(
         Props.of("output.jobb.innerJobC", "jobb.innerJobC"));
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerFlow", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobB", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobb:innerFlow", Status.RUNNING);
 
-    final Props jobbInnerJobD = nodeMap.get("jobb:innerFlow").getInputProps();
-    Assert.assertEquals("test1.1", jobbInnerJobD.get("param1"));
-    Assert.assertEquals("override.4", jobbInnerJobD.get("param4"));
-    Assert.assertEquals("jobb.innerJobB",
+    Props jobbInnerJobD = runner.getExecutableFlow().getExecutableNodePath("jobb:innerFlow").getInputProps();
+    assertEquals("test1.1", jobbInnerJobD.get("param1"));
+    assertEquals("override.4", jobbInnerJobD.get("param4"));
+    assertEquals("jobb.innerJobB",
         jobbInnerJobD.get("output.jobb.innerJobB"));
-    Assert.assertEquals("jobb.innerJobC",
+    assertEquals("jobb.innerJobC",
         jobbInnerJobD.get("output.jobb.innerJobC"));
 
     // 4. Finish up on inner flow for jobb
     InteractiveTestJob.getTestJob("jobb:innerFlow").succeedJob(
         Props.of("output1.jobb", "test1", "output2.jobb", "test2"));
-    pause(250);
-    expectedStateMap.put("jobb:innerFlow", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    final Props jobbOutput = nodeMap.get("jobb").getOutputProps();
-    Assert.assertEquals("test1", jobbOutput.get("output1.jobb"));
-    Assert.assertEquals("test2", jobbOutput.get("output2.jobb"));
+    assertStatus("jobb:innerFlow", Status.SUCCEEDED);
+    assertStatus("jobb", Status.SUCCEEDED);
+    Props jobbOutput = runner.getExecutableFlow().getExecutableNodePath("jobb").getOutputProps();
+    assertEquals("test1", jobbOutput.get("output1.jobb"));
+    assertEquals("test2", jobbOutput.get("output2.jobb"));
 
     // 5. Finish jobc, jobd
     InteractiveTestJob.getTestJob("jobc").succeedJob(
         Props.of("output.jobc", "jobc"));
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobc", Status.SUCCEEDED);
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
     InteractiveTestJob.getTestJob("jobd:innerFlow2").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerFlow2", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.SUCCEEDED);
+    assertStatus("jobd", Status.SUCCEEDED);
+    assertStatus("jobe", Status.RUNNING);
 
-    final Props jobd = nodeMap.get("jobe").getInputProps();
-    Assert.assertEquals("test1", jobd.get("output1.jobb"));
-    Assert.assertEquals("jobc", jobd.get("output.jobc"));
+    Props jobd = runner.getExecutableFlow().getExecutableNodePath("jobe").getInputProps();
+    assertEquals("test1", jobd.get("output1.jobb"));
+    assertEquals("jobc", jobd.get("output.jobc"));
 
     // 6. Finish off flow
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
     InteractiveTestJob.getTestJob("jobe").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.SUCCEEDED);
-    expectedStateMap.put("jobf", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobe", Status.SUCCEEDED);
+    assertStatus("jobf", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobf", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.SUCCEEDED, flow.getStatus());
-
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobf", Status.SUCCEEDED);
+    assertFlowStatus(Status.SUCCEEDED);
   }
 
   /**
    * Tests a flow with Disabled jobs and flows. They should properly SKIP
    * executions
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testDisabledNormal() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
+    ExecutableFlow flow = runner.getExecutableFlow();
     flow.getExecutableNode("jobb").setStatus(Status.DISABLED);
-    ((ExecutableFlowBase) flow.getExecutableNode("jobd")).getExecutableNode(
+    ((ExecutableFlowBase)flow.getExecutableNode("jobd")).getExecutableNode(
         "innerJobA").setStatus(Status.DISABLED);
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY, others should be skipped
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.SKIPPED);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.SKIPPED);
-    expectedStateMap.put("jobd:innerFlow2", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.READY);
-    expectedStateMap.put("jobb:innerJobB", Status.READY);
-    expectedStateMap.put("jobb:innerJobC", Status.READY);
-    expectedStateMap.put("jobb:innerFlow", Status.READY);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.SKIPPED);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.SKIPPED);
+    assertStatus("jobd:innerFlow2", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.READY);
+    assertStatus("jobb:innerJobB", Status.READY);
+    assertStatus("jobb:innerJobC", Status.READY);
+    assertStatus("jobb:innerFlow", Status.READY);
 
     // 3. jobb:Inner completes
     /// innerJobA completes
     InteractiveTestJob.getTestJob("jobc").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerFlow2").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerFlow2", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.SUCCEEDED);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerFlow2", Status.SUCCEEDED);
+    assertStatus("jobd", Status.SUCCEEDED);
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("jobe", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobe").succeedJob();
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobe", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobf", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobe", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobf", Status.RUNNING);
 
     // 4. Finish up on inner flow for jobb
     InteractiveTestJob.getTestJob("jobf").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobf", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobf", Status.SUCCEEDED);
 
-    Assert.assertEquals(Status.SUCCEEDED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.SUCCEEDED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests a failure with the default FINISH_CURRENTLY_RUNNING.
    * After the first failure, every job that started should complete, and the
    * rest of the jobs should be skipped.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testNormalFailure1() throws Exception {
     // Test propagation of KILLED status to embedded flows.
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY, others should be skipped
     InteractiveTestJob.getTestJob("joba").failJob();
-    pause(250);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
-    expectedStateMap.put("joba", Status.FAILED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.CANCELLED);
-    expectedStateMap.put("jobc", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.CANCELLED);
-    expectedStateMap.put("jobd:innerJobA", Status.READY);
-    expectedStateMap.put("jobd:innerFlow2", Status.READY);
-    expectedStateMap.put("jobb:innerJobA", Status.READY);
-    expectedStateMap.put("jobb:innerFlow", Status.READY);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
+    assertFlowStatus(Status.FAILED_FINISHING);
+    assertStatus("joba", Status.FAILED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.CANCELLED);
+    assertStatus("jobc", Status.CANCELLED);
+    assertStatus("jobd", Status.CANCELLED);
+    assertStatus("jobd:innerJobA", Status.READY);
+    assertStatus("jobd:innerFlow2", Status.READY);
+    assertStatus("jobb:innerJobA", Status.READY);
+    assertStatus("jobb:innerFlow", Status.READY);
+    assertStatus("jobe", Status.CANCELLED);
 
     // 3. jobb:Inner completes
     /// innerJobA completes
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobf", Status.CANCELLED);
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
   /**
    * Test #2 on the default failure case.
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testNormalFailure2() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY, others should be skipped
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").failJob();
-    pause(250);
-    expectedStateMap.put("joba1", Status.FAILED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba1", Status.FAILED);
 
     // 3. joba completes, everything is killed
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerJobC", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobb", Status.KILLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.CANCELLED);
+    assertStatus("jobb:innerJobC", Status.CANCELLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobd", Status.KILLED);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobc").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
-  @Ignore
   @Test
   public void testNormalFailure3() throws Exception {
     // Test propagation of CANCELLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB in subflow FAILS
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    pause(250);
-    expectedStateMap.put("jobb", Status.FAILED_FINISHING);
-    expectedStateMap.put("jobb:innerJobB", Status.FAILED);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb", Status.FAILED_FINISHING);
+    assertStatus("jobb:innerJobB", Status.FAILED);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobb", Status.FAILED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobb", Status.FAILED);
 
     // 3. jobc completes, everything is killed
     InteractiveTestJob.getTestJob("jobc").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
   /**
@@ -558,79 +491,63 @@ public class FlowRunnerTest2 {
    * In this case, all jobs which have had its pre-requisite met can continue
    * to run. Finishes when the failure is propagated to the last node of the
    * flow.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testFailedFinishingFailure3() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.FINISH_ALL_POSSIBLE);
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB in subflow FAILS
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    pause(250);
-    expectedStateMap.put("jobb", Status.FAILED_FINISHING);
-    expectedStateMap.put("jobb:innerJobB", Status.FAILED);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb", Status.FAILED_FINISHING);
+    assertStatus("jobb:innerJobB", Status.FAILED);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb", Status.FAILED);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerFlow2", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
 
     InteractiveTestJob.getTestJob("jobd:innerFlow2").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerFlow2", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.SUCCEEDED);
+    assertStatus("jobd", Status.SUCCEEDED);
 
     // 3. jobc completes, everything is killed
     InteractiveTestJob.getTestJob("jobc").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
   /**
@@ -639,349 +556,282 @@ public class FlowRunnerTest2 {
    *
    * Any jobs that are running will be assigned a KILLED state, and any nodes
    * which were skipped due to prior errors will be given a CANCELLED state.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testCancelOnFailure() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.CANCEL_ALL);
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB in subflow FAILS
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    pause(250);
-    expectedStateMap.put("jobb", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobB", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobC", Status.KILLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobc", Status.KILLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    expectedStateMap.put("jobd:innerJobA", Status.KILLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobb:innerJobB", Status.FAILED);
+    assertStatus("jobb:innerJobC", Status.KILLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobc", Status.KILLED);
+    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobd:innerJobA", Status.KILLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
 
-    Assert.assertFalse(thread.isAlive());
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-
+    assertThreadShutDown();
+    assertFlowStatus(Status.KILLED);
   }
 
   /**
    * Tests retries after a failure
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testRetryOnFailure() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
+    ExecutableFlow flow = runner.getExecutableFlow();
     flow.getExecutableNode("joba").setStatus(Status.DISABLED);
-    ((ExecutableFlowBase) flow.getExecutableNode("jobb")).getExecutableNode(
+    ((ExecutableFlowBase)flow.getExecutableNode("jobb")).getExecutableNode(
         "innerFlow").setStatus(Status.DISABLED);
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
-    // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.SKIPPED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SKIPPED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
     InteractiveTestJob.getTestJob("jobb:innerJobC").failJob();
-    pause(250);
+    assertStatus("jobb:innerJobB", Status.FAILED);
+    assertStatus("jobb:innerJobC", Status.FAILED);
+    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobb:innerFlow", Status.SKIPPED);
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobB", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobC", Status.FAILED);
-    expectedStateMap.put("jobb:innerFlow", Status.SKIPPED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.KILLED);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
-    final ExecutableNode node = nodeMap.get("jobd:innerFlow2");
-    final ExecutableFlowBase base = node.getParentFlow();
-    for (final String nodeId : node.getInNodes()) {
-      final ExecutableNode inNode = base.getExecutableNode(nodeId);
+    ExecutableNode node = runner.getExecutableFlow().getExecutableNodePath("jobd:innerFlow2");
+    ExecutableFlowBase base = node.getParentFlow();
+    for (String nodeId : node.getInNodes()) {
+      ExecutableNode inNode = base.getExecutableNode(nodeId);
       System.out.println(inNode.getId() + " > " + inNode.getStatus());
     }
 
     runner.retryFailures("me");
-    pause(500);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerFlow", Status.DISABLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.RUNNING);
-    Assert.assertEquals(Status.RUNNING, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertTrue(thread.isAlive());
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerFlow", Status.DISABLED);
+    assertStatus("jobd:innerFlow2", Status.RUNNING);
+    assertFlowStatus(Status.RUNNING);
+    assertThreadRunning();
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerFlow2").succeedJob();
     InteractiveTestJob.getTestJob("jobc").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerFlow", Status.SKIPPED);
-    expectedStateMap.put("jobb", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerFlow2", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerFlow", Status.SKIPPED);
+    assertStatus("jobb", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("jobd", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.SUCCEEDED);
+    assertStatus("jobe", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobe").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobe", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobe", Status.SUCCEEDED);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobf", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobf", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobf", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.SUCCEEDED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobf", Status.SUCCEEDED);
+    assertFlowStatus(Status.SUCCEEDED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests the manual Killing of a flow. In this case, the flow is just fine
    * before the cancel
    * is called.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testCancel() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.CANCEL_ALL);
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(1000);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB in subflow FAILS
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     runner.kill("me");
-    pause(250);
 
-    expectedStateMap.put("jobb", Status.KILLED);
-    expectedStateMap.put("jobb:innerJobB", Status.KILLED);
-    expectedStateMap.put("jobb:innerJobC", Status.KILLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobc", Status.KILLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    expectedStateMap.put("jobd:innerJobA", Status.KILLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
+    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobb:innerJobB", Status.KILLED);
+    assertStatus("jobb:innerJobC", Status.KILLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobc", Status.KILLED);
+    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobd:innerJobA", Status.KILLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
 
-    Assert.assertEquals(Status.KILLED, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.KILLED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests the manual invocation of cancel on a flow that is FAILED_FINISHING
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testManualCancelOnFailure() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB in subflow FAILS
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.FAILED);
-    expectedStateMap.put("jobb", Status.FAILED_FINISHING);
-    Assert.assertEquals(Status.FAILED_FINISHING, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobB", Status.FAILED);
+    assertStatus("jobb", Status.FAILED_FINISHING);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
     runner.kill("me");
-    pause(1000);
 
-    expectedStateMap.put("jobb", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobC", Status.KILLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobc", Status.KILLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    expectedStateMap.put("jobd:innerJobA", Status.KILLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
+    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobb:innerJobC", Status.KILLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobc", Status.KILLED);
+    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobd:innerJobA", Status.KILLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
 
-    Assert.assertEquals(Status.KILLED, flow.getStatus());
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.KILLED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests that pause and resume work
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testPause() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     runner.pause("test");
     InteractiveTestJob.getTestJob("joba").succeedJob();
     // 2.1 JOB A COMPLETES SUCCESSFULLY AFTER PAUSE
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertFlowStatus(Status.PAUSED);
 
     // 2.2 Flow is unpaused
     runner.resume("test");
-    pause(250);
-    Assert.assertEquals(flow.getStatus(), Status.RUNNING);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertFlowStatus(Status.RUNNING);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
     // 3. jobb:Inner completes
     runner.pause("test");
@@ -989,428 +839,333 @@ public class FlowRunnerTest2 {
     /// innerJobA completes, but paused
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob(
         Props.of("output.jobb.innerJobA", "jobb.innerJobA"));
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
 
     runner.resume("test");
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
 
     /// innerJobB, C completes
     InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob(
         Props.of("output.jobb.innerJobB", "jobb.innerJobB"));
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob(
         Props.of("output.jobb.innerJobC", "jobb.innerJobC"));
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerFlow", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobB", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobb:innerFlow", Status.RUNNING);
 
     // 4. Finish up on inner flow for jobb
     InteractiveTestJob.getTestJob("jobb:innerFlow").succeedJob(
         Props.of("output1.jobb", "test1", "output2.jobb", "test2"));
-    pause(250);
-    expectedStateMap.put("jobb:innerFlow", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerFlow", Status.SUCCEEDED);
+    assertStatus("jobb", Status.SUCCEEDED);
 
     // 5. Finish jobc, jobd
     InteractiveTestJob.getTestJob("jobc").succeedJob(
         Props.of("output.jobc", "jobc"));
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobc", Status.SUCCEEDED);
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
     InteractiveTestJob.getTestJob("jobd:innerFlow2").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerFlow2", Status.SUCCEEDED);
-    expectedStateMap.put("jobd", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerFlow2", Status.SUCCEEDED);
+    assertStatus("jobd", Status.SUCCEEDED);
+    assertStatus("jobe", Status.RUNNING);
 
     // 6. Finish off flow
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
     InteractiveTestJob.getTestJob("jobe").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.SUCCEEDED);
-    expectedStateMap.put("jobf", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobe", Status.SUCCEEDED);
+    assertStatus("jobf", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobf", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.SUCCEEDED, flow.getStatus());
-
-    Assert.assertFalse(thread.isAlive());
+    assertStatus("jobf", Status.SUCCEEDED);
+    assertFlowStatus(Status.SUCCEEDED);
+    assertThreadShutDown();
   }
 
   /**
    * Test the condition for a manual invocation of a KILL (cancel) on a flow
    * that has been paused. The flow should unpause and be killed immediately.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testPauseKill() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf");
-
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf");
 
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
     runner.pause("me");
-    pause(250);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    expectedStateMap.put("jobd:innerJobA", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    assertStatus("jobd:innerJobA", Status.SUCCEEDED);
 
     runner.kill("me");
-    pause(250);
-    expectedStateMap.put("joba1", Status.KILLED);
-    expectedStateMap.put("jobb:innerJobB", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerJobC", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobb", Status.KILLED);
-    expectedStateMap.put("jobc", Status.KILLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.KILLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
+    assertStatus("joba1", Status.KILLED);
+    assertStatus("jobb:innerJobB", Status.CANCELLED);
+    assertStatus("jobb:innerJobC", Status.CANCELLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobc", Status.KILLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
 
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.KILLED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.KILLED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests the case where a failure occurs on a Paused flow. In this case, the
    * flow should stay paused.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testPauseFail() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.FINISH_CURRENTLY_RUNNING);
 
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
-
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
     runner.pause("me");
-    pause(250);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertStatus("jobd:innerJobA", Status.FAILED);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
+    // When flow is paused, no new jobs are started. So these two jobs that were already running
+    // are allowed to finish, but their dependencies aren't started.
+    // Now, ensure that jobd:innerJobA has completely finished as failed before resuming.
+    // If we would resume before the job failure has been completely processed, FlowRunner would be
+    // able to start some new jobs instead of cancelling everything.
+    waitEventFired("jobd:innerJobA", Status.FAILED);
+    assertFlowStatus(Status.PAUSED);
 
     runner.resume("me");
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerJobC", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobb", Status.KILLED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.FAILED);
+    assertStatus("jobb:innerJobB", Status.CANCELLED);
+    assertStatus("jobb:innerJobC", Status.CANCELLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.FAILED);
 
     InteractiveTestJob.getTestJob("jobc").succeedJob();
     InteractiveTestJob.getTestJob("joba1").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobf", Status.CANCELLED);
+    assertStatus("jobe", Status.CANCELLED);
 
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
   /**
    * Test the condition when a Finish all possible is called during a pause.
    * The Failure is not acted upon until the flow is resumed.
+   *
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testPauseFailFinishAll() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.FINISH_ALL_POSSIBLE);
 
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
-
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
 
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(250);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
     runner.pause("me");
-    pause(250);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobA", Status.SUCCEEDED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.FAILED);
+    assertStatus("jobb:innerJobA", Status.SUCCEEDED);
 
     runner.resume("me");
-    pause(250);
-    expectedStateMap.put("jobb:innerJobB", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobC", Status.RUNNING);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.FAILED);
+    assertStatus("jobb:innerJobB", Status.RUNNING);
+    assertStatus("jobb:innerJobC", Status.RUNNING);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.FAILED);
 
     InteractiveTestJob.getTestJob("jobc").succeedJob();
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob();
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
-    pause(250);
     InteractiveTestJob.getTestJob("jobb:innerFlow").succeedJob();
-    pause(250);
-    expectedStateMap.put("jobc", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobB", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerJobC", Status.SUCCEEDED);
-    expectedStateMap.put("jobb:innerFlow", Status.SUCCEEDED);
-    expectedStateMap.put("jobb", Status.SUCCEEDED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
+    assertStatus("jobc", Status.SUCCEEDED);
+    assertStatus("joba1", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobB", Status.SUCCEEDED);
+    assertStatus("jobb:innerJobC", Status.SUCCEEDED);
+    assertStatus("jobb:innerFlow", Status.SUCCEEDED);
+    assertStatus("jobb", Status.SUCCEEDED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
 
-    compareStates(expectedStateMap, nodeMap);
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.FAILED);
+    assertThreadShutDown();
   }
 
   /**
    * Tests the case when a flow is paused and a failure causes a kill. The
    * flow should die immediately regardless of the 'paused' status.
+   * @throws Exception
    */
-  @Ignore
   @Test
   public void testPauseFailKill() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    final FlowRunner runner = createFlowRunner(eventCollector, "jobf",
+    EventCollectorListener eventCollector = new EventCollectorListener();
+    runner = createFlowRunner(eventCollector, "jobf",
         FailureAction.CANCEL_ALL);
-
-    final Map<String, Status> expectedStateMap = new HashMap<>();
-    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
-
+    
     // 1. START FLOW
-    final ExecutableFlow flow = runner.getExecutableFlow();
-    createExpectedStateMap(flow, expectedStateMap, nodeMap);
-    final Thread thread = runFlowRunnerInThread(runner);
-    pause(250);
+    runFlowRunnerInThread(runner);
     // After it starts up, only joba should be running
-    expectedStateMap.put("joba", Status.RUNNING);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.RUNNING);
+    assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY
     InteractiveTestJob.getTestJob("joba").succeedJob();
-    pause(500);
-    expectedStateMap.put("joba", Status.SUCCEEDED);
-    expectedStateMap.put("joba1", Status.RUNNING);
-    expectedStateMap.put("jobb", Status.RUNNING);
-    expectedStateMap.put("jobc", Status.RUNNING);
-    expectedStateMap.put("jobd", Status.RUNNING);
-    expectedStateMap.put("jobd:innerJobA", Status.RUNNING);
-    expectedStateMap.put("jobb:innerJobA", Status.RUNNING);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("joba", Status.SUCCEEDED);
+    assertStatus("joba1", Status.RUNNING);
+    assertStatus("jobb", Status.RUNNING);
+    assertStatus("jobc", Status.RUNNING);
+    assertStatus("jobd", Status.RUNNING);
+    assertStatus("jobd:innerJobA", Status.RUNNING);
+    assertStatus("jobb:innerJobA", Status.RUNNING);
 
     runner.pause("me");
-    pause(250);
-    Assert.assertEquals(flow.getStatus(), Status.PAUSED);
+    assertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
-    pause(250);
-    expectedStateMap.put("jobd:innerJobA", Status.FAILED);
-    expectedStateMap.put("jobd:innerFlow2", Status.CANCELLED);
-    expectedStateMap.put("jobd", Status.FAILED);
-    expectedStateMap.put("jobb:innerJobA", Status.KILLED);
-    expectedStateMap.put("jobb:innerJobB", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerJobC", Status.CANCELLED);
-    expectedStateMap.put("jobb:innerFlow", Status.CANCELLED);
-    expectedStateMap.put("jobb", Status.KILLED);
-    expectedStateMap.put("jobc", Status.KILLED);
-    expectedStateMap.put("jobe", Status.CANCELLED);
-    expectedStateMap.put("jobf", Status.CANCELLED);
-    expectedStateMap.put("joba1", Status.KILLED);
-    compareStates(expectedStateMap, nodeMap);
+    assertStatus("jobd:innerJobA", Status.FAILED);
+    assertStatus("jobd:innerFlow2", Status.CANCELLED);
+    assertStatus("jobd", Status.FAILED);
+    assertStatus("jobb:innerJobA", Status.KILLED);
+    assertStatus("jobb:innerJobB", Status.CANCELLED);
+    assertStatus("jobb:innerJobC", Status.CANCELLED);
+    assertStatus("jobb:innerFlow", Status.CANCELLED);
+    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobc", Status.KILLED);
+    assertStatus("jobe", Status.CANCELLED);
+    assertStatus("jobf", Status.CANCELLED);
+    assertStatus("joba1", Status.KILLED);
 
-    Assert.assertEquals(Status.FAILED, flow.getStatus());
-    Assert.assertFalse(thread.isAlive());
+    assertFlowStatus(Status.KILLED);
+    assertThreadShutDown();
   }
 
-
-  private Thread runFlowRunnerInThread(final FlowRunner runner) {
-    final Thread thread = new Thread(runner);
+  private Thread runFlowRunnerInThread(FlowRunner runner) {
+    Thread thread = new Thread(runner);
     thread.start();
     return thread;
   }
 
-  private void pause(final long millisec) {
+  private void sleep(long millisec) {
     try {
       Thread.sleep(millisec);
-    } catch (final InterruptedException e) {
+    }
+    catch (InterruptedException e) {
     }
   }
-
-  private void createExpectedStateMap(final ExecutableFlowBase flow,
-      final Map<String, Status> expectedStateMap,
-      final Map<String, ExecutableNode> nodeMap) {
-    for (final ExecutableNode node : flow.getExecutableNodes()) {
-      expectedStateMap.put(node.getNestedId(), node.getStatus());
-      nodeMap.put(node.getNestedId(), node);
-      if (node instanceof ExecutableFlowBase) {
-        createExpectedStateMap((ExecutableFlowBase) node, expectedStateMap,
-            nodeMap);
-      }
-    }
-  }
-
-  private void compareStates(final Map<String, Status> expectedStateMap,
-      final Map<String, ExecutableNode> nodeMap) {
-    for (final String printedId : expectedStateMap.keySet()) {
-      final Status expectedStatus = expectedStateMap.get(printedId);
-      final ExecutableNode node = nodeMap.get(printedId);
-
-      if (expectedStatus != node.getStatus()) {
-        Assert.fail("Expected values do not match for " + printedId
-            + ". Expected " + expectedStatus + ", instead received "
-            + node.getStatus());
-      }
-    }
-  }
-
-  private void prepareProject(final Project project, final File directory)
+  
+  private void prepareProject(Project project, File directory)
       throws ProjectManagerException, IOException {
-    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), this.logger);
+    DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), logger);
     loader.loadProjectFlow(project, directory);
     if (!loader.getErrors().isEmpty()) {
-      for (final String error : loader.getErrors()) {
+      for (String error: loader.getErrors()) {
         System.out.println(error);
       }
-
       throw new RuntimeException("Errors found in setup");
     }
 
-    this.flowMap = loader.getFlowMap();
-    project.setFlows(this.flowMap);
-    FileUtils.copyDirectory(directory, this.workingDir);
+    flowMap = loader.getFlowMap();
+    project.setFlows(flowMap);
+    FileUtils.copyDirectory(directory, workingDir);
   }
 
-  private FlowRunner createFlowRunner(final EventCollectorListener eventCollector,
-      final String flowName) throws Exception {
+  private FlowRunner createFlowRunner(EventCollectorListener eventCollector,
+      String flowName) throws Exception {
     return createFlowRunner(eventCollector, flowName,
         FailureAction.FINISH_CURRENTLY_RUNNING);
   }
 
-  private FlowRunner createFlowRunner(final EventCollectorListener eventCollector,
-      final String flowName, final FailureAction action) throws Exception {
+  private FlowRunner createFlowRunner(EventCollectorListener eventCollector,
+      String flowName, FailureAction action) throws Exception {
     return createFlowRunner(eventCollector, flowName, action, new Props());
   }
 
-  private FlowRunner createFlowRunner(final EventCollectorListener eventCollector,
-      final String flowName, final FailureAction action, final Props azkabanProps)
-      throws Exception {
-    final Flow flow = this.flowMap.get(flowName);
+  private FlowRunner createFlowRunner(EventCollectorListener eventCollector,
+      String flowName, FailureAction action, Props azkabanProps) throws Exception {
+    Flow flow = flowMap.get(flowName);
 
-    final int exId = id++;
-    final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
-    exFlow.setExecutionPath(this.workingDir.getPath());
+    int exId = id++;
+    ExecutableFlow exFlow = new ExecutableFlow(project, flow);
+    exFlow.setExecutionPath(workingDir.getPath());
     exFlow.setExecutionId(exId);
 
-    final Map<String, String> flowParam = new HashMap<>();
+    Map<String, String> flowParam = new HashMap<String, String>();
     flowParam.put("param4", "override.4");
     flowParam.put("param10", "override.10");
     flowParam.put("param11", "override.11");
     exFlow.getExecutionOptions().addAllFlowParameters(flowParam);
     exFlow.getExecutionOptions().setFailureAction(action);
-    this.fakeExecutorLoader.uploadExecutableFlow(exFlow);
+    fakeExecutorLoader.uploadExecutableFlow(exFlow);
 
-    final FlowRunner runner = new FlowRunner(
-        this.fakeExecutorLoader.fetchExecutableFlow(exId), this.fakeExecutorLoader,
-        this.fakeProjectLoader, this.jobtypeManager, azkabanProps);
+    FlowRunner runner = new FlowRunner(
+        fakeExecutorLoader.fetchExecutableFlow(exId), fakeExecutorLoader,
+        fakeProjectLoader, jobtypeManager, azkabanProps);
 
     runner.addListener(eventCollector);
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -397,7 +397,6 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     // After it starts up, only joba should be running
     assertStatus("joba", Status.RUNNING);
-    assertStatus("joba", Status.RUNNING);
     assertStatus("joba1", Status.RUNNING);
 
     // 2. JOB A COMPLETES SUCCESSFULLY, others should be skipped

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -1,0 +1,168 @@
+package azkaban.execapp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import azkaban.event.Event;
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.InteractiveTestJob;
+import azkaban.executor.Status;
+import java.util.function.Function;
+import org.junit.Assert;
+
+public class FlowRunnerTestBase {
+
+  protected FlowRunner runner;
+  protected EventCollectorListener eventCollector;
+
+  public void assertThreadShutDown() {
+    waitFlowRunner(runner -> runner.getExecutableFlow().isFlowFinished() && !runner.isRunnerThreadAlive());
+  }
+
+  public void assertThreadRunning() {
+    waitFlowRunner(runner -> !runner.getExecutableFlow().isFlowFinished() && runner.isRunnerThreadAlive());
+  }
+
+  public void waitFlowRunner(Function<FlowRunner, Boolean> statusCheck) {
+    for (int i = 0; i < 100; i++) {
+      if (statusCheck.apply(runner)) {
+        return;
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        try {
+          EventCollectorListener.handleEvent.wait(10L);
+        } catch (InterruptedException e) {
+        }
+      }
+    }
+    Assert.fail("Flow didn't reach expected status");
+  }
+
+  public void waitJobStatuses(Function<Status, Boolean> statusCheck,
+      String... jobs) {
+    for (int i = 0; i < 100; i++) {
+      if (checkJobStatuses(statusCheck, jobs)) {
+        return;
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        try {
+          EventCollectorListener.handleEvent.wait(10L);
+        } catch (InterruptedException e) {
+        }
+      }
+    }
+    Assert.fail("Jobs didn't reach expected statuses");
+  }
+
+  public void waitJobsStarted(FlowRunner runner, String... jobs) {
+    waitJobStatuses(FlowRunnerTest::isStarted, jobs);
+  }
+
+  protected void waitEventFired(String nestedId, Status status) throws InterruptedException {
+    for (int i = 0; i < 100; i++) {
+      for (Event event : eventCollector.getEventList()) {
+        if (event.getData().getStatus() == status && event.getData().getNestedId().equals(nestedId)) {
+          return;
+        }
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        EventCollectorListener.handleEvent.wait(10L);
+      }
+    }
+    fail("Event wasn't fired with [" + nestedId + "], " + status);
+  }
+
+  public static boolean isStarted(Status status) {
+    if (status == Status.QUEUED) {
+      return false;
+    } else if (!Status.isStatusFinished(status) && !Status.isStatusRunning(status)) {
+      return false;
+    }
+    return true;
+  }
+
+  public boolean checkJobStatuses(Function<Status, Boolean> statusCheck,
+      String[] jobs) {
+    ExecutableFlow exFlow = runner.getExecutableFlow();
+    for (String name : jobs) {
+      ExecutableNode node = exFlow.getExecutableNodePath(name);
+      assertNotNull(name + " wasn't found", node);
+      if (!statusCheck.apply(node.getStatus())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  protected void assertFlowStatus(Status status) {
+    ExecutableFlow flow = runner.getExecutableFlow();
+    for (int i = 0; i < 100; i++) {
+      if (flow.getStatus() == status) {
+        break;
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        try {
+          EventCollectorListener.handleEvent.wait(10L);
+        } catch (InterruptedException e) {
+        }
+      }
+    }
+    printStatuses(status, flow);
+    assertEquals(status, flow.getStatus());
+  }
+
+  protected void assertStatus(String name, Status status) {
+    ExecutableFlow exFlow = runner.getExecutableFlow();
+    ExecutableNode node = exFlow.getExecutableNodePath(name);
+    assertNotNull(name + " wasn't found", node);
+    for (int i = 0; i < 100; i++) {
+      if (node.getStatus() == status) {
+        break;
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        try {
+          EventCollectorListener.handleEvent.wait(10L);
+        } catch (InterruptedException e) {
+        }
+      }
+    }
+    printStatuses(status, node);
+    assertEquals("Wrong status for [" + name + "]", status, node.getStatus());
+  }
+
+  protected void printStatuses(Status status, ExecutableNode node) {
+    if (status != node.getStatus()) {
+      printTestJobs();
+      printFlowJobs(runner.getExecutableFlow());
+    }
+  }
+
+  private void printTestJobs() {
+    for (String testJob : InteractiveTestJob.testJobs.keySet()) {
+      ExecutableNode testNode = runner.getExecutableFlow().getExecutableNodePath(testJob);
+      System.err.println("testJob: " + testNode.getNestedId() + " " + testNode.getStatus());
+    }
+  }
+
+  private void printFlowJobs(ExecutableFlowBase flow) {
+    System.err.println("ExecutableFlow: " + flow.getNestedId() + " " + flow.getStatus());
+    for (ExecutableNode node : flow.getExecutableNodes()) {
+      if (node instanceof ExecutableFlowBase) {
+        printFlowJobs((ExecutableFlowBase) node);
+      } else {
+        System.err.println("ExecutableNode: " + node.getNestedId() + " " + node.getStatus());
+      }
+    }
+  }
+
+  protected void succeedJobs(String... jobs) {
+    waitJobsStarted(runner, jobs);
+    for (String name : jobs) {
+      InteractiveTestJob.getTestJob(name).succeedJob();
+    }
+  }
+
+}

--- a/azkaban-exec-server/src/test/resources/log4j.properties
+++ b/azkaban-exec-server/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
 log4j.rootLogger=INFO, Console
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%c{1}] %m%n
+log4j.appender.Console.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS Z} %p [%t] [%c{1}] %m%n

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-pass.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry-fail.job
@@ -1,8 +1,7 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=true
 passRetry=3
 retries=2
-retry.backoff=2000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job-retry.job
@@ -1,8 +1,7 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=true
 passRetry=2
 retries=3
-retry.backoff=1000
+retry.backoff=0
 

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job1.job
@@ -1,4 +1,3 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
-seconds=1
+type=test
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job10.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job8,job9
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job2d.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=1
+seconds=0
 fail=true

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job3.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job2
-seconds=3
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job4.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job2
-seconds=8
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job5.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job3,job4
-seconds=5
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job6.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job1
-seconds=4
+seconds=1
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job7.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job5,job6
-seconds=2
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job8.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job7
-seconds=3
+seconds=0
 fail=false

--- a/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
+++ b/azkaban-test/src/test/resources/azkaban/test/executions/exectest1/job9.job
@@ -1,5 +1,4 @@
-type=java
-job.class=azkaban.test.executor.SleepJavaJob
+type=test
 dependencies=job7
-seconds=4
+seconds=0
 fail=false


### PR DESCRIPTION
Make `FlowRunnerTest` & `FlowRunnerTest2` work, and make them run fast.

Good to have the `FlowRunnerTest2` as well because it has useful test cases for the flow pause feature.

Based on https://github.com/azkaban/azkaban/pull/1115, but:
- Now also `FlowRunnerTest2` runs, and it's all in one commit.
- `FlowRunnerTest` is also now simpler because there's no need for additional `waitJobsStarted(..)` calls: `assertStatus()` handles both waiting and assertion.

----

This is the minimal change to just make the tests pass again. Background discussion can be seen at https://github.com/azkaban/azkaban/pull/1105.

1. Fix setting job status in `JobRunner`.
    - It was setting status like this: `RUNNING -> KILLED -> FAILED -> KILLED`.
    - Now it's only `RUNNING -> KILLED`, as it should.
1. Make the `FlowRunnerTest` and `FlowRunnerTest2` pass again.
    - Fixed file paths, cleaning up thread state etc. to make the test pass consistently.
    - Removed `@Ignore`.

Changes required to make `FlowRunnerTest` run:
1. `PropsUtils` to tolerate null values in the property map. That shouldn't normally ever happen, but this makes testing easier when you don't need to insert every property that would be provided on a full-blown flow execution.
1. Others: see the diff.

Changes to improve debugging test/job failures:
1. `JobRunner` to print strackrace if an exception is thrown – otherwise it was impossible to see the failure anywhere when a job run failed like this.