### PR TITLE
Fix bug stuck in pipeline mode

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -338,6 +338,8 @@ public class FlowRunnerManager implements EventListener,
       if (runner != null) {
         watcher = new LocalFlowWatcher(runner);
       } else {
+        // also ends up here if execute is called with pipelineExecId that's not running any more
+        // (it could have just finished, for example)
         watcher = new RemoteFlowWatcher(pipelineExecId, this.executorLoader);
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
@@ -90,7 +90,7 @@ public abstract class FlowWatcher {
     if (node != null) {
       ExecutableFlowBase parentFlow = node.getParentFlow();
       while (parentFlow != null) {
-        Status parentStatus = node.getParentFlow().getStatus();
+        Status parentStatus = parentFlow.getStatus();
         if (parentStatus == Status.SKIPPED || parentStatus == Status.DISABLED) {
           return Status.SKIPPED;
         }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
@@ -17,6 +17,7 @@
 package azkaban.execapp.event;
 
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.Status;
 import java.util.Map;
@@ -82,8 +83,19 @@ public abstract class FlowWatcher {
   }
 
   public Status peekStatus(final String jobId) {
+    if (Status.isStatusFinished(this.flow.getStatus())) {
+      return null;
+    }
     final ExecutableNode node = this.flow.getExecutableNodePath(jobId);
     if (node != null) {
+      ExecutableFlowBase parentFlow = node.getParentFlow();
+      while (parentFlow != null) {
+        Status parentStatus = node.getParentFlow().getStatus();
+        if (parentStatus == Status.SKIPPED || parentStatus == Status.DISABLED) {
+          return Status.SKIPPED;
+        }
+        parentFlow = parentFlow.getParentFlow();
+      }
       return node.getStatus();
     }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
@@ -39,7 +39,6 @@ import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.IOException;
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,9 +59,6 @@ public class RemoteFlowWatcherTest {
     this.jobtypeManager =
         new JobTypeManager(null, null, this.getClass().getClassLoader());
     this.jobtypeManager.getJobTypePluginSet().addPluginClass("test", InteractiveTestJob.class);
-    Utils.initServiceProvider();
-    JmxJobMBeanManager.getInstance().initialize(new Props());
-    InteractiveTestJob.setQuickSuccess(true);
     Utils.initServiceProvider();
     JmxJobMBeanManager.getInstance().initialize(new Props());
     InteractiveTestJob.setQuickSuccess(true);
@@ -131,9 +127,6 @@ public class RemoteFlowWatcherTest {
 
     runner2Thread.start();
     runner2Thread.join();
-
-    FileUtils.deleteDirectory(workingDir1);
-    FileUtils.deleteDirectory(workingDir2);
 
     assertPipelineLevel2(runner1.getExecutableFlow(), runner2.getExecutableFlow(), true);
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
@@ -62,6 +62,9 @@ public class RemoteFlowWatcherTest {
     Utils.initServiceProvider();
     JmxJobMBeanManager.getInstance().initialize(new Props());
     InteractiveTestJob.setQuickSuccess(true);
+    Utils.initServiceProvider();
+    JmxJobMBeanManager.getInstance().initialize(new Props());
+    InteractiveTestJob.setQuickSuccess(true);
   }
 
   @After


### PR DESCRIPTION
Blocked by 2 other PRs, see https://github.com/azkaban/azkaban/pull/1248.

----

Fix bug where pipelined execution gets stuck

If you had executed a flow with some subflows disabled and then started another execution in pipeline mode, the next execution remained blocked forever by the jobs inside sub-flows, because they remained in READY state instead of being set to SKIPPED.

**This was a pretty nasty bug because for example next morning's scheduled run can get stuck after you've launched an execution with some jobs disabled on the previous day.**

I think it would make sense to clean this up also on the flow saving side: when subflow status is changed from DISABLED to SKIPPED, all jobs in the subflows would also be marked as SKIPPED.

Indeed was able to reproduce with the new test method `testRemoteFlowWatcherBlockingJobsLeftInReadyState` that it gets stuck – before this fix.

----

Seems like this also fixes the issue https://github.com/azkaban/azkaban/issues/717 "Job in pipeline mode is blocked by another execution, where the job is disabled" that I posted before. So that's the case where a disabled job is blocking a pipelined execution _until the blocking execution finishes all its enabled jobs_ (even when both executions are running on the same executor at the same time).

----

Builds on https://github.com/azkaban/azkaban/pull/1243 which made FlowRunnerPipelineTest run.

----

There's actually another ~bug that caused this to happen for us: it seems that sometimes azkaban-web sets the pipelineExecId to point to an execution that has finished hours ago (about 24 hours ago in our case – and also there had been another finished execution after that, why not pick that one – although it wouldn't make sense either because it had also finished a couple hours before the stuck execution started :P). That could be investigated as a separate issue, but as long as the fix in this PR is in place at least execution won't get stuck even if that happens. Also there's a valid case left any way for the RemoteFlowWatcher to be chosen: when the execution that azkaban-web chose for pipelineExecId happens to just finish before azkaban-executor starts running the new execution.

----

TODO: once the pre-requisite PRs have been merged, get this additional test into this PR: https://github.com/azkaban/azkaban/pull/1248. That test genuinely reproduces the problem: use a flow with subflows and disable some subflow. The jobs inside the subflow remain in READY state.