### PR TITLE
Consolidate the duplicate code into one prepareProject method

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
@@ -33,7 +33,6 @@ import azkaban.jobtype.JobTypePluginSet;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
-import azkaban.project.ProjectManagerException;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.IOException;
@@ -101,7 +100,8 @@ public class FlowRunnerPipelineTest {
     this.project = new Project(1, "testProject");
 
     final File dir = new File("unit/executions/embedded2");
-    prepareProject(this.project, dir);
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(this.project, dir, this.logger, this.workingDir);
 
     InteractiveTestJob.clearTestJobs();
   }
@@ -645,12 +645,6 @@ public class FlowRunnerPipelineTest {
             + node.getStatus());
       }
     }
-  }
-
-  private void prepareProject(final Project project, final File sourceDir)
-      throws ProjectManagerException, IOException {
-    this.flowMap = FlowRunnerTestUtil
-        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   // private void printCurrentState(String prefix, ExecutableFlowBase flow) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 LinkedIn Corp.
+ * Copyright 2017 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
@@ -30,7 +30,6 @@ import azkaban.executor.Status;
 import azkaban.flow.Flow;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
-import azkaban.project.DirectoryFlowLoader;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
@@ -648,22 +647,10 @@ public class FlowRunnerPipelineTest {
     }
   }
 
