### PR TITLE
Adding pid to /status API

### DIFF
--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -54,6 +54,7 @@ public class Constants {
 
   public static class ConfigurationKeys {
     // These properties are configurable through azkaban.properties
+    public static final String AZKABAN_PID_FILENAME = "azkaban.pid.filename";
 
     // Defines a list of external links, each referred to as a topic
     public static final String AZKABAN_SERVER_EXTERNAL_TOPICS = "azkaban.server.external.topics";

--- a/azkaban-web-server/src/main/java/azkaban/webapp/Status.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/Status.java
@@ -29,18 +29,21 @@ import java.util.Map;
 public class Status {
 
   private final String version;
+  private final String pid;
   private final String installationPath;
   private final long usedMemory, xmx;
   private final boolean isDatabaseUp;
   private final Map<Integer, Executor> executorStatusMap;
 
   Status(final String version,
+      final String pid,
       final String installationPath,
       final long usedMemory,
       final long xmx,
       final boolean isDatabaseUp,
       final Map<Integer, Executor> executorStatusMap) {
     this.version = version;
+    this.pid = pid;
     this.installationPath = installationPath;
     this.usedMemory = usedMemory;
     this.xmx = xmx;


### PR DESCRIPTION
Adding Process ID to status API info. The pid is read from the pid file which is configurable via `azkaban.pid.filename`. By default this value is `currentpid`.

Example:
```
{
    "version": "unknown",
    "pid": "69041",
    ...
}
```