### PR TITLE
Fixed "Center Job/Flow/Graph" button

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -652,7 +652,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
     // position.
     // Rather do this than to traverse backwards through the scene graph.
     var ctm = node.gNode.getCTM();
-    var transform = node.gNode.getTransformToElement();
     var globalCTM = this.mainG.getCTM().inverse();
     var otherTransform = globalCTM.multiply(ctm);
     // Also a beauty of affine transformation. The translate is always the


### PR DESCRIPTION
The "centerNode" function calls getTransformToElement(), which was [removed from the SVG spec](https://www.w3.org/TR/SVG2/changes.html#types) and also from browsers such as Chrome and Firefox, so the "Center" context menu button that appears when right-clicking in the graph view doesn't work. Fortunately it doesn't seem to use this call for anything so simply removing the line makes the button work again.

Tested by injecting the modified svg-graph.js as a Greasemonkey script in Firefox 55.0.1, and locally modifying the script in the debugger in Chrome 60.0.3112.90.