### PR TITLE
Ignore the slow TriggerManager tests

### DIFF
--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
@@ -33,8 +33,11 @@ import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
+// todo HappyRay: fix these slow tests or delete them.
 public class TriggerManagerTest {
 
   private static TriggerLoader triggerLoader;


### PR DESCRIPTION
This will shave > 5 seconds of test time.

The triggermanager code is scheduled to be removed soon. It's not
worth fixing these tests. We will avoid changing these classes and if
 we have to, the person has to run these tests manually.