### PR TITLE
remove job runner from active job runner list when job finishes

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1119,6 +1119,7 @@ public class FlowRunner extends EventHandler implements Runnable {
           }
 
           FlowRunner.this.finishedNodes.add(node);
+          activeJobRunners.remove(runner);
           node.getParentFlow().setUpdateTime(System.currentTimeMillis());
           interrupt();
           fireEventListeners(event);


### PR DESCRIPTION
activeJobRunners maintains all active job runners, so we should remove inactive job runners when job finishes. As a consequence, activeJobRunners will keep queuing up and querying activeJobRunners by job name will return invalid job runner. This PR fixes this issue.