### PR TITLE
Declare mockito and assertj as dependencies for all java subprojects

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -66,9 +66,7 @@ dependencies {
     compile('io.dropwizard.metrics:metrics-core:3.1.0')
     compile('io.dropwizard.metrics:metrics-jvm:3.1.0')
 
-    testCompile('org.mockito:mockito-all:1.10.19')
     testCompile(project(':azkaban-test').sourceSets.test.output)
-    testCompile('org.assertj:assertj-core:3.8.0')
 
     testRuntime('com.h2database:h2:1.4.193')
     testRuntime('org.slf4j:slf4j-log4j12:1.7.18')

--- a/azkaban-db/build.gradle
+++ b/azkaban-db/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     compile('commons-dbutils:commons-dbutils:1.5')
     compile('org.apache.commons:commons-dbcp2:2.1.1')
 
-    testCompile('org.mockito:mockito-all:1.10.19')
     testRuntime('com.h2database:h2:1.4.193')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ subprojects {
 
         dependencies {
             testCompile('junit:junit:4.12')
+            testCompile('org.assertj:assertj-core:3.8.0')
+            testCompile('org.mockito:mockito-all:1.10.19')
         }
     }
 


### PR DESCRIPTION
This is to promote consistency.