### PR TITLE
Fix: Azkaban does not fetch tokens from all HCAT servers

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -16,7 +16,7 @@
 
 package azkaban.security;
 
-import azkaban.hive.HiveMetaStoreClientFactory;
+import azkaban.hive.IMetaStoreClientFactory;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
@@ -127,7 +127,6 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
   private final ExecuteAsUser executeAsUser;
   private final Configuration conf;
   private final ConcurrentMap<String, UserGroupInformation> userUgiMap;
-  private final HiveMetaStoreClientFactory hiveMetaStoreClientFactory;
 
   private UserGroupInformation loginUser = null;
   private String keytabLocation;
@@ -221,8 +220,6 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
     }
 
     this.userUgiMap = new ConcurrentHashMap<>();
-    this.hiveMetaStoreClientFactory = new HiveMetaStoreClientFactory(new HiveConf());
-
     log.info("Hadoop Security Manager initialized");
   }
 
@@ -406,7 +403,7 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
   private void cancelHiveToken(final Token<? extends TokenIdentifier> t)
       throws HadoopSecurityManagerException {
     try {
-      final IMetaStoreClient hiveClient = this.hiveMetaStoreClientFactory.create();
+      final IMetaStoreClient hiveClient = new IMetaStoreClientFactory(new HiveConf()).create();
       hiveClient.cancelDelegationToken(t.encodeToUrlString());
     } catch (final Exception e) {
       throw new HadoopSecurityManagerException("Failed to cancel Token. "
@@ -469,7 +466,7 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
     logger.info(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL.varname + ": "
         + hiveConf.get(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL.varname));
 
-    final IMetaStoreClient hiveClient = this.hiveMetaStoreClientFactory.create();
+    final IMetaStoreClient hiveClient = new IMetaStoreClientFactory(hiveConf).create();
     final String hcatTokenStr =
         hiveClient.getDelegationToken(userToProxy, UserGroupInformation
             .getLoginUser().getShortUserName());

--- a/azkaban-hadoop-security-plugin/src/test/java/azkaban/hive/IMetaStoreClientFactoryTest.java
+++ b/azkaban-hadoop-security-plugin/src/test/java/azkaban/hive/IMetaStoreClientFactoryTest.java
@@ -21,10 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.thrift.TException;
 import org.junit.Test;
@@ -39,8 +39,7 @@ public class IMetaStoreClientFactoryTest {
     cleanup();
 
     final IMetaStoreClient msc = new IMetaStoreClientFactory(new HiveConf()).create();
-
-    assertThat(msc instanceof RetryingMetaStoreClient);
+    assertThat(msc).isInstanceOf(Proxy.class);
 
     final String DB_NAME = "test_db";
     final String DB_DESCRIPTION = "test database";


### PR DESCRIPTION
The `IMetaStoreClientFactory` previously `HiveMetaStoreClientFactory` would always use the default `HiveConf` from the host machine to create a Metastore client. This is incorrect since, in order to fetch delegation tokens from different clusters, it needs to use the conf as per the remote cluster.

Changes
- removing the factory as a member and constructing it ad hoc in every case
- renamed the factory and removed the dependency on pooling factory (refactor)
- renamed the test and added an assert (refactor)
