### PR TITLE
disallow no action SLA

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -204,14 +204,16 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
         }
       }
 
+      if (slaOptions.isEmpty()) {
+        throw new ScheduleManagerException(
+            String.format("SLA for schedule %s must have at least one action", scheduleId));
+      }
+
       sched.setSlaOptions(slaOptions);
       this.scheduleManager.insertSchedule(sched);
-
-      if (slaOptions != null) {
-        this.projectManager.postProjectEvent(project, EventType.SLA,
-            user.getUserId(), "SLA for flow " + sched.getFlowName()
-                + " has been added/changed.");
-      }
+      this.projectManager.postProjectEvent(project, EventType.SLA,
+          user.getUserId(), "SLA for flow " + sched.getFlowName()
+              + " has been added/changed.");
 
     } catch (final ServletException e) {
       ret.put("error", e.getMessage());


### PR DESCRIPTION
This PR is attempting to solve issue https://github.com/azkaban/azkaban/issues/1363.
Currently if we setup SLA but with no action specified, there will be no warning, and schedule page will show "has SLA" is true.
However, action should be required when setting up SLA. 

This PR added a non empty check on SLA actions when adding SLA for a schedule. Warning window will show up if action is not specified when setting SLA.
Old check was not checking the number of actions at all when updating SLA. The null check was used when uploading project logs.
Verified manually, but will automate the test in the internal integration test framework
