### PR TITLE
Have method to check allowsOnDuplicateKey

### DIFF
--- a/azkaban-db/src/main/java/azkaban/db/AzkabanDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/AzkabanDataSource.java
@@ -20,4 +20,6 @@ import org.apache.commons.dbcp2.BasicDataSource;
 public abstract class AzkabanDataSource extends BasicDataSource {
 
   public abstract String getDBType();
+
+  public abstract boolean allowsOnDuplicateKey();
 }

--- a/azkaban-db/src/main/java/azkaban/db/H2FileDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/H2FileDataSource.java
@@ -31,4 +31,9 @@ public class H2FileDataSource extends AzkabanDataSource {
   public String getDBType() {
     return "h2";
   }
+
+  @Override
+  public boolean allowsOnDuplicateKey() {
+    return false;
+  }
 }

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -76,4 +76,9 @@ public class MySQLDataSource extends AzkabanDataSource {
   public String getDBType() {
     return "mysql";
   }
+
+  @Override
+  public boolean allowsOnDuplicateKey() {
+    return true;
+  }
 }

--- a/azkaban-db/src/test/java/azkaban/db/AzDBTestUtility.java
+++ b/azkaban-db/src/test/java/azkaban/db/AzDBTestUtility.java
@@ -31,5 +31,10 @@ class AzDBTestUtility {
     public String getDBType() {
       return "h2-in-memory";
     }
+
+    @Override
+    public boolean allowsOnDuplicateKey() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
When I was refactoring [this code](https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/project/JdbcProjectLoader.java#L682), I noticed that we need to consider allowsOnDuplicateKey since the original Azkaban database modules has this. So I'm completing now.