### PR TITLE
Fix line length style check violation in OsMemoryUtil

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
@@ -40,7 +40,8 @@ class OsMemoryUtil {
 
     final List<String> lines;
     // The file /proc/meminfo is assumed to contain only ASCII characters.
-    // The assumption is that the file is not too big. So it is simpler to read the whole file into memory.
+    // The assumption is that the file is not too big. So it is simpler to read the whole file
+    // into memory.
     try {
       lines = Files.readAllLines(Paths.get(MEM_INFO_FILE), StandardCharsets.UTF_8);
     } catch (final IOException e) {


### PR DESCRIPTION
This is the last warning including style check for this file I can find.

Reformatting doesn't seem to correct this problem automatically.