### PR TITLE
Simplify tests: EventCollectorListener & runner tests

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
@@ -63,7 +63,7 @@ public class EventCollectorListener implements EventListener {
     return true;
   }
 
-  public void checkEventExists(final Type... expected) {
+  public void assertEvents(final Type... expected) {
     Object[] captured = this.eventList.stream()
         .filter(event -> event.getRunner() != null)
         .map(event -> event.getType())

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
@@ -16,6 +16,9 @@
 
 package azkaban.execapp;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
 import azkaban.event.EventListener;
@@ -49,13 +52,6 @@ public class EventCollectorListener implements EventListener {
     return this.eventList;
   }
 
-  public void writeAllEvents() {
-    for (final Event event : this.eventList) {
-      System.out.print(event.getType());
-      System.out.print(",");
-    }
-  }
-
   public boolean checkOrdering() {
     final long time = 0;
     for (final Event event : this.eventList) {
@@ -67,27 +63,11 @@ public class EventCollectorListener implements EventListener {
     return true;
   }
 
-  public void checkEventExists(final Type[] types) {
-    int index = 0;
-    for (final Event event : this.eventList) {
-      if (event.getRunner() == null) {
-        continue;
-      }
-
-      if (index >= types.length) {
-        throw new RuntimeException("More events than expected. Got "
-            + event.getType());
-      }
-      final Type type = types[index++];
-
-      if (type != event.getType()) {
-        throw new RuntimeException("Got " + event.getType() + ", expected "
-            + type + " index:" + index);
-      }
-    }
-
-    if (types.length != index) {
-      throw new RuntimeException("Not enough events.");
-    }
+  public void checkEventExists(final Type... expected) {
+    Object[] captured = this.eventList.stream()
+        .filter(event -> event.getRunner() != null)
+        .map(event -> event.getType())
+        .toArray();
+    assertThat(captured, is(expected));
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -117,14 +117,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SUCCEEDED);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
@@ -163,14 +156,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SKIPPED);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
@@ -200,14 +186,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
@@ -238,14 +217,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job9", Status.CANCELLED);
     assertStatus("job10", Status.CANCELLED);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-      eventCollector.writeAllEvents();
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
@@ -275,14 +247,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-      eventCollector.writeAllEvents();
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
@@ -312,14 +277,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
 
     assertFlowStatus(Status.KILLED);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.FLOW_STARTED,
-          Type.FLOW_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-      eventCollector.writeAllEvents();
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -95,10 +95,10 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
 
   @Test
   public void exec1Normal() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
+    this.runner = createFlowRunner(this.loader, this.eventCollector, "exec1");
 
     startThread(this.runner);
     succeedJobs("job3", "job4", "job6");
@@ -117,13 +117,13 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SUCCEEDED);
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void exec1Disabled() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
     final ExecutableFlow exFlow = prepareExecDir(TEST_DIR, "exec1", 1);
 
@@ -133,7 +133,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     exFlow.getExecutableNode("job5").setStatus(Status.DISABLED);
     exFlow.getExecutableNode("job10").setStatus(Status.DISABLED);
 
-    this.runner = createFlowRunner(exFlow, this.loader, eventCollector);
+    this.runner = createFlowRunner(exFlow, this.loader, this.eventCollector);
 
     Assert.assertTrue(!this.runner.isKilled());
     assertFlowStatus(Status.READY);
@@ -156,17 +156,17 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SKIPPED);
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void exec1Failed() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
     final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec2", 1);
 
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, this.eventCollector);
 
     startThread(this.runner);
     succeedJobs("job6");
@@ -186,18 +186,18 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void exec1FailedKillAll() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
     final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec2", 1);
     flow.getExecutionOptions().setFailureAction(FailureAction.CANCEL_ALL);
 
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, this.eventCollector);
 
     startThread(this.runner);
     assertThreadShutDown();
@@ -217,18 +217,18 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job9", Status.CANCELLED);
     assertStatus("job10", Status.CANCELLED);
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void exec1FailedFinishRest() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
     final ExecutableFlow flow = prepareExecDir(TEST_DIR, "exec3", 1);
     flow.getExecutionOptions().setFailureAction(
         FailureAction.FINISH_ALL_POSSIBLE);
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    this.runner = createFlowRunner(flow, this.loader, this.eventCollector);
 
     startThread(this.runner);
     succeedJobs("job3");
@@ -247,15 +247,15 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void execAndCancel() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
+    this.runner = createFlowRunner(this.loader, this.eventCollector, "exec1");
 
     startThread(this.runner);
 
@@ -277,15 +277,15 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
 
     assertFlowStatus(Status.KILLED);
 
-    eventCollector.checkEventExists(Type.FLOW_STARTED, Type.FLOW_FINISHED);
+    assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
 
   @Test
   public void execRetries() throws Exception {
-    final EventCollectorListener eventCollector = new EventCollectorListener();
-    eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
+    this.eventCollector = new EventCollectorListener();
+    this.eventCollector.setEventFilterOut(Event.Type.JOB_FINISHED,
         Event.Type.JOB_STARTED, Event.Type.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec4-retry");
+    this.runner = createFlowRunner(this.loader, this.eventCollector, "exec4-retry");
 
     startThread(this.runner);
     assertThreadShutDown();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import azkaban.event.Event;
+import azkaban.event.Event.Type;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
@@ -168,6 +169,10 @@ public class FlowRunnerTestBase {
     for (final String name : jobs) {
       InteractiveTestJob.getTestJob(name).succeedJob();
     }
+  }
+
+  protected void assertEvents(final Type... types) {
+    eventCollector.assertEvents(types);
   }
 
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -102,13 +102,7 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
-    Assert.assertTrue(eventCollector.checkOrdering());
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Ignore
@@ -137,12 +131,7 @@ public class JobRunnerTest {
     Assert.assertTrue(!runner.isKilled());
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Test
@@ -173,12 +162,7 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == null);
 
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_FINISHED);
   }
 
   @Test
