### PR TITLE
Prevent IDE auto formatting from messing up ascii art in javadoc

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -57,7 +57,7 @@ import org.junit.Test;
  *
  * Flow jobf looks like the following:
  *
- *
+ * <pre>
  *       joba       joba1
  *      /  |  \      |
  *     /   |   \     |
@@ -68,25 +68,30 @@ import org.junit.Test;
  *         |     /
  *         |    /
  *        jobf
+ * </pre>
  *
- *  The job 'jobb' is an embedded flow:
+ * The job 'jobb' is an embedded flow:
  *
- *  jobb:innerFlow
+ * jobb:innerFlow
  *
+ * <pre>
  *        innerJobA
  *        /       \
  *   innerJobB   innerJobC
  *        \       /
  *        innerFlow
  *
+ * </pre>
  *
- *  The job 'jobd' is a simple embedded flow:
+ * The job 'jobd' is a simple embedded flow:
  *
- *  jobd:innerFlow2
+ * jobd:innerFlow2
  *
+ * <pre>
  *       innerJobA
  *           |
  *       innerFlow2
+ * </pre>
  *
  * The following tests checks each stage of the flow run by forcing jobs to succeed or fail.
  */


### PR DESCRIPTION
Issue:

 The javadoc of the FlowRunnerTest2 class uses ascii art to describe
 the DAG. When intellij auto format runs, it renders the art
 incorrectly.

 Fix:

 Wrapped the parts affected in ```<pre> </pre>``` blocks.