### PR TITLE
Change the travis config to run the check task instead of the build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
+script: ./gradlew check
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:


### PR DESCRIPTION
Travis by default runs the gradle check task
 See
 https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle

 We can skip assemble task with this change. If we discover a problem with assemble task later, we can fix it later. Given that
  changes to the Gradle build script is not very often and
  developers can run the build script locally when they do, it's a
  better trade off.
 see https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks