### PR TITLE
Fix value out of range exception when storing CANCELLED status in DB.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -33,9 +33,8 @@ public enum Status {
   DISABLED(100),
   QUEUED(110),
   FAILED_SUCCEEDED(120),
-  CANCELLED(130);
-  // status is TINYINT and in H2 DB the possible values are: -128 to 127
-  // so trying to store CANCELLED in H2 fails at the moment
+  CANCELLED(125);
+  // status is TINYINT in DB and the value ranges from -128 to 127
 
   private static final ImmutableMap<Integer, Status> numValMap = Arrays.stream(Status.values())
       .collect(ImmutableMap.toImmutableMap(status -> status.getNumVal(), status -> status));


### PR DESCRIPTION
When running one of the integration tests - kill the flow right after it executes, we are seeing below error:

Caused by: java.sql.SQLException: Data truncation: Out of range value for column 'status' at row 1 Query: UPDATE execution_flows SET status=?,update_time=?,start_time=?,end_time=?,enc_type=?,flow_data=? WHERE exec_id=? Parameters: [130, 1500497708092, 1500497 ......

Status is TINYINT and the max value is 127, so trying to store value 130 in DB throws an exception. Changing CANCELLED from 130 to 125 fixes the problem.

This change is backward compatible since we never run into the situation where CANCELLED status was stored in DB in the past. This value has never been persisted. With the new change of KILLING status, it could happen that we need to store this CANCELLED status in DB now.