### PR TITLE
revert XMLUserManager error message customization

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -60,7 +60,6 @@ public class XmlUserManager implements UserManager {
   private static final Logger logger = Logger.getLogger(XmlUserManager.class
       .getName());
   private final String xmlPath;
-  private final String passwordErrorMessage;
 
   private HashMap<String, User> users;
   private HashMap<String, String> userPassword;
@@ -73,7 +72,7 @@ public class XmlUserManager implements UserManager {
    */
   public XmlUserManager(final Props props) {
     this.xmlPath = props.getString(XML_FILE_PARAM);
-    this.passwordErrorMessage = props.getString("azkaban.error.password.message", "Username/password not found.");
+
     parseXMLFile();
   }
 
@@ -261,7 +260,7 @@ public class XmlUserManager implements UserManager {
     }
 
     if (foundPassword == null || !foundPassword.equals(password)) {
-      throw new UserManagerException(this.passwordErrorMessage);
+      throw new UserManagerException("Username/Password not found.");
     }
     // Once it gets to this point, no exception has been thrown. User
     // shoudn't be


### PR DESCRIPTION
This commit reverts the XMLUserManager code since it is found that we don't need to customize XML error login message, since only headless users access from `XMLUserManager`. Standard users go through `LDAPUserManager`, which we already added this feature.

The original PR is at: #1277 