### PR TITLE
Fix for failure to kill the job caused by race condition.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -374,6 +374,10 @@ public class ProcessJob extends AbstractProcessJob {
     if (this.process == null) {
       throw new IllegalStateException("Not started.");
     }
+
+    info("Wait for process to start.");
+    this.process.awaitStartup();
+
     final boolean processkilled = this.process
         .softKill(KILL_TIME.toMillis(), TimeUnit.MILLISECONDS);
     if (!processkilled) {


### PR DESCRIPTION
When running integration test - killing a flow immediately after it starts, users encounter below exception intermittently and are not able to actually kill the flow, even though the status shows KILLING for some time and finally changes to KILLED. The status itself is misleading and users could miss the chance to retry killing the flow.

Logs:
25-07-2017 17:14:53 PDT IntegrationTest_jobCommand ERROR - Kill has been called.
25-07-2017 17:14:53 PDT IntegrationTest_jobCommand ERROR - Process has not yet started.
25-07-2017 17:14:53 PDT IntegrationTest_jobCommand ERROR - Failed trying to cancel job. Maybe it hasn't started running yet or just finished.
25-07-2017 17:15:03 PDT IntegrationTest_jobCommand INFO - Process completed successfully in 10 seconds.
25-07-2017 17:15:03 PDT IntegrationTest_jobCommand INFO - Finishing job IntegrationTest_jobCommand attempt: 0 at 1501028103180 with status KILLED

Problem analysis:
1. run the process:
azkaban.jobExecutor.utils.process.AzkabanProcess#run
2. at the same time, kill the job:
azkaban.jobExecutor.ProcessJob#cancel
azkaban.jobExecutor.utils.process.AzkabanProcess#softKill 
azkaban.jobExecutor.utils.process.AzkabanProcess#checkStarted
here it throws exception, because the process just starts and hasn't reached java.util.concurrent.CountDownLatch#countDown yet, 
and thus this.startupLatch.getCount() != 0, which means process has not fully started yet. So the job couldn't be killed.

Solution:
By adding this.process.awaitStartup(), the kill thread will wait for ( startupLatch.await ) the run thread to decrement the count of the latch ( startupLatch.countDown ) and then release itself to continue with the kill.
Verified the fix with integration tests.
