### PR TITLE
update travis by disable daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build
+script: ./gradlew clean build --no-daemon
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:


### PR DESCRIPTION
It is stated in Gradle docs that gradle daemon should not be run in CI environments.
https://docs.gradle.org/3.3/userguide/gradle_daemon.html#when_should_i_not_use_the_gradle_daemon