### PR TITLE
delete rentention logs every hour

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1639,12 +1639,12 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /*
-   * cleaner thread to clean up execution_logs, etc in DB. Runs every day.
+   * cleaner thread to clean up execution_logs, etc in DB. Runs every hour.
    */
   private class CleanerThread extends Thread {
     // log file retention is 1 month.
 
-    // check every day
+    // check every hour
     private static final long CLEANER_THREAD_WAIT_INTERVAL_MS = 60 * 60 * 1000;
 
     private final long executionLogsRetentionMs;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1645,8 +1645,7 @@ public class ExecutorManager extends EventHandler implements
     // log file retention is 1 month.
 
     // check every day
-    private static final long CLEANER_THREAD_WAIT_INTERVAL_MS =
-        24 * 60 * 60 * 1000;
+    private static final long CLEANER_THREAD_WAIT_INTERVAL_MS = 60 * 60 * 1000;
 
     private final long executionLogsRetentionMs;
 


### PR DESCRIPTION
We observed the long deletion transaction in our production Azkaban cluster. In mysql, if delete transaction is large (The data going to be deleted is too big), it occupies too much undo space (buffer), which affect other transactions and other databases. So we change every day one time's deletion to every hour.