### PR TITLE
Enable parallel tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,8 +120,12 @@ subprojects {
             testCompile deps.assertj
             testCompile deps.junit
             testCompile deps.mockito
+        }
 
-
+        test {
+            // Set maxParallelForks to a large number and let gradle to force it to a the
+            // max-workers number when needed.
+            maxParallelForks =  12
         }
     }
 


### PR DESCRIPTION
Testing:

Reduced the test time from 15 seconds to 12 seconds on my mac.

./gradlew azkaban-common:cleanTest azkaban-common:test

See
http://mrhaki.blogspot.com/2010/11/gradle-goodness-running-tests-in.html
https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html
https://docs.gradle.org/current/userguide/java_plugin.html#sec:test_execution