### PR TITLE
Test cleanup: simplify prepareProject usage

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
@@ -99,7 +99,7 @@ public class FlowRunnerPipelineTest {
     this.fakeExecutorLoader = new MockExecutorLoader();
     this.project = new Project(1, "testProject");
 
-    final File dir = new File("unit/executions/embedded2");
+    final String dir = "unit/executions/embedded2";
     this.flowMap = FlowRunnerTestUtil
         .prepareProject(this.project, dir, this.logger, this.workingDir);
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -90,7 +90,7 @@ public class FlowRunnerPropertyResolutionTest {
     this.fakeExecutorLoader = new MockExecutorLoader();
     this.project = new Project(1, "testProject");
 
-    final File dir = new File("unit/executions/execpropstest");
+    final String dir = "unit/executions/execpropstest";
     this.flowMap = FlowRunnerTestUtil
         .prepareProject(this.project, dir, this.logger, this.workingDir);
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -95,8 +95,6 @@ import org.junit.Test;
  */
 public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
-  private static final File TEST_DIR = new File(
-      "../azkaban-test/src/test/resources/azkaban/test/executions/embedded2");
   private static int id = 101;
   private final Logger logger = Logger.getLogger(FlowRunnerTest2.class);
   private File workingDir;
@@ -127,8 +125,9 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     Utils.initServiceProvider();
     JmxJobMBeanManager.getInstance().initialize(new Props());
 
+    final String dir = "../azkaban-test/src/test/resources/azkaban/test/executions/embedded2";
     this.flowMap = FlowRunnerTestUtil
-        .prepareProject(this.project, TEST_DIR, this.logger, this.workingDir);
+        .prepareProject(this.project, dir, this.logger, this.workingDir);
 
     InteractiveTestJob.clearTestJobs();
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -41,11 +41,12 @@ class FlowRunnerTestUtil {
    * @throws ProjectManagerException the project manager exception
    * @throws IOException the io exception
    */
-  static Map<String, Flow> prepareProject(final Project project, final File sourceDir,
+  static Map<String, Flow> prepareProject(final Project project, final String sourceDir,
       final Logger logger, final File workingDir)
       throws ProjectManagerException, IOException {
+    File sourceDirFile = new File(sourceDir);
     final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props(), logger);
-    loader.loadProjectFlow(project, sourceDir);
+    loader.loadProjectFlow(project, sourceDirFile);
     if (!loader.getErrors().isEmpty()) {
       for (final String error : loader.getErrors()) {
         System.out.println(error);
@@ -57,7 +58,7 @@ class FlowRunnerTestUtil {
 
     final Map<String, Flow> flowMap = loader.getFlowMap();
     project.setFlows(flowMap);
-    FileUtils.copyDirectory(sourceDir, workingDir);
+    FileUtils.copyDirectory(sourceDirFile, workingDir);
 
     return flowMap;
   }


### PR DESCRIPTION
Now takes String instead of File.

Discussed at https://github.com/azkaban/azkaban/pull/1151#discussion_r120014278.