### PR TITLE
Make ExecutableNode.status volatile

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -49,7 +49,7 @@ public class ExecutableNode {
   public static final String PASTATTEMPTS_PARAM = "pastAttempts";
   private String id;
   private String type = null;
-  private Status status = Status.READY;
+  private volatile Status status = Status.READY;
   private long startTime = -1;
   private long endTime = -1;
   private long updateTime = -1;


### PR DESCRIPTION
For background, see also: https://github.com/azkaban/azkaban/pull/1120.

This gives guarantees especially for unit tests that need to check for statuses in a multi-threaded environment. But also `FlowRunner` thread vs. `JobRunner` threads benefit from this, although I haven't been able to prove that there would be any critical issues there.

The volatile modifier may not be absolutely needed between the updates made by `FlowRunner` thread and `JobRunner` threads, because most of the time it's fine if there is some delay. `FlowRunner` can check again later and eventually see the updates by the `JobRunner`s. But I wouldn't be surprised if there are also real race conditions where flow gets stuck or flow gets eventually saved with some incorrect job statuses. So all in all, it's good to make that status field volatile also for the production code, not only tests.

After this change I didn't get a single error when I ran FlowRunnerTest and FlowRunnerTest2 locally 1000 times in a row (without any ignores. There was also this stability fix in place when running them: https://github.com/azkaban/azkaban/pull/1158).