### PR TITLE
Suppressing ImmutableEnumChecker warning

### DIFF
--- a/azkaban-common/src/main/java/azkaban/ServiceProvider.java
+++ b/azkaban-common/src/main/java/azkaban/ServiceProvider.java
@@ -30,6 +30,7 @@ import com.google.inject.Injector;
  * scope so that Guice can automatically resolve dependencies and provide the required services
  * directly.
  */
+@SuppressWarnings("ImmutableEnumChecker")
 public enum ServiceProvider {
   SERVICE_PROVIDER;
 


### PR DESCRIPTION
http://errorprone.info/bugpattern/ImmutableEnumChecker

Collaborated with @suvodeep-pyne 

Suppressed the warning instead of guicing the class as done in other PRs.

We want to keep this class an enum because it is the most secure way to build a singleton in Java. We can't guice this class because this class allows hacky usage of guice in places that haven't been fully guiced yet.

This class will be deprecated in the future as the code is transitioned to full guice.