### PR TITLE
Fix compiler warnings in AzkabanExecutorServer

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -44,13 +44,11 @@ import azkaban.server.AzkabanServer;
 import azkaban.utils.Props;
 import azkaban.utils.StdOutErrRedirect;
 import azkaban.utils.Utils;
-import com.google.common.base.Throwables;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -279,7 +277,7 @@ public class AzkabanExecutorServer {
     MetricsManager.INSTANCE.startReporting("AZ-EXEC", this.props);
   }
 
-  private void insertExecutorEntryIntoDB() {
+  private void insertExecutorEntryIntoDB() throws ExecutorManagerException {
     try {
       final String host = requireNonNull(getHost());
       final int port = getPort();
@@ -291,19 +289,19 @@ public class AzkabanExecutorServer {
       // If executor already exists, ignore it
     } catch (final ExecutorManagerException e) {
       logger.error("Error inserting executor entry into DB", e);
-      Throwables.propagate(e);
+      throw e;
     }
   }
 
-  private void dumpPortToFile() {
+  private void dumpPortToFile() throws IOException {
     // By default this should write to the working directory
     try (BufferedWriter writer = Files
         .newBufferedWriter(Paths.get(AZKABAN_EXECUTOR_PORT_FILENAME), StandardCharsets.UTF_8)) {
       writer.write(String.valueOf(getPort()));
       writer.write("\n");
     } catch (final IOException e) {
-      logger.error(e);
-      Throwables.propagate(e);
+      logger.error("Failed to write the port number to a file", e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
Also fixed a logger error which logs only the exception message
instead of the complete call stack.

Warnings fixed:

from gradle:

Note: /Users/ruyang/oss/azkaban/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

compiler:

Warning:(294, 17) java: propagate(java.lang.Throwable) in com.google.common.base.Throwables has been deprecated
Warning:(306, 17) java: propagate(java.lang.Throwable) in com.google.common.base.Throwables has been deprecated