### PR TITLE
Add the project-report gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ allprojects {
         mavenCentral()
         mavenLocal()
     }
+
+    apply plugin: 'project-report'
 }
 
 ext.versions = [

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 
 apply plugin: 'com.cinnober.gradle.semver-git'
 apply plugin: 'idea'
+apply plugin: 'build-dashboard'
 
 allprojects {
     repositories {


### PR DESCRIPTION
See
https://docs.gradle.org/3.3/userguide/project_reports_plugin.html
http://mrhaki.blogspot.com/2014/08/gradle-goodness-getting-more-dependency.html

Also, add the build-dashboard plugin

see https://docs.gradle.org/current/userguide/buildDashboard_plugin.html

testing:

ruyang-mn1:azkaban ruyang$ ./gradlew azkaban-exe-server:dependencyReport
Parallel execution with configuration on demand is an incubating feature.
:azkaban-exec-server:dependencyReport
See the report at: file:///Users/ruyang/oss/azkaban/azkaban-exec-server/build/reports/project/dependencies.txt

BUILD SUCCESSFUL