### PR TITLE
TriggerManager needs to persist updated trigger when updating trigger

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -137,6 +137,11 @@ public class TriggerManager extends EventHandler implements
       this.runnerThread.deleteTrigger(triggerIdMap.get(t.getTriggerId()));
       this.runnerThread.addTrigger(t);
       triggerIdMap.put(t.getTriggerId(), t);
+      try {
+        this.triggerLoader.updateTrigger(t);
+      } catch (final TriggerLoaderException e) {
+        throw new TriggerManagerException(e);
+      }
     }
   }
 


### PR DESCRIPTION
Previously, TriggerManager won't persist updated schedule when schedule gets updated(e.x. add new SLA rule to a schedule). It gets persisted only when schedule gets triggered. So if we add a  SLA rule to a schedule or do a reschedule, and restart the web server after it, these updates will be lost.