### PR TITLE
Remove hamcrest assertion library

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     compile('io.dropwizard.metrics:metrics-core:3.1.0')
     compile('io.dropwizard.metrics:metrics-jvm:3.1.0')
 
-    testCompile('org.hamcrest:hamcrest-all:1.3')
     testCompile('org.mockito:mockito-all:1.10.19')
     testCompile(project(':azkaban-test').sourceSets.test.output)
     testCompile('org.assertj:assertj-core:3.8.0')

--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -58,7 +58,6 @@ dependencies {
 
   testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
   testCompile('commons-collections:commons-collections:3.2.2')
-  testCompile('org.hamcrest:hamcrest-all:1.3')
 
   //AZ web module tests need to access classes defined in azkaban-common test module
   testCompile project(':azkaban-common').sourceSets.test.output


### PR DESCRIPTION
We will standardize on assertj library, which has a few advantages.
see
http://randomthoughtsonjavaprogramming.blogspot.com/2017/03/assertj-vs-hamcrest.html

This will speed up the Travis build process a bit.