### PR TITLE
Disallowing users from logging in via URI QueryString

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -353,14 +353,17 @@ public abstract class LoginAbstractAzkabanServlet extends
    * Disallows users from logging in by passing their
    * username and password via the request header where it'd be logged.
    *
-   * Login attempt is expected if the query string contains the word password and there is a
-   * parameter named password.
+   * This returns true if:
    *
-   * The query string will be empty if the password is passed incorrectly.
-   * The parameter map will contain a password for any login attempt.
+   * 1. The parameter map contains a key called password which indicates a login attempt.
+   * AND
+   * 2. The query string contains the word password meaning they passed their sensitive information
+   * via the query string instead of in the request body.
    *
-   * Returns false if req indicates an attempt to login.
-   * Otherwise returns true.
+   * Otherwise returns false.
+   *
+   * Example of illegal post request:
+   * curl -X POST http://localhost:8081/?action=login\&username=azkaban\&password=azkaban
    */
   private boolean isIllegalPostRequest(final HttpServletRequest req) {
     return (req.getParameterMap().containsKey("password") && req.getQueryString() != null &&

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -148,7 +148,7 @@ public abstract class LoginAbstractAzkabanServlet extends
     buf.append("\"");
     buf.append(req.getMethod()).append(" ");
     buf.append(req.getRequestURI()).append(" ");
-    if (req.getQueryString() != null && allowedPostRequest(req)) {
+    if (req.getQueryString() != null && !isIllegalPostRequest(req)) {
       buf.append(req.getQueryString()).append(" ");
     } else {
       buf.append("-").append(" ");
@@ -277,7 +277,7 @@ public abstract class LoginAbstractAzkabanServlet extends
     Session session = getSessionFromRequest(req);
     this.webMetrics.markWebPostCall();
     logRequest(req, session);
-    if (!allowedPostRequest(req)) {
+    if (isIllegalPostRequest(req)) {
       writeResponse(resp, "Login error. Must pass username and password in request body");
       return;
     }
@@ -362,8 +362,8 @@ public abstract class LoginAbstractAzkabanServlet extends
    * Returns false if req indicates an attempt to login.
    * Otherwise returns true.
    */
-  private boolean allowedPostRequest(final HttpServletRequest req) {
-    return !(req.getParameterMap().containsKey("password") && req.getQueryString() != null &&
+  private boolean isIllegalPostRequest(final HttpServletRequest req) {
+    return (req.getParameterMap().containsKey("password") && req.getQueryString() != null &&
         req.getQueryString().contains("password"));
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -350,24 +350,22 @@ public abstract class LoginAbstractAzkabanServlet extends
   }
 
   /**
-   * Disallows users from logging in by passing their
-   * username and password via the request header where it'd be logged.
-   *
-   * This returns true if:
-   *
-   * 1. The parameter map contains a key called password which indicates a login attempt.
-   * AND
-   * 2. The query string contains the word password meaning they passed their sensitive information
-   * via the query string instead of in the request body.
-   *
-   * Otherwise returns false.
+   * Disallows users from logging in by passing their username and password via the request header
+   * where it'd be logged.
    *
    * Example of illegal post request:
    * curl -X POST http://localhost:8081/?action=login\&username=azkaban\&password=azkaban
+   *
+   * req.getParameterMap() or req.getParameterNames() cannot be used because they draw no
+   * distinction between the illegal request above and the following valid request:
+   * curl -X POST -d "action=login&username=azkaban&password=azkaban" http://localhost:8081/
+   *
+   * "password=" is searched for because it leverages the query syntax to determine that the user is
+   * passing the password as a parameter name. There is no other ajax call that has a parameter
+   * that includes the string "password" at the end which could throw false positives.
    */
   private boolean isIllegalPostRequest(final HttpServletRequest req) {
-    return (req.getParameterMap().containsKey("password") && req.getQueryString() != null &&
-        req.getQueryString().contains("password"));
+    return (req.getQueryString() != null && req.getQueryString().contains("password="));
   }
 
   private Session createSession(final HttpServletRequest req)

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -137,7 +137,7 @@ public abstract class LoginAbstractAzkabanServlet extends
    * Log out request - the format should be close to Apache access log format
    */
   private void logRequest(final HttpServletRequest req, final Session session,
-      final Boolean allowedQueryString) {
+      final boolean allowedQueryString) {
     final StringBuilder buf = new StringBuilder();
     buf.append(getRealClientIpAddr(req)).append(" ");
     if (session != null && session.getUser() != null) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -353,12 +353,18 @@ public abstract class LoginAbstractAzkabanServlet extends
    * Disallows users from logging in by passing their
    * username and password via the request header where it'd be logged.
    *
-   * Returns false if req.getParameterMap() indicates an attempt to login.
+   * Login attempt is expected if the query string contains the word password and there is a
+   * parameter named password.
+   *
+   * The query string will be empty if the password is passed incorrectly.
+   * The parameter map will contain a password for any login attempt.
+   *
+   * Returns false if req indicates an attempt to login.
    * Otherwise returns true.
    */
   private boolean allowedPostRequest(final HttpServletRequest req) {
-    return !(req.getParameterMap().containsKey("username") && req.getParameterMap()
-        .containsKey("password"));
+    return !(req.getParameterMap().containsKey("password") && req.getQueryString() != null &&
+        req.getQueryString().contains("password"));
   }
 
   private Session createSession(final HttpServletRequest req)

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
@@ -27,6 +27,7 @@ import azkaban.fixture.MockLoginAzkabanServlet;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -184,7 +185,7 @@ public class LoginAbstractAzkabanServletTest {
   }
 
   /**
-   * Simulates users passing username/password via query string
+   * Simulates users passing username/password via URI
    * where it would be logged by Azkaban Web Server
    */
   @Test
@@ -192,10 +193,17 @@ public class LoginAbstractAzkabanServletTest {
 
     final String clientIp = "127.0.0.1:10000";
     final String sessionId = "111";
+    final String[] mockCredentials = {"azkaban"};
+    final HashMap<String, String[]> mockParameterMap = new HashMap<String, String[]>() {
+      {
+        put("username", mockCredentials);
+        put("password", mockCredentials);
+      }
+    };
 
     final HttpServletRequest req = MockLoginAzkabanServlet
         .getRequestWithNoUpstream(clientIp, sessionId, "POST");
-    when(req.getQueryString()).thenReturn("action=login&username=azkaban&password=azkaban");
+    when(req.getParameterMap()).thenReturn(mockParameterMap);
     final StringWriter writer = new StringWriter();
     final HttpServletResponse resp = getResponse(writer);
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
@@ -182,4 +182,30 @@ public class LoginAbstractAzkabanServletTest {
     // Assert that our response was written (we have a valid session)
     assertEquals("SUCCESS_MOCK_LOGIN_SERVLET", writer.toString());
   }
+
+  /**
+   * Simulates users passing username/password via query string
+   * where it would be logged by Azkaban Web Server
+   */
+  @Test
+  public void testLoginRevealingCredentialsShouldThrowFailure() throws Exception {
+
+    final String clientIp = "127.0.0.1:10000";
+    final String sessionId = "111";
+
+    final HttpServletRequest req = MockLoginAzkabanServlet
+        .getRequestWithNoUpstream(clientIp, sessionId, "POST");
+    when(req.getQueryString()).thenReturn("action=login&username=azkaban&password=azkaban");
+    final StringWriter writer = new StringWriter();
+    final HttpServletResponse resp = getResponse(writer);
+
+    final MockLoginAzkabanServlet servlet = MockLoginAzkabanServlet.getServletWithSession(sessionId,
+        "user", "127.0.0.1");
+
+    servlet.doPost(req, resp);
+
+    // Assert that expected error message is returned
+    assertEquals("Login error. Must pass username and password in request body", writer.toString());
+
+  }
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTest.java
@@ -193,6 +193,7 @@ public class LoginAbstractAzkabanServletTest {
 
     final String clientIp = "127.0.0.1:10000";
     final String sessionId = "111";
+    final String queryString = "action=login&username=azkaban&password=azkaban";
     final String[] mockCredentials = {"azkaban"};
     final HashMap<String, String[]> mockParameterMap = new HashMap<String, String[]>() {
       {
@@ -204,6 +205,7 @@ public class LoginAbstractAzkabanServletTest {
     final HttpServletRequest req = MockLoginAzkabanServlet
         .getRequestWithNoUpstream(clientIp, sessionId, "POST");
     when(req.getParameterMap()).thenReturn(mockParameterMap);
+    when(req.getQueryString()).thenReturn(queryString);
     final StringWriter writer = new StringWriter();
     final HttpServletResponse resp = getResponse(writer);
 


### PR DESCRIPTION
Related to #990 

Users currently can login by passing their credentials through the query string in the URI in this method:

`curl -X POST http://localhost:8081/?action=login\&username=azkaban\&password=azkaban`

This leads to sensitive information being logged in access logs and overall isn't a secure method of logging in.

This PR fails these attempts and returns an appropriate warning to users. It also stops the query string from being logged when these requests are made.

This PR includes testing to replicate this user behavior for future regression testing.