### PR TITLE
Fix slow BasicTimeCheckerTest

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
@@ -131,7 +132,7 @@ public class BasicTimeChecker implements ConditionChecker {
 
   @Override
   public Boolean eval() {
-    return this.nextCheckTime < System.currentTimeMillis();
+    return this.nextCheckTime < DateTimeUtils.currentTimeMillis();
   }
 
   @Override


### PR DESCRIPTION
Issue:

The test sleeps for 20 seconds and the comments are wrong.
When debugging the test, the test would fail since it is time sensitive.

Fix:
Switch to use Jodatime utility to get the current time and manipulate
 the time in the test.

It's better to use the java time api and use a Guice injected wrapper
 class to manipulate time.
 However given that BasicTimeChecker is scheduled to be deprecated
 soon. It's not worth investing in it now.