### PR TITLE
refactor MysqlDataSource

### DIFF
--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -123,7 +123,7 @@ public class AzkabanCommonModule extends AbstractModule {
     final String password = props.getString("mysql.password");
     final int numConnections = props.getInt("mysql.numconnections");
 
-    return MySQLDataSource.getInstance(host, port, database, user, password, numConnections);
+    return new MySQLDataSource(host, port, database, user, password, numConnections);
   }
 
   @Inject

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -25,10 +25,7 @@ public class MySQLDataSource extends AzkabanDataSource {
 
   private static final Logger logger = Logger.getLogger(MySQLDataSource.class);
 
-  private static volatile MySQLDataSource instance = null;
-
-  // TODO kunkun-tang: have guice inject working here
-  private MySQLDataSource(final String host, final int port, final String dbName,
+  public MySQLDataSource(final String host, final int port, final String dbName,
       final String user, final String password, final int numConnections) {
     super();
 
@@ -42,22 +39,6 @@ public class MySQLDataSource extends AzkabanDataSource {
     setMaxTotal(numConnections);
     setValidationQuery("/* ping */ select 1");
     setTestOnBorrow(true);
-  }
-
-  /**
-   * Get a singleton object for MySQL BasicDataSource
-   */
-  public static MySQLDataSource getInstance(final String host, final int port, final String dbName,
-      final String user, final String password, final int numConnections) {
-    if (instance == null) {
-      synchronized (MySQLDataSource.class) {
-        if (instance == null) {
-          logger.info("Instantiating MetricReportManager");
-          instance = new MySQLDataSource(host, port, dbName, user, password, numConnections);
-        }
-      }
-    }
-    return instance;
   }
 
   /**


### PR DESCRIPTION
MysqlDataSource used to be a singleton class. However, we are trying to apply guicification to it. As one step of completing gucification to this class, we do a refactor. The reason we can not entirely gucify today:
* The class depends on Props, which is in `azkaban-common` module. `Azkaban-db` can not call `Props` today.