### PR TITLE
Removing sessionId from logger statements

### DIFF
--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -56,8 +56,7 @@ public class ProjectManagerResource extends ResourceContextHolder {
       @ActionParam("packageUrl") final String packageUrl)
       throws ProjectManagerException, RestLiServiceException, UserManagerException,
       ServletException, IOException {
-    logger.info("Deploy called. {sessionId: " + sessionId + ", projectName: "
-        + projectName + ", packageUrl:" + packageUrl + "}");
+    logger.info("Deploy called. {ProjectName: " + projectName + ", packageUrl:" + packageUrl + "}");
 
     final String ip = ResourceUtils.getRealClientIpAddr(this.getContext());
     final User user = ResourceUtils.getUserFromSessionId(sessionId, ip);

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -56,7 +56,7 @@ public class ProjectManagerResource extends ResourceContextHolder {
       @ActionParam("packageUrl") final String packageUrl)
       throws ProjectManagerException, RestLiServiceException, UserManagerException,
       ServletException, IOException {
-    logger.info("Deploy called. {ProjectName: " + projectName + ", packageUrl:" + packageUrl + "}");
+    logger.info("Deploy called. {projectName: " + projectName + ", packageUrl:" + packageUrl + "}");
 
     final String ip = ResourceUtils.getRealClientIpAddr(this.getContext());
     final User user = ResourceUtils.getUserFromSessionId(sessionId, ip);

--- a/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
@@ -49,8 +49,7 @@ public class UserManagerResource extends ResourceContextHolder {
 
     final Session session = createSession(username, password, ip);
 
-    logger.info("Session id " + session.getSessionId() + " created for user '"
-        + username + "' and ip " + ip);
+    logger.info("Session id created for user '" + username + "' and ip " + ip);
     return session.getSessionId();
   }
 


### PR DESCRIPTION
Fixing error reported in LIHADOOP-26732.
sessionId shouldn't be logged anywhere. Looked through related files and couldn't find any other occurrences.
@HappyRay @ameyamk does this look sufficient?