### PR TITLE
Update distributionUrl

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://downloads.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
Was running gradlew build instalDist and kept getting a url error. This should fix it I believe.