### PR TITLE
Support for HDFS Quota Metrics 

### DIFF
--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
@@ -17,6 +17,8 @@
 
 package azkaban;
 
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_HDFS_METRICS_POLL_INTERVAL_MS;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_HDFS_METRICS_ROOT_URI;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_HDFS_ROOT_URI;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_LOCAL_BASEDIR;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_TYPE;
@@ -26,6 +28,7 @@ import azkaban.storage.StorageImplementationType;
 import azkaban.utils.Props;
 import com.google.inject.Inject;
 import java.net.URI;
+import java.time.Duration;
 import org.apache.log4j.Logger;
 
 
@@ -35,6 +38,9 @@ public class AzkabanCommonModuleConfig {
 
   private final Props props;
   private final URI hdfsRootUri;
+  private final URI hdfsMetricsRootUri;
+  private final Duration hdfsMetricsPollInterval;
+
   /**
    * Storage Implementation This can be any of the {@link StorageImplementationType} values in which
    * case {@link StorageFactory} will create the appropriate storage instance. Or one can feed in a
@@ -54,6 +60,13 @@ public class AzkabanCommonModuleConfig {
         .getString(AZKABAN_STORAGE_LOCAL_BASEDIR, this.localStorageBaseDirPath);
     this.hdfsRootUri = props.get(AZKABAN_STORAGE_HDFS_ROOT_URI) != null ? props
         .getUri(AZKABAN_STORAGE_HDFS_ROOT_URI) : null;
+    this.hdfsMetricsRootUri = props.get(AZKABAN_STORAGE_HDFS_METRICS_ROOT_URI) != null ? props
+        .getUri(AZKABAN_STORAGE_HDFS_METRICS_ROOT_URI) : null;
+    this.hdfsMetricsPollInterval =
+        props.get(AZKABAN_STORAGE_HDFS_METRICS_POLL_INTERVAL_MS) != null
+            ? Duration.ofMillis(
+            Long.parseLong(props.getString(AZKABAN_STORAGE_HDFS_METRICS_POLL_INTERVAL_MS)))
+            : Duration.ofMinutes(1);
   }
 
   public Props getProps() {
@@ -70,5 +83,13 @@ public class AzkabanCommonModuleConfig {
 
   public URI getHdfsRootUri() {
     return this.hdfsRootUri;
+  }
+
+  public URI getHdfsMetricsRootUri() {
+    return this.hdfsMetricsRootUri;
+  }
+
+  public Duration getHdfsMetricsPollInterval() {
+    return this.hdfsMetricsPollInterval;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -103,6 +103,17 @@ public class Constants {
     public static final String AZKABAN_KERBEROS_PRINCIPAL = "azkaban.kerberos.principal";
     public static final String AZKABAN_KEYTAB_PATH = "azkaban.keytab.path";
     public static final String PROJECT_TEMP_DIR = "project.temp.dir";
+
+    /**
+     * Quota monitoring for HDFS dir
+     * Configure the root uri for monitoring the quota of an HDFS directory
+     */
+    public static final String AZKABAN_STORAGE_HDFS_METRICS_ROOT_URI =
+        "azkaban.storage.hdfs.metrics.root.uri";
+
+    // Poll Interval for query HDFS Metrics in millisec
+    public static final String AZKABAN_STORAGE_HDFS_METRICS_POLL_INTERVAL_MS =
+        "azkaban.storage.hdfs.metrics.poll.interval.ms";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/metrics/HdfsMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/HdfsMetrics.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban.metrics;
+
+import azkaban.AzkabanCommonModuleConfig;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.fs.ContentSummary;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class HdfsMetrics {
+
+  private static final Logger log = LoggerFactory.getLogger(HdfsMetrics.class);
+  private static final String PREFIX = "HDFS-quota-";
+
+  private final MetricsManager metricsManager;
+  private final FileSystem hdfs;
+  private final String path;
+  private final Duration interval;
+  private final ContentSummaryWrapper metricsData = new ContentSummaryWrapper();
+
+  @Inject
+  public HdfsMetrics(final MetricsManager metricsManager, final FileSystem hdfs,
+      final AzkabanCommonModuleConfig config) {
+    this.metricsManager = metricsManager;
+    this.hdfs = hdfs;
+    this.path = config.getHdfsMetricsRootUri().getPath();
+    this.interval = config.getHdfsMetricsPollInterval();
+  }
+
+  public void registerMetrics() {
+    startFetcherThread();
+
+    this.metricsManager.addGauge(PREFIX + "length", this.metricsData.length::get);
+    this.metricsManager.addGauge(PREFIX + "fileCount", this.metricsData.fileCount::get);
+    this.metricsManager.addGauge(PREFIX + "directoryCount", this.metricsData.directoryCount::get);
+    this.metricsManager.addGauge(PREFIX + "quota", this.metricsData.quota::get);
+    this.metricsManager.addGauge(PREFIX + "spaceConsumed", this.metricsData.spaceConsumed::get);
+    this.metricsManager.addGauge(PREFIX + "spaceQuota", this.metricsData.spaceQuota::get);
+  }
+
+  /**
+   * The fetcher thread is a daemon thread. It thread calls HDFS APIs on every interval.
+   */
+  private void startFetcherThread() {
+    final Thread thread = new Thread(() -> {
+      try {
+        fetchHdfsMetrics();
+        Thread.sleep(this.interval.toMillis());
+      } catch (final Exception e) {
+        log.error("HDFS Fetcher Thread interrupted. Continuing", e);
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  private void fetchHdfsMetrics() {
+    try {
+      this.metricsData.setValues(this.hdfs.getContentSummary(new Path(this.path)));
+    } catch (final IOException e) {
+      log.error("Error: Unable to fetch ContentSummary from HDFS instance", e);
+    }
+  }
+
+  public static class ContentSummaryWrapper {
+
+    private final AtomicLong length = new AtomicLong();
+    private final AtomicLong fileCount = new AtomicLong();
+    private final AtomicLong directoryCount = new AtomicLong();
+    private final AtomicLong quota = new AtomicLong();
+    private final AtomicLong spaceConsumed = new AtomicLong();
+    private final AtomicLong spaceQuota = new AtomicLong();
+
+    public void setValues(final ContentSummary contentSummary) {
+      this.length.set(contentSummary.getLength());
+      this.fileCount.set(contentSummary.getFileCount());
+      this.directoryCount.set(contentSummary.getDirectoryCount());
+      this.quota.set(contentSummary.getQuota());
+      this.spaceConsumed.set(contentSummary.getSpaceConsumed());
+      this.spaceQuota.set(contentSummary.getSpaceConsumed());
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import azkaban.AzkabanCommonModuleConfig;
+import azkaban.metrics.HdfsMetrics;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageException;
 import azkaban.spi.StorageMetadata;
@@ -43,16 +44,20 @@ public class HdfsStorage implements Storage {
   private final HdfsAuth hdfsAuth;
   private final URI rootUri;
   private final FileSystem hdfs;
+  private final HdfsMetrics hdfsMetrics;
 
   @Inject
   public HdfsStorage(final HdfsAuth hdfsAuth, final FileSystem hdfs,
-      final AzkabanCommonModuleConfig config) {
+      final HdfsMetrics hdfsMetrics, final AzkabanCommonModuleConfig config) {
     this.hdfsAuth = requireNonNull(hdfsAuth);
     this.hdfs = requireNonNull(hdfs);
+    this.hdfsMetrics = requireNonNull(hdfsMetrics);
 
     this.rootUri = config.getHdfsRootUri();
     requireNonNull(this.rootUri.getAuthority(), "URI must have host:port mentioned.");
     checkArgument(HDFS_SCHEME.equals(this.rootUri.getScheme()));
+
+    hdfsMetrics.registerMetrics();
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import azkaban.AzkabanCommonModuleConfig;
+import azkaban.metrics.HdfsMetrics;
 import azkaban.spi.StorageMetadata;
 import azkaban.utils.Md5Hasher;
 import java.io.File;
@@ -48,7 +49,7 @@ public class HdfsStorageTest {
     final AzkabanCommonModuleConfig config = mock(AzkabanCommonModuleConfig.class);
     when(config.getHdfsRootUri()).thenReturn(URI.create("hdfs://localhost:9000/path/to/foo"));
 
-    this.hdfsStorage = new HdfsStorage(this.hdfsAuth, this.hdfs, hdfsMetrics, config);
+    this.hdfsStorage = new HdfsStorage(this.hdfsAuth, this.hdfs, mock(HdfsMetrics.class), config);
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -48,7 +48,7 @@ public class HdfsStorageTest {
     final AzkabanCommonModuleConfig config = mock(AzkabanCommonModuleConfig.class);
     when(config.getHdfsRootUri()).thenReturn(URI.create("hdfs://localhost:9000/path/to/foo"));
 
-    this.hdfsStorage = new HdfsStorage(this.hdfsAuth, this.hdfs, config);
+    this.hdfsStorage = new HdfsStorage(this.hdfsAuth, this.hdfs, hdfsMetrics, config);
   }
 
   @Test


### PR DESCRIPTION
This patch provides the ability for Azkaban to monitor and report (via the internal Metrics framework) HDFS quota stats for a configured directory and also a polling interval. By default, the polling interval is 1 min.