### PR TITLE
JobRunner uploadExecutableNode improvement

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -625,8 +625,8 @@ public class JobRunner extends EventHandler implements Runnable {
   private void uploadExecutableNode() {
     try {
       this.loader.uploadExecutableNode(this.node, this.props);
-    } catch (final ExecutorManagerException e1) {
-      this.logger.error("Error writing initial node properties");
+    } catch (final ExecutorManagerException e) {
+      this.logger.error("Error writing initial node properties", e);
     }
   }
 


### PR DESCRIPTION
I would suggest having https://github.com/azkaban/azkaban/pull/1167 instead of this, but this is of course a smaller change..

Include stack trace in error logging.

Based on this discussion / request by @chengren311: https://github.com/azkaban/azkaban/pull/1148#pullrequestreview-41936280