### PR TITLE
Change API's concurrent default option to skip

### DIFF
--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -87,16 +87,17 @@ public class HttpRequestUtils {
     String concurrentOption = "skip";
     if (hasParam(req, "concurrentOption")) {
       concurrentOption = getParam(req, "concurrentOption");
-      execOptions.setConcurrentOption(concurrentOption);
-      if (concurrentOption.equals("pipeline")) {
-        final int pipelineLevel = getIntParam(req, "pipelineLevel");
-        execOptions.setPipelineLevel(pipelineLevel);
-      } else if (concurrentOption.equals("queue")) {
-        // Not yet implemented
-        final int queueLevel = getIntParam(req, "queueLevel", 1);
-        execOptions.setPipelineLevel(queueLevel);
-      }
     }
+    execOptions.setConcurrentOption(concurrentOption);
+    if (concurrentOption.equals("pipeline")) {
+      final int pipelineLevel = getIntParam(req, "pipelineLevel");
+      execOptions.setPipelineLevel(pipelineLevel);
+    } else if (concurrentOption.equals("queue")) {
+      // Not yet implemented
+      final int queueLevel = getIntParam(req, "queueLevel", 1);
+      execOptions.setPipelineLevel(queueLevel);
+    }
+
     String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
     if (hasParam(req, "mailCreator")) {
       mailCreator = getParam(req, "mailCreator");

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -84,10 +84,7 @@ public class HttpRequestUtils {
           "notifyFailureLast")));
     }
 
-    String concurrentOption = "skip";
-    if (hasParam(req, "concurrentOption")) {
-      concurrentOption = getParam(req, "concurrentOption");
-    }
+    String concurrentOption = getParam(req, "concurrentOption", "skip");
     execOptions.setConcurrentOption(concurrentOption);
     if (concurrentOption.equals("pipeline")) {
       final int pipelineLevel = getIntParam(req, "pipelineLevel");


### PR DESCRIPTION
Today, given a schedule, the default option for concurrent setting is `ignore`, that is, allowing concurrent executions whatever schedule triggers. This could be regarded as a bug in current AZ. The reason is that, In UI, the default schedule option is "skip" while API's default option is "ignore". The inconsistency between API and UI should be resolved.

This commit fixes the option to `skip`. When next schedule triggers, as long as the last execution hasn't finished, it won't trigger the next execution. As a consequence, this commit changes API's default option to "skip" and UI's default behavior is not affected. Tested on our staging cluster, and working.