### PR TITLE
Open access of /jmx and /stats page to all users.

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -74,12 +74,6 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     if (hasParam(req, "ajax")) {
       Map<String, Object> ret = new HashMap<>();
 
-      if (!hasPermission(session.getUser(), Permission.Type.METRICS)) {
-        ret.put("error", "User " + session.getUser().getUserId()
-            + " has no permission.");
-        this.writeJSON(resp, ret, true);
-        return;
-      }
       final String ajax = getParam(req, "ajax");
       if (JMX_GET_ALL_EXECUTOR_ATTRIBUTES.equals(ajax)) {
         if (!hasParam(req, JMX_MBEAN) || !hasParam(req, JMX_HOSTPORT)) {
@@ -177,13 +171,6 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/jmxpage.vm");
 
-    if (!hasPermission(session.getUser(), Permission.Type.METRICS)) {
-      page.add("errorMsg", "User " + session.getUser().getUserId()
-          + " has no permission.");
-      page.render();
-      return;
-    }
-
     page.add("mbeans", this.server.getMbeanNames());
 
     final Map<String, Object> executorMBeans = new HashMap<>();
@@ -213,17 +200,5 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
   protected void handlePost(final HttpServletRequest req, final HttpServletResponse resp,
       final Session session) throws ServletException, IOException {
 
-  }
-
-  protected boolean hasPermission(final User user, final Permission.Type type) {
-    for (final String roleName : user.getRoles()) {
-      final Role role = this.userManager.getRole(roleName);
-      if (role.getPermission().isPermissionSet(type)
-          || role.getPermission().isPermissionSet(Permission.Type.ADMIN)) {
-        return true;
-      }
-    }
-
-    return false;
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
@@ -181,11 +181,6 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
       final Session session)
       throws ServletException {
     final Page page = newPage(req, resp, session, "azkaban/webapp/servlet/velocity/statsPage.vm");
-    if (!hasPermission(session.getUser(), Permission.Type.METRICS)) {
-      page.add("errorMsg", "User " + session.getUser().getUserId() + " has no permission.");
-      page.render();
-      return;
-    }
 
     try {
       final Collection<Executor> executors = this.execManager.getAllActiveExecutors();
@@ -214,17 +209,6 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
       final Session session)
       throws ServletException,
       IOException {
-  }
-
-  protected boolean hasPermission(final User user, final Permission.Type type) {
-    for (final String roleName : user.getRoles()) {
-      final Role role = this.userManager.getRole(roleName);
-      if (role.getPermission().isPermissionSet(type) || role.getPermission()
-          .isPermissionSet(Permission.Type.ADMIN)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**


### PR DESCRIPTION
Tested on localhost:
1. Add in azkaban-users.xml:
`<user username="azktest1" password="azktest1" group="azk1" roles="all-except-admin"/>`
2. Launch solo server with username azktest1. 
3. Verify azktest1 can access /jmx and /stats page.