@@ -209,12 +193,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(runner.getLogFilePath() == null);
     Assert.assertTrue(!runner.isKilled());
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_FINISHED);
   }
 
   @Ignore
@@ -253,14 +232,7 @@ public class JobRunnerTest {
     Assert.assertTrue(logFile.exists());
     Assert.assertTrue(eventCollector.checkOrdering());
     Assert.assertTrue(runner.isKilled());
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      System.out.println(e.getMessage());
-
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Ignore
@@ -295,12 +267,7 @@ public class JobRunnerTest {
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
     Assert.assertTrue(eventCollector.checkOrdering());
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_STARTED,
-          Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Test
@@ -339,12 +306,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(logFile.exists());
 
-    Assert.assertTrue(eventCollector.checkOrdering());
-    try {
-      eventCollector.checkEventExists(new Type[]{Type.JOB_FINISHED});
-    } catch (final Exception e) {
-      Assert.fail(e.getMessage());
-    }
+    eventCollector.checkEventExists(Type.JOB_FINISHED);
   }
 
   private Props createProps(final int sleepSec, final boolean fail) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -45,6 +45,7 @@ public class JobRunnerTest {
   private final Logger logger = Logger.getLogger("JobRunnerTest");
   private File workingDir;
   private JobTypeManager jobtypeManager;
+  private EventCollectorListener eventCollector;
 
   public JobRunnerTest() {
 
@@ -77,7 +78,7 @@ public class JobRunnerTest {
   @Test
   public void testBasicRun() {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     final ExecutableNode node = runner.getNode();
@@ -102,14 +103,14 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Ignore
   @Test
   public void testFailedRun() {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, true, loader, eventCollector);
     final ExecutableNode node = runner.getNode();
@@ -131,13 +132,13 @@ public class JobRunnerTest {
     Assert.assertTrue(!runner.isKilled());
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Test
   public void testDisabledRun() {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     final ExecutableNode node = runner.getNode();
@@ -162,13 +163,13 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == null);
 
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_FINISHED);
   }
 
   @Test
   public void testPreKilledRun() {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     final ExecutableNode node = runner.getNode();
@@ -193,7 +194,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(runner.getLogFilePath() == null);
     Assert.assertTrue(!runner.isKilled());
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_FINISHED);
   }
 
   @Ignore
@@ -202,7 +203,7 @@ public class JobRunnerTest {
   // The change history doesn't mention why this test was ignored.
   public void testCancelRun() throws InterruptedException {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(13, "testJob", 10, false, loader, eventCollector);
     final ExecutableNode node = runner.getNode();
@@ -232,14 +233,14 @@ public class JobRunnerTest {
     Assert.assertTrue(logFile.exists());
     Assert.assertTrue(eventCollector.checkOrdering());
     Assert.assertTrue(runner.isKilled());
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Ignore
   @Test
   public void testDelayedExecutionJob() {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     runner.setDelayStart(5000);
@@ -267,13 +268,13 @@ public class JobRunnerTest {
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
     Assert.assertTrue(eventCollector.checkOrdering());
-    eventCollector.checkEventExists(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
+    assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
   @Test
   public void testDelayedExecutionCancelledJob() throws InterruptedException {
     final MockExecutorLoader loader = new MockExecutorLoader();
-    final EventCollectorListener eventCollector = new EventCollectorListener();
+    eventCollector = new EventCollectorListener();
     final JobRunner runner =
         createJobRunner(1, "testJob", 1, false, loader, eventCollector);
     runner.setDelayStart(5000);
@@ -306,7 +307,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(logFile.exists());
 
-    eventCollector.checkEventExists(Type.JOB_FINISHED);
+    assertEvents(Type.JOB_FINISHED);
   }
 
   private Props createProps(final int sleepSec, final boolean fail) {
@@ -345,6 +346,10 @@ public class JobRunnerTest {
 
     runner.addListener(listener);
     return runner;
+  }
+
+  private void assertEvents(final Type... types) {
+    eventCollector.assertEvents(types);
   }
 
 }


### PR DESCRIPTION
1st commit: "Simplify tests: usage of `EventCollectorListener#checkEventExists`".

- Using hamcrest matcher `is` to compare arrays, because it gives an informative error message, like:

```
java.lang.AssertionError:
Expected: is [<FLOW_STARTED>, <FLOW_FINISHED>]
     but: was [<FLOW_STARTED>]
```

- `EventCollectorListener #writeAllEvents` deleted because not used anywhere.

----

2nd commit "Test cleanup: better naming, more readable" is kind of optional, but I think it makes this even better.

----

3rd commit: "Test cleanup: simplify, remove duplicate code" (I was a bit lazy when creating the `FlowRunnerTestBase`).