### PR TITLE
New status: KILLING

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1479,7 +1479,7 @@ public class ExecutorManager extends EventHandler implements
         continue;
         // case UNKNOWN:
       case READY:
-        node.setStatus(Status.KILLED);
+        node.setStatus(Status.KILLING);
         break;
       default:
         node.setStatus(Status.FAILED);

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -16,8 +16,8 @@
 
 package azkaban.executor;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 
 public enum Status {
   READY(10),
@@ -37,13 +37,8 @@ public enum Status {
   // status is TINYINT and in H2 DB the possible values are: -128 to 127
   // so trying to store CANCELLED in H2 fails at the moment
 
-  private static final Map<Integer, Status> numValMap = new HashMap<>();
-
-  static {
-    for (final Status status : Status.values()) {
-      numValMap.put(status.getNumVal(), status);
-    }
-  }
+  private static final ImmutableMap<Integer, Status> numValMap = Arrays.stream(Status.values())
+      .collect(ImmutableMap.toImmutableMap(status -> status.getNumVal(), status -> status));
 
   private final int numVal;
 

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -16,12 +16,16 @@
 
 package azkaban.executor;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum Status {
   READY(10),
   PREPARING(20),
   RUNNING(30),
   PAUSED(40),
   SUCCEEDED(50),
+  KILLING(55),
   KILLED(60),
   FAILED(70),
   FAILED_FINISHING(80),
@@ -30,6 +34,16 @@ public enum Status {
   QUEUED(110),
   FAILED_SUCCEEDED(120),
   CANCELLED(130);
+  // status is TINYINT and in H2 DB the possible values are: -128 to 127
+  // so trying to store CANCELLED in H2 fails at the moment
+
+  private static final Map<Integer, Status> numValMap = new HashMap<>();
+
+  static {
+    for (Status status : Status.values()) {
+      numValMap.put(status.getNumVal(), status);
+    }
+  }
 
   private final int numVal;
 
@@ -38,36 +52,10 @@ public enum Status {
   }
 
   public static Status fromInteger(final int x) {
-    switch (x) {
-      case 10:
-        return READY;
-      case 20:
-        return PREPARING;
-      case 30:
-        return RUNNING;
-      case 40:
-        return PAUSED;
-      case 50:
-        return SUCCEEDED;
-      case 60:
-        return KILLED;
-      case 70:
-        return FAILED;
-      case 80:
-        return FAILED_FINISHING;
-      case 90:
-        return SKIPPED;
-      case 100:
-        return DISABLED;
-      case 110:
-        return QUEUED;
-      case 120:
-        return FAILED_SUCCEEDED;
-      case 130:
-        return CANCELLED;
-      default:
-        return READY;
+    if (numValMap.containsKey (x)) {
+      return numValMap.get(x);
     }
+    return READY;
   }
 
   public static boolean isStatusFinished(final Status status) {

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -47,10 +47,7 @@ public enum Status {
   }
 
   public static Status fromInteger(final int x) {
-    if (numValMap.containsKey(x)) {
-      return numValMap.get(x);
-    }
-    return READY;
+    return numValMap.getOrDefault(x, READY);
   }
 
   public static boolean isStatusFinished(final Status status) {

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -40,7 +40,7 @@ public enum Status {
   private static final Map<Integer, Status> numValMap = new HashMap<>();
 
   static {
-    for (Status status : Status.values()) {
+    for (final Status status : Status.values()) {
       numValMap.put(status.getNumVal(), status);
     }
   }
@@ -52,7 +52,7 @@ public enum Status {
   }
 
   public static Status fromInteger(final int x) {
-    if (numValMap.containsKey (x)) {
+    if (numValMap.containsKey(x)) {
       return numValMap.get(x);
     }
     return READY;

--- a/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
@@ -97,6 +97,8 @@ public class WebUtils {
         return "Paused";
       case SKIPPED:
         return "Skipped";
+      case KILLING:
+        return "Killing";
       default:
     }
     return "Unknown";

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -63,6 +63,12 @@ public class InteractiveTestJob extends AbstractProcessJob {
     testJobs.clear();
   }
 
+  public static void clearTestJobs(final String... names) {
+    for (final String name : names) {
+      assertNotNull(testJobs.remove(name));
+    }
+  }
+
   @Override
   public void run() throws Exception {
     final String nestedFlowPath =
@@ -154,12 +160,6 @@ public class InteractiveTestJob extends AbstractProcessJob {
     info("Killing job");
     if (!this.ignoreCancel) {
       failJob();
-    }
-  }
-
-  public static void clearTestJobs(final String... names) {
-    for (String name : names) {
-      assertNotNull(testJobs.remove(name));
     }
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -33,6 +33,7 @@ public class InteractiveTestJob extends AbstractProcessJob {
   private Props generatedProperties = new Props();
   private boolean isWaiting = true;
   private boolean succeed = true;
+  private boolean ignoreCancel = false;
 
   public InteractiveTestJob(final String jobId, final Props sysProps, final Props jobProps,
       final Logger log) {
@@ -137,6 +138,12 @@ public class InteractiveTestJob extends AbstractProcessJob {
     }
   }
 
+  public void ignoreCancel() {
+    synchronized (this) {
+      this.ignoreCancel = true;
+    }
+  }
+
   @Override
   public Props getJobGeneratedProperties() {
     return this.generatedProperties;
@@ -145,7 +152,9 @@ public class InteractiveTestJob extends AbstractProcessJob {
   @Override
   public void cancel() throws InterruptedException {
     info("Killing job");
-    failJob();
+    if (!this.ignoreCancel) {
+      failJob();
+    }
   }
 
   public static void clearTestJobs(final String... names) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -112,13 +112,13 @@ public class FlowRunner extends EventHandler implements Runnable {
   private String jobLogFileSize = "5MB";
   private int jobLogNumFiles = 4;
 
-  private boolean flowPaused = false;
-  private boolean flowFailed = false;
-  private boolean flowFinished = false;
-  private boolean flowKilled = false;
+  private volatile boolean flowPaused = false;
+  private volatile boolean flowFailed = false;
+  private volatile boolean flowFinished = false;
+  private volatile boolean flowKilled = false;
 
   // The following is state that will trigger a retry of all failed jobs
-  private boolean retryFailedJobs = false;
+  private volatile boolean retryFailedJobs = false;
 
   /**
    * Constructor. This will create its own ExecutorService for thread pools

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -546,7 +546,7 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   private void propagateStatus(final ExecutableFlowBase base, final Status status) {
-    if (!Status.isStatusFinished(base.getStatus())) {
+    if (!Status.isStatusFinished(base.getStatus()) && base.getStatus() != Status.KILLING) {
       this.logger.info("Setting " + base.getNestedId() + " to " + status);
       base.setStatus(status);
       if (base.getParentFlow() != null) {
@@ -597,10 +597,9 @@ public class FlowRunner extends EventHandler implements Runnable {
     final long durationSec = (flow.getEndTime() - flow.getStartTime()) / 1000;
     switch (flow.getStatus()) {
       case FAILED_FINISHING:
-        final Status status = isKilled() ? Status.KILLED : Status.FAILED;
-        this.logger.info("Setting flow '" + id + "' status to " + status + " in "
+        this.logger.info("Setting flow '" + id + "' status to FAILED in "
             + durationSec + " seconds");
-        flow.setStatus(status);
+        flow.setStatus(Status.FAILED);
         break;
       case KILLING:
         this.logger

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -478,7 +478,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     return false;
   }
 
-  private boolean notReadyToRun(Status status) {
+  private boolean notReadyToRun(final Status status) {
     return Status.isStatusFinished(status)
         || Status.isStatusRunning(status)
         || Status.KILLING == status;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -594,7 +594,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     switch (flow.getStatus()) {
       case FAILED_FINISHING:
         Status status = isKilled() ? Status.KILLED : Status.FAILED;
-        this.logger.info("Setting flow '" + id + "' status to "+status+" in "
+        this.logger.info("Setting flow '" + id + "' status to " + status + " in "
             + durationSec + " seconds");
         flow.setStatus(status);
         break;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -593,13 +593,14 @@ public class FlowRunner extends EventHandler implements Runnable {
     final long durationSec = (flow.getEndTime() - flow.getStartTime()) / 1000;
     switch (flow.getStatus()) {
       case FAILED_FINISHING:
-        Status status = isKilled() ? Status.KILLED : Status.FAILED;
+        final Status status = isKilled() ? Status.KILLED : Status.FAILED;
         this.logger.info("Setting flow '" + id + "' status to " + status + " in "
             + durationSec + " seconds");
         flow.setStatus(status);
         break;
       case KILLING:
-        logger.info("Setting flow '" + id + "' status to KILLED in " + durationSec + " seconds");
+        this.logger
+            .info("Setting flow '" + id + "' status to KILLED in " + durationSec + " seconds");
         flow.setStatus(Status.KILLED);
         break;
       case FAILED:

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -462,9 +462,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     // Instant kill or skip if necessary.
     boolean jobsRun = false;
     for (final ExecutableNode node : nodesToCheck) {
-      if (Status.isStatusFinished(node.getStatus())
-          || Status.isStatusRunning(node.getStatus())
-          || Status.KILLING == node.getStatus()) {
+      if (notReadyToRun(node.getStatus())) {
         // Really shouldn't get in here.
         continue;
       }
@@ -478,6 +476,12 @@ public class FlowRunner extends EventHandler implements Runnable {
     }
 
     return false;
+  }
+
+  private boolean notReadyToRun(Status status) {
+    return Status.isStatusFinished(status)
+        || Status.isStatusRunning(status)
+        || Status.KILLING == status;
   }
 
   private boolean runReadyJob(final ExecutableNode node) throws IOException {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -345,7 +345,7 @@ public class JobRunner extends EventHandler implements Runnable {
         this.azkabanProps
             .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
 
-    final JSONObject layout = LogUtil.createLogPatternLayoutJsonObject(props, jobId);
+    final JSONObject layout = LogUtil.createLogPatternLayoutJsonObject(this.props, this.jobId);
 
     kafkaProducer.setLayout(new PatternLayoutEscaped(layout.toString()));
     kafkaProducer.activateOptions();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -762,7 +762,7 @@ public class JobRunner extends EventHandler implements Runnable {
       this.node.setOutputProps(this.job.getJobGeneratedProperties());
     }
 
-    // If the job is still running, set the status to Success.
+    // If the job is still running (but not killed), set the status to Success.
     if (!Status.isStatusFinished(finalStatus) && finalStatus != Status.KILLING) {
       finalStatus = changeStatus(Status.SUCCEEDED);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -92,7 +92,7 @@ public class JobRunner extends EventHandler implements Runnable {
   private int jobLogBackupIndex;
 
   private long delayStartMs = 0;
-  private boolean killed = false;
+  private volatile boolean killed = false;
   private BlockingStatus currentBlockStatus = null;
 
   public JobRunner(final ExecutableNode node, final File workingDir, final ExecutorLoader loader,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -740,7 +740,7 @@ public class JobRunner extends EventHandler implements Runnable {
     Status finalStatus;
     try {
       this.job.run();
-      finalStatus = node.getStatus();
+      finalStatus = this.node.getStatus();
     } catch (final Throwable e) {
       if (this.props.getBoolean("job.succeed.on.failure", false)) {
         finalStatus = changeStatus(Status.FAILED_SUCCEEDED);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -263,7 +263,12 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job2", Status.SUCCEEDED);
     waitJobsStarted(this.runner, "job3", "job4", "job6");
 
+    InteractiveTestJob.getTestJob("job3").ignoreCancel();
     this.runner.kill("me");
+    assertStatus("job3", Status.KILLING);
+    assertFlowStatus(Status.KILLING);
+    InteractiveTestJob.getTestJob("job3").failJob();
+
     Assert.assertTrue(this.runner.isKilled());
 
     assertStatus("job5", Status.CANCELLED);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -579,7 +579,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobb", Status.KILLED);
     assertStatus("jobb:innerJobB", Status.FAILED);
     assertStatus("jobb:innerJobC", Status.KILLED);
     assertStatus("jobb:innerFlow", Status.CANCELLED);
@@ -771,7 +771,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     this.runner.kill("me");
 
-    assertStatus("jobb", Status.FAILED);
+    assertStatus("jobb", Status.KILLED);
     assertStatus("jobb:innerJobC", Status.KILLED);
     assertStatus("jobb:innerFlow", Status.CANCELLED);
     assertStatus("jobc", Status.KILLED);
@@ -1067,7 +1067,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
     assertStatus("jobd:innerJobA", Status.FAILED);
     assertStatus("jobd:innerFlow2", Status.CANCELLED);
-    assertStatus("jobd", Status.FAILED);
+    assertStatus("jobd", Status.KILLED);
     assertStatus("jobb:innerJobA", Status.KILLED);
     assertStatus("jobb:innerJobB", Status.CANCELLED);
     assertStatus("jobb:innerJobC", Status.CANCELLED);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -579,7 +579,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobC", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
-    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobb", Status.FAILED);
     assertStatus("jobb:innerJobB", Status.FAILED);
     assertStatus("jobb:innerJobC", Status.KILLED);
     assertStatus("jobb:innerFlow", Status.CANCELLED);
@@ -771,7 +771,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     this.runner.kill("me");
 
-    assertStatus("jobb", Status.KILLED);
+    assertStatus("jobb", Status.FAILED);
     assertStatus("jobb:innerJobC", Status.KILLED);
     assertStatus("jobb:innerFlow", Status.CANCELLED);
     assertStatus("jobc", Status.KILLED);
@@ -1067,7 +1067,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
     assertStatus("jobd:innerJobA", Status.FAILED);
     assertStatus("jobd:innerFlow2", Status.CANCELLED);
-    assertStatus("jobd", Status.KILLED);
+    assertStatus("jobd", Status.FAILED);
     assertStatus("jobb:innerJobA", Status.KILLED);
     assertStatus("jobb:innerJobB", Status.CANCELLED);
     assertStatus("jobb:innerJobC", Status.CANCELLED);

--- a/azkaban-web-server/src/main/less/azkaban-graph.less
+++ b/azkaban-web-server/src/main/less/azkaban-graph.less
@@ -94,6 +94,15 @@
   fill: #FFF;
 }
 
+.KILLING > g > rect {
+  fill: #FF9999;
+  stroke: #FF9999;
+}
+
+.KILLING > g > text {
+  fill: #FFF;
+}
+
 .CANCELLED > g > rect {
   fill: #FF9999;
   stroke: #FF9999;

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -65,6 +65,18 @@
     background-color: @flow-killed-color;
   }
 
+  // #ff9999 = killing vs. #3398cc = running
+  &.KILLING {
+    background-color: @flow-killing-color;
+    background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
+    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+    background-size: 40px 40px;
+    -webkit-animation: progress-bar-stripes 2s linear infinite;
+            animation: progress-bar-stripes 2s linear infinite;
+  }
+
   &.RUNNING {
     background-color: @flow-running-color;
     background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
@@ -113,6 +125,10 @@ td {
 
     &.KILLED {
       background-color: @flow-killed-color;
+    }
+
+    &.KILLING {
+      background-color: @flow-killing-color;
     }
 
     &.PAUSED {
@@ -167,6 +183,10 @@ td {
 
   &.KILLED {
     color: @flow-killed-color;
+  }
+
+  &.KILLING {
+    color: @flow-killing-color;
   }
 
   &.CANCELLED {
@@ -307,6 +327,10 @@ li.tree-list-item {
     }
 
     &.KILLED .icon {
+      background-position: 0px 0px;
+    }
+
+    &.KILLING .icon {
       background-position: 0px 0px;
     }
 

--- a/azkaban-web-server/src/main/less/variables.less
+++ b/azkaban-web-server/src/main/less/variables.less
@@ -3,6 +3,7 @@
 @flow-succeeded-color: #5cb85c;
 @flow-failed-color: #d9534f;
 @flow-killed-color: #d9534f;
+@flow-killing-color: #ff9999;
 @flow-paused-color: #c82123;
 @flow-running-color: #3398cc;
 @flow-failed-finishing-color: #f19153;

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -197,6 +197,7 @@
                       <option value=30>Running</option>
                       <option value=40>Paused</option>
                       <option value=50>Succeed</option>
+                      <option value=55>Killing</option>
                       <option value=60>Killed</option>
                       <option value=70>Failed</option>
                       <option value=80>Failed Finishing</option>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -24,6 +24,7 @@ var statusStringMap = {
   "FAILED_FINISHING": "Running w/Failure",
   "RUNNING": "Running",
   "WAITING": "Waiting",
+  "KILLING": "Killing",
   "KILLED": "Killed",
   "CANCELLED": "Cancelled",
   "DISABLED": "Disabled",

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -205,6 +205,8 @@ azkaban.FlowTabView = Backbone.View.extend({
 		else if (data.status == "KILLED") {
 			$("#executebtn").show();
 		}
+		else if (data.status == "KILLING") {
+		}
 	},
 
 	handleCancelClick: function(evt) {
@@ -446,6 +448,10 @@ var updaterFunction = function() {
 			data.status == "PREPARING") {
 			// 2 min updates
 			setTimeout(function() {updaterFunction();}, 2*60*1000);
+		}
+		else if (data.status == "KILLING") {
+			// 20 s updates
+			setTimeout(function() {updaterFunction();}, 30*1000);
 		}
 		else if (data.status != "SUCCEEDED" && data.status != "FAILED") {
 			// 2 min updates

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -450,7 +450,7 @@ var updaterFunction = function() {
 			setTimeout(function() {updaterFunction();}, 2*60*1000);
 		}
 		else if (data.status == "KILLING") {
-			// 20 s updates
+			// 30 s updates - should finish soon now
 			setTimeout(function() {updaterFunction();}, 30*1000);
 		}
 		else if (data.status != "SUCCEEDED" && data.status != "FAILED") {

--- a/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
@@ -93,6 +93,9 @@ azkaban.TimeGraphView = Backbone.View.extend({
       else if (status == 'PAUSED') {
         return '#c92123';
       }
+      else if (status == 'KILLING') {
+        return '#ff9999';
+      }
       else if (status == 'FAILED' ||
           status == 'FAILED_FINISHING' ||
           status == 'KILLED') {


### PR DESCRIPTION
Implements https://github.com/azkaban/azkaban/issues/1122: _Azkaban to have KILLING status transition_.

- New status transition after `kill()` is called: `.. -> KILLING -> KILLED`.
- Don't set the status to `KILLED` before all job threads have exited.

Execution graph:

![killing-1-graph](https://cloud.githubusercontent.com/assets/4446608/26831078/c7ff5ab8-4ad3-11e7-89e8-c71ee73f39c2.png)

Execution Job List:

![killing-2-job list](https://cloud.githubusercontent.com/assets/4446608/26831090/d19bec30-4ad3-11e7-9e85-661030ed470e.png)

History:

![killing-3-history](https://cloud.githubusercontent.com/assets/4446608/26831096/d77d8c80-4ad3-11e7-8824-367f5ee2e36a.png)

----

After this change, I would like to rename these private booleans:
- `JobRunner: killed -> cancelRequested`
- `FlowRunner: flowKilled -> killRequested`

Otherwise it's quite easy to assume that those `killed` booleans mean already having `KILLED` status, when it can also be `KILLING`.