### PR TITLE
build: use a fixed google errorprone version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,12 @@ subprojects {
     // Set the same version for all sub-projects to root project version
     version = rootProject.version
 
+    configurations.errorprone {
+        dependencies {
+            errorprone 'com.google.errorprone:error_prone_core:2.0.15'
+        }
+    }
+
     plugins.withType(JavaPlugin) {
         sourceCompatibility = JavaVersion.VERSION_1_8
 
@@ -184,7 +190,6 @@ subprojects {
         }
     }
 }
-
 
 /**
  * Gradle wrapper task.


### PR DESCRIPTION
## Issue:
"The plugin adds an errorprone configuration that automatically uses the
 latest release of error-prone. You can override it to use a specific
 version "
see https://github.com/tbroyer/gradle-errorprone-plugin

It appears that by latest version it will use the last locally cached
version. This caused inconsistency in builds.

Also, it introduces additional variables in the build. 
e.g. see #1380 

## Fix:
Specify a fixed version

Will update to the latest version after the internal Artifactory
is updated with the latest version.

## Test:
Delete the gradle cache and run the build again and verify in the
console output that the specified version is downloaded.