### PR TITLE
make passwordPlaceHolder and password error message configurable

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -60,6 +60,7 @@ public class XmlUserManager implements UserManager {
   private static final Logger logger = Logger.getLogger(XmlUserManager.class
       .getName());
   private final String xmlPath;
+  private final String passwordErrorMessage;
 
   private HashMap<String, User> users;
   private HashMap<String, String> userPassword;
@@ -72,7 +73,7 @@ public class XmlUserManager implements UserManager {
    */
   public XmlUserManager(final Props props) {
     this.xmlPath = props.getString(XML_FILE_PARAM);
-
+    this.passwordErrorMessage = props.getString("azkaban.error.password.message", "Username/password not found.");
     parseXMLFile();
   }
 
@@ -260,7 +261,7 @@ public class XmlUserManager implements UserManager {
     }
 
     if (foundPassword == null || !foundPassword.equals(password)) {
-      throw new UserManagerException("Username/Password not found.");
+      throw new UserManagerException(this.passwordErrorMessage);
     }
     // Once it gets to this point, no exception has been thrown. User
     // shoudn't be

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -105,7 +105,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     this.name = props.getString("azkaban.name", "");
     this.label = props.getString("azkaban.label", "");
     this.color = props.getString("azkaban.color", "#FF0000");
-    this.passwordPlaceholder = props.getString("azkaban.password.placeholder", "password");
+    this.passwordPlaceholder = props.getString("azkaban.password.placeholder", "Password");
 
     if (this.application instanceof AzkabanWebServer) {
       final AzkabanWebServer server = (AzkabanWebServer) this.application;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -58,6 +58,8 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
   private static final String AZKABAN_FAILURE_MESSAGE =
       "azkaban.failure.message";
   private static final long serialVersionUID = -1;
+
+  protected String passwordPlaceholder;
   private AzkabanServer application;
   private String name;
   private String label;
@@ -103,6 +105,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     this.name = props.getString("azkaban.name", "");
     this.label = props.getString("azkaban.label", "");
     this.color = props.getString("azkaban.color", "#FF0000");
+    this.passwordPlaceholder = props.getString("azkaban.password.placeholder", "password");
 
     if (this.application instanceof AzkabanWebServer) {
       final AzkabanWebServer server = (AzkabanWebServer) this.application;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -264,6 +264,7 @@ public abstract class LoginAbstractAzkabanServlet extends
   private void handleLogin(final HttpServletRequest req, final HttpServletResponse resp,
       final String errorMsg) throws ServletException, IOException {
     final Page page = newPage(req, resp, "azkaban/webapp/servlet/velocity/login.vm");
+    page.add("passwordPlaceholder", this.passwordPlaceholder);
     if (errorMsg != null) {
       page.add("errorMsg", errorMsg);
     }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/login.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/login.vm
@@ -40,7 +40,7 @@
             <fieldset>
               <legend>Login</legend>
               <input type="text" class="form-control" name="username" id="username" placeholder="Username">
-              <input type="password" class="form-control" name="password" id="password" placeholder="Password">
+              <input type="password" class="form-control" name="password" id="password" placeholder="${passwordPlaceholder}">
               <button type="button" class="btn btn-primary btn-lg btn-block" id="login-submit">Login</button>
             </fieldset>
           </form>


### PR DESCRIPTION
Some Azkaban instance needs 2FA authentications. In that case, the password field in login UI doesn't only include user's password. We modified the UI and make password placeholder configurable, such that Azkaban admins will be able to define.

Tested on localhost.