### PR TITLE
Disable the project upload functionality, if user doesn't have the right permissions.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/Permission.java
+++ b/azkaban-common/src/main/java/azkaban/user/Permission.java
@@ -191,6 +191,9 @@ public class Permission {
     SCHEDULE(0x0000008),
     METRICS(0x0000010),
     CREATEPROJECTS(0x40000000), // Only used for roles
+    // Users with this permission can upload projects when the property "lockdown.upload.projects"
+    // is turned on
+    UPLOADPROJECTS(0x0008000),
     ADMIN(0x8000000);
 
     private final int numVal;

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -1,0 +1,24 @@
+package azkaban.user;
+
+public final class UserUtils {
+  private UserUtils() {
+
+  }
+
+  /**
+   * @return - Returns true if the given user is an ADMIN, or if user has the required permission
+   * for the action requested.
+   */
+  public static boolean hasPermissionforAction(final UserManager userManager, final User user,
+      final Permission.Type type) {
+    for (final String roleName : user.getRoles()) {
+      final Role role = userManager.getRole(roleName);
+      final Permission perm = role.getPermission();
+      if (perm.isPermissionSet(Permission.Type.ADMIN) || perm.isPermissionSet(type)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/user/PermissionTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/PermissionTest.java
@@ -16,7 +16,7 @@
 
 package azkaban.user;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import azkaban.user.Permission.Type;
 import org.junit.After;
@@ -47,7 +47,7 @@ public class PermissionTest {
     final Permission perm2 = new Permission();
     perm2.addPermission(Type.READ);
     info("Compare " + perm1.toString() + " and " + perm2.toString());
-    assertTrue(perm1.equals(perm2));
+    assertThat(perm1.equals(perm2)).isTrue();
   }
 
   @Test
@@ -58,7 +58,7 @@ public class PermissionTest {
     final Permission perm2 = new Permission();
     perm2.addPermission(new Type[]{Type.EXECUTE, Type.READ});
     info("Compare " + perm1.toString() + " and " + perm2.toString());
-    assertTrue(perm1.equals(perm2));
+    assertThat(perm1.equals(perm2)).isTrue();
   }
 
   @Test
@@ -70,7 +70,7 @@ public class PermissionTest {
     final Permission perm2 = new Permission();
     perm2.addPermission(new Type[]{Type.READ, Type.WRITE});
     info("Compare " + perm1.toString() + " and " + perm2.toString());
-    assertTrue(perm1.equals(perm2));
+    assertThat(perm1.equals(perm2)).isTrue();
   }
 
   @Test
@@ -82,7 +82,7 @@ public class PermissionTest {
     final Permission perm2 = new Permission();
     perm2.addPermission(new Type[]{Type.READ, Type.WRITE});
     info("Compare " + perm1.toString() + " and " + perm2.toString());
-    assertTrue(perm1.equals(perm2));
+    assertThat(perm1.equals(perm2)).isTrue();
   }
 
   @Test
@@ -94,7 +94,7 @@ public class PermissionTest {
     final String[] array = permission.toStringArray();
     final Permission permission2 = new Permission();
     permission2.addPermissionsByName(array);
-    assertTrue(permission.equals(permission2));
+    assertThat(permission.equals(permission2)).isTrue();
   }
 
   @Test
@@ -105,10 +105,32 @@ public class PermissionTest {
     final int flags = permission.toFlags();
     final Permission permission2 = new Permission(flags);
 
-    assertTrue(permission2.isPermissionSet(Type.READ));
-    assertTrue(permission2.isPermissionSet(Type.WRITE));
+    assertThat(permission2.isPermissionSet(Type.READ)).isTrue();
+    assertThat(permission2.isPermissionSet(Type.WRITE)).isTrue();
 
-    assertTrue(permission.equals(permission2));
+    assertThat(permission.equals(permission2)).isTrue();
+  }
+
+  /**
+   * Verify that the binary bit for UPLOADPROJECTS is not turned on
+   * by setting the other permissions.
+   */
+  @Test
+  public void testUploadProjectFlag() throws Exception {
+    final Permission permission = new Permission();
+    permission.addPermission(new Type[]{Type.UPLOADPROJECTS});
+
+    final int flags = permission.toFlags();
+    final Permission permission2 = new Permission(flags);
+    assertThat(permission2.isPermissionSet(Type.UPLOADPROJECTS)).isTrue();
+    assertThat(permission.equals(permission2)).isTrue();
+
+    permission.removePermissions(new Type[]{Type.UPLOADPROJECTS});
+    final Type[] allPermissions = new Type[]{
+        Type.READ, Type.WRITE, Type.EXECUTE, Type.METRICS, Type.SCHEDULE, Type.CREATEPROJECTS
+    };
+    permission.addPermission(allPermissions);
+    assertThat(permission.isPermissionSet(Type.UPLOADPROJECTS)).isFalse();
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/user/UserUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/UserUtilsTest.java
@@ -1,0 +1,31 @@
+package azkaban.user;
+
+import static azkaban.user.Permission.Type.UPLOADPROJECTS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import azkaban.utils.TestUtils;
+import org.junit.Test;
+
+
+public class UserUtilsTest {
+  @Test
+  public void testAdminUserCanUploadProject() throws UserManagerException {
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    final User testAdmin = userManager.getUser("testAdmin", "testAdmin");
+    assertThat(UserUtils.hasPermissionforAction(userManager, testAdmin, UPLOADPROJECTS)).isTrue();
+  }
+
+  @Test
+  public void testRegularUserCantUploadProject() {
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    final User user = TestUtils.getTestUser();
+    assertThat(UserUtils.hasPermissionforAction(userManager, user, UPLOADPROJECTS)).isFalse();
+  }
+
+  @Test
+  public void testUserWithPermissionsCanUploadProject() throws UserManagerException {
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    final User testUpload = userManager.getUser("testUpload", "testUpload");
+    assertThat(UserUtils.hasPermissionforAction(userManager, testUpload, UPLOADPROJECTS)).isTrue();
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/PageUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/PageUtils.java
@@ -1,0 +1,30 @@
+package azkaban.webapp.servlet;
+
+import azkaban.server.session.Session;
+import azkaban.user.Permission;
+import azkaban.user.User;
+import azkaban.user.UserManager;
+import azkaban.user.UserUtils;
+
+
+public final class PageUtils {
+
+  private PageUtils() {
+
+  }
+
+  /**
+   * Method hides the upload button for regular users from relevant pages when the property
+   * "lockdown.upload.projects" is set. The button is displayed for admin users and users with
+   * upload permissions.
+   */
+  public static void hideUploadButtonWhenNeeded(final Page page, final Session session, final UserManager userManager,
+      final Boolean lockdownUploadProjects) {
+    final User user = session.getUser();
+
+    if (lockdownUploadProjects && !UserUtils.hasPermissionforAction(userManager, user,
+        Permission.Type.UPLOADPROJECTS)) {
+      page.add("hideUploadProject", true);
+    }
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
@@ -20,9 +20,9 @@ import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.server.session.Session;
 import azkaban.user.Permission;
-import azkaban.user.Role;
 import azkaban.user.User;
 import azkaban.user.UserManager;
+import azkaban.user.UserUtils;
 import azkaban.utils.Pair;
 import azkaban.webapp.AzkabanWebServer;
 import java.io.IOException;
@@ -160,7 +160,8 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
     final Page page =
         newPage(req, resp, session, "azkaban/webapp/servlet/velocity/index.vm");
 
-    if (this.lockdownCreateProjects && !hasPermissionToCreateProject(user)) {
+    if (this.lockdownCreateProjects &&
+        !UserUtils.hasPermissionforAction(this.userManager, user, Permission.Type.CREATEPROJECTS)) {
       page.add("hideCreateProject", true);
     }
 
@@ -218,19 +219,6 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
   protected void handlePost(final HttpServletRequest req, final HttpServletResponse resp,
       final Session session) throws ServletException, IOException {
     // TODO Auto-generated method stub
-  }
-
-  private boolean hasPermissionToCreateProject(final User user) {
-    for (final String roleName : user.getRoles()) {
-      final Role role = this.userManager.getRole(roleName);
-      final Permission perm = role.getPermission();
-      if (perm.isPermissionSet(Permission.Type.ADMIN)
-          || perm.isPermissionSet(Permission.Type.CREATEPROJECTS)) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   /**

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
@@ -25,9 +25,11 @@
               <button id="project-delete-btn" class="btn btn-sm btn-danger">
                 <span class="glyphicon glyphicon-trash"></span> Delete Project
               </button>
+#if (!$hideUploadProject)
               <button id="project-upload-btn" class="btn btn-sm btn-primary">
                 <span class="glyphicon glyphicon-upload"></span> Upload
               </button>
+#end
               <a class="btn btn-sm btn-info" href="${context}/manager?project=${project.name}&download=true">
                 <span class="glyphicon glyphicon-download"></span> Download
               </a>

--- a/azkaban-web-server/src/test/java/azkaban/fixture/VelocityTemplateTestUtil.java
+++ b/azkaban-web-server/src/test/java/azkaban/fixture/VelocityTemplateTestUtil.java
@@ -6,7 +6,7 @@ import org.apache.velocity.app.VelocityEngine;
 
 
 /**
- * Test utility to render a template.
+ * Test utility to render a template and other helper methods.
  */
 public class VelocityTemplateTestUtil {
 
@@ -27,4 +27,17 @@ public class VelocityTemplateTestUtil {
     engine.mergeTemplate(TEMPLATE_BASE_DIR + templateName + ".vm", "UTF-8", context, stringWriter);
     return stringWriter.getBuffer().toString();
   }
+
+  /**
+   *
+   * @param source the rendered template as a String
+   * @param target the String fragment within the template
+   * @return - boolean
+   */
+  public static boolean ignoreCaseContains(final String source, final String target) {
+    final String sourceNoSpace = source.replaceAll("\\s+", "");
+    final String targetNoSpace = target.replaceAll("\\s+", "");
+    return sourceNoSpace.contains(targetNoSpace);
+  }
+
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutionFlowViewTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutionFlowViewTest.java
@@ -17,12 +17,6 @@ public class ExecutionFlowViewTest {
           + "class=\"btn btn-info btn-sm\" type=\"button\" target=\"_blank\" "
           + "title=\"Analyze job in Dr. Elephant\">Dr. Elephant</a></li>";
 
-  private static boolean ignoreCaseContains(final String source, final String target) {
-    final String sourceNoSpace = source.replaceAll("\\s+", "");
-    final String targetNoSpace = target.replaceAll("\\s+", "");
-    return sourceNoSpace.contains(targetNoSpace);
-  }
-
   /**
    * Test aims to check that the external analyzer button is displayed
    * in the page.
@@ -42,6 +36,7 @@ public class ExecutionFlowViewTest {
 
     final String result =
         VelocityTemplateTestUtil.renderTemplate("executingflowpage", context);
-    assertTrue(ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT));
+    assertTrue(VelocityTemplateTestUtil.
+        ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT));
   }
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/PageUtilsTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/PageUtilsTest.java
@@ -1,0 +1,88 @@
+package azkaban.webapp.servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import azkaban.server.session.Session;
+import azkaban.user.User;
+import azkaban.user.UserManager;
+import azkaban.user.UserManagerException;
+import azkaban.utils.TestUtils;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.Test;
+
+
+public class PageUtilsTest {
+  @Test
+  public void testUploadButtonisHiddenWhenGlobalPropertyIsSet()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException,
+             ClassNotFoundException, InstantiationException, IOException {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    final User user = TestUtils.getTestUser();
+    final Session session = new Session("fake-session-id", user, "127.0.0.1");
+
+    final VelocityEngine velocityEngine = new VelocityEngine();
+    velocityEngine.init("src/test/resources/velocity.properties");
+    final Page page = new Page(httpServletRequest, httpServletResponse, velocityEngine,
+        "azkaban/webapp/servlet/velocity/permissionspage.vm");
+
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    PageUtils.hideUploadButtonWhenNeeded(page, session, userManager, true);
+
+    final Field velocityContextField = Page.class.getDeclaredField("context");
+    velocityContextField.setAccessible(true);
+    final VelocityContext velocityContext = (VelocityContext) velocityContextField.get(page);
+    assertThat((boolean) velocityContext.get("hideUploadProject")).isTrue();
+  }
+
+  @Test
+  public void testUploadButtonIsVisibleToAllWhenGlobalPropertyIsNotSet()
+      throws NoSuchFieldException, IllegalAccessException {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    final User user = TestUtils.getTestUser();
+    final Session session = new Session("fake-session-id", user, "127.0.0.1");
+
+    final VelocityEngine velocityEngine = new VelocityEngine();
+    velocityEngine.init("src/test/resources/velocity.properties");
+    final Page page = new Page(httpServletRequest, httpServletResponse, velocityEngine,
+        "azkaban/webapp/servlet/velocity/permissionspage.vm");
+
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    PageUtils.hideUploadButtonWhenNeeded(page, session, userManager, false);
+
+    final Field velocityContextField = Page.class.getDeclaredField("context");
+    velocityContextField.setAccessible(true);
+    final VelocityContext velocityContext = (VelocityContext) velocityContextField.get(page);
+    assertThat(velocityContext.containsKey("hideUploadProject")).isFalse();
+  }
+
+  @Test
+  public void testUploadButtonIsEnabledForAdminUser()
+      throws NoSuchFieldException, IllegalAccessException, UserManagerException {
+    final HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    final HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    final UserManager userManager = TestUtils.createTestXmlUserManager();
+    final User testAdmin = userManager.getUser("testAdmin", "testAdmin");
+    final Session session = new Session("fake-session-id", testAdmin, "127.0.0.1");
+
+    final VelocityEngine velocityEngine = new VelocityEngine();
+    velocityEngine.init("src/test/resources/velocity.properties");
+    final Page page = new Page(httpServletRequest, httpServletResponse, velocityEngine,
+        "azkaban/webapp/servlet/velocity/permissionspage.vm");
+
+    PageUtils.hideUploadButtonWhenNeeded(page, session, userManager, false);
+
+    final Field velocityContextField = Page.class.getDeclaredField("context");
+    velocityContextField.setAccessible(true);
+    final VelocityContext velocityContext = (VelocityContext) velocityContextField.get(page);
+    assertThat(velocityContext.get("hideUploadProject")).isNull();
+  }
+}

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
@@ -1,0 +1,37 @@
+package azkaban.webapp.servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import azkaban.fixture.VelocityContextTestUtil;
+import azkaban.fixture.VelocityTemplateTestUtil;
+import org.apache.velocity.VelocityContext;
+import org.junit.Test;
+
+/**
+ * Test validates the enable/disable feature of the 'Upload' button
+ */
+public class ProjectPageHeaderTest {
+  private static final String UPLOAD_BUTTON
+      = "<button id=\"project-upload-btn\" class=\"btn btn-sm btn-primary\">"
+      + "<span class=\"glyphicon glyphicon-upload\"></span> Upload </button>";
+
+  @Test
+  public void testUploadButtonIsPresent() {
+    final VelocityContext context = VelocityContextTestUtil.getInstance();
+    context.put("hideUploadProject", false);
+
+    final String result =
+        VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);
+    assertThat(VelocityTemplateTestUtil.ignoreCaseContains(result, UPLOAD_BUTTON)).isTrue();
+  }
+
+  @Test
+  public void testUploadButtonIsNotPresent() {
+    final VelocityContext context = VelocityContextTestUtil.getInstance();
+    context.put("hideUploadProject", true);
+
+    final String result =
+        VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);
+    assertThat(VelocityTemplateTestUtil.ignoreCaseContains(result, UPLOAD_BUTTON)).isFalse();
+  }
+}

--- a/test/src/test/resources/azkaban/test/azkaban-users.xml
+++ b/test/src/test/resources/azkaban/test/azkaban-users.xml
@@ -1,5 +1,7 @@
 <azkaban-users>
   <user groups="azkaban" password="testAdmin" roles="admin" username="testAdmin"/>
+  <user password="testUpload" roles="upload" username="testUpload"/>
   <user password="testUser" username="testUser"/>
   <role name="admin" permissions="ADMIN"/>
+  <role name="upload" permissions="UPLOADPROJECTS"/>
 </azkaban-users>


### PR DESCRIPTION
Detailed changes:
1. Upload button is enabled only for admin users and users with UPLOADPROJECTS
permission when the property 'lockdown.upload.projects' is set to true.
2. New permission UPLOADPROJECTS is created
3. Handle the case for ajax upload as well
4. Tests included

Verified all changes against the azkaban-solo-server.