### PR TITLE
JobRunner uploadExecutableNode improvement

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -584,8 +584,9 @@ public class JobRunner extends EventHandler implements Runnable {
     // Start the node.
     this.node.setStartTime(System.currentTimeMillis());
     Status finalStatus = this.node.getStatus();
-    uploadExecutableNode();
-    if (!errorFound && !isKilled()) {
+    if (!uploadExecutableNode()) {
+      finalStatus = changeStatus(Status.FAILED);
+    } else if (!errorFound && !isKilled()) {
       fireEvent(Event.create(this, Type.JOB_STARTED, new EventData(this.node)));
 
       final Status prepareStatus = prepareJob();
@@ -622,11 +623,13 @@ public class JobRunner extends EventHandler implements Runnable {
     writeStatus();
   }
 
-  private void uploadExecutableNode() {
+  private boolean uploadExecutableNode() {
     try {
       this.loader.uploadExecutableNode(this.node, this.props);
-    } catch (final ExecutorManagerException e1) {
-      this.logger.error("Error writing initial node properties");
+      return true;
+    } catch (final ExecutorManagerException e) {
+      this.logger.error("Error writing initial node properties", e);
+      return false;
     }
   }
 


### PR DESCRIPTION
If initial upload fails:
- Don't run the Job instance, just report failed status
- At the end, try to update the node in DB any way (as FAILED), because _maybe_ it was created regardless of the caught exception
- Include stack trace in error logging

Based on this discussion / request by @chengren311 & @HappyRay: https://github.com/azkaban/azkaban/pull/1148#pullrequestreview-41936280