### PR TITLE
Enable gradle build cache for faster build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2017 LinkedIn Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
 group=com.linkedin
 # optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
 # optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha>-SNAPSHOT"
@@ -15,3 +31,4 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 #Allows generation of idea/eclipse metadata for a specific subproject and its upstream project dependencies
 ide.recursive=true
+org.gradle.caching=true


### PR DESCRIPTION
See
https://docs.gradle.org/3.5/userguide/build_cache.html

A clean build took 22 seconds vs > 1 minute before this change.

output:

BUILD SUCCESSFUL

Total time: 22.587 secs

120 tasks in build, out of which 81 (68%) were executed
 13  (11%) up-to-date
 13  (11%) no-source
 13  (11%) loaded from cache
  6   (5%) cache miss
 75  (63%) not cacheable