### PR TITLE
Small formatting tweak to LoginAbstractAzkabanServlet

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -76,14 +76,10 @@ public abstract class LoginAbstractAzkabanServlet extends
     contextType.put(".woff", "application/x-font-woff");
   }
 
+  private final WebMetrics webMetrics = SERVICE_PROVIDER.getInstance(WebMetrics.class);
   private File webResourceDirectory = null;
-
   private MultipartParser multipartParser;
-
   private boolean shouldLogRawUserAgent = false;
-
-  // TODO: reallocf properly guicify WebMetrics
-  private WebMetrics webMetrics = SERVICE_PROVIDER.getInstance(WebMetrics.class);
 
   @Override
   public void init(final ServletConfig config) throws ServletException {
@@ -104,7 +100,7 @@ public abstract class LoginAbstractAzkabanServlet extends
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
 
-    webMetrics.markWebGetCall();
+    this.webMetrics.markWebGetCall();
     // Set session id
     final Session session = getSessionFromRequest(req);
     logRequest(req, session);
@@ -279,7 +275,7 @@ public abstract class LoginAbstractAzkabanServlet extends
   protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
     Session session = getSessionFromRequest(req);
-    webMetrics.markWebPostCall();
+    this.webMetrics.markWebPostCall();
     logRequest(req, session);
 
     // Handle Multipart differently from other post messages


### PR DESCRIPTION
Applied SaveAction, which was disabled for prior PR. No other changes made.

Also removed unnecessary comment. All occurrences of SERVICE_PROVIDER are hacky, so its existence is a reminder of additional refactoring by itself.

Made this commit because I'll be working on LoginAbstractAzkabanServlet for LIHADOOP-28574 and don't want the changes to overlap.