### PR TITLE
Revert "remove unused member variables in Session and User class (#1294)"

### DIFF
--- a/azkaban-common/src/main/java/azkaban/server/session/Session.java
+++ b/azkaban-common/src/main/java/azkaban/server/session/Session.java
@@ -16,6 +16,8 @@
 package azkaban.server.session;
 
 import azkaban.user.User;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Container for the session, mapping session id to user in map
@@ -25,6 +27,7 @@ public class Session {
   private final User user;
   private final String sessionId;
   private final String ip;
+  private final Map<String, Object> sessionData = new HashMap<>();
 
   /**
    * Constructor for the session
@@ -53,4 +56,11 @@ public class Session {
     return this.ip;
   }
 
+  public void setSessionData(final String key, final Object value) {
+    this.sessionData.put(key, value);
+  }
+
+  public Object getSessionData(final String key) {
+    return this.sessionData.get(key);
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/user/User.java
+++ b/azkaban-common/src/main/java/azkaban/user/User.java
@@ -17,6 +17,7 @@
 package azkaban.user;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -26,6 +27,7 @@ public class User {
   private final String userid;
   private final Set<String> roles = new HashSet<>();
   private final Set<String> groups = new HashSet<>();
+  private final HashMap<String, String> properties = new HashMap<>();
   private String email = "";
   private UserPermissions userPermissions;
 
@@ -86,6 +88,10 @@ public class User {
 
   public boolean hasRole(final String role) {
     return this.roles.contains(role);
+  }
+
+  public String getProperty(final String name) {
+    return this.properties.get(name);
   }
 
   @Override


### PR DESCRIPTION
This reverts commit 9d079ec665bc7b434fbfa46e8140d5e0949a7c86.

This change removes an API (getSessionData) relied upon by the hdfs viewer.