### PR TITLE
Throwing error in assignUserDirOwnership in ProcessJob

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -386,7 +386,7 @@ public class ProcessJob extends AbstractProcessJob {
    *
    * @param effectiveUser user/proxy user running the job
    */
-  private void assignUserDirOwnership(final String effectiveUser) throws IOException {
+  private void assignUserDirOwnership(final String effectiveUser) throws Exception {
     final ExecuteAsUser executeAsUser = new ExecuteAsUser(
         this.sysProps.getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER));
     final String groupName = this.sysProps.getString(AZKABAN_SERVER_GROUP_NAME, "azkaban");
@@ -395,8 +395,8 @@ public class ProcessJob extends AbstractProcessJob {
     info("Change current working directory ownership to " + effectiveUser + ":" + groupName + ".");
     final int result = executeAsUser.execute("root", changeOwnershipCommand);
     if (result != 0) {
-      error("Failed to change current working directory ownership. Error code: " + Integer
-          .toString(result));
+      handleError("Failed to change current working directory ownership. Error code: " + Integer
+          .toString(result), null);
     }
   }
 


### PR DESCRIPTION
Updating PR #1325.

Instead of simply displaying an error message when assignUserDirOwnership fails, now it throws an Exception using the handleError method.

This is better because if the flow fails later due to unexpected permissions for the user then it would be hard to detect that the failure of assignUserDirOwnership is the root cause. Now the flow will fail quickly and be easier to diagnose.