### PR TITLE
Implemented delete API for local Storage

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -111,6 +111,12 @@ public class LocalStorage implements Storage {
   @Override
   public boolean delete(final String key) {
     final File file = getFile(key);
-    return file.exists() && file.delete();
+    final boolean result = file.exists() && file.delete();
+    if (result) {
+      log.warn("Deleted file: " + file.getAbsolutePath());
+    } else {
+      log.warn("Unable to delete file: " + file.getAbsolutePath());
+    }
+    return result;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -65,12 +65,16 @@ public class LocalStorage implements Storage {
     return baseDirectory;
   }
 
+  private File getFile(final String key) {
+    return new File(this.rootDirectory, key);
+  }
+
   /**
    * @param key Relative path of the file from the baseDirectory
    */
   @Override
   public InputStream get(final String key) throws IOException {
-    return new FileInputStream(new File(this.rootDirectory, key));
+    return new FileInputStream(getFile(key));
   }
 
   @Override
@@ -106,6 +110,7 @@ public class LocalStorage implements Storage {
 
   @Override
   public boolean delete(final String key) {
-    throw new UnsupportedOperationException("delete has not been implemented.");
+    final File file = getFile(key);
+    return file.exists() && file.delete();
   }
 }

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -26,6 +26,7 @@ import azkaban.AzkabanCommonModuleConfig;
 import azkaban.spi.StorageMetadata;
 import azkaban.utils.Md5Hasher;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
@@ -58,7 +59,7 @@ public class LocalStorageTest {
   }
 
   @Test
-  public void testPutGet() throws Exception {
+  public void testPutGetDelete() throws Exception {
     final ClassLoader classLoader = getClass().getClassLoader();
     final File testFile = new File(classLoader.getResource(SAMPLE_FILE).getFile());
 
@@ -86,6 +87,17 @@ public class LocalStorageTest {
     final File getFile = new File("tmp.get");
     FileUtils.copyInputStreamToFile(getIs, getFile);
     assertTrue(FileUtils.contentEquals(testFile, getFile));
+
+    // Cleanup temp file
     getFile.delete();
+
+    assertTrue(this.localStorage.delete(key));
+    boolean exceptionThrown = false;
+    try {
+      this.localStorage.get(key);
+    } catch (final FileNotFoundException e) {
+      exceptionThrown = true;
+    }
+    assertTrue(exceptionThrown);
   }
 }


### PR DESCRIPTION
Delete API was missing for `LocalStorage`. Added it. Updated test.