### PR TITLE
Delete executions directory on executor shutdown to reclaim disk space

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -196,6 +196,7 @@ public class AzkabanExecutorServer {
         logger.warn("Shutting down executor...");
         try {
           app.shutdownNow();
+          app.getFlowRunnerManager().deleteExecutionDirectory();
         } catch (final Exception e) {
           logger.error("Error while shutting down http server.", e);
         }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -739,7 +739,6 @@ public class FlowRunnerManager implements EventListener,
         logger.error(e);
       }
     }
-    deleteExecutionDirectory();
     logger.warn("Shutdown FlowRunnerManager complete.");
   }
 
@@ -751,14 +750,13 @@ public class FlowRunnerManager implements EventListener,
     logger.warn("Shutting down FlowRunnerManager now...");
     this.executorService.shutdownNow();
     this.triggerManager.shutdown();
-    deleteExecutionDirectory();
   }
 
   /**
    * Deleting old execution directory to free disk space.
    */
-  private void deleteExecutionDirectory() {
-    logger.warn("Deleting execution dir: " + this.executionDirectory.toString());
+  public void deleteExecutionDirectory() {
+    logger.warn("Deleting execution dir: " + this.executionDirectory.getAbsolutePath());
     try {
       FileUtils.deleteDirectory(this.executionDirectory);
     } catch (final IOException e) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -721,6 +721,7 @@ public class FlowRunnerManager implements EventListener,
         logger.error(e);
       }
     }
+    deleteExecutionDirectory();
     logger.warn("Shutdown FlowRunnerManager complete.");
   }
 
@@ -732,6 +733,19 @@ public class FlowRunnerManager implements EventListener,
     logger.warn("Shutting down FlowRunnerManager now...");
     this.executorService.shutdownNow();
     this.triggerManager.shutdown();
+    deleteExecutionDirectory();
+  }
+
+  /**
+   * Deleting old execution directory to free disk space.
+   */
+  private void deleteExecutionDirectory() {
+    logger.warn("Deleting execution dir: " + this.executionDirectory.toString());
+    try {
+      FileUtils.deleteDirectory(this.executionDirectory);
+    } catch (final IOException e) {
+      logger.error(e);
+    }
   }
 
   private class CleanerThread extends Thread {


### PR DESCRIPTION
The execution directory can bloat to be relatively large, which could lead to problems if the executor is shutdown and stale executions remain sitting on the executor occupying disk space.

This change deletes the execution directory on executor shutdown. The directory itself is created on executor initialization, so the directory isn't necessary to reset the executor later.

Note that the execution directory will not be deleted until AFTER all flows are done if the executor is brought down via shutdown() - so it will not delete partially-written logs before they are uploaded to the database.