### PR TITLE
git: ignore out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ temp/
 *.iws
 .ideaDataSources/
 .shelf
+# Intellij default build output directory
+out/


### PR DESCRIPTION
Intellij generates build output in the out directory.
Gradle uses build directory.
When running unit tests or solo server in intellij, build from intellij
is still required.

See
https://youtrack.jetbrains.com/issue/IDEA-175172