### PR TITLE
Fixed LocalStorage: Weird characters in filename

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
@@ -82,7 +82,7 @@ public class LocalStorage implements Storage {
 
     final File targetFile = new File(projectDir, String.format("%s-%s.zip",
         String.valueOf(metadata.getProjectId()),
-        new String(metadata.getHash(), StandardCharsets.UTF_8)));
+        new String(Hex.encodeHex(metadata.getHash()))));
 
     if (targetFile.exists()) {
       log.info(String.format("Duplicate found: meta: %s, targetFile: %s, ", metadata,

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -27,7 +27,7 @@ import azkaban.spi.StorageMetadata;
 import azkaban.utils.Md5Hasher;
 import java.io.File;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.After;
@@ -73,7 +73,7 @@ public class LocalStorageTest {
         .append(File.separator)
         .append(metadata.getProjectId())
         .append("-")
-        .append(new String(metadata.getHash(), StandardCharsets.UTF_8))
+        .append(new String(Hex.encodeHex(metadata.getHash())))
         .append(".zip")
         .toString()
     );


### PR DESCRIPTION
The local storage uses hash to create a filename. With the current code it generates weird characters in the file name. Updating the logic to the one similar with `HdfsStorage`. This fixes the filename issue.

Example old filename: `1/1-��ΰ�Ǉ�.����*�.zip`
Example new filename: `1/1-c5e616ceb09bc787e52eb99bab8d2a8c.zip`