### PR TITLE
Fix JobRunner bug when job is cancelled early

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -584,13 +584,9 @@ public class JobRunner extends EventHandler implements Runnable {
     // Start the node.
     this.node.setStartTime(System.currentTimeMillis());
     Status finalStatus = this.node.getStatus();
+    uploadExecutableNode();
     if (!errorFound && !isKilled()) {
       fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(this.node)));
-      try {
-        this.loader.uploadExecutableNode(this.node, this.props);
-      } catch (final ExecutorManagerException e1) {
-        this.logger.error("Error writing initial node properties");
-      }
 
       final Status prepareStatus = prepareJob();
       if (prepareStatus != null) {
@@ -624,6 +620,14 @@ public class JobRunner extends EventHandler implements Runnable {
     finalizeLogFile(attemptNo);
     finalizeAttachmentFile();
     writeStatus();
+  }
+
+  private void uploadExecutableNode() {
+    try {
+      this.loader.uploadExecutableNode(this.node, this.props);
+    } catch (final ExecutorManagerException e1) {
+      this.logger.error("Error writing initial node properties");
+    }
   }
 
   private Status prepareJob() throws RuntimeException {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -306,6 +306,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(logFile.exists());
 
+    Assert.assertEquals(2L, (long) loader.getNodeUpdateCount("testJob"));
     eventCollector.checkEventExists(Type.JOB_FINISHED);
   }
 


### PR DESCRIPTION
This bug was revealed by `JobRunnerTest#testDelayedExecutionCancelledJob`:

If job was cancelled early, there was no initial "upload" ([JobRunner.java#L590](https://github.com/azkaban/azkaban/blob/c55e88237ebc252eaedca6e2ea32e38cf853fca2/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java#L590)) for the `ExecutableNode`, just an eventual "update" ([JobRunner.java#L626](https://github.com/azkaban/azkaban/blob/c55e88237ebc252eaedca6e2ea32e38cf853fca2/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java#L626)).

This bug also kicks in when running against the DB, because there would be an `UPDATE` without a preceding `INSERT`. So nothing would be written into the DB, because the `WHERE` conditions of the `UPDATE` don't match any row.

Test console output **before** the fix:

```
Create temp dir
2017/06/04 01:14:28.643 +0300 INFO [main] [JobTypeManager] Loading plugin default job types
2017/06/04 01:14:28.736 +0300 INFO [JobRunner-testJob-1] [JobRunnerTest] Created file appender for job testJob
2017/06/04 01:14:28.736 +0300 INFO [JobRunner-testJob-1] [JobRunnerTest] Attached file appender for job testJob
2017/06/04 01:14:30.736 +0300 INFO [JobRunner-testJob-1] [JobRunnerTest] No attachment file for job testJob written.
2017/06/04 01:14:30.737 +0300 ERROR [JobRunner-testJob-1] [JobRunner] Unexpected exception
java.lang.NullPointerException
	at azkaban.executor.MockExecutorLoader.updateExecutableNode(MockExecutorLoader.java:121)
	at azkaban.execapp.JobRunner.writeStatus(JobRunner.java:395)
	at azkaban.execapp.JobRunner.doRun(JobRunner.java:626)
	at azkaban.execapp.JobRunner.run(JobRunner.java:558)
	at java.lang.Thread.run(Thread.java:745)
Exception in thread "JobRunner-testJob-1" java.lang.NullPointerException
	at azkaban.executor.MockExecutorLoader.updateExecutableNode(MockExecutorLoader.java:121)
	at azkaban.execapp.JobRunner.writeStatus(JobRunner.java:395)
	at azkaban.execapp.JobRunner.doRun(JobRunner.java:626)
	at azkaban.execapp.JobRunner.run(JobRunner.java:558)
	at java.lang.Thread.run(Thread.java:745)
Teardown temp dir
```