### PR TITLE
HDFS instance needs to be created post UGI login

### DIFF
--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -34,6 +34,7 @@ import azkaban.project.ProjectLoader;
 import azkaban.spi.AzkabanException;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageException;
+import azkaban.storage.HdfsAuth;
 import azkaban.storage.StorageImplementationType;
 import azkaban.trigger.JdbcTriggerImpl;
 import azkaban.trigger.TriggerLoader;
@@ -79,6 +80,7 @@ public class AzkabanCommonModule extends AbstractModule {
     bind(ProjectLoader.class).to(JdbcProjectLoader.class).in(Scopes.SINGLETON);
     bind(Props.class).toInstance(this.config.getProps());
     bind(Storage.class).to(resolveStorageClassType()).in(Scopes.SINGLETON);
+    bind(HdfsAuth.class).in(Scopes.SINGLETON);
     bind(DatabaseOperator.class).to(DatabaseOperatorImpl.class).in(Scopes.SINGLETON);
     bind(TriggerLoader.class).to(JdbcTriggerImpl.class).in(Scopes.SINGLETON);
     bind(DataSource.class).to(AzkabanDataSource.class);
@@ -147,8 +149,9 @@ public class AzkabanCommonModule extends AbstractModule {
   @Inject
   @Provides
   @Singleton
-  public FileSystem createHadoopFileSystem(final Configuration hadoopConf) {
+  public FileSystem createHadoopFileSystem(final Configuration hadoopConf, final HdfsAuth auth) {
     try {
+      auth.authorize();
       return FileSystem.get(hadoopConf);
     } catch (final IOException e) {
       log.error("Unable to initialize HDFS", e);


### PR DESCRIPTION
Despite authorizing prior to any HDFS call, the HDFS storage code does not seem to work without an existing Kerberos session. The problem is that the `FileSystem.get()` API needs to be called after a successful UGI login. Currently that is not the case. The Hadoop code caches the logged in user at the time of creating the File System object and this is not reflected in the stack traces making it difficult to debug.

Fix: ensure UGI auth prior to creation of file system object.