### PR TITLE
Suppressing FutureReturnValueIgnored warnings

### DIFF
--- a/azkaban-common/src/main/java/azkaban/metric/MetricReportManager.java
+++ b/azkaban-common/src/main/java/azkaban/metric/MetricReportManager.java
@@ -97,6 +97,7 @@ public class MetricReportManager {
    * each element of metrics List is responsible to call this method and report metrics
    * @param metric
    */
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void reportMetric(final IMetric<?> metric) {
     if (metric != null && isAvailable()) {
       try {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -706,6 +706,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     return props;
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void runExecutableNode(final ExecutableNode node) throws IOException {
     // Collect output props from the job's dependencies.
     prepareJobProperties(node);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
@@ -78,6 +78,7 @@ public class TriggerManager {
     return actions;
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void addTrigger(final int execId, final List<SlaOption> slaOptions) {
     for (final SlaOption sla : slaOptions) {
       final Condition triggerCond = createCondition(sla, execId, "slaFailChecker", "isSlaFailed()");


### PR DESCRIPTION
http://errorprone.info/bugpattern/FutureReturnValueIgnored

Errorprone suggests "@SuppressWarnings("unused")" when compiling, but this did not appear to remove the warning.

Following the recommendation suggested in the link above and adding "@SuppressWarnings("FutureReturnValueIgnored")" seemed to do the trick.