### PR TITLE
Standardize on "System.currentTimeMillis()" within the ExecutorManager class

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1687,10 +1687,10 @@ public class ExecutorManager extends EventHandler implements
 
     private void cleanExecutionLogs() {
       logger.info("Cleaning old logs from execution_logs");
-      long cutoff = DateTime.now().getMillis() - executionLogsRetentionMs;
+      long cutoff = System.currentTimeMillis() - executionLogsRetentionMs;
       logger.info("Cleaning old log files before "
           + new DateTime(cutoff).toString());
-      cleanOldExecutionLogs(DateTime.now().getMillis()
+      cleanOldExecutionLogs(System.currentTimeMillis()
           - executionLogsRetentionMs);
     }
   }


### PR DESCRIPTION
This is a small change to standardize on using System.currentTimeMillis() within the ExecutorManager class.  

