### PR TITLE
Having setExpireCondition to help products relying on azkaban

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -16,41 +16,33 @@
 
 package azkaban.trigger;
 
+import static java.util.Objects.requireNonNull;
+
+import azkaban.utils.JSONUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.log4j.Logger;
-
 import org.joda.time.DateTime;
-
-import azkaban.utils.JSONUtils;
-
-import static java.util.Objects.*;
 
 
 public class Trigger {
 
-  private static Logger logger = Logger.getLogger(Trigger.class);
-
-  private int triggerId = -1;
-  private long lastModifyTime;
+  private static final Logger logger = Logger.getLogger(Trigger.class);
+  private static ActionTypeLoader actionTypeLoader;
   private final long submitTime;
   private final String submitUser;
   private final String source;
-  private TriggerStatus status = TriggerStatus.READY;
-
-  private final Condition triggerCondition;
-  private final Condition expireCondition;
   private final List<TriggerAction> actions;
   private final List<TriggerAction> expireActions;
-
-  private Map<String, Object> info = new HashMap<String, Object>();
-  private Map<String, Object> context = new HashMap<String, Object>();
-
-  private static ActionTypeLoader actionTypeLoader;
-
+  private Condition expireCondition;
+  private Condition triggerCondition;
+  private int triggerId = -1;
+  private long lastModifyTime;
+  private TriggerStatus status = TriggerStatus.READY;
+  private Map<String, Object> info = new HashMap<>();
+  private Map<String, Object> context = new HashMap<>();
   private boolean resetOnTrigger = true;
   private boolean resetOnExpire = true;
 
@@ -59,6 +51,132 @@ public class Trigger {
   @SuppressWarnings("unused")
   private Trigger() throws TriggerManagerException {
     throw new TriggerManagerException("Triggers should always be specified");
+  }
+
+  private Trigger(int triggerId, long lastModifyTime, long submitTime,
+      String submitUser, String source, Condition triggerCondition,
+      Condition expireCondition, List<TriggerAction> actions,
+      List<TriggerAction> expireActions, Map<String, Object> info,
+      Map<String, Object> context) {
+    requireNonNull(submitUser);
+    requireNonNull(source);
+    requireNonNull(triggerCondition);
+    requireNonNull(expireActions);
+    requireNonNull(info);
+    requireNonNull(context);
+
+    this.lastModifyTime = lastModifyTime;
+    this.submitTime = submitTime;
+    this.submitUser = submitUser;
+    this.source = source;
+    this.triggerCondition = triggerCondition;
+    this.expireCondition = expireCondition;
+    this.actions = actions;
+    this.triggerId = triggerId;
+    this.expireActions = expireActions;
+    this.info = info;
+    this.context = context;
+  }
+
+  public static ActionTypeLoader getActionTypeLoader() {
+    return actionTypeLoader;
+  }
+
+  public static synchronized void setActionTypeLoader(ActionTypeLoader loader) {
+    Trigger.actionTypeLoader = loader;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Trigger fromJson(Object obj) throws Exception {
+
+    if (actionTypeLoader == null) {
+      throw new Exception("Trigger Action Type loader not initialized.");
+    }
+
+    Map<String, Object> jsonObj = (HashMap<String, Object>) obj;
+
+    Trigger trigger = null;
+    try {
+      logger.info("Decoding for " + JSONUtils.toJSON(obj));
+      Condition triggerCond =
+          Condition.fromJson(jsonObj.get("triggerCondition"));
+      Condition expireCond = Condition.fromJson(jsonObj.get("expireCondition"));
+      List<TriggerAction> actions = new ArrayList<>();
+      List<Object> actionsJson = (List<Object>) jsonObj.get("actions");
+      for (Object actObj : actionsJson) {
+        Map<String, Object> oneActionJson = (HashMap<String, Object>) actObj;
+        String type = (String) oneActionJson.get("type");
+        TriggerAction act =
+            actionTypeLoader.createActionFromJson(type,
+                oneActionJson.get("actionJson"));
+        actions.add(act);
+      }
+      List<TriggerAction> expireActions = new ArrayList<>();
+      List<Object> expireActionsJson =
+          (List<Object>) jsonObj.get("expireActions");
+      for (Object expireActObj : expireActionsJson) {
+        Map<String, Object> oneExpireActionJson =
+            (HashMap<String, Object>) expireActObj;
+        String type = (String) oneExpireActionJson.get("type");
+        TriggerAction expireAct =
+            actionTypeLoader.createActionFromJson(type,
+                oneExpireActionJson.get("actionJson"));
+        expireActions.add(expireAct);
+      }
+      boolean resetOnTrigger =
+          Boolean.valueOf((String) jsonObj.get("resetOnTrigger"));
+      boolean resetOnExpire =
+          Boolean.valueOf((String) jsonObj.get("resetOnExpire"));
+      String submitUser = (String) jsonObj.get("submitUser");
+      String source = (String) jsonObj.get("source");
+      long submitTime = Long.valueOf((String) jsonObj.get("submitTime"));
+      long lastModifyTime =
+          Long.valueOf((String) jsonObj.get("lastModifyTime"));
+      int triggerId = Integer.valueOf((String) jsonObj.get("triggerId"));
+      TriggerStatus status =
+          TriggerStatus.valueOf((String) jsonObj.get("status"));
+      Map<String, Object> info = (Map<String, Object>) jsonObj.get("info");
+      Map<String, Object> context =
+          (Map<String, Object>) jsonObj.get("context");
+      if (context == null) {
+        context = new HashMap<>();
+      }
+      for (ConditionChecker checker : triggerCond.getCheckers().values()) {
+        checker.setContext(context);
+      }
+      for (ConditionChecker checker : expireCond.getCheckers().values()) {
+        checker.setContext(context);
+      }
+      for (TriggerAction action : actions) {
+        action.setContext(context);
+      }
+      for (TriggerAction action : expireActions) {
+        action.setContext(context);
+      }
+
+      trigger = new Trigger.TriggerBuilder("azkaban",
+          source,
+          triggerCond,
+          expireCond,
+          actions)
+          .setId(triggerId)
+          .setLastModifyTime(lastModifyTime)
+          .setSubmitTime(submitTime)
+          .setExpireActions(expireActions)
+          .setInfo(info)
+          .setContext(context)
+          .build();
+
+      trigger.setResetOnExpire(resetOnExpire);
+      trigger.setResetOnTrigger(resetOnTrigger);
+      trigger.setStatus(status);
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.error("Failed to decode the trigger.", e);
+      throw new Exception("Failed to decode the trigger.", e);
+    }
+
+    return trigger;
   }
 
   public void updateNextCheckTime() {
@@ -95,8 +213,16 @@ public class Trigger {
     return triggerCondition;
   }
 
+  public void setTriggerCondition(Condition triggerCondition) {
+    this.triggerCondition = triggerCondition;
+  }
+
   public Condition getExpireCondition() {
     return expireCondition;
+  }
+
+  public void setExpireCondition(Condition expireCondition) {
+    this.expireCondition = expireCondition;
   }
 
   public List<TriggerAction> getActions() {
@@ -123,22 +249,137 @@ public class Trigger {
     this.context = context;
   }
 
+  public boolean isResetOnTrigger() {
+    return resetOnTrigger;
+  }
+
+  public void setResetOnTrigger(boolean resetOnTrigger) {
+    this.resetOnTrigger = resetOnTrigger;
+  }
+
+  public boolean isResetOnExpire() {
+    return resetOnExpire;
+  }
+
+  public void setResetOnExpire(boolean resetOnExpire) {
+    this.resetOnExpire = resetOnExpire;
+  }
+
+  public long getLastModifyTime() {
+    return lastModifyTime;
+  }
+
+  public void setLastModifyTime(long lastModifyTime) {
+    this.lastModifyTime = lastModifyTime;
+  }
+
+  public int getTriggerId() {
+    return triggerId;
+  }
+
+  public void setTriggerId(int id) {
+    this.triggerId = id;
+  }
+
+  public boolean triggerConditionMet() {
+    return triggerCondition.isMet();
+  }
+
+  public boolean expireConditionMet() {
+    return expireCondition.isMet();
+  }
+
+  public void resetTriggerConditions() {
+    triggerCondition.resetCheckers();
+    updateNextCheckTime();
+  }
+
+  public void resetExpireCondition() {
+    expireCondition.resetCheckers();
+    updateNextCheckTime();
+  }
+
+  public List<TriggerAction> getTriggerActions() {
+    return actions;
+  }
+
+  public Map<String, Object> toJson() {
+    Map<String, Object> jsonObj = new HashMap<>();
+    jsonObj.put("triggerCondition", triggerCondition.toJson());
+    jsonObj.put("expireCondition", expireCondition.toJson());
+    List<Object> actionsJson = new ArrayList<>();
+    for (TriggerAction action : actions) {
+      Map<String, Object> oneActionJson = new HashMap<>();
+      oneActionJson.put("type", action.getType());
+      oneActionJson.put("actionJson", action.toJson());
+      actionsJson.add(oneActionJson);
+    }
+    jsonObj.put("actions", actionsJson);
+    List<Object> expireActionsJson = new ArrayList<>();
+    for (TriggerAction expireAction : expireActions) {
+      Map<String, Object> oneExpireActionJson = new HashMap<>();
+      oneExpireActionJson.put("type", expireAction.getType());
+      oneExpireActionJson.put("actionJson", expireAction.toJson());
+      expireActionsJson.add(oneExpireActionJson);
+    }
+    jsonObj.put("expireActions", expireActionsJson);
+
+    jsonObj.put("resetOnTrigger", String.valueOf(resetOnTrigger));
+    jsonObj.put("resetOnExpire", String.valueOf(resetOnExpire));
+    jsonObj.put("submitUser", submitUser);
+    jsonObj.put("source", source);
+    jsonObj.put("submitTime", String.valueOf(submitTime));
+    jsonObj.put("lastModifyTime", String.valueOf(lastModifyTime));
+    jsonObj.put("triggerId", String.valueOf(triggerId));
+    jsonObj.put("status", status.toString());
+    jsonObj.put("info", info);
+    jsonObj.put("context", context);
+    return jsonObj;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public String getDescription() {
+    StringBuffer actionsString = new StringBuffer();
+    for (TriggerAction act : actions) {
+      actionsString.append(", ");
+      actionsString.append(act.getDescription());
+    }
+    return "Trigger from " + getSource() + " with trigger condition of "
+        + triggerCondition.getExpression() + " and expire condition of "
+        + expireCondition.getExpression() + actionsString;
+  }
+
+  public void stopCheckers() {
+    for (ConditionChecker checker : triggerCondition.getCheckers().values()) {
+      checker.stopChecker();
+    }
+    for (ConditionChecker checker : expireCondition.getCheckers().values()) {
+      checker.stopChecker();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "Trigger Id: " + getTriggerId() + ", Description: " + getDescription();
+  }
 
   public static class TriggerBuilder {
-    private int triggerId = -1;
-    private long lastModifyTime;
-    private long submitTime;
     private final String submitUser;
     private final String source;
     private final TriggerStatus status = TriggerStatus.READY;
-
     private final Condition triggerCondition;
     private final List<TriggerAction> actions;
     private final Condition expireCondition;
+    private int triggerId = -1;
+    private long lastModifyTime;
+    private long submitTime;
     private List<TriggerAction> expireActions = new ArrayList<>();
 
-    private Map<String, Object> info = new HashMap<String, Object>();
-    private Map<String, Object> context = new HashMap<String, Object>();
+    private Map<String, Object> info = new HashMap<>();
+    private Map<String, Object> context = new HashMap<>();
 
     public TriggerBuilder(String submitUser,
                           String source,
@@ -198,249 +439,6 @@ public class Trigger {
                         info,
                         context);
     }
-  }
-
-  private Trigger(int triggerId, long lastModifyTime, long submitTime,
-      String submitUser, String source, Condition triggerCondition,
-      Condition expireCondition, List<TriggerAction> actions,
-      List<TriggerAction> expireActions, Map<String, Object> info,
-      Map<String, Object> context) {
-    requireNonNull(submitUser);
-    requireNonNull(source);
-    requireNonNull(triggerCondition);
-    requireNonNull(expireActions);
-    requireNonNull(info);
-    requireNonNull(context);
-
-    this.lastModifyTime = lastModifyTime;
-    this.submitTime = submitTime;
-    this.submitUser = submitUser;
-    this.source = source;
-    this.triggerCondition = triggerCondition;
-    this.expireCondition = expireCondition;
-    this.actions = actions;
-    this.triggerId = triggerId;
-    this.expireActions = expireActions;
-    this.info = info;
-    this.context = context;
-  }
-
-  public static synchronized void setActionTypeLoader(ActionTypeLoader loader) {
-    Trigger.actionTypeLoader = loader;
-  }
-
-  public static ActionTypeLoader getActionTypeLoader() {
-    return actionTypeLoader;
-  }
-
-  public boolean isResetOnTrigger() {
-    return resetOnTrigger;
-  }
-
-  public void setResetOnTrigger(boolean resetOnTrigger) {
-    this.resetOnTrigger = resetOnTrigger;
-  }
-
-  public boolean isResetOnExpire() {
-    return resetOnExpire;
-  }
-
-  public void setResetOnExpire(boolean resetOnExpire) {
-    this.resetOnExpire = resetOnExpire;
-  }
-
-  public long getLastModifyTime() {
-    return lastModifyTime;
-  }
-
-  public void setLastModifyTime(long lastModifyTime) {
-    this.lastModifyTime = lastModifyTime;
-  }
-
-  public void setTriggerId(int id) {
-    this.triggerId = id;
-  }
-
-  public int getTriggerId() {
-    return triggerId;
-  }
-
-  public boolean triggerConditionMet() {
-    return triggerCondition.isMet();
-  }
-
-  public boolean expireConditionMet() {
-    return expireCondition.isMet();
-  }
-
-  public void resetTriggerConditions() {
-    triggerCondition.resetCheckers();
-    updateNextCheckTime();
-  }
-
-  public void resetExpireCondition() {
-    expireCondition.resetCheckers();
-    updateNextCheckTime();
-  }
-
-  public List<TriggerAction> getTriggerActions() {
-    return actions;
-  }
-
-  public Map<String, Object> toJson() {
-    Map<String, Object> jsonObj = new HashMap<String, Object>();
-    jsonObj.put("triggerCondition", triggerCondition.toJson());
-    jsonObj.put("expireCondition", expireCondition.toJson());
-    List<Object> actionsJson = new ArrayList<Object>();
-    for (TriggerAction action : actions) {
-      Map<String, Object> oneActionJson = new HashMap<String, Object>();
-      oneActionJson.put("type", action.getType());
-      oneActionJson.put("actionJson", action.toJson());
-      actionsJson.add(oneActionJson);
-    }
-    jsonObj.put("actions", actionsJson);
-    List<Object> expireActionsJson = new ArrayList<Object>();
-    for (TriggerAction expireAction : expireActions) {
-      Map<String, Object> oneExpireActionJson = new HashMap<String, Object>();
-      oneExpireActionJson.put("type", expireAction.getType());
-      oneExpireActionJson.put("actionJson", expireAction.toJson());
-      expireActionsJson.add(oneExpireActionJson);
-    }
-    jsonObj.put("expireActions", expireActionsJson);
-
-    jsonObj.put("resetOnTrigger", String.valueOf(resetOnTrigger));
-    jsonObj.put("resetOnExpire", String.valueOf(resetOnExpire));
-    jsonObj.put("submitUser", submitUser);
-    jsonObj.put("source", source);
-    jsonObj.put("submitTime", String.valueOf(submitTime));
-    jsonObj.put("lastModifyTime", String.valueOf(lastModifyTime));
-    jsonObj.put("triggerId", String.valueOf(triggerId));
-    jsonObj.put("status", status.toString());
-    jsonObj.put("info", info);
-    jsonObj.put("context", context);
-    return jsonObj;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  @SuppressWarnings("unchecked")
-  public static Trigger fromJson(Object obj) throws Exception {
-
-    if (actionTypeLoader == null) {
-      throw new Exception("Trigger Action Type loader not initialized.");
-    }
-
-    Map<String, Object> jsonObj = (HashMap<String, Object>) obj;
-
-    Trigger trigger = null;
-    try {
-      logger.info("Decoding for " + JSONUtils.toJSON(obj));
-      Condition triggerCond =
-          Condition.fromJson(jsonObj.get("triggerCondition"));
-      Condition expireCond = Condition.fromJson(jsonObj.get("expireCondition"));
-      List<TriggerAction> actions = new ArrayList<TriggerAction>();
-      List<Object> actionsJson = (List<Object>) jsonObj.get("actions");
-      for (Object actObj : actionsJson) {
-        Map<String, Object> oneActionJson = (HashMap<String, Object>) actObj;
-        String type = (String) oneActionJson.get("type");
-        TriggerAction act =
-            actionTypeLoader.createActionFromJson(type,
-                oneActionJson.get("actionJson"));
-        actions.add(act);
-      }
-      List<TriggerAction> expireActions = new ArrayList<TriggerAction>();
-      List<Object> expireActionsJson =
-          (List<Object>) jsonObj.get("expireActions");
-      for (Object expireActObj : expireActionsJson) {
-        Map<String, Object> oneExpireActionJson =
-            (HashMap<String, Object>) expireActObj;
-        String type = (String) oneExpireActionJson.get("type");
-        TriggerAction expireAct =
-            actionTypeLoader.createActionFromJson(type,
-                oneExpireActionJson.get("actionJson"));
-        expireActions.add(expireAct);
-      }
-      boolean resetOnTrigger =
-          Boolean.valueOf((String) jsonObj.get("resetOnTrigger"));
-      boolean resetOnExpire =
-          Boolean.valueOf((String) jsonObj.get("resetOnExpire"));
-      String submitUser = (String) jsonObj.get("submitUser");
-      String source = (String) jsonObj.get("source");
-      long submitTime = Long.valueOf((String) jsonObj.get("submitTime"));
-      long lastModifyTime =
-          Long.valueOf((String) jsonObj.get("lastModifyTime"));
-      int triggerId = Integer.valueOf((String) jsonObj.get("triggerId"));
-      TriggerStatus status =
-          TriggerStatus.valueOf((String) jsonObj.get("status"));
-      Map<String, Object> info = (Map<String, Object>) jsonObj.get("info");
-      Map<String, Object> context =
-          (Map<String, Object>) jsonObj.get("context");
-      if (context == null) {
-        context = new HashMap<String, Object>();
-      }
-      for (ConditionChecker checker : triggerCond.getCheckers().values()) {
-        checker.setContext(context);
-      }
-      for (ConditionChecker checker : expireCond.getCheckers().values()) {
-        checker.setContext(context);
-      }
-      for (TriggerAction action : actions) {
-        action.setContext(context);
-      }
-      for (TriggerAction action : expireActions) {
-        action.setContext(context);
-      }
-
-      trigger = new Trigger.TriggerBuilder("azkaban",
-          source,
-          triggerCond,
-          expireCond,
-          actions)
-          .setId(triggerId)
-          .setLastModifyTime(lastModifyTime)
-          .setSubmitTime(submitTime)
-          .setExpireActions(expireActions)
-          .setInfo(info)
-          .setContext(context)
-          .build();
-
-      trigger.setResetOnExpire(resetOnExpire);
-      trigger.setResetOnTrigger(resetOnTrigger);
-      trigger.setStatus(status);
-    } catch (Exception e) {
-      e.printStackTrace();
-      logger.error("Failed to decode the trigger.", e);
-      throw new Exception("Failed to decode the trigger.", e);
-    }
-
-    return trigger;
-  }
-
-  public String getDescription() {
-    StringBuffer actionsString = new StringBuffer();
-    for (TriggerAction act : actions) {
-      actionsString.append(", ");
-      actionsString.append(act.getDescription());
-    }
-    return "Trigger from " + getSource() + " with trigger condition of "
-        + triggerCondition.getExpression() + " and expire condition of "
-        + expireCondition.getExpression() + actionsString;
-  }
-
-  public void stopCheckers() {
-    for (ConditionChecker checker : triggerCondition.getCheckers().values()) {
-      checker.stopChecker();
-    }
-    for (ConditionChecker checker : expireCondition.getCheckers().values()) {
-      checker.stopChecker();
-    }
-  }
-
-  @Override
-  public String toString() {
-    return "Trigger Id: " + getTriggerId() + ", Description: " + getDescription();
   }
 
 }


### PR DESCRIPTION
In this patch, I added two method `setTriggerCondition` and `setExpireCondition` to the Trigger Class. The reason behind is that one of our products relying on Azkaban library needs to modify Trigger object by inserting newly constructed ExpireCondition.

All other changes are made by Smart Intellij.