### PR TITLE
Remove UpdateActiveFlowReference

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -193,8 +193,6 @@ public class FlowRunner extends EventHandler implements Runnable {
       setupFlowExecution();
       this.flow.setStartTime(System.currentTimeMillis());
 
-      updateFlowReference();
-
       this.logger.info("Updating initial flow directory.");
       updateFlow();
       this.logger.info("Fetching job and shared properties.");
@@ -271,15 +269,6 @@ public class FlowRunner extends EventHandler implements Runnable {
     // The current thread is used for interrupting blocks
     this.flowRunnerThread = Thread.currentThread();
     this.flowRunnerThread.setName("FlowRunner-exec-" + this.flow.getExecutionId());
-  }
-
-  private void updateFlowReference() throws ExecutorManagerException {
-    this.logger.info("Update active reference");
-    if (!this.executorLoader.updateExecutableReference(this.execId,
-        System.currentTimeMillis())) {
-      throw new ExecutorManagerException(
-          "The executor reference doesn't exist. May have been killed prematurely.");
-    }
   }
 
   private void updateFlow() {


### PR DESCRIPTION
When a flow starts to run, it sets the update_time of the flow as the current time in active_executing_flows table. However, this update_time is not used (notice that it is different from the update_time in execution_flows table). As part of deprecating active_executing_flows table, this updateFlowReference logic needs to be removed. To keep backward compatibility with old executors, we have to deprecate the table gradually. Make sure this updating table change on executor is released first, then in the next release I will push another change on web server of inserting into and removing this table as part of cleaning updaterThread.