### PR TITLE
Enable gradle caching in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,13 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build 
+script: ./gradlew clean build
+
+# see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
see
https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle

Testing:

Verified that the caching is working:
First run
https://travis-ci.org/azkaban/azkaban/builds/241850300
116.08s$ ./gradlew clean build
Downloading https://services.gradle.org/distributions/gradle-3.5-all.zip
.....................................................................................................................................

Second run:
https://travis-ci.org/azkaban/azkaban/builds/241850739

66.50s$ ./gradlew clean build
Starting a Gradle Daemon (subsequent builds will be faster)
Parallel execution with configuration on demand is an incubating feature.
Using the 'clean' task in combination with parallel execution may lead to unexpected runtime behavior.
:azkaban-hadoop-security-plugin:clean
:azkaban-test:clean
