### PR TITLE
 Log statement added for web server restarts

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1687,10 +1687,10 @@ public class ExecutorManager extends EventHandler implements
 
     private void cleanExecutionLogs() {
       logger.info("Cleaning old logs from execution_logs");
-      long cutoff = DateTime.now().getMillis() - executionLogsRetentionMs;
+      long cutoff = System.currentTimeMillis() - executionLogsRetentionMs;
       logger.info("Cleaning old log files before "
           + new DateTime(cutoff).toString());
-      cleanOldExecutionLogs(DateTime.now().getMillis()
+      cleanOldExecutionLogs(System.currentTimeMillis()
           - executionLogsRetentionMs);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -28,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1644,7 +1646,10 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
 
     QueryRunner runner = createQueryRunner();
     int updateNum = 0;
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssXX:XX");
+    Date dateobj  = new Date(millis);
     try {
+      logger.info("Purging execution logs older then: " + dateobj.toString() + " from database");
       updateNum = runner.update(DELETE_BY_TIME, millis);
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1663,7 +1668,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
     private static String FETCH_ALL_EXECUTORS =
       "SELECT id, host, port, active FROM executors";
     private static String FETCH_ACTIVE_EXECUTORS =
-      "SELECT id, host, port, active FROM executors where active=true";
+      "SELECT id, host, port, active FROM executors wherje active=true";
     private static String FETCH_EXECUTOR_BY_ID =
       "SELECT id, host, port, active FROM executors where id=?";
     private static String FETCH_EXECUTOR_BY_HOST_PORT =

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -1668,7 +1668,7 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
     private static String FETCH_ALL_EXECUTORS =
       "SELECT id, host, port, active FROM executors";
     private static String FETCH_ACTIVE_EXECUTORS =
-      "SELECT id, host, port, active FROM executors wherje active=true";
+      "SELECT id, host, port, active FROM executors where active=true";
     private static String FETCH_EXECUTOR_BY_ID =
       "SELECT id, host, port, active FROM executors where id=?";
     private static String FETCH_EXECUTOR_BY_HOST_PORT =


### PR DESCRIPTION
 When the execution_logs table has a large number of entries, it can take over 5 minutes for a web server restart without meaningful output.
    
This change will notify operations that a SQL query is being executed and could cause a delay when restarting the web server.

I had the following output in my logs using azkaban solo backed by the H2 database.

```
2017/08/10 19:38:42.007 -0700 INFO [JdbcExecutorLoader] [Azkaban] Purging execution logs older then: Thu May 18 19:38:42 PDT 2017 from database
```