### PR TITLE
Running chmod g+s on executions directory to enable proper execution cleanup

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -214,7 +214,7 @@ public class FlowRunnerManager implements EventListener,
    * is system dependent, so the only way to set this bit is to start a new process and run
    * the shell command "chmod g+s " + execution directory name.
    *
-   * Note that this will only work on unix systems.
+   * Note that this should work on most Linux distributions and MacOS, but will not work on Windows.
    */
   private void setgidPermissionOnExecutionDirectory() throws IOException {
     logger.info("Creating subprocess to run shell command: chmod g+s "

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -162,6 +162,11 @@ public class FlowRunnerManager implements EventListener,
     this.executionDirectory = new File(props.getString("azkaban.execution.dir", "executions"));
     if (!this.executionDirectory.exists()) {
       this.executionDirectory.mkdirs();
+      // setting sticky bit on this.executionDirectory to allow cleanup thread to delete all
+      // user-generated files/directories
+      logger.info("Creating subprocess to run shell command: chmod g+s "
+          + this.executionDirectory.toString());
+      Runtime.getRuntime().exec("chmod g+s " + this.executionDirectory.toString());
     }
     this.projectDirectory = new File(props.getString("azkaban.project.dir", "projects"));
     if (!this.projectDirectory.exists()) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -162,11 +162,7 @@ public class FlowRunnerManager implements EventListener,
     this.executionDirectory = new File(props.getString("azkaban.execution.dir", "executions"));
     if (!this.executionDirectory.exists()) {
       this.executionDirectory.mkdirs();
-      // setting sticky bit on this.executionDirectory to allow cleanup thread to delete all
-      // user-generated files/directories
-      logger.info("Creating subprocess to run shell command: chmod g+s "
-          + this.executionDirectory.toString());
-      Runtime.getRuntime().exec("chmod g+s " + this.executionDirectory.toString());
+      setgidPermissionOnExecutionDirectory();
     }
     this.projectDirectory = new File(props.getString("azkaban.project.dir", "projects"));
     if (!this.projectDirectory.exists()) {
@@ -207,6 +203,23 @@ public class FlowRunnerManager implements EventListener,
             AzkabanExecutorServer.JOBTYPE_PLUGIN_DIR,
             JobTypeManager.DEFAULT_JOBTYPEPLUGINDIR), this.globalProps,
             getClass().getClassLoader());
+  }
+
+  /**
+   * Setting the gid bit on the execution directory forces all files/directories created within
+   * the directory to be a part of the azkaban group. Then, when users create their own files,
+   * the azkaban cleanup thread can properly remove them.
+   *
+   * Java does not provide a standard library api for setting the gid bit because the gid bit
+   * is system dependent, so the only way to set this bit is to start a new process and run
+   * the shell command "chmod g+s " + execution directory name.
+   *
+   * Note that this will only work on unix systems.
+   */
+  private void setgidPermissionOnExecutionDirectory() throws IOException {
+    logger.info("Creating subprocess to run shell command: chmod g+s "
+        + this.executionDirectory.toString());
+    Runtime.getRuntime().exec("chmod g+s " + this.executionDirectory.toString());
   }
 
   private TrackingThreadPool createExecutorService(final int nThreads) {
@@ -396,16 +409,16 @@ public class FlowRunnerManager implements EventListener,
   }
 
 
-  public void cancelJobBySLA(int execId, String jobId)
+  public void cancelJobBySLA(final int execId, final String jobId)
       throws ExecutorManagerException {
-    FlowRunner flowRunner = runningFlows.get(execId);
+    final FlowRunner flowRunner = this.runningFlows.get(execId);
 
     if (flowRunner == null) {
       throw new ExecutorManagerException("Execution " + execId
           + " is not running.");
     }
 
-    for (JobRunner jobRunner : flowRunner.getActiveJobRunners()) {
+    for (final JobRunner jobRunner : flowRunner.getActiveJobRunners()) {
       if (jobRunner.getJobId().equals(jobId)) {
         logger.info("Killing job " + jobId + " in execution " + execId + " by SLA");
         jobRunner.killBySLA();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -207,8 +207,8 @@ public class FlowRunnerManager implements EventListener,
 
   /**
    * Setting the gid bit on the execution directory forces all files/directories created within
-   * the directory to be a part of the azkaban group. Then, when users create their own files,
-   * the azkaban cleanup thread can properly remove them.
+   * the directory to be a part of the group associated with the azkaban process. Then, when users
+   * create their own files, the azkaban cleanup thread can properly remove them.
    *
    * Java does not provide a standard library api for setting the gid bit because the gid bit
    * is system dependent, so the only way to set this bit is to start a new process and run


### PR DESCRIPTION
Setting the gid bit on the group for a directory causes all items created within that directory to inherit the group of the directory. So all items users create in their /execution/<exec_id> directory will automatically be a part of the azkaban group. This allows the azkaban cleanup thread to properly remove user-generated files/directories.

The gid bit is system-specific, so there is [no java standard library api](https://stackoverflow.com/questions/5045869/change-sticky-bit-with-java) for setting it. The solution I proposed spawns a subprocess that performs the chmod command. I don't think this is very clean, but I haven't been able to find a better way. Anybody have any ideas?

Another option would be to build this executionDirectory as part of our build process, but that isn't how we do things right now (tested by running deploy on holdem4 jenkins job without any of the other steps and verifying no /executions directory is created until system start).