### PR TITLE
Improve JobRunnerTest stability

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -28,13 +28,13 @@ public class FlowRunnerTestBase {
   public void assertThreadShutDown() {
     waitFlowRunner(
         runner -> Status.isStatusFinished(runner.getExecutableFlow().getStatus())
-        && !runner.isRunnerThreadAlive());
+            && !runner.isRunnerThreadAlive());
   }
 
   public void assertThreadRunning() {
     waitFlowRunner(
         runner -> Status.isStatusRunning(runner.getExecutableFlow().getStatus())
-        && runner.isRunnerThreadAlive());
+            && runner.isRunnerThreadAlive());
   }
 
   public void waitFlowRunner(final Function<FlowRunner, Boolean> statusCheck) {
@@ -103,7 +103,7 @@ public class FlowRunnerTestBase {
 
   protected void assertFlowStatus(final Status status) {
     final ExecutableFlow flow = this.runner.getExecutableFlow();
-    waitForStatus(flow, status);
+    StatusTestUtils.waitForStatus(flow, status);
     printStatuses(status, flow);
     assertEquals(status, flow.getStatus());
   }
@@ -112,24 +112,9 @@ public class FlowRunnerTestBase {
     final ExecutableFlow exFlow = this.runner.getExecutableFlow();
     final ExecutableNode node = exFlow.getExecutableNodePath(name);
     assertNotNull(name + " wasn't found", node);
-    waitForStatus(node, status);
+    StatusTestUtils.waitForStatus(node, status);
     printStatuses(status, node);
     assertEquals("Wrong status for [" + name + "]", status, node.getStatus());
-  }
-
-  private void waitForStatus(ExecutableNode node, Status status) {
-    for (int i = 0; i < 1000; i++) {
-      if (node.getStatus() == status) {
-        break;
-      }
-      synchronized (EventCollectorListener.handleEvent) {
-        try {
-          EventCollectorListener.handleEvent.wait(10L);
-        } catch (final InterruptedException e) {
-          i--;
-        }
-      }
-    }
   }
 
   protected void printStatuses(final Status status, final ExecutableNode node) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/StatusTestUtils.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/StatusTestUtils.java
@@ -1,0 +1,23 @@
+package azkaban.execapp;
+
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.Status;
+
+public class StatusTestUtils {
+
+  public static void waitForStatus(final ExecutableNode node, final Status status) {
+    for (int i = 0; i < 1000; i++) {
+      if (node.getStatus() == status) {
+        break;
+      }
+      synchronized (EventCollectorListener.handleEvent) {
+        try {
+          EventCollectorListener.handleEvent.wait(10L);
+        } catch (final InterruptedException e) {
+          i--;
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- Remove some redundant sleeping, replace with more eager waiting
- Add sleep to another place to increase stability
- Extracted common purpose method into a new helper class

Aims to fix this kind of random failure (happened in current master):
https://travis-ci.org/azkaban/azkaban/builds/266111102

```
azkaban.execapp.JobRunnerTest > testDelayedExecutionCancelledJob FAILED
    java.lang.AssertionError: expected:<2> but was:<1>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at azkaban.execapp.JobRunnerTest.testDelayedExecutionCancelledJob(JobRunnerTest.java:309)
```