### PR TITLE
Fixing ClassCanBeStatic warning in ProcessJobTest

### DIFF
--- a/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
@@ -204,7 +204,7 @@ public class ProcessJobTest {
     assertThat(sleepBeforeRunJob.getProgress()).isEqualTo(0.0);
   }
 
-  class SleepBeforeRunJob extends ProcessJob implements Runnable {
+  static class SleepBeforeRunJob extends ProcessJob implements Runnable {
 
     public SleepBeforeRunJob(final String jobId, final Props sysProps, final Props jobProps,
         final Logger log) {


### PR DESCRIPTION
http://errorprone.info/bugpattern/ClassCanBeStatic

warning: [ClassCanBeStatic] Inner class is non-static but does not reference enclosing class
  class SleepBeforeRunJob extends ProcessJob implements Runnable {
  ^
    (see http://errorprone.info/bugpattern/ClassCanBeStatic)
  Did you mean 'static class SleepBeforeRunJob extends ProcessJob implements Runnable {'?