### PR TITLE
fix end time schedule 

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -44,7 +44,7 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
   private long lastUpdateTime = -1;
 
   public TriggerBasedScheduleLoader(final TriggerManager triggerManager,
-                                    final String triggerSource) {
+      final String triggerSource) {
     this.triggerManager = triggerManager;
     this.triggerSource = triggerSource;
   }
@@ -129,8 +129,9 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
 
   private Schedule triggerToSchedule(final Trigger t) throws ScheduleManagerException {
 
-    final BasicTimeChecker triggerTimeChecker = getBasicTimeChecker(t.getTriggerCondition().getCheckers());
-    final BasicTimeChecker endTimeChecker = getBasicTimeChecker(t.getExpireCondition().getCheckers());
+    final BasicTimeChecker triggerTimeChecker = getBasicTimeChecker(
+        t.getTriggerCondition().getCheckers());
+    final BasicTimeChecker endTimeChecker = getEndTimeChecker(t);
 
     final List<TriggerAction> actions = t.getActions();
     ExecuteFlowAction act = null;
@@ -147,7 +148,8 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
           act.getFlowName(),
           t.getStatus().toString(),
           triggerTimeChecker.getFirstCheckTime(),
-          endTimeChecker == null? Constants.DEFAULT_SCHEDULE_END_EPOCH_TIME: endTimeChecker.getNextCheckTime(),
+          endTimeChecker == null ? Constants.DEFAULT_SCHEDULE_END_EPOCH_TIME
+              : endTimeChecker.getNextCheckTime(),
           triggerTimeChecker.getTimeZone(),
           triggerTimeChecker.getPeriod(),
           t.getLastModifyTime(),
@@ -173,6 +175,14 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
     }
     return null;
   }
+
+  private BasicTimeChecker getEndTimeChecker(final Trigger t) {
+    if (t.getExpireCondition().getExpression().contains("EndTimeChecker")) {
+      return getBasicTimeChecker(t.getExpireCondition().getCheckers());
+    }
+    return null;
+  }
+
 
   @Override
   public void removeSchedule(final Schedule s) throws ScheduleManagerException {


### PR DESCRIPTION
An issue was introduced in https://github.com/azkaban/azkaban/pull/1110 that causing schedule end time is set to a past date whenever SLA changes are made.
It's caused by incompatibility of new code https://github.com/azkaban/azkaban/pull/1110 with old schedule metadata. SLA change triggers reloading updated schedules into memory. But instead of using a default schedule end time, which we set to some day in year 2050, it always mistakenly uses a past date as the expiring time of the schedule. 
This fixes the issue by setting appropriate end time of the schedule.