### PR TITLE
Fixing known security bug via proper *nix permissioning

### DIFF
--- a/azkaban-common/src/main/c/execute-as-user.c
+++ b/azkaban-common/src/main/c/execute-as-user.c
@@ -53,7 +53,7 @@ int change_user(char *username, uid_t user, gid_t group) {
 
     if (initgroups(username, group) != 0) {
         fprintf(LOGFILE, "Error setting supplementary groups for user %s: %s\n",
-            user, strerror(errno));
+            username, strerror(errno));
         return SETUID_OPER_FAILED;
     }
     if (seteuid(0) != 0) {

--- a/azkaban-common/src/main/c/execute-as-user.c
+++ b/azkaban-common/src/main/c/execute-as-user.c
@@ -90,24 +90,24 @@ int main(int argc, char **argv){
     }
 
     if (argc < 3) {
-        fprintf(ERRORFILE, "Requires at least 3 variables: ./execute-as-user uid command [args]");
+        fprintf(ERRORFILE, "Requires at least 3 variables: ./execute-as-user username command [args]");
         return INVALID_INPUT;
     }
 
-    char *uid = argv[1];
+    char *username = argv[1];
 
     // gather information about user
-    struct passwd *user_info = getpwnam(uid);
+    struct passwd *user_info = getpwnam(username);
     if (user_info == NULL){
-        fprintf(LOGFILE, "user does not exist: %s", uid);
+        fprintf(LOGFILE, "user does not exist: %s", username);
         return USER_NOT_FOUND;
     }
 
     // try to change user
-    fprintf(LOGFILE, "Changing user: user: %s, uid: %d, gid: %d\n", uid, user_info->pw_uid, user_info->pw_gid);
-    int retval = change_user(uid, user_info->pw_uid, user_info->pw_gid);
+    fprintf(LOGFILE, "Changing user: user: %s, uid: %d, gid: %d\n", username, user_info->pw_uid, user_info->pw_gid);
+    int retval = change_user(username, user_info->pw_uid, user_info->pw_gid);
     if (retval != 0){
-        fprintf(LOGFILE, "Error changing user to %s\n", uid);
+        fprintf(LOGFILE, "Error changing user to %s\n", username);
         return SETUID_OPER_FAILED;
     }
 

--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -37,6 +37,9 @@ public class Constants {
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
 
+  // Path name of execute-as-user executable
+  public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
+
   // Internal username used to perform SLA action
   public static final String AZKABAN_SLA_CHECKER_USERNAME = "azkaban_sla";
 

--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -37,9 +37,6 @@ public class Constants {
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
 
-  // Path name of execute-as-user executable
-  public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
-
   // Internal username used to perform SLA action
   public static final String AZKABAN_SLA_CHECKER_USERNAME = "azkaban_sla";
 
@@ -89,6 +86,12 @@ public class Constants {
 
     // List of users we prevent azkaban from running flows as. (ie: root, azkaban)
     public static final String BLACK_LISTED_USERS = "azkaban.server.blacklist.users";
+
+    // Path name of execute-as-user executable
+    public static final String AZKABAN_SERVER_NATIVE_LIB_FOLDER = "azkaban.native.lib";
+
+    // Name of *nix group associated with the process running Azkaban
+    public static final String AZKABAN_SERVER_GROUP_NAME = "azkaban.group.name";
 
     // Legacy configs section, new configs should follow the naming convention of azkaban.server.<rest of the name> for server configs.
 

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -50,6 +50,7 @@ public class ProcessJob extends AbstractProcessJob {
 
   public static final String COMMAND = "command";
   public static final String AZKABAN_MEMORY_CHECK = "azkaban.memory.check";
+  // Use AZKABAN_SERVER_NATIVE_LIB_FOLDER Configuration Key instead
   @Deprecated
   public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   public static final String EXECUTE_AS_USER = "execute.as.user";
@@ -230,7 +231,7 @@ public class ProcessJob extends AbstractProcessJob {
     // nativeLibFolder specifies the path for execute-as-user file,
     // which will change user from Azkaban to effectiveUser
     if (isExecuteAsUser) {
-      final String nativeLibFolder = this.sysProps.getString(NATIVE_LIB_FOLDER);
+      final String nativeLibFolder = this.sysProps.getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER);
       executeAsUserBinaryPath = String.format("%s/%s", nativeLibFolder, "execute-as-user");
       effectiveUser = getEffectiveUser(this.jobProps);
       // Throw exception if Azkaban tries to run flow as a prohibited user

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -50,7 +50,7 @@ public class ProcessJob extends AbstractProcessJob {
 
   public static final String COMMAND = "command";
   public static final String AZKABAN_MEMORY_CHECK = "azkaban.memory.check";
-  // Use AZKABAN_SERVER_NATIVE_LIB_FOLDER Configuration Key instead
+  // Use azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER instead
   @Deprecated
   public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   public static final String EXECUTE_AS_USER = "execute.as.user";

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -16,6 +16,7 @@
 
 package azkaban.jobExecutor;
 
+import static azkaban.Constants.NATIVE_LIB_FOLDER;
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 
 import azkaban.Constants;
@@ -23,11 +24,13 @@ import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.utils.process.AzkabanProcess;
 import azkaban.jobExecutor.utils.process.AzkabanProcessBuilder;
 import azkaban.metrics.CommonMetrics;
+import azkaban.utils.ExecuteAsUser;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.SystemMemoryInfo;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,12 +49,16 @@ public class ProcessJob extends AbstractProcessJob {
 
   public static final String COMMAND = "command";
   public static final String AZKABAN_MEMORY_CHECK = "azkaban.memory.check";
-  public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   public static final String EXECUTE_AS_USER = "execute.as.user";
   public static final String USER_TO_PROXY = "user.to.proxy";
   public static final String KRB5CCNAME = "KRB5CCNAME";
   private static final Duration KILL_TIME = Duration.ofSeconds(30);
   private static final String MEMCHECK_ENABLED = "memCheck.enabled";
+  private static final String CHOWN = "chown";
+  private static final String CREATE_FILE = "touch";
+  private static final String GROUP_NAME = "azkaban";
+  private static final int SUCCESSFUL_EXECUTION = 0;
+  private static final String TEMP_FILE_NAME = "user_can_write";
   private final CommonMetrics commonMetrics;
   private volatile AzkabanProcess process;
   private volatile boolean killed = false;
@@ -230,6 +237,11 @@ public class ProcessJob extends AbstractProcessJob {
             String.format("Not permitted to proxy as '%s' through Azkaban", effectiveUser)
         );
       }
+      // Set parent directory permissions to <uid>:azkaban so user can write in their execution directory
+      // if the directory is not permissioned correctly already (should happen once per execution)
+      if (!canWriteInCurrentWorkingDirectory(effectiveUser)) {
+        assignUserDirOwnership(effectiveUser);
+      }
     }
 
     for (String command : commands) {
@@ -271,8 +283,8 @@ public class ProcessJob extends AbstractProcessJob {
         this.process = builder.build();
       }
       try {
-          this.process.run();
-          this.success = true;
+        this.process.run();
+        this.success = true;
       } catch (final Throwable e) {
         for (final File file : propFiles) {
           if (file != null && file.exists()) {
@@ -342,6 +354,46 @@ public class ProcessJob extends AbstractProcessJob {
     }
     info("effective user is: " + effectiveUser);
     return effectiveUser;
+  }
+
+  /**
+   * Checks to see if user has write access to current working directory which many users
+   * need for their jobs to store temporary data/jars on the executor.
+   *
+   * Accomplishes this by using execute-as-user to try to create an empty file in the cwd.
+   *
+   * @param effectiveUser user/proxy user running the job
+   * @return true if user has write permissions in current working directory otherwise false
+   */
+  private boolean canWriteInCurrentWorkingDirectory(final String effectiveUser)
+      throws IOException {
+    final ExecuteAsUser executeAsUser = new ExecuteAsUser(
+        this.sysProps.getString(NATIVE_LIB_FOLDER));
+    final List<String> checkIfUserCanWriteCommand = Arrays
+        .asList(CREATE_FILE, getWorkingDirectory() + "/" + TEMP_FILE_NAME);
+    final int result = executeAsUser.execute(effectiveUser, checkIfUserCanWriteCommand);
+    return result == SUCCESSFUL_EXECUTION;
+  }
+
+  /**
+   * Changes permission on current working directory so that the directory is owned by the user
+   * and the group remains azkaban.
+   *
+   * Leverages execute-as-user with "root" as the user to run the command.
+   *
+   * @param effectiveUser user/proxy user running the job
+   */
+  private void assignUserDirOwnership(final String effectiveUser) throws IOException {
+    final ExecuteAsUser executeAsUser = new ExecuteAsUser(
+        this.sysProps.getString(NATIVE_LIB_FOLDER));
+    final List<String> changeOwnershipCommand = Arrays
+        .asList(CHOWN, effectiveUser + ":" + GROUP_NAME, getWorkingDirectory());
+    info("Change current working directory ownership to " + effectiveUser + ":" + GROUP_NAME + ".");
+    final int result = executeAsUser.execute("root", changeOwnershipCommand);
+    if (result != 0) {
+      error("Failed to change current working directory ownership. Error code: " + Integer
+          .toString(result));
+    }
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -224,13 +224,13 @@ public class ProcessJob extends AbstractProcessJob {
       final String nativeLibFolder = this.sysProps.getString(NATIVE_LIB_FOLDER);
       executeAsUserBinaryPath = String.format("%s/%s", nativeLibFolder, "execute-as-user");
       effectiveUser = getEffectiveUser(this.jobProps);
-        // Throw exception if Azkaban tries to run flow as a prohibited user
-        if (blackListedUsers.contains(effectiveUser)) {
-          throw new RuntimeException(
-              String.format("Not permitted to proxy as '%s' through Azkaban", effectiveUser)
-          );
-        }
+      // Throw exception if Azkaban tries to run flow as a prohibited user
+      if (blackListedUsers.contains(effectiveUser)) {
+        throw new RuntimeException(
+            String.format("Not permitted to proxy as '%s' through Azkaban", effectiveUser)
+        );
       }
+    }
 
     for (String command : commands) {
       AzkabanProcessBuilder builder = null;

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUser.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUser.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package azkaban.security;
+package azkaban.utils;
 
 import java.io.File;
 import java.io.IOException;

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -16,8 +16,11 @@
 
 package azkaban.security;
 
+import static azkaban.Constants.NATIVE_LIB_FOLDER;
+
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.ExecuteAsUser;
 import azkaban.utils.Props;
 import azkaban.utils.UndefinedPropertyException;
 import java.io.DataOutputStream;
@@ -65,15 +68,6 @@ import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 
 public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
-
-  /**
-   * TODO Remove duplicated constants from plugins.
-   *
-   * Azkaban plugins don't depend on a common submodule from which they both can inherit code. Thus,
-   * constants are copied around and any changes to the constant values will break Azkaban. This
-   * needs to be fixed as part of a plugin infrastructure implementation.
-   */
-  public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
 
   /**
    * TODO: This should be exposed as a configurable parameter

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -16,7 +16,7 @@
 
 package azkaban.security;
 
-import static azkaban.Constants.NATIVE_LIB_FOLDER;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
 
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
@@ -69,6 +69,8 @@ import org.apache.thrift.TException;
 
 public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
 
+  @Deprecated
+  public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   /**
    * TODO: This should be exposed as a configurable parameter
    *
@@ -131,7 +133,7 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
 
   private HadoopSecurityManager_H_2_0(final Props props)
       throws HadoopSecurityManagerException, IOException {
-    this.executeAsUser = new ExecuteAsUser(props.getString(NATIVE_LIB_FOLDER));
+    this.executeAsUser = new ExecuteAsUser(props.getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER));
 
     // for now, assume the same/compatible native library, the same/compatible
     // hadoop-core jar

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -69,6 +69,7 @@ import org.apache.thrift.TException;
 
 public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
 
+  // Use AZKABAN_SERVER_NATIVE_LIB_FOLDER Configuration Key instead
   @Deprecated
   public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   /**

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -69,7 +69,7 @@ import org.apache.thrift.TException;
 
 public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
 
-  // Use AZKABAN_SERVER_NATIVE_LIB_FOLDER Configuration Key instead
+  // Use azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER instead
   @Deprecated
   public static final String NATIVE_LIB_FOLDER = "azkaban.native.lib";
   /**


### PR DESCRIPTION
Right now, Azkaban leverages the execute-as-user script so that users' jobs are run via a process of the user's creation instead of as the Azkaban process. This is really important because it restricts users from interfering with Azkaban or reading secure information that Azkaban holds.

While this script works well, it has a bug in which it doesn't remove the "azkaban" group from the users list of groups. This is not secure. It did have a side-effect though that should be kept: it allowed users to write to their /execution/<exec_id>/src directory. This is desired because it gives users the ability to cache temporary data on the executor between jobs in a flow.

This PR does two things:
- It fixes the security bug in execute-as-user.c by calling the initgroups() function for the effective user.
- It uses the execute-as-user executable to set up the /execution/<exec_id>/src directory so that its permissions allow the user to work within it . It also makes sure that this is done in a way that can be cleaned up later by the Azkaban thread. It does this by executing the command: `chown <user>:azkaban`

This particular change will be hard to test with unit testing, but it will easy to test within the integration testing suite (I discussed this with @jamiesjc). It can be done completely with two test:
- The first one tries to write to the current working directory. If the flow concludes successfully (i.e. the file is successfully created), the test passes.
- The second tries to perform an "improper" action reserved for members of the "azkaban" group. If the flow fails (i.e. the action cannot be performed), the test passes.
Together I believe this will give sufficient test coverage for this part of the code and each test should be quick (one job flows that should terminate in < 1 second)