### PR TITLE
Delete execution directory on flow completion.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Layout;
@@ -221,6 +222,12 @@ public class FlowRunner extends EventHandler implements Runnable {
       this.logger.info("Setting end time for flow " + this.execId + " to "
           + System.currentTimeMillis());
       closeLogger();
+      this.logger.info("Deleting execution directory " + this.execDir.toString());
+      try {
+        FileUtils.deleteDirectory(this.execDir);
+      } catch (final Exception IOException) {
+        this.logger.error("Failed to delete execution directory " + this.execDir.toString());
+      }
 
       updateFlow();
       this.fireEventListeners(Event.create(this, Type.FLOW_FINISHED, new EventData(this.flow)));


### PR DESCRIPTION
Right now we store the project information, all user-generated intermediary files, and the job logs in the /executions/<execution_id> on the executor. The job logs have already been moved to the database and the project information will be re-copied for each subsequent execution, so storing this data on disk isn't necessary.

This change should hopefully free up some disk space. The only downside is we won't be able to get user's flow logs if they do not get uploaded to the database due to some error, but after discussing with @HappyRay we agreed that it's worth it to reclaim the disk space.

Tested on solo-server with both normal flows and nested flows.