### PR TITLE
make job retry log more clear

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -602,9 +602,8 @@ public class JobRunner extends EventHandler implements Runnable {
     }
 
     final int attemptNo = this.node.getAttempt();
-    logInfo("Finishing job " + this.jobId + " attempt: " + attemptNo + " at "
+    logInfo("Finishing job " + this.jobId + (this.node.getAttempt() > 0 ? (" retry: " + attemptNo) : "") + " at "
         + this.node.getEndTime() + " with status " + this.node.getStatus());
-
     fireEvent(Event.create(this, Type.JOB_FINISHED,
         new EventData(finalStatus, this.node.getNestedId())), false);
     finalizeLogFile(attemptNo);
@@ -633,12 +632,8 @@ public class JobRunner extends EventHandler implements Runnable {
         return null;
       }
 
-      if (this.node.getAttempt() > 0) {
-        logInfo("Starting job " + this.jobId + " retry " + this.node.getAttempt()
-            + " at " + this.node.getStartTime());
-      } else {
-        logInfo("Starting job " + this.jobId + " at " + this.node.getStartTime());
-      }
+      logInfo("Starting job " + this.jobId + (this.node.getAttempt() > 0 ? (" retry: " + this.node.getAttempt()) : "") + " at "
+          + this.node.getStartTime());
 
       // If it's an embedded flow, we'll add the nested flow info to the job
       // conf

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -634,7 +634,7 @@ public class JobRunner extends EventHandler implements Runnable {
       }
 
       if (this.node.getAttempt() > 0) {
-        logInfo("Starting job " + this.jobId + " attempt " + this.node.getAttempt()
+        logInfo("Starting job " + this.jobId + " retry " + this.node.getAttempt()
             + " at " + this.node.getStartTime());
       } else {
         logInfo("Starting job " + this.jobId + " at " + this.node.getStartTime());


### PR DESCRIPTION
previously if a job retries, log looks like this:
Starting job 1 attempt 1 at 1502324648910

it makes people misinterpret this as the 1st attempt of running the job, this PR changes the message: 
Starting job 1 retry 1 at 1502324648910 
