### PR TITLE
hiding internals of azkaban-db tests in other module

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     testRuntime deps.h2
 
     testCompile project(':test')
-    testCompile project(':azkaban-db').sourceSets.test.output
+    testCompile project(path: ':azkaban-db', configuration: 'testOutput')
 }
 
 tasks.withType(JavaCompile) {

--- a/azkaban-db/build.gradle
+++ b/azkaban-db/build.gradle
@@ -16,6 +16,19 @@
  */
 apply plugin: 'distribution'
 
+task testJar(type: Jar, dependsOn: testClasses) {
+    from sourceSets.test.output
+    classifier = 'test'
+}
+
+configurations {
+    testOutput
+}
+
+artifacts {
+    testOutput testJar
+}
+
 dependencies {
 
     // todo kunkun-tang: consolidate dependencies in azkaban-common and azkaban-db

--- a/azkaban-db/build.gradle
+++ b/azkaban-db/build.gradle
@@ -22,7 +22,7 @@ task testJar(type: Jar, dependsOn: testClasses) {
 }
 
 configurations {
-    testOutput
+    testOutput.extendsFrom (testCompile)
 }
 
 artifacts {


### PR DESCRIPTION
This PR is a follow-up of #1361 , which aimed at clearing the submodule dependency management. We explicitly depend on some internals from `azkaban-db`. It would be nice if we could hide this detail.

The solution originated from:
https://softnoise.wordpress.com/2014/09/07/gradle-sub-project-test-dependencies-in-multi-project-builds/