### PR TITLE
Test stability: FlowRunnerTest2

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import static azkaban.flow.CommonJobProperties.JOB_ATTEMPT;
+import static org.junit.Assert.assertNotNull;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.AbstractProcessJob;
@@ -140,5 +141,11 @@ public class InteractiveTestJob extends AbstractProcessJob {
   public void cancel() throws InterruptedException {
     info("Killing job");
     failJob();
+  }
+
+  public static void clearTestJobs(final String... names) {
+    for (String name : names) {
+      assertNotNull(testJobs.remove(name));
+    }
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -45,7 +45,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -549,8 +548,6 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
    * Any jobs that are running will be assigned a KILLED state, and any nodes which were skipped due
    * to prior errors will be given a CANCELLED state.
    */
-  //todo HappyRay: fix the flaky test issue #1155
-  @Ignore
   @Test
   public void testCancelOnFailure() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
@@ -600,8 +597,6 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
   /**
    * Tests retries after a failure
    */
-  //todo HappyRay: fix the flaky test issue #1155
-  @Ignore
   @Test
   public void testRetryOnFailure() throws Exception {
     // Test propagation of KILLED status to embedded flows different branch
@@ -648,6 +643,8 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
       System.out.println(inNode.getId() + " > " + inNode.getStatus());
     }
 
+    assertStatus("jobb:innerFlow", Status.SKIPPED);
+    InteractiveTestJob.clearTestJobs("jobb:innerJobB", "jobb:innerJobC");
     this.runner.retryFailures("me");
     assertStatus("jobb:innerJobB", Status.RUNNING);
     assertStatus("jobb:innerJobC", Status.RUNNING);
@@ -984,8 +981,6 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
    * Test the condition when a Finish all possible is called during a pause. The Failure is not
    * acted upon until the flow is resumed.
    */
-  //todo HappyRay: fix the flaky test issue #1155
-  @Ignore
   @Test
   public void testPauseFailFinishAll() throws Exception {
     final EventCollectorListener eventCollector = new EventCollectorListener();


### PR DESCRIPTION
See also https://github.com/azkaban/azkaban/pull/1160.

Clear previous test jobs so that `.succeedJob()` is called on the retried job instance.
So now we can remove all `@Ignore`s.

----

How does this help?

When a job run is started, the created job type instance gets added into `InteractiveTestJob`'s map. If a job is retried, another instance is created, but for `InteractiveTestJob` the key=jobname is the same.

My commit message says:
> Clear previous test jobs so that .succeedJob() is called on the retried job instance.

So occasionally it happened that `InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob` was targeted at the original failed instance. After that the retry attempt instance was added into `InteractiveTestJob`'s map, but `succeedJob` was never called on it, so it was left in `RUNNING` state.