### PR TITLE
Test stability: longer max wait

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -118,7 +118,7 @@ public class FlowRunnerTestBase {
   }
 
   private void waitForStatus(ExecutableNode node, Status status) {
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
       if (node.getStatus() == status) {
         break;
       }


### PR DESCRIPTION
- Additional stability even if test runner is slow (like supposedly on Travis sometimes)
- This doesn't make the tests any slower than before, as long as they pass

----

Why would this help? Even locally the FlowRunner tests started failing when I put 10 instead of 100 max tries (10 ms wait per try). 1000 should make it pretty robust :)

For background, see:
- PR https://github.com/azkaban/azkaban/pull/1179#issuecomment-307183316
  - https://travis-ci.org/azkaban/azkaban/builds/240580566?utm_source=github_status&utm_medium=notification
- PR https://github.com/azkaban/azkaban/pull/1201#issuecomment-307639293
- PR https://github.com/azkaban/azkaban/pull/1186