### PR TITLE
refactor JDBC Execuloader class to leverage new azkaban-db

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorHandlerSet.java
@@ -23,31 +23,26 @@ import java.util.Map;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.log4j.Logger;
 
-public class JdbcExecutorHandlerSet {
+class JdbcExecutorHandlerSet {
 
-  private static final Logger logger = Logger.getLogger(JdbcExecutorImpl.class);
+  private static final Logger logger = Logger.getLogger(JdbcExecutorHandlerSet.class);
 
   public static class FetchExecutableFlows implements
       ResultSetHandler<List<ExecutableFlow>> {
 
-    public static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
+    static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows ";
-    public static String FETCH_EXECUTABLE_FLOW =
+    static String FETCH_EXECUTABLE_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE exec_id=?";
-    // private static String FETCH_ACTIVE_EXECUTABLE_FLOW =
-    // "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data "
-    // +
-    // "FROM execution_flows ex " +
-    // "INNER JOIN active_executing_flows ax ON ex.exec_id = ax.exec_id";
-    public static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
+    static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
-    public static String FETCH_EXECUTABLE_FLOW_HISTORY =
+    static String FETCH_EXECUTABLE_FLOW_HISTORY =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
-    public static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
+    static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? AND status=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
@@ -55,7 +50,7 @@ public class JdbcExecutorHandlerSet {
     @Override
     public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {
       if (!rs.next()) {
-        return Collections.<ExecutableFlow> emptyList();
+        return Collections.emptyList();
       }
 
       final List<ExecutableFlow> execFlows = new ArrayList<>();
@@ -98,15 +93,15 @@ public class JdbcExecutorHandlerSet {
   public static class FetchExecutorHandler implements
       ResultSetHandler<List<Executor>> {
 
-    public static String FETCH_ALL_EXECUTORS =
+    static String FETCH_ALL_EXECUTORS =
         "SELECT id, host, port, active FROM executors";
-    public static String FETCH_ACTIVE_EXECUTORS =
+    static String FETCH_ACTIVE_EXECUTORS =
         "SELECT id, host, port, active FROM executors where active=true";
-    public static String FETCH_EXECUTOR_BY_ID =
+    static String FETCH_EXECUTOR_BY_ID =
         "SELECT id, host, port, active FROM executors where id=?";
-    public static String FETCH_EXECUTOR_BY_HOST_PORT =
+    static String FETCH_EXECUTOR_BY_HOST_PORT =
         "SELECT id, host, port, active FROM executors where host=? AND port=?";
-    public static String FETCH_EXECUTION_EXECUTOR =
+    static String FETCH_EXECUTION_EXECUTOR =
         "SELECT ex.id, ex.host, ex.port, ex.active FROM "
             + " executors ex INNER JOIN execution_flows ef "
             + "on ex.id = ef.executor_id  where exec_id=?";
@@ -114,7 +109,7 @@ public class JdbcExecutorHandlerSet {
     @Override
     public List<Executor> handle(final ResultSet rs) throws SQLException {
       if (!rs.next()) {
-        return Collections.<Executor> emptyList();
+        return Collections.emptyList();
       }
 
       final List<Executor> executors = new ArrayList<>();
@@ -137,14 +132,14 @@ public class JdbcExecutorHandlerSet {
   public static class ExecutorLogsResultHandler implements
       ResultSetHandler<List<ExecutorLogEvent>> {
 
-    public static String SELECT_EXECUTOR_EVENTS_ORDER =
+    static String SELECT_EXECUTOR_EVENTS_ORDER =
         "SELECT executor_id, event_type, event_time, username, message FROM executor_events "
             + " WHERE executor_id=? ORDER BY event_time LIMIT ? OFFSET ?";
 
     @Override
     public List<ExecutorLogEvent> handle(final ResultSet rs) throws SQLException {
       if (!rs.next()) {
-        return Collections.<ExecutorLogEvent> emptyList();
+        return Collections.emptyList();
       }
 
       final ArrayList<ExecutorLogEvent> events = new ArrayList<>();
@@ -167,7 +162,7 @@ public class JdbcExecutorHandlerSet {
 
   public static class FetchLogsHandler implements ResultSetHandler<LogData> {
 
-    public static String FETCH_LOGS =
+    static String FETCH_LOGS =
         "SELECT exec_id, name, attempt, enc_type, start_byte, end_byte, log "
             + "FROM execution_logs "
             + "WHERE exec_id=? AND name=? AND attempt=? AND end_byte > ? "
@@ -176,7 +171,7 @@ public class JdbcExecutorHandlerSet {
     private final int startByte;
     private final int endByte;
 
-    public FetchLogsHandler(final int startByte, final int endByte) {
+    FetchLogsHandler(final int startByte, final int endByte) {
       this.startByte = startByte;
       this.endByte = endByte;
     }
@@ -190,9 +185,6 @@ public class JdbcExecutorHandlerSet {
       final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
 
       do {
-        // int execId = rs.getInt(1);
-        // String name = rs.getString(2);
-        final int attempt = rs.getInt(3);
         final EncodingType encType = EncodingType.fromInteger(rs.getInt(4));
         final int startByte = rs.getInt(5);
         final int endByte = rs.getInt(6);
@@ -228,16 +220,16 @@ public class JdbcExecutorHandlerSet {
   public static class FetchExecutableJobHandler implements
       ResultSetHandler<List<ExecutableJobInfo>> {
 
-    public static String FETCH_EXECUTABLE_NODE =
+    static String FETCH_EXECUTABLE_NODE =
         "SELECT exec_id, project_id, version, flow_id, job_id, "
             + "start_time, end_time, status, attempt "
             + "FROM execution_jobs WHERE exec_id=? "
             + "AND job_id=? AND attempt=?";
-    public static String FETCH_EXECUTABLE_NODE_ATTEMPTS =
+    static String FETCH_EXECUTABLE_NODE_ATTEMPTS =
         "SELECT exec_id, project_id, version, flow_id, job_id, "
             + "start_time, end_time, status, attempt FROM execution_jobs "
             + "WHERE exec_id=? AND job_id=?";
-    public static String FETCH_PROJECT_EXECUTABLE_NODE =
+    static String FETCH_PROJECT_EXECUTABLE_NODE =
         "SELECT exec_id, project_id, version, flow_id, job_id, "
             + "start_time, end_time, status, attempt FROM execution_jobs "
             + "WHERE project_id=? AND job_id=? "
@@ -246,7 +238,7 @@ public class JdbcExecutorHandlerSet {
     @Override
     public List<ExecutableJobInfo> handle(final ResultSet rs) throws SQLException {
       if (!rs.next()) {
-        return Collections.<ExecutableJobInfo> emptyList();
+        return Collections.emptyList();
       }
 
       final List<ExecutableJobInfo> execNodes = new ArrayList<>();
@@ -274,7 +266,7 @@ public class JdbcExecutorHandlerSet {
   public static class FetchExecutableJobAttachmentsHandler implements
       ResultSetHandler<String> {
 
-    public static String FETCH_ATTACHMENTS_EXECUTABLE_NODE =
+    static String FETCH_ATTACHMENTS_EXECUTABLE_NODE =
         "SELECT attachments FROM execution_jobs WHERE exec_id=? AND job_id=?";
 
     @Override
@@ -297,11 +289,11 @@ public class JdbcExecutorHandlerSet {
     public static class FetchExecutableJobPropsHandler implements
       ResultSetHandler<Pair<Props, Props>> {
 
-    public static String FETCH_OUTPUT_PARAM_EXECUTABLE_NODE =
+    static String FETCH_OUTPUT_PARAM_EXECUTABLE_NODE =
         "SELECT output_params FROM execution_jobs WHERE exec_id=? AND job_id=?";
-    public static String FETCH_INPUT_PARAM_EXECUTABLE_NODE =
+    static String FETCH_INPUT_PARAM_EXECUTABLE_NODE =
         "SELECT input_params FROM execution_jobs WHERE exec_id=? AND job_id=?";
-    public static String FETCH_INPUT_OUTPUT_PARAM_EXECUTABLE_NODE =
+    static String FETCH_INPUT_OUTPUT_PARAM_EXECUTABLE_NODE =
         "SELECT input_params, output_params "
             + "FROM execution_jobs WHERE exec_id=? AND job_id=?";
 
@@ -362,7 +354,7 @@ public class JdbcExecutorHandlerSet {
   public static class FetchQueuedExecutableFlows implements
       ResultSetHandler<List<Pair<ExecutionReference, ExecutableFlow>>> {
     // Select queued unassigned flows
-    public static final String FETCH_QUEUED_EXECUTABLE_FLOW =
+    static final String FETCH_QUEUED_EXECUTABLE_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows"
             + " Where executor_id is NULL AND status = "
             + Status.PREPARING.getNumVal();
@@ -415,7 +407,7 @@ public class JdbcExecutorHandlerSet {
   public static class FetchRecentlyFinishedFlows implements
       ResultSetHandler<List<ExecutableFlow>> {
     // Execution_flows table is already indexed by end_time
-    public static String FETCH_RECENTLY_FINISHED_FLOW =
+    static String FETCH_RECENTLY_FINISHED_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE end_time > ? AND status IN (?, ?, ?)";
 
@@ -461,7 +453,7 @@ public class JdbcExecutorHandlerSet {
   public static class FetchActiveExecutableFlows implements
       ResultSetHandler<Map<Integer, Pair<ExecutionReference, ExecutableFlow>>> {
     // Select running and executor assigned flows
-    public static String FETCH_ACTIVE_EXECUTABLE_FLOW =
+    static String FETCH_ACTIVE_EXECUTABLE_FLOW =
         "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
             + "et.port port, et.id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
@@ -525,7 +517,7 @@ public class JdbcExecutorHandlerSet {
   public static class FetchActiveExecutableFlowByExecId implements
       ResultSetHandler<List<Pair<ExecutionReference, ExecutableFlow>>> {
 
-    public static String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID =
+    static String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID =
         "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
             + "et.port port, et.id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
@@ -585,14 +577,12 @@ public class JdbcExecutorHandlerSet {
 
   public static class IntHandler implements ResultSetHandler<Integer> {
 
-    public static String NUM_EXECUTIONS =
+    static String NUM_EXECUTIONS =
         "SELECT COUNT(1) FROM execution_flows";
-    public static String NUM_FLOW_EXECUTIONS =
+    static String NUM_FLOW_EXECUTIONS =
         "SELECT COUNT(1) FROM execution_flows WHERE project_id=? AND flow_id=?";
-    public static String NUM_JOB_EXECUTIONS =
+    static String NUM_JOB_EXECUTIONS =
         "SELECT COUNT(1) FROM execution_jobs WHERE project_id=? AND job_id=?";
-    public static String FETCH_EXECUTOR_ID =
-        "SELECT executor_id FROM execution_flows WHERE exec_id=?";
 
     @Override
     public Integer handle(final ResultSet rs) throws SQLException {

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorHandlerSet.java
@@ -1,0 +1,605 @@
+package azkaban.executor;
+
+import azkaban.database.AbstractJdbcLoader.EncodingType;
+import azkaban.executor.ExecutorLogEvent.EventType;
+import azkaban.utils.FileIOUtils;
+import azkaban.utils.FileIOUtils.LogData;
+import azkaban.utils.GZIPUtils;
+import azkaban.utils.JSONUtils;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
+import azkaban.utils.PropsUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.dbutils.ResultSetHandler;
+import org.apache.log4j.Logger;
+
+public class JdbcExecutorHandlerSet {
+
+  private static final Logger logger = Logger.getLogger(JdbcExecutorImpl.class);
+
+  public static class FetchExecutableFlows implements
+      ResultSetHandler<List<ExecutableFlow>> {
+
+    public static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows ";
+    public static String FETCH_EXECUTABLE_FLOW =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+            + "WHERE exec_id=?";
+    // private static String FETCH_ACTIVE_EXECUTABLE_FLOW =
+    // "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data "
+    // +
+    // "FROM execution_flows ex " +
+    // "INNER JOIN active_executing_flows ax ON ex.exec_id = ax.exec_id";
+    public static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+            + "ORDER BY exec_id DESC LIMIT ?, ?";
+    public static String FETCH_EXECUTABLE_FLOW_HISTORY =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+            + "WHERE project_id=? AND flow_id=? "
+            + "ORDER BY exec_id DESC LIMIT ?, ?";
+    public static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+            + "WHERE project_id=? AND flow_id=? AND status=? "
+            + "ORDER BY exec_id DESC LIMIT ?, ?";
+
+    @Override
+    public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.<ExecutableFlow> emptyList();
+      }
+
+      final List<ExecutableFlow> execFlows = new ArrayList<>();
+      do {
+        final int id = rs.getInt(1);
+        final int encodingType = rs.getInt(2);
+        final byte[] data = rs.getBytes(3);
+
+        if (data != null) {
+          final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Object flowObj;
+          try {
+            // Convoluted way to inflate strings. Should find common package
+            // or helper function.
+            if (encType == EncodingType.GZIP) {
+              // Decompress the sucker.
+              final String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              final String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            final ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+            execFlows.add(exFlow);
+          } catch (final IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  /**
+   * JDBC ResultSetHandler to fetch records from executors table
+   */
+  public static class FetchExecutorHandler implements
+      ResultSetHandler<List<Executor>> {
+
+    public static String FETCH_ALL_EXECUTORS =
+        "SELECT id, host, port, active FROM executors";
+    public static String FETCH_ACTIVE_EXECUTORS =
+        "SELECT id, host, port, active FROM executors where active=true";
+    public static String FETCH_EXECUTOR_BY_ID =
+        "SELECT id, host, port, active FROM executors where id=?";
+    public static String FETCH_EXECUTOR_BY_HOST_PORT =
+        "SELECT id, host, port, active FROM executors where host=? AND port=?";
+    public static String FETCH_EXECUTION_EXECUTOR =
+        "SELECT ex.id, ex.host, ex.port, ex.active FROM "
+            + " executors ex INNER JOIN execution_flows ef "
+            + "on ex.id = ef.executor_id  where exec_id=?";
+
+    @Override
+    public List<Executor> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.<Executor> emptyList();
+      }
+
+      final List<Executor> executors = new ArrayList<>();
+      do {
+        final int id = rs.getInt(1);
+        final String host = rs.getString(2);
+        final int port = rs.getInt(3);
+        final boolean active = rs.getBoolean(4);
+        final Executor executor = new Executor(id, host, port, active);
+        executors.add(executor);
+      } while (rs.next());
+
+      return executors;
+    }
+  }
+
+  /**
+   * JDBC ResultSetHandler to fetch records from executor_events table
+   */
+  public static class ExecutorLogsResultHandler implements
+      ResultSetHandler<List<ExecutorLogEvent>> {
+
+    public static String SELECT_EXECUTOR_EVENTS_ORDER =
+        "SELECT executor_id, event_type, event_time, username, message FROM executor_events "
+            + " WHERE executor_id=? ORDER BY event_time LIMIT ? OFFSET ?";
+
+    @Override
+    public List<ExecutorLogEvent> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.<ExecutorLogEvent> emptyList();
+      }
+
+      final ArrayList<ExecutorLogEvent> events = new ArrayList<>();
+      do {
+        final int executorId = rs.getInt(1);
+        final int eventType = rs.getInt(2);
+        final Date eventTime = rs.getDate(3);
+        final String username = rs.getString(4);
+        final String message = rs.getString(5);
+
+        final ExecutorLogEvent event =
+            new ExecutorLogEvent(executorId, username, eventTime,
+                EventType.fromInteger(eventType), message);
+        events.add(event);
+      } while (rs.next());
+
+      return events;
+    }
+  }
+
+  public static class FetchLogsHandler implements ResultSetHandler<LogData> {
+
+    public static String FETCH_LOGS =
+        "SELECT exec_id, name, attempt, enc_type, start_byte, end_byte, log "
+            + "FROM execution_logs "
+            + "WHERE exec_id=? AND name=? AND attempt=? AND end_byte > ? "
+            + "AND start_byte <= ? ORDER BY start_byte";
+
+    private final int startByte;
+    private final int endByte;
+
+    public FetchLogsHandler(final int startByte, final int endByte) {
+      this.startByte = startByte;
+      this.endByte = endByte;
+    }
+
+    @Override
+    public LogData handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return null;
+      }
+
+      final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+
+      do {
+        // int execId = rs.getInt(1);
+        // String name = rs.getString(2);
+        final int attempt = rs.getInt(3);
+        final EncodingType encType = EncodingType.fromInteger(rs.getInt(4));
+        final int startByte = rs.getInt(5);
+        final int endByte = rs.getInt(6);
+
+        final byte[] data = rs.getBytes(7);
+
+        final int offset =
+            this.startByte > startByte ? this.startByte - startByte : 0;
+        final int length =
+            this.endByte < endByte ? this.endByte - startByte - offset
+                : endByte - startByte - offset;
+        try {
+          byte[] buffer = data;
+          if (encType == EncodingType.GZIP) {
+            buffer = GZIPUtils.unGzipBytes(data);
+          }
+
+          byteStream.write(buffer, offset, length);
+        } catch (final IOException e) {
+          throw new SQLException(e);
+        }
+      } while (rs.next());
+
+      final byte[] buffer = byteStream.toByteArray();
+      final Pair<Integer, Integer> result =
+          FileIOUtils.getUtf8Range(buffer, 0, buffer.length);
+
+      return new LogData(this.startByte + result.getFirst(), result.getSecond(),
+          new String(buffer, result.getFirst(), result.getSecond(), StandardCharsets.UTF_8));
+    }
+  }
+
+  public static class FetchExecutableJobHandler implements
+      ResultSetHandler<List<ExecutableJobInfo>> {
+
+    public static String FETCH_EXECUTABLE_NODE =
+        "SELECT exec_id, project_id, version, flow_id, job_id, "
+            + "start_time, end_time, status, attempt "
+            + "FROM execution_jobs WHERE exec_id=? "
+            + "AND job_id=? AND attempt=?";
+    public static String FETCH_EXECUTABLE_NODE_ATTEMPTS =
+        "SELECT exec_id, project_id, version, flow_id, job_id, "
+            + "start_time, end_time, status, attempt FROM execution_jobs "
+            + "WHERE exec_id=? AND job_id=?";
+    public static String FETCH_PROJECT_EXECUTABLE_NODE =
+        "SELECT exec_id, project_id, version, flow_id, job_id, "
+            + "start_time, end_time, status, attempt FROM execution_jobs "
+            + "WHERE project_id=? AND job_id=? "
+            + "ORDER BY exec_id DESC LIMIT ?, ? ";
+
+    @Override
+    public List<ExecutableJobInfo> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.<ExecutableJobInfo> emptyList();
+      }
+
+      final List<ExecutableJobInfo> execNodes = new ArrayList<>();
+      do {
+        final int execId = rs.getInt(1);
+        final int projectId = rs.getInt(2);
+        final int version = rs.getInt(3);
+        final String flowId = rs.getString(4);
+        final String jobId = rs.getString(5);
+        final long startTime = rs.getLong(6);
+        final long endTime = rs.getLong(7);
+        final Status status = Status.fromInteger(rs.getInt(8));
+        final int attempt = rs.getInt(9);
+
+        final ExecutableJobInfo info =
+            new ExecutableJobInfo(execId, projectId, version, flowId, jobId,
+                startTime, endTime, status, attempt);
+        execNodes.add(info);
+      } while (rs.next());
+
+      return execNodes;
+    }
+  }
+
+  public static class FetchExecutableJobAttachmentsHandler implements
+      ResultSetHandler<String> {
+
+    public static String FETCH_ATTACHMENTS_EXECUTABLE_NODE =
+        "SELECT attachments FROM execution_jobs WHERE exec_id=? AND job_id=?";
+
+    @Override
+    public String handle(final ResultSet rs) throws SQLException {
+      String attachmentsJson = null;
+      if (rs.next()) {
+        try {
+          final byte[] attachments = rs.getBytes(1);
+          if (attachments != null) {
+            attachmentsJson = GZIPUtils.unGzipString(attachments, "UTF-8");
+          }
+        } catch (final IOException e) {
+          throw new SQLException("Error decoding job attachments", e);
+        }
+      }
+      return attachmentsJson;
+    }
+  }
+
+    public static class FetchExecutableJobPropsHandler implements
+      ResultSetHandler<Pair<Props, Props>> {
+
+    public static String FETCH_OUTPUT_PARAM_EXECUTABLE_NODE =
+        "SELECT output_params FROM execution_jobs WHERE exec_id=? AND job_id=?";
+    public static String FETCH_INPUT_PARAM_EXECUTABLE_NODE =
+        "SELECT input_params FROM execution_jobs WHERE exec_id=? AND job_id=?";
+    public static String FETCH_INPUT_OUTPUT_PARAM_EXECUTABLE_NODE =
+        "SELECT input_params, output_params "
+            + "FROM execution_jobs WHERE exec_id=? AND job_id=?";
+
+    @Override
+    public Pair<Props, Props> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return new Pair<>(null, null);
+      }
+
+      if (rs.getMetaData().getColumnCount() > 1) {
+        final byte[] input = rs.getBytes(1);
+        final byte[] output = rs.getBytes(2);
+
+        Props inputProps = null;
+        Props outputProps = null;
+        try {
+          if (input != null) {
+            final String jsonInputString = GZIPUtils.unGzipString(input, "UTF-8");
+            inputProps =
+                PropsUtils.fromHierarchicalMap((Map<String, Object>) JSONUtils
+                    .parseJSONFromString(jsonInputString));
+
+          }
+          if (output != null) {
+            final String jsonOutputString = GZIPUtils.unGzipString(output, "UTF-8");
+            outputProps =
+                PropsUtils.fromHierarchicalMap((Map<String, Object>) JSONUtils
+                    .parseJSONFromString(jsonOutputString));
+          }
+        } catch (final IOException e) {
+          throw new SQLException("Error decoding param data", e);
+        }
+
+        return new Pair<>(inputProps, outputProps);
+      } else {
+        final byte[] params = rs.getBytes(1);
+        Props props = null;
+        try {
+          if (params != null) {
+            final String jsonProps = GZIPUtils.unGzipString(params, "UTF-8");
+
+            props =
+                PropsUtils.fromHierarchicalMap((Map<String, Object>) JSONUtils
+                    .parseJSONFromString(jsonProps));
+          }
+        } catch (final IOException e) {
+          throw new SQLException("Error decoding param data", e);
+        }
+
+        return new Pair<>(props, null);
+      }
+    }
+  }
+
+  /**
+   * JDBC ResultSetHandler to fetch queued executions
+   */
+  public static class FetchQueuedExecutableFlows implements
+      ResultSetHandler<List<Pair<ExecutionReference, ExecutableFlow>>> {
+    // Select queued unassigned flows
+    public static final String FETCH_QUEUED_EXECUTABLE_FLOW =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows"
+            + " Where executor_id is NULL AND status = "
+            + Status.PREPARING.getNumVal();
+
+    @Override
+    public List<Pair<ExecutionReference, ExecutableFlow>> handle(final ResultSet rs)
+        throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyList();
+      }
+
+      final List<Pair<ExecutionReference, ExecutableFlow>> execFlows =
+          new ArrayList<>();
+      do {
+        final int id = rs.getInt(1);
+        final int encodingType = rs.getInt(2);
+        final byte[] data = rs.getBytes(3);
+
+        if (data == null) {
+          logger.error("Found a flow with empty data blob exec_id: " + id);
+        } else {
+          final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Object flowObj;
+          try {
+            // Convoluted way to inflate strings. Should find common package or
+            // helper function.
+            if (encType == EncodingType.GZIP) {
+              // Decompress the sucker.
+              final String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              final String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            final ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+            final ExecutionReference ref = new ExecutionReference(id);
+            execFlows.add(new Pair<>(ref, exFlow));
+          } catch (final IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  public static class FetchRecentlyFinishedFlows implements
+      ResultSetHandler<List<ExecutableFlow>> {
+    // Execution_flows table is already indexed by end_time
+    public static String FETCH_RECENTLY_FINISHED_FLOW =
+        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+            + "WHERE end_time > ? AND status IN (?, ?, ?)";
+
+    @Override
+    public List<ExecutableFlow> handle(
+        final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyList();
+      }
+
+      final List<ExecutableFlow> execFlows = new ArrayList<>();
+      do {
+        final int id = rs.getInt(1);
+        final int encodingType = rs.getInt(2);
+        final byte[] data = rs.getBytes(3);
+
+        if (data != null) {
+          final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Object flowObj;
+          try {
+            if (encType == EncodingType.GZIP) {
+              final String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              final String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            final ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+
+            execFlows.add(exFlow);
+          } catch (final IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  public static class FetchActiveExecutableFlows implements
+      ResultSetHandler<Map<Integer, Pair<ExecutionReference, ExecutableFlow>>> {
+    // Select running and executor assigned flows
+    public static String FETCH_ACTIVE_EXECUTABLE_FLOW =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, et.id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " INNER JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")";
+
+    @Override
+    public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> handle(
+        final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyMap();
+      }
+
+      final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> execFlows =
+          new HashMap<>();
+      do {
+        final int id = rs.getInt(1);
+        final int encodingType = rs.getInt(2);
+        final byte[] data = rs.getBytes(3);
+        final String host = rs.getString(4);
+        final int port = rs.getInt(5);
+        final int executorId = rs.getInt(6);
+        final boolean executorStatus = rs.getBoolean(7);
+
+        if (data == null) {
+          execFlows.put(id, null);
+        } else {
+          final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Object flowObj;
+          try {
+            // Convoluted way to inflate strings. Should find common package or
+            // helper function.
+            if (encType == EncodingType.GZIP) {
+              // Decompress the sucker.
+              final String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              final String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            final ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+            final Executor executor = new Executor(executorId, host, port, executorStatus);
+            final ExecutionReference ref = new ExecutionReference(id, executor);
+            execFlows.put(id, new Pair<>(ref, exFlow));
+          } catch (final IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  public static class FetchActiveExecutableFlowByExecId implements
+      ResultSetHandler<List<Pair<ExecutionReference, ExecutableFlow>>> {
+
+    public static String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, et.id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " INNER JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.exec_id = ? AND ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")";
+
+    @Override
+    public List<Pair<ExecutionReference, ExecutableFlow>> handle(final ResultSet rs)
+        throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyList();
+      }
+
+      final List<Pair<ExecutionReference, ExecutableFlow>> execFlows =
+          new ArrayList<>();
+      do {
+        final int id = rs.getInt(1);
+        final int encodingType = rs.getInt(2);
+        final byte[] data = rs.getBytes(3);
+        final String host = rs.getString(4);
+        final int port = rs.getInt(5);
+        final int executorId = rs.getInt(6);
+        final boolean executorStatus = rs.getBoolean(7);
+
+        if (data == null) {
+          logger.error("Found a flow with empty data blob exec_id: " + id);
+        } else {
+          final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Object flowObj;
+          try {
+            if (encType == EncodingType.GZIP) {
+              final String jsonString = GZIPUtils.unGzipString(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            } else {
+              final String jsonString = new String(data, "UTF-8");
+              flowObj = JSONUtils.parseJSONFromString(jsonString);
+            }
+
+            final ExecutableFlow exFlow =
+                ExecutableFlow.createExecutableFlowFromObject(flowObj);
+            final Executor executor = new Executor(executorId, host, port, executorStatus);
+            final ExecutionReference ref = new ExecutionReference(id, executor);
+            execFlows.add(new Pair<>(ref, exFlow));
+          } catch (final IOException e) {
+            throw new SQLException("Error retrieving flow data " + id, e);
+          }
+        }
+      } while (rs.next());
+
+      return execFlows;
+    }
+  }
+
+  public static class IntHandler implements ResultSetHandler<Integer> {
+
+    public static String NUM_EXECUTIONS =
+        "SELECT COUNT(1) FROM execution_flows";
+    public static String NUM_FLOW_EXECUTIONS =
+        "SELECT COUNT(1) FROM execution_flows WHERE project_id=? AND flow_id=?";
+    public static String NUM_JOB_EXECUTIONS =
+        "SELECT COUNT(1) FROM execution_jobs WHERE project_id=? AND job_id=?";
+    public static String FETCH_EXECUTOR_ID =
+        "SELECT executor_id FROM execution_flows WHERE exec_id=?";
+
+    @Override
+    public Integer handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return 0;
+      }
+      return rs.getInt(1);
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorImpl.java
@@ -1,0 +1,822 @@
+package azkaban.executor;
+
+import azkaban.database.AbstractJdbcLoader;
+import azkaban.database.EncodingType;
+import azkaban.db.DatabaseOperator;
+import azkaban.db.DatabaseTransOperator;
+import azkaban.db.SQLTransaction;
+import azkaban.executor.ExecutorLogEvent.EventType;
+import azkaban.executor.JdbcExecutorHandlerSet.ExecutorLogsResultHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchActiveExecutableFlowByExecId;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchActiveExecutableFlows;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchExecutableFlows;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchExecutableJobAttachmentsHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchExecutableJobHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchExecutableJobPropsHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchExecutorHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchLogsHandler;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchQueuedExecutableFlows;
+import azkaban.executor.JdbcExecutorHandlerSet.FetchRecentlyFinishedFlows;
+import azkaban.executor.JdbcExecutorHandlerSet.IntHandler;
+import azkaban.utils.FileIOUtils.LogData;
+import azkaban.utils.GZIPUtils;
+import azkaban.utils.JSONUtils;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
+import azkaban.utils.PropsUtils;
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+
+public class JdbcExecutorImpl implements ExecutorLoader {
+
+  private static final Logger logger = Logger.getLogger(JdbcExecutorImpl.class);
+  private final DatabaseOperator dbOperator;
+
+  public JdbcExecutorImpl(final DatabaseOperator databaseOperator) {
+    this.dbOperator = databaseOperator;
+  }
+
+  @Override
+  public synchronized void uploadExecutableFlow(final ExecutableFlow flow)
+      throws ExecutorManagerException {
+    final String INSERT_EXECUTABLE_FLOW = "INSERT INTO execution_flows "
+        + "(project_id, flow_id, version, status, submit_time, submit_user, update_time) "
+        + "values (?,?,?,?,?,?,?)";
+    final long submitTime = System.currentTimeMillis();
+
+    final SQLTransaction<Long> insertAndGetLastID = transOperator -> {
+      transOperator.update(INSERT_EXECUTABLE_FLOW, flow.getProjectId(),
+          flow.getFlowId(), flow.getVersion(), Status.PREPARING.getNumVal(),
+          submitTime, flow.getSubmitUser(), submitTime);
+      transOperator.getConnection().commit();
+      return transOperator.getLastInsertId();
+    };
+
+    try {
+      final long id = this.dbOperator.transaction(insertAndGetLastID);
+      logger.info("Flow given " + flow.getFlowId() + " given id " + id);
+      flow.setExecutionId((int) id);
+      updateExecutableFlow(flow);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error creating execution.", e);
+    }
+  }
+
+  @Override
+  public ExecutableFlow fetchExecutableFlow(final int execId) throws ExecutorManagerException {
+    final FetchExecutableFlows flowHandler = new FetchExecutableFlows();
+    try {
+      final List<ExecutableFlow> properties = this.dbOperator
+          .query(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW,
+              flowHandler, id);
+      if (properties.isEmpty()) {
+        return null;
+      } else {
+        return properties.get(0);
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching flow id " + id, e);
+    }
+  }
+
+  /**
+   * maxAge indicates how long finished flows are shown in Recently Finished flow page.
+   */
+  @Override
+  public List<ExecutableFlow> fetchRecentlyFinishedFlows(final Duration maxAge)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchRecentlyFinishedFlows.FETCH_RECENTLY_FINISHED_FLOW,
+          new FetchRecentlyFinishedFlows(), System.currentTimeMillis() - maxAge.toMillis(),
+          Status.SUCCEEDED.getNumVal(), Status.KILLED.getNumVal(),
+          Status.FAILED.getNumVal());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching recently finished flows", e);
+    }
+  }
+
+  @Override
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOW,
+          new FetchActiveExecutableFlows());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
+      throws ExecutorManagerException {
+    try {
+      final List<Pair<ExecutionReference, ExecutableFlow>> flows =
+          this.dbOperator
+              .query(FetchActiveExecutableFlowByExecId.FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXECID,
+                  new FetchActiveExecutableFlowByExecId(), execId);
+      if (flows.isEmpty()) {
+        return null;
+      } else {
+        return flows.get(0);
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows by exec id", e);
+    }
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int skip, final int num)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_ALL_EXECUTABLE_FLOW_HISTORY,
+          new FetchExecutableFlows(), skip, num);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching flow History", e);
+    }
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+                                               final int skip, final int num)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_HISTORY,
+          new FetchExecutableFlows(), projectId, flowId, skip, num);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching flow history", e);
+    }
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+                                               final int skip, final int num,
+                                               final Status status)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_BY_STATUS,
+          new FetchExecutableFlows(), projectId, flowId, status.getNumVal(), skip, num);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final String projContain, final String flowContains,
+                                               final String userNameContains, final int status,
+                                               final long startData,
+                                               final long endData, final int skip, final int num)
+      throws ExecutorManagerException {
+    String query = FetchExecutableFlows.FETCH_BASE_EXECUTABLE_FLOW_QUERY;
+    final List<Object> params = new ArrayList<Object>();
+
+    boolean first = true;
+    if (projContain != null && !projContain.isEmpty()) {
+      query += " ef JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?";
+      params.add('%' + projContain + '%');
+      first = false;
+    }
+
+    // todo kunkun-tang: we don't need the below complicated logics. We should just use a simple way.
+    if (flowContains != null && !flowContains.isEmpty()) {
+      if (first) {
+        query += " WHERE ";
+        first = false;
+      } else {
+        query += " AND ";
+      }
+
+      query += " flow_id LIKE ?";
+      params.add('%' + flowContains + '%');
+    }
+
+    if (userNameContains != null && !userNameContains.isEmpty()) {
+      if (first) {
+        query += " WHERE ";
+        first = false;
+      } else {
+        query += " AND ";
+      }
+      query += " submit_user LIKE ?";
+      params.add('%' + userNameContains + '%');
+    }
+
+    if (status != 0) {
+      if (first) {
+        query += " WHERE ";
+        first = false;
+      } else {
+        query += " AND ";
+      }
+      query += " status = ?";
+      params.add(status);
+    }
+
+    if (startTime > 0) {
+      if (first) {
+        query += " WHERE ";
+        first = false;
+      } else {
+        query += " AND ";
+      }
+      query += " start_time > ?";
+      params.add(startTime);
+    }
+
+    if (endTime > 0) {
+      if (first) {
+        query += " WHERE ";
+        first = false;
+      } else {
+        query += " AND ";
+      }
+      query += " end_time < ?";
+      params.add(endTime);
+    }
+
+    if (skip > -1 && num > 0) {
+      query += "  ORDER BY exec_id DESC LIMIT ?, ?";
+      params.add(skip);
+      params.add(num);
+    }
+
+    try {
+      return this.dbOperator.query(query, new FetchExecutableFlows(), params.toArray());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  @Override
+  public List<Executor> fetchAllExecutors() throws ExecutorManagerException {
+    try {
+      return this.dbOperator
+          .query(FetchExecutableFlows.FETCH_ALL_EXECUTORS, new FetchExecutorHandler());
+    } catch (final Exception e) {
+      throw new ExecutorManagerException("Error fetching executors", e);
+    }
+  }
+
+  @Override
+  public List<Executor> fetchActiveExecutors() throws ExecutorManagerException {
+    try {
+      return this.dbOperator
+          .query(FetchExecutorHandler.FETCH_ACTIVE_EXECUTORS, new FetchExecutorHandler());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active executors", e);
+    }
+  }
+
+  @Override
+  public Executor fetchExecutor(final String host, final int port) throws ExecutorManagerException {
+    try {
+      final List<Executor> executors =
+          this.dbOperator.query(FetchExecutorHandler.FETCH_EXECUTOR_BY_HOST_PORT,
+              new FetchExecutorHandler(), host, port);
+      if (executors.isEmpty()) {
+        return null;
+      } else {
+        return executors.get(0);
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(String.format(
+          "Error fetching executor %s:%d", host, port), e);
+    }
+  }
+
+  @Override
+  public Executor fetchExecutor(final int executorId) throws ExecutorManagerException {
+    try {
+      final List<Executor> executors = this.dbOperator
+          .query(FetchExecutorHandler.FETCH_EXECUTOR_BY_ID,
+              new FetchExecutorHandler(), executorId);
+      if (executors.isEmpty()) {
+        return null;
+      } else {
+        return executors.get(0);
+      }
+    } catch (final Exception e) {
+      throw new ExecutorManagerException(String.format(
+          "Error fetching executor with id: %d", executorId), e);
+    }
+  }
+
+  @Override
+  public Executor addExecutor(final String host, final int port) throws ExecutorManagerException {
+    // verify, if executor already exists
+    if (fetchExecutor(host, port) != null) {
+      throw new ExecutorManagerException(String.format(
+          "Executor %s:%d already exist", host, port));
+    }
+    // add new executor
+    addExecutorHelper(host, port);
+
+    // fetch newly added executor
+    return fetchExecutor(host, port);
+  }
+
+  private void addExecutorHelper(final String host, final int port)
+      throws ExecutorManagerException {
+    final String INSERT = "INSERT INTO executors (host, port) values (?,?)";
+    try {
+      this.dbOperator.update(INSERT, host, port);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(String.format("Error adding %s:%d ",
+          host, port), e);
+    }
+  }
+
+  @Override
+  public void updateExecutor(final Executor executor) throws ExecutorManagerException {
+    final String UPDATE =
+        "UPDATE executors SET host=?, port=?, active=? where id=?";
+
+    try {
+      final int rows = this.dbOperator.update(UPDATE, executor.getHost(), executor.getPort(),
+          executor.isActive(), executor.getId());
+      if (rows == 0) {
+        throw new ExecutorManagerException("No executor with id :" + executor.getId());
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error inactivating executor "
+          + executor.getId(), e);
+    }
+  }
+
+  @Override
+  public void removeExecutor(final String host, final int port) throws ExecutorManagerException {
+    final String DELETE = "DELETE FROM executors WHERE host=? AND port=?";
+    try {
+      final int rows = this.dbOperator.update(DELETE, host, port);
+      if (rows == 0) {
+        throw new ExecutorManagerException("No executor with host, port :"
+            + "(" + host + "," + port + ")");
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error removing executor with host, port : "
+          + "(" + host + "," + port + ")", e);
+    }
+  }
+
+  @Override
+  public void postExecutorEvent(final Executor executor, final EventType type, final String user,
+                                final String message)
+      throws ExecutorManagerException {
+    final String INSERT_PROJECT_EVENTS =
+        "INSERT INTO executor_events (executor_id, event_type, event_time, username, message) values (?,?,?,?,?)";
+    try {
+      this.dbOperator.update(INSERT_PROJECT_EVENTS, executor.getId(), type.getNumVal(),
+          new Date(), user, message);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Failed to post executor event", e);
+    }
+  }
+
+  @Override
+  public List<ExecutorLogEvent> getExecutorEvents(final Executor executor, final int num,
+                                                  final int offset)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(ExecutorLogsResultHandler.SELECT_EXECUTOR_EVENTS_ORDER,
+          new ExecutorLogsResultHandler(), executor.getId(), num, offset);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Failed to fetch events for executor id : " + executor.getId(), e);
+    }
+  }
+
+  @Override
+  public void addActiveExecutableReference(final ExecutionReference reference)
+      throws ExecutorManagerException {
+    final String INSERT = "INSERT INTO active_executing_flows "
+        + "(exec_id, update_time) values (?,?)";
+    try {
+      this.dbOperator.update(INSERT, reference.getExecId(), reference.getUpdateTime());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Error updating active flow reference " + reference.getExecId(), e);
+    }
+  }
+
+  @Override
+  public void removeActiveExecutableReference(final int execId) throws ExecutorManagerException {
+    final String DELETE = "DELETE FROM active_executing_flows WHERE exec_id=?";
+    try {
+      this.dbOperator.update(DELETE, execId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Error deleting active flow reference " + execId, e);
+    }
+  }
+
+  @Override
+  public void unassignExecutor(final int executionId) throws ExecutorManagerException {
+    final String UPDATE = "UPDATE execution_flows SET executor_id=NULL where exec_id=?";
+    try {
+      final int rows = this.dbOperator.update(UPDATE, executionId);
+      if (rows == 0) {
+        throw new ExecutorManagerException(String.format(
+            "Failed to unassign executor for execution : %d  ", executionId));
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error updating execution id " + executionId, e);
+    }
+
+  }
+
+  @Override
+  public void assignExecutor(final int executorId, final int executionId)
+      throws ExecutorManagerException {
+    final String UPDATE =
+        "UPDATE execution_flows SET executor_id=? where exec_id=?";
+    try {
+      if (fetchExecutor(executorId) == null) {
+        throw new ExecutorManagerException(String.format(
+            "Failed to assign non-existent executor Id: %d to execution : %d  ",
+            executorId, executionId));
+      }
+
+      if (this.dbOperator.update(UPDATE, executorId, executionId) == 0) {
+        throw new ExecutorManagerException(String.format(
+            "Failed to assign executor Id: %d to non-existent execution : %d  ",
+            executorId, executionId));
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error updating executor id "
+          + executorId, e);
+    }
+  }
+
+  @Override
+  public Executor fetchExecutorByExecutionId(final int executionId)
+      throws ExecutorManagerException {
+    final FetchExecutorHandler executorHandler = new FetchExecutorHandler();
+    try {
+      final List<Executor> executors = this.dbOperator
+          .query(FetchExecutorHandler.FETCH_EXECUTION_EXECUTOR,
+              executorHandler, executionId);
+      if (executors.size() > 0) {
+        return executors.get(0);
+      } else {
+        return null;
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Error fetching executor for exec_id : " + executionId, e);
+    }
+  }
+
+  @Override
+  public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchQueuedExecutableFlows.FETCH_QUEUED_EXECUTABLE_FLOW,
+          new FetchQueuedExecutableFlows());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  @Override
+  public boolean updateExecutableReference(final int execId, final long updateTime)
+      throws ExecutorManagerException {
+    final String DELETE =
+        "UPDATE active_executing_flows set update_time=? WHERE exec_id=?";
+
+    int updateNum = 0;
+    try {
+      updateNum = this.dbOperator.update(DELETE, updateTime, execId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Error deleting active flow reference " + execId, e);
+    }
+
+    // Should be 1.
+    return updateNum > 0;
+  }
+
+  // TODO kunkun-tang: the interface's parameter is called endByte, but actually is length.
+  @Override
+  public LogData fetchLogs(final int execId, final String name, final int attempt,
+                           final int startByte, final int length)
+      throws ExecutorManagerException {
+    final FetchLogsHandler handler = new FetchLogsHandler(startByte, length + startByte);
+    try {
+      return this.dbOperator.query(FetchLogsHandler.FETCH_LOGS, handler,
+          execId, name, attempt, startByte, startByte + length);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching logs " + execId
+          + " : " + name, e);
+    }
+  }
+
+  // TODO kunkun-tang: the interface's parameter is called name, but actually is jobId.
+  @Override
+  public List<Object> fetchAttachments(final int execId, final String jobId, final int attempt)
+      throws ExecutorManagerException {
+    try {
+      final String attachments = this.dbOperator.query(
+          FetchExecutableJobAttachmentsHandler.FETCH_ATTACHMENTS_EXECUTABLE_NODE,
+          new FetchExecutableJobAttachmentsHandler(), execId, jobId);
+      if (attachments == null) {
+        return null;
+      } else {
+        return (List<Object>) JSONUtils.parseJSONFromString(attachments);
+      }
+    } catch (final IOException e) {
+      throw new ExecutorManagerException(
+          "Error converting job attachments to JSON " + jobId, e);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException(
+          "Error query job attachments " + jobId, e);
+    }
+  }
+
+  @Override
+  public void uploadLogFile(final int execId, final String name, final int attempt,
+                            final File... files)
+      throws ExecutorManagerException {
+    final SQLTransaction<Integer> transaction = transOperator -> {
+      addProjectToProjectVersions(transOperator, projectId, version, localFile, uploader, md5,
+          resourceId);
+      return 1;
+    };
+  }
+
+  private void uploadLogPart(final DatabaseTransOperator transOperator, final int execId,
+                             final String name,
+                             final int attempt, final int startByte, final int endByte,
+                             final AbstractJdbcLoader.EncodingType encType,
+                             final byte[] buffer, final int length)
+      throws SQLException, IOException {
+    final String INSERT_EXECUTION_LOGS = "INSERT INTO execution_logs "
+        + "(exec_id, name, attempt, enc_type, start_byte, end_byte, "
+        + "log, upload_time) VALUES (?,?,?,?,?,?,?,?)";
+
+    byte[] buf = buffer;
+    if (encType == AbstractJdbcLoader.EncodingType.GZIP) {
+      buf = GZIPUtils.gzipBytes(buf, 0, length);
+    } else if (length < buf.length) {
+      buf = Arrays.copyOf(buffer, length);
+    }
+
+    transOperator.update(INSERT_EXECUTION_LOGS, execId, name, attempt,
+        encType.getNumVal(), startByte, startByte + length, buf, DateTime.now()
+            .getMillis());
+  }
+
+  @Override
+  public void uploadAttachmentFile(final ExecutableNode node, final File file)
+      throws ExecutorManagerException {
+    final String UPDATE_EXECUTION_NODE_ATTACHMENTS =
+        "UPDATE execution_jobs " + "SET attachments=? "
+            + "WHERE exec_id=? AND flow_id=? AND job_id=? AND attempt=?";
+    try {
+      final String jsonString = FileUtils.readFileToString(file);
+      final byte[] attachments = GZIPUtils.gzipString(jsonString, "UTF-8");
+      this.dbOperator.update(UPDATE_EXECUTION_NODE_ATTACHMENTS, attachments,
+          node.getExecutableFlow().getExecutionId(), node.getParentFlow()
+              .getNestedId(), node.getId(), node.getAttempt());
+    } catch (final IOException | SQLException e) {
+      throw new ExecutorManagerException("Error uploading attachments.", e);
+    }
+  }
+
+  @Override
+  public void updateExecutableFlow(final ExecutableFlow flow) throws ExecutorManagerException {
+    updateExecutableFlow(flow, EncodingType.GZIP);
+  }
+
+  public void updateExecutableFlow(final ExecutableFlow flow, final EncodingType encType)
+      throws ExecutorManagerException {
+    final String UPDATE_EXECUTABLE_FLOW_DATA =
+        "UPDATE execution_flows "
+            + "SET status=?,update_time=?,start_time=?,end_time=?,enc_type=?,flow_data=? "
+            + "WHERE exec_id=?";
+
+    final String json = JSONUtils.toJSON(flow.toObject());
+    byte[] data = null;
+    try {
+      final byte[] stringData = json.getBytes("UTF-8");
+      data = stringData;
+      // Todo kunkun-tang: use a common method to transform stringData to data.
+      if (encType == EncodingType.GZIP) {
+        data = GZIPUtils.gzipBytes(stringData);
+      }
+    } catch (final IOException e) {
+      throw new ExecutorManagerException("Error encoding the execution flow.");
+    }
+
+    try {
+      this.dbOperator.update(UPDATE_EXECUTABLE_FLOW_DATA, flow.getStatus()
+          .getNumVal(), flow.getUpdateTime(), flow.getStartTime(), flow
+          .getEndTime(), encType.getNumVal(), data, flow.getExecutionId());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error updating flow.", e);
+    }
+  }
+
+  @Override
+  public void uploadExecutableNode(final ExecutableNode node, final Props inputProps)
+      throws ExecutorManagerException {
+    final String INSERT_EXECUTION_NODE = "INSERT INTO execution_jobs "
+        + "(exec_id, project_id, version, flow_id, job_id, start_time, "
+        + "end_time, status, input_params, attempt) VALUES (?,?,?,?,?,?,?,?,?,?)";
+
+    byte[] inputParam = null;
+    if (inputProps != null) {
+      try {
+        final String jsonString =
+            JSONUtils.toJSON(PropsUtils.toHierarchicalMap(inputProps));
+        inputParam = GZIPUtils.gzipString(jsonString, "UTF-8");
+      } catch (final IOException e) {
+        throw new ExecutorManagerException("Error encoding input params");
+      }
+    }
+
+    final ExecutableFlow flow = node.getExecutableFlow();
+    final String flowId = node.getParentFlow().getFlowPath();
+    logger.info("Uploading flowId " + flowId);
+    try {
+      this.dbOperator.update(INSERT_EXECUTION_NODE, flow.getExecutionId(),
+          flow.getProjectId(), flow.getVersion(), flowId, node.getId(),
+          node.getStartTime(), node.getEndTime(), node.getStatus().getNumVal(),
+          inputParam, node.getAttempt());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error writing job " + node.getId(), e);
+    }
+  }
+
+  @Override
+  public List<ExecutableJobInfo> fetchJobInfoAttempts(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    try {
+      final List<ExecutableJobInfo> info = this.dbOperator.query(
+          FetchExecutableJobHandler.FETCH_EXECUTABLE_NODE_ATTEMPTS,
+          new FetchExecutableJobHandler(), execId, jobId);
+      if (info == null || info.isEmpty()) {
+        return null;
+      } else {
+        return info;
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job info " + jobId, e);
+    }
+  }
+
+  @Override
+  public ExecutableJobInfo fetchJobInfo(final int execId, final String jobId, final int attempts)
+      throws ExecutorManagerException {
+    try {
+      final List<ExecutableJobInfo> info =
+          this.dbOperator.query(FetchExecutableJobHandler.FETCH_EXECUTABLE_NODE,
+              new FetchExecutableJobHandler(), execId, jobId, attempts);
+      if (info == null || info.isEmpty()) {
+        return null;
+      } else {
+        return info.get(0);
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job info " + jobId, e);
+    }
+  }
+
+  @Override
+  public List<ExecutableJobInfo> fetchJobHistory(final int projectId,
+                                                 final String jobId,
+                                                 final int skip,
+                                                 final int size) throws ExecutorManagerException {
+    try {
+      final List<ExecutableJobInfo> info =
+          this.dbOperator.query(FetchExecutableJobHandler.FETCH_PROJECT_EXECUTABLE_NODE,
+              new FetchExecutableJobHandler(), projectId, jobId, skip, size);
+      if (info == null || info.isEmpty()) {
+        return null;
+      } else {
+        return info;
+      }
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job info " + jobId, e);
+    }
+  }
+
+  @Override
+  public void updateExecutableNode(final ExecutableNode node) throws ExecutorManagerException {
+    final String UPSERT_EXECUTION_NODE = "UPDATE execution_jobs "
+        + "SET start_time=?, end_time=?, status=?, output_params=? "
+        + "WHERE exec_id=? AND flow_id=? AND job_id=? AND attempt=?";
+
+    byte[] outputParam = null;
+    final Props outputProps = node.getOutputProps();
+    if (outputProps != null) {
+      try {
+        final String jsonString =
+            JSONUtils.toJSON(PropsUtils.toHierarchicalMap(outputProps));
+        outputParam = GZIPUtils.gzipString(jsonString, "UTF-8");
+      } catch (final IOException e) {
+        throw new ExecutorManagerException("Error encoding input params");
+      }
+    }
+    try {
+      this.dbOperator.update(UPSERT_EXECUTION_NODE, node.getStartTime(), node
+          .getEndTime(), node.getStatus().getNumVal(), outputParam, node
+          .getExecutableFlow().getExecutionId(), node.getParentFlow()
+          .getFlowPath(), node.getId(), node.getAttempt());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error updating job " + node.getId(), e);
+    }
+  }
+
+  @Override
+  public int fetchNumExecutableFlows(final int projectId, final String flowId)
+      throws ExecutorManagerException {
+    final IntHandler intHandler = new IntHandler();
+    try {
+      return this.dbOperator.query(IntHandler.NUM_FLOW_EXECUTIONS, intHandler, projectId, flowId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching num executions", e);
+    }
+  }
+
+  @Override
+  public int fetchNumExecutableFlows() throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(IntHandler.NUM_EXECUTIONS, new IntHandler());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching num executions", e);
+    }
+  }
+
+  @Override
+  public int fetchNumExecutableNodes(final int projectId, final String jobId)
+      throws ExecutorManagerException {
+    final IntHandler intHandler = new IntHandler();
+    try {
+      return this.dbOperator.query(IntHandler.NUM_JOB_EXECUTIONS, intHandler, projectId, jobId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching num executions", e);
+    }
+  }
+
+  @Override
+  public Props fetchExecutionJobInputProps(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    try {
+      final Pair<Props, Props> props = this.dbOperator.query(
+          FetchExecutableJobPropsHandler.FETCH_INPUT_PARAM_EXECUTABLE_NODE,
+          new FetchExecutableJobPropsHandler(), execId, jobId);
+      return props.getFirst();
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job params " + execId
+          + " " + jobId, e);
+    }
+  }
+
+  @Override
+  public Props fetchExecutionJobOutputProps(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    try {
+      final Pair<Props, Props> props = this.dbOperator.query(
+          FetchExecutableJobPropsHandler.FETCH_OUTPUT_PARAM_EXECUTABLE_NODE,
+          new FetchExecutableJobPropsHandler(), execId, jobId);
+      return props.getFirst();
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job params " + execId
+          + " " + jobId, e);
+    }
+  }
+
+  @Override
+  public Pair<Props, Props> fetchExecutionJobProps(final int execId, final String jobId)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(
+          FetchExecutableJobPropsHandler.FETCH_INPUT_OUTPUT_PARAM_EXECUTABLE_NODE,
+          new FetchExecutableJobPropsHandler(), execId, jobId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error querying job params " + execId
+          + " " + jobId, e);
+    }
+  }
+
+  @Override
+  public int removeExecutionLogsByTime(final long millis) throws ExecutorManagerException {
+    final String DELETE_BY_TIME =
+        "DELETE FROM execution_logs WHERE upload_time < ?";
+    try {
+      return this.dbOperator.update(DELETE_BY_TIME, millis);
+    } catch (final SQLException e) {
+      e.printStackTrace();
+      throw new ExecutorManagerException(
+          "Error deleting old execution_logs before " + millis, e);
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.executor;
 
 import azkaban.database.EncodingType;

--- a/azkaban-common/src/test/java/azkaban/executor/JdbcExecutorImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JdbcExecutorImplTest.java
@@ -60,7 +60,7 @@ public class JdbcExecutorImplTest {
     final String sqlScriptsDir = new File("../azkaban-db/src/main/sql/").getCanonicalPath();
     props.put("database.sql.scripts.dir", sqlScriptsDir);
 
-    // TODO kunkun-tang: Need to refactor AzkabanDatabaseSetup to accept datasource in azakaban-db
+    // TODO kunkun-tang: Need to refactor AzkabanDatabaseSetup to accept datasource in azkaban-db
     final azkaban.database.AzkabanDataSource dataSourceForSetupDB =
         new azkaban.database.AzkabanConnectionPoolTest.EmbeddedH2BasicDataSource();
     final AzkabanDatabaseSetup setup = new AzkabanDatabaseSetup(dataSourceForSetupDB, props);
@@ -256,7 +256,7 @@ public class JdbcExecutorImplTest {
     // no execution flows at all i.e. no running, completed or queued flows
     Assert.assertTrue(queuedFlows.isEmpty());
 
-    final String host = "lcoalhost";
+    final String host = "localhost";
     final int port = 12345;
     final Executor executor = this.loader.addExecutor(host, port);
 

--- a/azkaban-common/src/test/java/azkaban/executor/JdbcExecutorImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JdbcExecutorImplTest.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.executor;
+
+import static azkaban.db.AzDBTestUtility.EmbeddedH2BasicDataSource;
+
+import azkaban.database.AzkabanDatabaseSetup;
+import azkaban.db.AzkabanDataSource;
+import azkaban.db.DatabaseOperator;
+import azkaban.db.DatabaseOperatorImpl;
+import azkaban.utils.FileIOUtils.LogData;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
+import azkaban.utils.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.dbutils.QueryRunner;
+import org.joda.time.DateTimeUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JdbcExecutorImplTest {
+
+  private static final String UNIT_BASE_DIR =
+      "../test/src/test/resources/azkaban/test/executions";
+  private static final Props props = new Props();
+  private static final Duration RECENTLY_FINISHED_LIFETIME = Duration.ofMinutes(1);
+  private static final Duration FLOW_FINISHED_TIME = Duration.ofMinutes(2);
+  private static DatabaseOperator dbOperator;
+  private ExecutorLoader loader;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    final AzkabanDataSource dataSource = new EmbeddedH2BasicDataSource();
+    dbOperator = new DatabaseOperatorImpl(new QueryRunner(dataSource));
+
+    final String sqlScriptsDir = new File("../azkaban-db/src/main/sql/").getCanonicalPath();
+    props.put("database.sql.scripts.dir", sqlScriptsDir);
+
+    // TODO kunkun-tang: Need to refactor AzkabanDatabaseSetup to accept datasource in azakaban-db
+    final azkaban.database.AzkabanDataSource dataSourceForSetupDB =
+        new azkaban.database.AzkabanConnectionPoolTest.EmbeddedH2BasicDataSource();
+    final AzkabanDatabaseSetup setup = new AzkabanDatabaseSetup(dataSourceForSetupDB, props);
+    setup.loadTableInfo();
+    setup.updateDatabase(true, false);
+  }
+
+  @AfterClass
+  public static void destroyDB() {
+    try {
+      dbOperator.update("DROP ALL OBJECTS");
+    } catch (final SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private ExecutableFlow createTestFlow() throws Exception {
+    return TestUtils.createExecutableFlow("exectest1", "exec1");
+  }
+
+  @Before
+  public void setup() {
+    this.loader = new JdbcExecutorImpl(dbOperator);
+  }
+
+  @Test
+  public void testUploadAndFetchExecutionFlows() throws Exception {
+
+    final ExecutableFlow flow = createTestFlow();
+    this.loader.uploadExecutableFlow(flow);
+
+    final ExecutableFlow fetchFlow =
+        this.loader.fetchExecutableFlow(flow.getExecutionId());
+
+    Assert.assertTrue(flow != fetchFlow);
+    Assert.assertEquals(flow.getExecutionId(), fetchFlow.getExecutionId());
+    Assert.assertEquals(flow.getEndTime(), fetchFlow.getEndTime());
+    Assert.assertEquals(flow.getStartTime(), fetchFlow.getStartTime());
+    Assert.assertEquals(flow.getSubmitTime(), fetchFlow.getSubmitTime());
+    Assert.assertEquals(flow.getFlowId(), fetchFlow.getFlowId());
+    Assert.assertEquals(flow.getProjectId(), fetchFlow.getProjectId());
+    Assert.assertEquals(flow.getVersion(), fetchFlow.getVersion());
+    Assert.assertEquals(flow.getExecutionOptions().getFailureAction(),
+        fetchFlow.getExecutionOptions().getFailureAction());
+    Assert.assertEquals(new HashSet<>(flow.getEndNodes()),
+        new HashSet<>(fetchFlow.getEndNodes()));
+  }
+
+  @Test
+  public void testUpdateExecutionFlows() throws Exception {
+    final ExecutableFlow flow = createTestFlow();
+    this.loader.uploadExecutableFlow(flow);
+
+    final ExecutableFlow fetchFlow =
+        this.loader.fetchExecutableFlow(flow.getExecutionId());
+
+    fetchFlow.setEndTime(System.currentTimeMillis());
+    fetchFlow.setStatus(Status.SUCCEEDED);
+    this.loader.updateExecutableFlow(fetchFlow);
+    final ExecutableFlow fetchFlow2 =
+        this.loader.fetchExecutableFlow(flow.getExecutionId());
+
+    Assert.assertEquals(fetchFlow2.getEndTime(), fetchFlow.getEndTime());
+    Assert.assertEquals(fetchFlow2.getStatus(), fetchFlow.getStatus());
+  }
+
+  /* Test fetchQueuedFlows happy case */
+  @Test
+  public void testFetchQueuedFlows() throws ExecutorManagerException, IOException {
+
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    flow.setStatus(Status.PREPARING);
+    this.loader.uploadExecutableFlow(flow);
+    final ExecutableFlow flow2 = TestUtils.createExecutableFlow("exectest1", "exec2");
+    flow2.setStatus(Status.PREPARING);
+    this.loader.uploadExecutableFlow(flow2);
+
+    final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows = this.loader.fetchQueuedFlows();
+    Assert.assertEquals(2, fetchedQueuedFlows.size());
+    final Pair<ExecutionReference, ExecutableFlow> fetchedFlow1 = fetchedQueuedFlows.get(0);
+    final Pair<ExecutionReference, ExecutableFlow> fetchedFlow2 = fetchedQueuedFlows.get(1);
+
+    Assert.assertEquals(flow.getExecutionId(), fetchedFlow1.getSecond().getExecutionId());
+    Assert.assertEquals(flow.getFlowId(), fetchedFlow1.getSecond().getFlowId());
+    Assert.assertEquals(flow.getProjectId(), fetchedFlow1.getSecond().getProjectId());
+    Assert.assertEquals(flow2.getExecutionId(), fetchedFlow2.getSecond().getExecutionId());
+    Assert.assertEquals(flow2.getFlowId(), fetchedFlow2.getSecond().getFlowId());
+    Assert.assertEquals(flow2.getProjectId(), fetchedFlow2.getSecond().getProjectId());
+  }
+
+  @Test
+  public void testUploadAndFetchExecutableNode() throws Exception {
+
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    flow.setExecutionId(10);
+
+    final File jobFile = new File(UNIT_BASE_DIR + "/exectest1", "job10.job");
+    final Props props = new Props(null, jobFile);
+    props.put("test", "test2");
+    final ExecutableNode oldNode = flow.getExecutableNode("job10");
+    oldNode.setStartTime(System.currentTimeMillis());
+    this.loader.uploadExecutableNode(oldNode, props);
+
+    final ExecutableJobInfo info = this.loader.fetchJobInfo(10, "job10", 0);
+    Assert.assertEquals(flow.getExecutionId(), info.getExecId());
+    Assert.assertEquals(flow.getProjectId(), info.getProjectId());
+    Assert.assertEquals(flow.getVersion(), info.getVersion());
+    Assert.assertEquals(flow.getFlowId(), info.getFlowId());
+    Assert.assertEquals(oldNode.getId(), info.getJobId());
+    Assert.assertEquals(oldNode.getStatus(), info.getStatus());
+    Assert.assertEquals(oldNode.getStartTime(), info.getStartTime());
+    Assert.assertEquals("endTime = " + oldNode.getEndTime()
+            + " info endTime = " + info.getEndTime(), oldNode.getEndTime(),
+        info.getEndTime());
+
+    // Fetch props
+    final Props outputProps = new Props();
+    outputProps.put("hello", "output");
+    oldNode.setOutputProps(outputProps);
+    oldNode.setEndTime(System.currentTimeMillis());
+    this.loader.updateExecutableNode(oldNode);
+
+    final Props fInputProps = this.loader.fetchExecutionJobInputProps(10, "job10");
+    final Props fOutputProps = this.loader.fetchExecutionJobOutputProps(10, "job10");
+    final Pair<Props, Props> inOutProps = this.loader.fetchExecutionJobProps(10, "job10");
+
+    Assert.assertEquals(fInputProps.get("test"), "test2");
+    Assert.assertEquals(fOutputProps.get("hello"), "output");
+    Assert.assertEquals(inOutProps.getFirst().get("test"), "test2");
+    Assert.assertEquals(inOutProps.getSecond().get("hello"), "output");
+  }
+
+  @Test(expected = ExecutorManagerException.class)
+  public void testUnassignExecutorException() throws Exception {
+      this.loader.unassignExecutor(2);
+  }
+
+  @Test
+  public void testAssignAndUnassignExecutor() throws Exception {
+    final String host = "localhost";
+    final int port = 12345;
+    final Executor executor = this.loader.addExecutor(host, port);
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow);
+    this.loader.assignExecutor(executor.getId(), flow.getExecutionId());
+    Assert.assertEquals(
+        this.loader.fetchExecutorByExecutionId(flow.getExecutionId()), executor);
+    this.loader.unassignExecutor(flow.getExecutionId());
+    Assert.assertEquals(
+        this.loader.fetchExecutorByExecutionId(flow.getExecutionId()), null);
+  }
+
+  /* Test exception when assigning a non-existent executor to a flow */
+  @Test(expected = ExecutorManagerException.class)
+  public void testAssignExecutorInvalidExecutor() throws Exception {
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow);
+    this.loader.assignExecutor(flow.getExecutionId(), 1);
+  }
+
+  /* Test exception when assigning an executor to a non-existent flow execution */
+  @Test(expected = ExecutorManagerException.class)
+  public void testAssignExecutorInvalidExecution() throws Exception{
+    final String host = "localhost";
+    final int port = 12345;
+    final Executor executor = this.loader.addExecutor(host, port);
+    this.loader.assignExecutor(2, executor.getId());
+  }
+
+  /* Test null return when an invalid execution flows */
+  @Test
+  public void testFetchMissingExecutorByExecution() throws Exception{
+    Assert.assertEquals(this.loader.fetchExecutorByExecutionId(1), null);
+  }
+
+  /* Test null return when for a non-dispatched execution */
+  @Test
+  public void testFetchExecutorByQueuedExecution()
+      throws ExecutorManagerException, IOException {
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow);
+    Assert.assertEquals(this.loader.fetchExecutorByExecutionId(flow.getExecutionId()),
+        null);
+  }
+
+  /* Test fetchQueuedFlows when there are no queued flows */
+  @Test
+  public void testFetchNoQueuedFlows() throws ExecutorManagerException,
+      IOException {
+    final List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows =
+        this.loader.fetchQueuedFlows();
+
+    // no execution flows at all i.e. no running, completed or queued flows
+    Assert.assertTrue(queuedFlows.isEmpty());
+
+    final String host = "lcoalhost";
+    final int port = 12345;
+    final Executor executor = this.loader.addExecutor(host, port);
+
+    // When a flow is assigned an executor, it is no longer in queued state
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow);
+    this.loader.assignExecutor(executor.getId(), flow.getExecutionId());
+    Assert.assertTrue(queuedFlows.isEmpty());
+
+    // When flow status is finished, it is no longer in queued state
+    final ExecutableFlow flow2 = TestUtils.createExecutableFlow("exectest1", "exec2");
+    this.loader.uploadExecutableFlow(flow2);
+    flow2.setStatus(Status.SUCCEEDED);
+    this.loader.updateExecutableFlow(flow2);
+    Assert.assertTrue(queuedFlows.isEmpty());
+  }
+
+  /* Test all executors fetch from empty executors */
+  @Test
+  public void testFetchEmptyExecutors() throws Exception {
+    final List<Executor> executors = this.loader.fetchAllExecutors();
+    Assert.assertEquals(executors.size(), 0);
+  }
+
+  /* Test active executors fetch from empty executors */
+  @Test
+  public void testFetchEmptyActiveExecutors() throws Exception {
+    final List<Executor> executors = this.loader.fetchActiveExecutors();
+    Assert.assertEquals(executors.size(), 0);
+  }
+
+  /* Test missing executor fetch with search by executor id */
+  @Test
+  public void testFetchMissingExecutorId() throws Exception {
+    final Executor executor = this.loader.fetchExecutor(0);
+    Assert.assertEquals(executor, null);
+  }
+
+  /* Test missing executor fetch with search by host:port */
+  @Test
+  public void testFetchMissingExecutorHostPort() throws Exception {
+    final Executor executor = this.loader.fetchExecutor("localhost", 12345);
+    Assert.assertEquals(executor, null);
+  }
+
+  /* Test executor events fetch from with no logged executor */
+  @Test
+  public void testFetchEmptyExecutorEvents() throws Exception {
+    final Executor executor = new Executor(1, "localhost", 12345, true);
+    final List<ExecutorLogEvent> executorEvents =
+        this.loader.getExecutorEvents(executor, 5, 0);
+    Assert.assertEquals(executorEvents.size(), 0);
+  }
+
+  /* Test to add duplicate executors */
+  @Test
+  public void testDuplicateAddExecutor() throws Exception {
+    try {
+      final String host = "localhost";
+      final int port = 12345;
+      this.loader.addExecutor(host, port);
+      this.loader.addExecutor(host, port);
+      Assert.fail("Expecting exception, but didn't get one");
+    } catch (final ExecutorManagerException ex) {
+      System.out.println("Test true");
+    }
+  }
+
+  /* Test to try update a non-existent executor */
+  @Test
+  public void testMissingExecutorUpdate() throws Exception {
+    try {
+      final Executor executor = new Executor(1, "localhost", 1234, true);
+      this.loader.updateExecutor(executor);
+      Assert.fail("Expecting exception, but didn't get one");
+    } catch (final ExecutorManagerException ex) {
+      System.out.println("Test true");
+    }
+    clearDB();
+  }
+
+  /* Test add & fetch by Id Executors */
+  @Test
+  public void testSingleExecutorFetchById() throws Exception {
+    final List<Executor> executors = addTestExecutors(this.loader);
+    for (final Executor executor : executors) {
+      final Executor fetchedExecutor = this.loader.fetchExecutor(executor.getId());
+      Assert.assertEquals(executor, fetchedExecutor);
+    }
+  }
+
+  /* Test fetch all executors */
+  @Test
+  public void testFetchAllExecutors() throws Exception {
+    final List<Executor> executors = addTestExecutors(this.loader);
+    executors.get(0).setActive(false);
+    this.loader.updateExecutor(executors.get(0));
+    final List<Executor> fetchedExecutors = this.loader.fetchAllExecutors();
+    Assert.assertEquals(executors.size(), fetchedExecutors.size());
+    Assert.assertArrayEquals(executors.toArray(), fetchedExecutors.toArray());
+  }
+
+  /* Test fetch only active executors */
+  @Test
+  public void testFetchActiveExecutors() throws Exception {
+    final List<Executor> executors = addTestExecutors(this.loader);
+
+    executors.get(0).setActive(true);
+    this.loader.updateExecutor(executors.get(0));
+    final List<Executor> fetchedExecutors = this.loader.fetchActiveExecutors();
+    Assert.assertEquals(executors.size(), fetchedExecutors.size() + 2);
+    Assert.assertEquals(executors.get(0), fetchedExecutors.get(0));
+  }
+
+  /* Test add & fetch by host:port Executors */
+  @Test
+  public void testSingleExecutorFetchHostPort() throws Exception {
+    final List<Executor> executors = addTestExecutors(this.loader);
+    for (final Executor executor : executors) {
+      final Executor fetchedExecutor =
+          this.loader.fetchExecutor(executor.getHost(), executor.getPort());
+      Assert.assertEquals(executor, fetchedExecutor);
+    }
+  }
+
+  /* Helper method used in methods testing jdbc interface for executors table */
+  private List<Executor> addTestExecutors(final ExecutorLoader loader)
+      throws ExecutorManagerException {
+    final List<Executor> executors = new ArrayList<>();
+    executors.add(loader.addExecutor("localhost1", 12345));
+    executors.add(loader.addExecutor("localhost2", 12346));
+    executors.add(loader.addExecutor("localhost1", 12347));
+    return executors;
+  }
+
+  /* Test Removing Executor */
+  @Test
+  public void testRemovingExecutor() throws Exception {
+    final Executor executor = this.loader.addExecutor("localhost1", 12345);
+    Assert.assertNotNull(executor);
+    this.loader.removeExecutor("localhost1", 12345);
+    final Executor fetchedExecutor = this.loader.fetchExecutor("localhost1", 12345);
+    Assert.assertNull(fetchedExecutor);
+  }
+
+  /* Test Executor reactivation */
+  @Test
+  public void testExecutorActivation() throws Exception {
+    final Executor executor = this.loader.addExecutor("localhost1", 12345);
+    Assert.assertFalse(executor.isActive());
+
+    executor.setActive(true);
+    this.loader.updateExecutor(executor);
+    final Executor fetchedExecutor = this.loader.fetchExecutor(executor.getId());
+    Assert.assertTrue(fetchedExecutor.isActive());
+  }
+
+  @Test
+  public void testFetchActiveFlowsExecutorAssigned() throws Exception {
+
+    // Upload flow1, executor assigned
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow1);
+    final Executor executor = this.loader.addExecutor("test", 1);
+    this.loader.assignExecutor(executor.getId(), flow1.getExecutionId());
+
+    // Upload flow2, executor not assigned
+    final ExecutableFlow flow2 = TestUtils.createExecutableFlow("exectest1", "exec2");
+    this.loader.uploadExecutableFlow(flow2);
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
+        this.loader.fetchActiveFlows();
+
+    Assert.assertTrue(activeFlows1.containsKey(flow1.getExecutionId()));
+    Assert.assertFalse(activeFlows1.containsKey(flow2.getExecutionId()));
+
+    final ExecutableFlow flow1Result =
+        activeFlows1.get(flow1.getExecutionId()).getSecond();
+    Assert.assertNotNull(flow1Result);
+    Assert.assertTrue(flow1 != flow1Result);
+    Assert.assertEquals(flow1.getExecutionId(), flow1Result.getExecutionId());
+    Assert.assertEquals(flow1.getEndTime(), flow1Result.getEndTime());
+    Assert.assertEquals(flow1.getStartTime(), flow1Result.getStartTime());
+    Assert.assertEquals(flow1.getSubmitTime(), flow1Result.getSubmitTime());
+    Assert.assertEquals(flow1.getFlowId(), flow1Result.getFlowId());
+    Assert.assertEquals(flow1.getProjectId(), flow1Result.getProjectId());
+    Assert.assertEquals(flow1.getVersion(), flow1Result.getVersion());
+    Assert.assertEquals(flow1.getExecutionOptions().getFailureAction(),
+        flow1Result.getExecutionOptions().getFailureAction());
+  }
+
+  @Test
+  public void testFetchActiveFlowsStatusChanged() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    // Flow status is PREPARING when uploaded, should be in active flows
+    this.loader.uploadExecutableFlow(flow1);
+    final Executor executor = this.loader.addExecutor("test", 1);
+    this.loader.assignExecutor(executor.getId(), flow1.getExecutionId());
+
+    Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows =
+        this.loader.fetchActiveFlows();
+    Assert.assertTrue(activeFlows.containsKey(flow1.getExecutionId()));
+
+    // When flow status becomes SUCCEEDED/KILLED/FAILED, it should not be in active state
+    flow1.setStatus(Status.SUCCEEDED);
+    this.loader.updateExecutableFlow(flow1);
+    activeFlows = this.loader.fetchActiveFlows();
+    Assert.assertFalse(activeFlows.containsKey(flow1.getExecutionId()));
+
+    flow1.setStatus(Status.KILLED);
+    this.loader.updateExecutableFlow(flow1);
+    activeFlows = this.loader.fetchActiveFlows();
+    Assert.assertFalse(activeFlows.containsKey(flow1.getExecutionId()));
+
+    flow1.setStatus(Status.FAILED);
+    this.loader.updateExecutableFlow(flow1);
+    activeFlows = this.loader.fetchActiveFlows();
+    Assert.assertFalse(activeFlows.containsKey(flow1.getExecutionId()));
+  }
+
+  @Test
+  public void testFetchActiveFlowsReferenceChanged() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow1);
+    final Executor executor = this.loader.addExecutor("test", 1);
+    this.loader.assignExecutor(executor.getId(), flow1.getExecutionId());
+    final ExecutionReference ref1 =
+        new ExecutionReference(flow1.getExecutionId(), executor);
+    this.loader.addActiveExecutableReference(ref1);
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
+        this.loader.fetchActiveFlows();
+    Assert.assertTrue(activeFlows1.containsKey(flow1.getExecutionId()));
+
+    // Verify active flows are not fetched from active_executing_flows DB table any more
+    this.loader.removeActiveExecutableReference(flow1.getExecutionId());
+    Assert.assertTrue(activeFlows1.containsKey(flow1.getExecutionId()));
+  }
+
+  @Test
+  public void testFetchActiveFlowByExecId() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow1);
+    final Executor executor = this.loader.addExecutor("test", 1);
+    this.loader.assignExecutor(executor.getId(), flow1.getExecutionId());
+
+    final Pair<ExecutionReference, ExecutableFlow> activeFlow1 =
+        this.loader.fetchActiveFlowByExecId(flow1.getExecutionId());
+
+    final ExecutionReference execRef1 = activeFlow1.getFirst();
+    final ExecutableFlow execFlow1 = activeFlow1.getSecond();
+    Assert.assertNotNull(execRef1);
+    Assert.assertNotNull(execFlow1);
+    Assert.assertEquals(flow1.getExecutionId(), execFlow1.getExecutionId());
+    Assert.assertEquals(flow1.getFlowId(), execFlow1.getFlowId());
+    Assert.assertEquals(flow1.getProjectId(), execFlow1.getProjectId());
+    Assert.assertEquals(flow1.getVersion(), execFlow1.getVersion());
+  }
+
+  @Test
+  public void testFetchRecentlyFinishedFlows() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow1);
+    flow1.setStatus(Status.SUCCEEDED);
+    flow1.setEndTime(DateTimeUtils.currentTimeMillis());
+    this.loader.updateExecutableFlow(flow1);
+    //Flow just finished. Fetch recently finished flows immediately. Should get it.
+    final List<ExecutableFlow> flows = this.loader.fetchRecentlyFinishedFlows(
+        RECENTLY_FINISHED_LIFETIME);
+    Assert.assertEquals(1, flows.size());
+    Assert.assertEquals(flow1.getExecutionId(), flows.get(0).getExecutionId());
+    Assert.assertEquals(flow1.getProjectName(), flows.get(0).getProjectName());
+    Assert.assertEquals(flow1.getFlowId(), flows.get(0).getFlowId());
+    Assert.assertEquals(flow1.getVersion(), flows.get(0).getVersion());
+  }
+
+  @Test
+  public void testFetchEmptyRecentlyFinishedFlows() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.loader.uploadExecutableFlow(flow1);
+    flow1.setStatus(Status.SUCCEEDED);
+    flow1.setEndTime(DateTimeUtils.currentTimeMillis());
+    this.loader.updateExecutableFlow(flow1);
+    //Todo jamiesjc: use java8.java.time api instead of jodatime
+    //Mock flow finished time to be 2 min ago.
+    DateTimeUtils.setCurrentMillisOffset(-FLOW_FINISHED_TIME.toMillis());
+    flow1.setEndTime(DateTimeUtils.currentTimeMillis());
+    this.loader.updateExecutableFlow(flow1);
+    //Fetch recently finished flows within 1 min. Should be empty.
+    final List<ExecutableFlow> flows = this.loader
+        .fetchRecentlyFinishedFlows(RECENTLY_FINISHED_LIFETIME);
+    Assert.assertTrue(flows.isEmpty());
+  }
+
+  @Test
+  public void testSmallUploadLog() throws ExecutorManagerException {
+    final File logDir = new File(UNIT_BASE_DIR + "/logtest");
+    final File[] smalllog =
+        { new File(logDir, "log1.log"), new File(logDir, "log2.log"),
+            new File(logDir, "log3.log") };
+
+    this.loader.uploadLogFile(1, "smallFiles", 0, smalllog);
+
+    final LogData data = this.loader.fetchLogs(1, "smallFiles", 0, 0, 50000);
+    Assert.assertNotNull(data);
+    Assert.assertEquals("Logs length is " + data.getLength(), data.getLength(),
+        53);
+
+    System.out.println(data.toString());
+
+    final LogData data2 = this.loader.fetchLogs(1, "smallFiles", 0, 10, 20);
+    System.out.println(data2.toString());
+    Assert.assertNotNull(data2);
+    Assert.assertEquals("Logs length is " + data2.getLength(),
+        data2.getLength(), 20);
+
+  }
+
+  @Test
+  public void testLargeUploadLog() throws ExecutorManagerException {
+    final File logDir = new File(UNIT_BASE_DIR + "/logtest");
+
+    // Multiple of 255 for Henry the Eigth
+    final File[] largelog =
+        { new File(logDir, "largeLog1.log"), new File(logDir, "largeLog2.log"),
+            new File(logDir, "largeLog3.log") };
+
+    this.loader.uploadLogFile(1, "largeFiles", 0, largelog);
+
+    final LogData logsResult = this.loader.fetchLogs(1, "largeFiles", 0, 0, 64000);
+    Assert.assertNotNull(logsResult);
+    Assert.assertEquals("Logs length is " + logsResult.getLength(),
+        logsResult.getLength(), 64000);
+
+    final LogData logsResult2 = this.loader.fetchLogs(1, "largeFiles", 0, 1000, 64000);
+    Assert.assertNotNull(logsResult2);
+    Assert.assertEquals("Logs length is " + logsResult2.getLength(),
+        logsResult2.getLength(), 64000);
+
+    final LogData logsResult3 = this.loader.fetchLogs(1, "largeFiles", 0, 330000, 400000);
+    Assert.assertNotNull(logsResult3);
+    Assert.assertEquals("Logs length is " + logsResult3.getLength(),
+        logsResult3.getLength(), 5493);
+
+    final LogData logsResult4 = this.loader.fetchLogs(1, "largeFiles", 0, 340000, 400000);
+    Assert.assertNull(logsResult4);
+
+    final LogData logsResult5 = this.loader.fetchLogs(1, "largeFiles", 0, 153600, 204800);
+    Assert.assertNotNull(logsResult5);
+    Assert.assertEquals("Logs length is " + logsResult5.getLength(),
+        logsResult5.getLength(), 181893);
+
+    final LogData logsResult6 = this.loader.fetchLogs(1, "largeFiles", 0, 150000, 250000);
+    Assert.assertNotNull(logsResult6);
+    Assert.assertEquals("Logs length is " + logsResult6.getLength(),
+        logsResult6.getLength(), 185493);
+  }
+
+  @After
+  public void clearDB() {
+    try {
+      dbOperator.update("DELETE FROM executors");
+      dbOperator.update("DELETE FROM executor_events");
+      dbOperator.update("DELETE FROM execution_logs");
+      dbOperator.update("DELETE FROM execution_jobs");
+      dbOperator.update("DELETE FROM execution_flows");
+      dbOperator.update("DELETE FROM active_executing_flows");
+      dbOperator.update("DELETE FROM active_sla");
+    } catch (final SQLException e) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
Similar to  #1079 , this change is aimed at re-constructing JDBC Executor loader class to
allow db retry feature to be leveraged. Fixed all tests from outdated JdbcExecutorLoader class, and use in-memory h2 for test.