### PR TITLE
fix guice initialize TriggerManager twice bug

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -26,6 +26,7 @@ import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorManager;
 import azkaban.utils.Props;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.PriorityBlockingQueue;
 import org.apache.log4j.Logger;
 
+@Singleton
 public class TriggerManager extends EventHandler implements
     TriggerManagerAdapter {
   public static final long DEFAULT_SCANNER_INTERVAL_MS = 60000;

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -22,12 +22,14 @@ import static azkaban.executor.ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import azkaban.AzkabanCommonModule;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.database.AzkabanDatabaseUpdater;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorLoader;
+import azkaban.trigger.TriggerManager;
 import azkaban.utils.Props;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -111,6 +113,11 @@ public class AzkabanWebServerTest {
     executorLoader.updateExecutor(executor);
 
     assertNotNull(injector.getInstance(AzkabanWebServer.class));
+
+    //Test if triggermanager is singletonly guiced. If not, the below test will fail.
+    final TriggerManager triggerManager1 = requireNonNull(injector.getInstance(TriggerManager.class));
+    final TriggerManager triggerManager2 = requireNonNull(injector.getInstance(TriggerManager.class));
+    assertTrue(triggerManager1 == triggerManager2);
     SERVICE_PROVIDER.unsetInjector();
   }
 }


### PR DESCRIPTION
This bug was found in local solo server built by July 19th's master code. Our integration test tried to add trigger, which run every minutes. The strange observation is that this trigger never run. We debugged the code and found that the [TriggerScannerThread](https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java#L67) was launched twice, and newly added triggers were put into the should-not-exist thread and never run. I noticed that TriggerManager did not bind to Singleton in Guice Conf. I made this change, and the thread was not launched twice. The bug disappeared.