### PR TITLE
Revert "New status: KILLING (#1172)"

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1483,7 +1483,7 @@ public class ExecutorManager extends EventHandler implements
         continue;
         // case UNKNOWN:
       case READY:
-        node.setStatus(Status.KILLING);
+        node.setStatus(Status.KILLED);
         break;
       default:
         node.setStatus(Status.FAILED);

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -25,7 +25,6 @@ public enum Status {
   RUNNING(30),
   PAUSED(40),
   SUCCEEDED(50),
-  KILLING(55),
   KILLED(60),
   FAILED(70),
   FAILED_FINISHING(80),

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -34,7 +34,7 @@ public enum Status {
   QUEUED(110),
   FAILED_SUCCEEDED(120),
   CANCELLED(125);
-  // status is TINYINT and in H2 DB the possible values are: -128 to 127
+  // status is TINYINT in DB and the value ranges from -128 to 127
 
   private static final ImmutableMap<Integer, Status> numValMap = Arrays.stream(Status.values())
       .collect(ImmutableMap.toImmutableMap(status -> status.getNumVal(), status -> status));

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -34,7 +34,7 @@ public enum Status {
   QUEUED(110),
   FAILED_SUCCEEDED(120),
   CANCELLED(125);
-  // status is TINYINT in DB and the value ranges from -128 to 127
+  // status is TINYINT and in H2 DB the possible values are: -128 to 127
 
   private static final ImmutableMap<Integer, Status> numValMap = Arrays.stream(Status.values())
       .collect(ImmutableMap.toImmutableMap(status -> status.getNumVal(), status -> status));

--- a/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/WebUtils.java
@@ -97,8 +97,6 @@ public class WebUtils {
         return "Paused";
       case SKIPPED:
         return "Skipped";
-      case KILLING:
-        return "Killing";
       default:
     }
     return "Unknown";

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -33,7 +33,6 @@ public class InteractiveTestJob extends AbstractProcessJob {
   private Props generatedProperties = new Props();
   private boolean isWaiting = true;
   private boolean succeed = true;
-  private boolean ignoreCancel = false;
 
   public InteractiveTestJob(final String jobId, final Props sysProps, final Props jobProps,
       final Logger log) {
@@ -61,12 +60,6 @@ public class InteractiveTestJob extends AbstractProcessJob {
 
   public static void clearTestJobs() {
     testJobs.clear();
-  }
-
-  public static void clearTestJobs(final String... names) {
-    for (final String name : names) {
-      assertNotNull(testJobs.remove(name));
-    }
   }
 
   @Override
@@ -144,12 +137,6 @@ public class InteractiveTestJob extends AbstractProcessJob {
     }
   }
 
-  public void ignoreCancel() {
-    synchronized (this) {
-      this.ignoreCancel = true;
-    }
-  }
-
   @Override
   public Props getJobGeneratedProperties() {
     return this.generatedProperties;
@@ -158,8 +145,12 @@ public class InteractiveTestJob extends AbstractProcessJob {
   @Override
   public void cancel() throws InterruptedException {
     info("Killing job");
-    if (!this.ignoreCancel) {
-      failJob();
+    failJob();
+  }
+
+  public static void clearTestJobs(final String... names) {
+    for (String name : names) {
+      assertNotNull(testJobs.remove(name));
     }
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -263,12 +263,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job2", Status.SUCCEEDED);
     waitJobsStarted(this.runner, "job3", "job4", "job6");
 
-    InteractiveTestJob.getTestJob("job3").ignoreCancel();
     this.runner.kill("me");
-    assertStatus("job3", Status.KILLING);
-    assertFlowStatus(Status.KILLING);
-    InteractiveTestJob.getTestJob("job3").failJob();
-
     Assert.assertTrue(this.runner.isKilled());
 
     assertStatus("job5", Status.CANCELLED);

--- a/azkaban-web-server/src/main/less/azkaban-graph.less
+++ b/azkaban-web-server/src/main/less/azkaban-graph.less
@@ -94,15 +94,6 @@
   fill: #FFF;
 }
 
-.KILLING > g > rect {
-  fill: #FF9999;
-  stroke: #FF9999;
-}
-
-.KILLING > g > text {
-  fill: #FFF;
-}
-
 .CANCELLED > g > rect {
   fill: #FF9999;
   stroke: #FF9999;

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -65,18 +65,6 @@
     background-color: @flow-killed-color;
   }
 
-  // #ff9999 = killing vs. #3398cc = running
-  &.KILLING {
-    background-color: @flow-killing-color;
-    background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
-    background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: -moz-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-    background-size: 40px 40px;
-    -webkit-animation: progress-bar-stripes 2s linear infinite;
-            animation: progress-bar-stripes 2s linear infinite;
-  }
-
   &.RUNNING {
     background-color: @flow-running-color;
     background-image: -webkit-gradient(linear, 0 100%, 100% 0, color-stop(0.25, rgba(255, 255, 255, 0.15)), color-stop(0.25, transparent), color-stop(0.5, transparent), color-stop(0.5, rgba(255, 255, 255, 0.15)), color-stop(0.75, rgba(255, 255, 255, 0.15)), color-stop(0.75, transparent), to(transparent));
@@ -125,10 +113,6 @@ td {
 
     &.KILLED {
       background-color: @flow-killed-color;
-    }
-
-    &.KILLING {
-      background-color: @flow-killing-color;
     }
 
     &.PAUSED {
@@ -183,10 +167,6 @@ td {
 
   &.KILLED {
     color: @flow-killed-color;
-  }
-
-  &.KILLING {
-    color: @flow-killing-color;
   }
 
   &.CANCELLED {
@@ -327,10 +307,6 @@ li.tree-list-item {
     }
 
     &.KILLED .icon {
-      background-position: 0px 0px;
-    }
-
-    &.KILLING .icon {
       background-position: 0px 0px;
     }
 

--- a/azkaban-web-server/src/main/less/variables.less
+++ b/azkaban-web-server/src/main/less/variables.less
@@ -3,7 +3,6 @@
 @flow-succeeded-color: #5cb85c;
 @flow-failed-color: #d9534f;
 @flow-killed-color: #d9534f;
-@flow-killing-color: #ff9999;
 @flow-paused-color: #c82123;
 @flow-running-color: #3398cc;
 @flow-failed-finishing-color: #f19153;

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -197,7 +197,6 @@
                       <option value=30>Running</option>
                       <option value=40>Paused</option>
                       <option value=50>Succeed</option>
-                      <option value=55>Killing</option>
                       <option value=60>Killed</option>
                       <option value=70>Failed</option>
                       <option value=80>Failed Finishing</option>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -24,7 +24,6 @@ var statusStringMap = {
   "FAILED_FINISHING": "Running w/Failure",
   "RUNNING": "Running",
   "WAITING": "Waiting",
-  "KILLING": "Killing",
   "KILLED": "Killed",
   "CANCELLED": "Cancelled",
   "DISABLED": "Disabled",

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -205,8 +205,6 @@ azkaban.FlowTabView = Backbone.View.extend({
 		else if (data.status == "KILLED") {
 			$("#executebtn").show();
 		}
-		else if (data.status == "KILLING") {
-		}
 	},
 
 	handleCancelClick: function(evt) {
@@ -448,10 +446,6 @@ var updaterFunction = function() {
 			data.status == "PREPARING") {
 			// 2 min updates
 			setTimeout(function() {updaterFunction();}, 2*60*1000);
-		}
-		else if (data.status == "KILLING") {
-			// 30 s updates - should finish soon now
-			setTimeout(function() {updaterFunction();}, 30*1000);
 		}
 		else if (data.status != "SUCCEEDED" && data.status != "FAILED") {
 			// 2 min updates

--- a/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/time-graph.js
@@ -93,9 +93,6 @@ azkaban.TimeGraphView = Backbone.View.extend({
       else if (status == 'PAUSED') {
         return '#c92123';
       }
-      else if (status == 'KILLING') {
-        return '#ff9999';
-      }
       else if (status == 'FAILED' ||
           status == 'FAILED_FINISHING' ||
           status == 'KILLED') {


### PR DESCRIPTION
This reverts commit d1b836a.

Conflicts:
	azkaban-common/src/main/java/azkaban/executor/Status.java
	azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java

From @jamiesjc: When we kill the flow immediately after it starts in our integration test, it couldn't be killed due to some race condition. Users will see on the execution page that the job is in KILLING status but it actually never gets killed. And users cannot click kill button again during the KILLING period.
At the time when we kill, the process might not have started yet or the jobRunner has not yet been added to the activeJobRunners.
You can check more details in the PR description: #1289. We are still working on the fix.