### PR TITLE
Test stability: longer max wait

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -38,7 +38,7 @@ public class FlowRunnerTestBase {
   }
 
   public void waitFlowRunner(final Function<FlowRunner, Boolean> statusCheck) {
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
       if (statusCheck.apply(this.runner)) {
         return;
       }
@@ -54,7 +54,7 @@ public class FlowRunnerTestBase {
 
   public void waitJobStatuses(final Function<Status, Boolean> statusCheck,
       final String... jobs) {
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
       if (checkJobStatuses(statusCheck, jobs)) {
         return;
       }
@@ -74,7 +74,7 @@ public class FlowRunnerTestBase {
 
   protected void waitEventFired(final String nestedId, final Status status)
       throws InterruptedException {
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 1000; i++) {
       for (final Event event : this.eventCollector.getEventList()) {
         if (event.getData().getStatus() == status && event.getData().getNestedId()
             .equals(nestedId)) {


### PR DESCRIPTION
This is to fix #1217 (failure on `waitFlowRunner()`).

Last time (PR #1207) I only did this (100->1000) for `waitForStatus()`, while I should've caught these all.

- Additional stability even if test runner is slow (like supposedly on Travis sometimes)
- This doesn't make the tests any slower than before, as long as they pass