### PR TITLE
Test stability: FlowRunnerTest2

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -389,62 +389,6 @@ public class ExecutableFlowBase extends ExecutableNode {
     }
   }
 
-  /**
-   * Only returns true if the status of all finished nodes is true.
-   */
-  public boolean isFlowFinished() {
-    for (final String end : getEndNodes()) {
-      final ExecutableNode node = getExecutableNode(end);
-      if (!Status.isStatusFinished(node.getStatus())) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Finds all jobs which are ready to run. This occurs when all of its
-   * dependency nodes are finished running.
-   *
-   * It will also return any subflow that has been completed such that the
-   * FlowRunner can properly handle them.
-   */
-  public List<ExecutableNode> findNextJobsToRun() {
-    final ArrayList<ExecutableNode> jobsToRun = new ArrayList<>();
-
-    if (isFlowFinished() && !Status.isStatusFinished(getStatus())) {
-      jobsToRun.add(this);
-    } else {
-      nodeloop:
-      for (final ExecutableNode node : this.executableNodes.values()) {
-        if (Status.isStatusFinished(node.getStatus())) {
-          continue;
-        }
-
-        if ((node instanceof ExecutableFlowBase)
-            && Status.isStatusRunning(node.getStatus())) {
-          // If the flow is still running, we traverse into the flow
-          jobsToRun.addAll(((ExecutableFlowBase) node).findNextJobsToRun());
-        } else if (Status.isStatusRunning(node.getStatus())) {
-          continue;
-        } else {
-          for (final String dependency : node.getInNodes()) {
-            // We find that the outer-loop is unfinished.
-            if (!Status.isStatusFinished(getExecutableNode(dependency)
-                .getStatus())) {
-              continue nodeloop;
-            }
-          }
-
-          jobsToRun.add(node);
-        }
-      }
-    }
-
-    return jobsToRun;
-  }
-
   public String getFlowPath() {
     if (this.getParentFlow() == null) {
       return this.getFlowId();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -49,7 +49,7 @@ public class ExecutableNode {
   public static final String PASTATTEMPTS_PARAM = "pastAttempts";
   private String id;
   private String type = null;
-  private Status status = Status.READY;
+  private volatile Status status = Status.READY;
   private long startTime = -1;
   private long endTime = -1;
   private long updateTime = -1;

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -29,12 +29,14 @@ public class FlowRunnerTestBase {
 
   public void assertThreadShutDown() {
     waitFlowRunner(
-        runner -> runner.getExecutableFlow().isFlowFinished() && !runner.isRunnerThreadAlive());
+        runner -> Status.isStatusFinished(runner.getExecutableFlow().getStatus())
+        && !runner.isRunnerThreadAlive());
   }
 
   public void assertThreadRunning() {
     waitFlowRunner(
-        runner -> !runner.getExecutableFlow().isFlowFinished() && runner.isRunnerThreadAlive());
+        runner -> Status.isStatusRunning(runner.getExecutableFlow().getStatus())
+        && runner.isRunnerThreadAlive());
   }
 
   public void waitFlowRunner(final Function<FlowRunner, Boolean> statusCheck) {


### PR DESCRIPTION
**Let's have https://github.com/azkaban/azkaban/pull/1159 before this, ok?**

Calling `ExecutableFlowBase#isFlowFinished` from the test thread wasn't a good idea.

In rare cases it failed with this exception (see https://github.com/azkaban/azkaban/pull/1157#issuecomment-306055490):

```
azkaban.execapp.FlowRunnerTest2 > testCancel FAILED
java.lang.NullPointerException
at azkaban.executor.ExecutableFlowBase.isFlowFinished(ExecutableFlowBase.java:398)
at azkaban.execapp.FlowRunnerTestBase.lambda$assertThreadShutDown$0(FlowRunnerTestBase.java:32)
at azkaban.execapp.FlowRunnerTestBase$$Lambda$9/1157486615.apply(Unknown Source)
at azkaban.execapp.FlowRunnerTestBase.waitFlowRunner(FlowRunnerTestBase.java:42)
at azkaban.execapp.FlowRunnerTestBase.assertThreadShutDown(FlowRunnerTestBase.java:31)
at azkaban.execapp.FlowRunnerTest2.testCancel(FlowRunnerTest2.java:729)
```

Extract from `ExecutableFlowBase` (this method is actually deleted in this PR):

```java
  /**
   * Only returns true if the status of all finished nodes is true.
   */
  public boolean isFlowFinished() {
    for (final String end : getEndNodes()) {
      final ExecutableNode node = getExecutableNode(end);
      // THIS IS WHERE THE NPE HAPPENED, so node was null
      if (!Status.isStatusFinished(node.getStatus())) {
        return false;
      }
    }

    return true;
  }
```

It must be that the NPE happened because this method was being called from the test main thread, and there is no synchronization on the "end nodes". So it was somehow possible that the test got a name for an end node but then couldn't get the ExecutableNode to match it.

I used `isFlowFinished()` (it existed previously, I didn't add it) in the test because it seemed like a handy way to check that, but seems that it didn't work reliably. And now I realized that this method is not being used at all otherwise, so it can be just removed.

Now checking flow completion in a thread-safe way.

Also delete unused methods in `ExecutableFlowBase`:
- `isFlowFinished`
- `findNextJobsToRun`

**Make `ExecutableNode.status` volatile**
- This gives guarantees especially for unit tests that need to check for statuses in a multi-threaded environment.
- But also `FlowRunner` thread vs. `JobRunner` threads benefit from this, although I haven't been able to prove that there would be any critical issues there.