### PR TITLE
fix Triggermanager Guice bug

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -16,6 +16,8 @@
 
 package azkaban.trigger;
 
+import static java.util.Objects.requireNonNull;
+
 import azkaban.event.Event;
 import azkaban.event.Event.Type;
 import azkaban.event.EventHandler;
@@ -58,7 +60,9 @@ public class TriggerManager extends EventHandler implements
   public TriggerManager(Props props, TriggerLoader triggerLoader,
       ExecutorManager executorManager) throws TriggerManagerException {
 
-    this.triggerLoader = triggerLoader;
+    requireNonNull(props);
+    requireNonNull(executorManager);
+    this.triggerLoader = requireNonNull(triggerLoader);
 
     long scannerInterval =
         props.getLong("trigger.scan.interval", DEFAULT_SCANNER_INTERVAL_MS);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -194,8 +194,8 @@ public class AzkabanWebServer extends AzkabanServer {
     // TODO remove hack. Move injection to constructor
     executorManager = SERVICE_PROVIDER.getInstance(ExecutorManager.class);
     projectManager = SERVICE_PROVIDER.getInstance(ProjectManager.class);
+    triggerManager = SERVICE_PROVIDER.getInstance(TriggerManager.class);
 
-    triggerManager = loadTriggerManager(props);
     loadBuiltinCheckersAndActions();
 
     // load all trigger agents here
@@ -276,12 +276,6 @@ public class AzkabanWebServer extends AzkabanServer {
     ScheduleLoader loader =
         new TriggerBasedScheduleLoader(tm, ScheduleManager.triggerSource);
     return new ScheduleManager(loader);
-  }
-
-  private TriggerManager loadTriggerManager(Props props)
-      throws TriggerManagerException {
-    TriggerLoader loader = new JdbcTriggerLoader(props);
-    return new TriggerManager(props, loader, executorManager);
   }
 
   private void loadBuiltinCheckersAndActions() {


### PR DESCRIPTION
I intended to guicify `TriggerManager` as part of last [PR](https://github.com/azkaban/azkaban/pull/1110/files#diff-f916ab7306f59ff720753937cf9a9ff1L62). I just realized that it was an incomplete Guice (mistake) without changes in AzkabanWebServer code. As a result, this PR made the fix and completely guicify `TriggerManager`.

Unless this PR gets merged, we will keep using outdated `JDBCTriggerLoader` code.

