### PR TITLE
Switch from MavenCentral to JCenter maven repository

### DIFF
--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    mavenCentral()
+    jcenter()
     maven {
       url 'https://plugins.gradle.org/m2/'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'idea'
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
         mavenLocal()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
         maven {
             url 'https://plugins.gradle.org/m2/'
         }


### PR DESCRIPTION
This is to speed up the build process.

Fix #1061
ref:
https://www.jfrog.com/knowledge-base/why-should-i-use-jcenter-over-maven-central/

http://kevinpelgrims.com/blog/2015/06/11/speeding-up-your-gradle-builds/