-  private void prepareProject(final Project project, final File directory)
-      throws ProjectManagerException,
-      IOException {
-    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), this.logger);
-    loader.loadProjectFlow(project, directory);
-    if (!loader.getErrors().isEmpty()) {
-      for (final String error : loader.getErrors()) {
-        System.out.println(error);
-      }
-
-      throw new RuntimeException("Errors found in setup");
-    }
-
-    this.flowMap = loader.getFlowMap();
-    project.setFlows(this.flowMap);
-    FileUtils.copyDirectory(directory, this.workingDir);
+  private void prepareProject(final Project project, final File sourceDir)
+      throws ProjectManagerException, IOException {
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   // private void printCurrentState(String prefix, ExecutableFlowBase flow) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -25,7 +25,6 @@ import azkaban.executor.JavaJob;
 import azkaban.executor.MockExecutorLoader;
 import azkaban.flow.Flow;
 import azkaban.jobtype.JobTypeManager;
-import azkaban.project.DirectoryFlowLoader;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
@@ -204,22 +203,10 @@ public class FlowRunnerPropertyResolutionTest {
     Assert.assertEquals("moo4", job3Props.get("props4"));
   }
 
-  private void prepareProject(final Project project, final File directory)
-      throws ProjectManagerException,
-      IOException {
-    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), this.logger);
-    loader.loadProjectFlow(project, directory);
-    if (!loader.getErrors().isEmpty()) {
-      for (final String error : loader.getErrors()) {
-        System.out.println(error);
-      }
-
-      throw new RuntimeException("Errors found in setup");
-    }
-
-    this.flowMap = loader.getFlowMap();
-    project.setFlows(this.flowMap);
-    FileUtils.copyDirectory(directory, this.workingDir);
+  private void prepareProject(final Project project, final File sourceDir)
+      throws ProjectManagerException, IOException {
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   private FlowRunner createFlowRunner(final String flowName,

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 LinkedIn Corp.
+ * Copyright 2017 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -28,7 +28,6 @@ import azkaban.jobtype.JobTypeManager;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
-import azkaban.project.ProjectManagerException;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.IOException;
@@ -92,7 +91,8 @@ public class FlowRunnerPropertyResolutionTest {
     this.project = new Project(1, "testProject");
 
     final File dir = new File("unit/executions/execpropstest");
-    prepareProject(this.project, dir);
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(this.project, dir, this.logger, this.workingDir);
 
     InteractiveTestJob.clearTestJobs();
   }
@@ -201,12 +201,6 @@ public class FlowRunnerPropertyResolutionTest {
     Assert.assertEquals("shared1", job3Props.get("props1"));
     Assert.assertEquals("shared2", job3Props.get("props2"));
     Assert.assertEquals("moo4", job3Props.get("props4"));
-  }
-
-  private void prepareProject(final Project project, final File sourceDir)
-      throws ProjectManagerException, IOException {
-    this.flowMap = FlowRunnerTestUtil
-        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   private FlowRunner createFlowRunner(final String flowName,

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 LinkedIn Corp.
+ * Copyright 2017 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -35,7 +35,6 @@ import azkaban.jobtype.JobTypePluginSet;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
-import azkaban.project.ProjectManagerException;
 import azkaban.test.Utils;
 import azkaban.utils.Props;
 import java.io.File;
@@ -128,7 +127,8 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     Utils.initServiceProvider();
     JmxJobMBeanManager.getInstance().initialize(new Props());
 
-    prepareProject(this.project, TEST_DIR);
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(this.project, TEST_DIR, this.logger, this.workingDir);
 
     InteractiveTestJob.clearTestJobs();
   }
@@ -1083,12 +1083,6 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
   private void runFlowRunnerInThread(final FlowRunner runner) {
     final Thread thread = new Thread(runner);
     thread.start();
-  }
-
-  private void prepareProject(final Project project, final File sourceDir)
-      throws ProjectManagerException, IOException {
-    this.flowMap = FlowRunnerTestUtil
-        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   private FlowRunner createFlowRunner(final EventCollectorListener eventCollector)

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -32,7 +32,6 @@ import azkaban.flow.Flow;
 import azkaban.jobExecutor.AllJobExecutorTests;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
-import azkaban.project.DirectoryFlowLoader;
 import azkaban.project.MockProjectLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
@@ -1086,20 +1085,10 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     thread.start();
   }
 
-  private void prepareProject(final Project project, final File directory)
+  private void prepareProject(final Project project, final File sourceDir)
       throws ProjectManagerException, IOException {
-    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), this.logger);
-    loader.loadProjectFlow(project, directory);
-    if (!loader.getErrors().isEmpty()) {
-      for (final String error : loader.getErrors()) {
-        System.out.println(error);
-      }
-      throw new RuntimeException("Errors found in setup");
-    }
-
-    this.flowMap = loader.getFlowMap();
-    project.setFlows(this.flowMap);
-    FileUtils.copyDirectory(directory, this.workingDir);
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(project, sourceDir, this.logger, this.workingDir);
   }
 
   private FlowRunner createFlowRunner(final EventCollectorListener eventCollector)

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -1,0 +1,49 @@
+package azkaban.execapp;
+
+import azkaban.flow.Flow;
+import azkaban.project.DirectoryFlowLoader;
+import azkaban.project.Project;
+import azkaban.project.ProjectManagerException;
+import azkaban.utils.Props;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+class FlowRunnerTestUtil {
+
+  /**
+   * Initialize the project with the flow definitions stored in the given source directory.
+   * Also copy the source directory to the working directory.
+   *
+   * @param project project to initialize
+   * @param sourceDir the source dir
+   * @param logger the logger
+   * @param workingDir the working dir
+   * @return the flow name to flow map
+   * @throws ProjectManagerException the project manager exception
+   * @throws IOException the io exception
+   */
+  static Map<String, Flow> prepareProject(final Project project, final File sourceDir,
+      final Logger logger, final File workingDir)
+      throws ProjectManagerException, IOException {
+    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), logger);
+    loader.loadProjectFlow(project, sourceDir);
+    if (!loader.getErrors().isEmpty()) {
+      for (final String error : loader.getErrors()) {
+        System.out.println(error);
+      }
+      throw new RuntimeException(String.format(
+          "Errors found in loading flows into a project ( %s ). From the directory: ( %s ).",
+          project.getName(), sourceDir));
+    }
+
+    final Map<String, Flow> flowMap = loader.getFlowMap();
+    project.setFlows(flowMap);
+    FileUtils.copyDirectory(sourceDir, workingDir);
+
+    return flowMap;
+  }
+
+}

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.execapp;
 
 import azkaban.flow.Flow;


### PR DESCRIPTION
Issue:

Three test classes in execapp have the same duplicate prepareProject
logic.

Fix:

Consolidated into one method in a shared test utility class.

Testing:
This change only affects the test code.
All tests passed.

With this change, the FlowRunnerTest2 has no intellij warnings left
except warnings about typos.