### PR TITLE
The final commit for JDBC Executor rewrite

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+//TODO jamiesjc: This class is deprecated as we don't fetch active_execution_flow table any long.
+// So this clas should be removed onwards.
 @Singleton
 public class ActiveExecutingFlowsDao {
 

--- a/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
@@ -16,52 +16,41 @@
 
 package azkaban.executor;
 
-import azkaban.database.AbstractJdbcLoader;
 import azkaban.db.DatabaseOperator;
-import azkaban.metrics.CommonMetrics;
-import azkaban.utils.Props;
 import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.dbutils.QueryRunner;
 
 @Singleton
-public class ActiveExecutingFlowsDao extends AbstractJdbcLoader{
+public class ActiveExecutingFlowsDao {
 
   private final DatabaseOperator dbOperator;
 
   @Inject
-  ActiveExecutingFlowsDao(final Props props, final CommonMetrics commonMetrics,
-                          final DatabaseOperator dbOperator) {
-    super(props, commonMetrics);
+  ActiveExecutingFlowsDao(final DatabaseOperator dbOperator) {
     this.dbOperator = dbOperator;
   }
 
   void addActiveExecutableReference(final ExecutionReference reference)
       throws ExecutorManagerException {
-    final String INSERT =
-        "INSERT INTO active_executing_flows "
-            + "(exec_id, update_time) values (?,?)";
-    final QueryRunner runner = createQueryRunner();
-
+    final String INSERT = "INSERT INTO active_executing_flows "
+        + "(exec_id, update_time) values (?,?)";
     try {
-      runner.update(INSERT, reference.getExecId(), reference.getUpdateTime());
+      this.dbOperator.update(INSERT, reference.getExecId(), reference.getUpdateTime());
     } catch (final SQLException e) {
       throw new ExecutorManagerException(
           "Error updating active flow reference " + reference.getExecId(), e);
     }
   }
 
-  void removeActiveExecutableReference(final int execid)
+  void removeActiveExecutableReference(final int execId)
       throws ExecutorManagerException {
     final String DELETE = "DELETE FROM active_executing_flows WHERE exec_id=?";
-
-    final QueryRunner runner = createQueryRunner();
     try {
-      runner.update(DELETE, execid);
+      this.dbOperator.update(DELETE, execId);
     } catch (final SQLException e) {
       throw new ExecutorManagerException(
-          "Error deleting active flow reference " + execid, e);
+          "Error deleting active flow reference " + execId, e);
     }
   }
 
@@ -70,16 +59,12 @@ public class ActiveExecutingFlowsDao extends AbstractJdbcLoader{
     final String DELETE =
         "UPDATE active_executing_flows set update_time=? WHERE exec_id=?";
 
-    final QueryRunner runner = createQueryRunner();
-    int updateNum = 0;
     try {
-      updateNum = runner.update(DELETE, updateTime, execId);
+      // Should be 1.
+      return this.dbOperator.update(DELETE, updateTime, execId) > 0;
     } catch (final SQLException e) {
       throw new ExecutorManagerException(
           "Error deleting active flow reference " + execId, e);
     }
-
-    // Should be 1.
-    return updateNum > 0;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ActiveExecutingFlowsDao.java
@@ -21,8 +21,9 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-//TODO jamiesjc: This class is deprecated as we don't fetch active_execution_flow table any long.
-// So this clas should be removed onwards.
+//TODO jamiesjc: This class is deprecated as we don't fetch active_execution_flow table any longer.
+// So this class should be removed onwards.
+@Deprecated
 @Singleton
 public class ActiveExecutingFlowsDao {
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorEventsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorEventsDao.java
@@ -16,11 +16,8 @@
 
 package azkaban.executor;
 
-import azkaban.database.AbstractJdbcLoader;
 import azkaban.db.DatabaseOperator;
 import azkaban.executor.ExecutorLogEvent.EventType;
-import azkaban.metrics.CommonMetrics;
-import azkaban.utils.Props;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -29,31 +26,25 @@ import java.util.Date;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 
 @Singleton
-public class ExecutorEventsDao extends AbstractJdbcLoader {
+public class ExecutorEventsDao {
 
   private final DatabaseOperator dbOperator;
 
   @Inject
-  public ExecutorEventsDao(final Props props, final CommonMetrics commonMetrics,
-                           final DatabaseOperator dbOperator) {
-    super(props, commonMetrics);
+  public ExecutorEventsDao(final DatabaseOperator dbOperator) {
     this.dbOperator = dbOperator;
   }
 
   public void postExecutorEvent(final Executor executor, final EventType type, final String user,
                                 final String message) throws ExecutorManagerException {
-    final QueryRunner runner = createQueryRunner();
-
     final String INSERT_PROJECT_EVENTS =
         "INSERT INTO executor_events (executor_id, event_type, event_time, username, message) values (?,?,?,?,?)";
-    final Date updateDate = new Date();
     try {
-      runner.update(INSERT_PROJECT_EVENTS, executor.getId(), type.getNumVal(),
-          updateDate, user, message);
+      this.dbOperator.update(INSERT_PROJECT_EVENTS, executor.getId(), type.getNumVal(),
+          new Date(), user, message);
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Failed to post executor event", e);
     }
@@ -62,20 +53,13 @@ public class ExecutorEventsDao extends AbstractJdbcLoader {
   public List<ExecutorLogEvent> getExecutorEvents(final Executor executor, final int num,
                                                   final int offset)
       throws ExecutorManagerException {
-    final QueryRunner runner = createQueryRunner();
-
-    final ExecutorLogsResultHandler logHandler = new ExecutorLogsResultHandler();
-    List<ExecutorLogEvent> events = null;
     try {
-      events =
-          runner.query(ExecutorLogsResultHandler.SELECT_EXECUTOR_EVENTS_ORDER,
-              logHandler, executor.getId(), num, offset);
+      return this.dbOperator.query(ExecutorLogsResultHandler.SELECT_EXECUTOR_EVENTS_ORDER,
+          new ExecutorLogsResultHandler(), executor.getId(), num, offset);
     } catch (final SQLException e) {
       throw new ExecutorManagerException(
           "Failed to fetch events for executor id : " + executor.getId(), e);
     }
-
-    return events;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -25,7 +25,6 @@ import azkaban.utils.Props;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.io.File;
-import java.io.IOException;
 import java.sql.Connection;
 import java.time.Duration;
 import java.util.List;
@@ -261,14 +260,6 @@ public class JdbcExecutorLoader extends AbstractJdbcLoader implements
   public void uploadLogFile(final int execId, final String name, final int attempt, final File... files)
       throws ExecutorManagerException {
     this.executionLogsDao.uploadLogFile(execId, name, attempt, files);
-  }
-
-  private void uploadLogFile(final Connection connection, final int execId, final String name,
-                             final int attempt, final File[] files, final EncodingType encType)
-      throws ExecutorManagerException, IOException {
-    // 50K buffer... if logs are greater than this, we chunk.
-    // However, we better prevent large log files from being uploaded somehow
-    this.executionLogsDao.uploadLogFile(connection, execId, name, attempt, files, encType);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -21,17 +21,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.db.DatabaseOperator;
 import azkaban.test.Utils;
+import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Pair;
+import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
+import java.io.File;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ExecutionFlowDaoTest {
@@ -43,6 +48,8 @@ public class ExecutionFlowDaoTest {
   private ExecutionFlowDao executionFlowDao;
   private ExecutorDao executorDao;
   private AssignExecutorDao assignExecutor;
+  private FetchActiveFlowDao fetchActiveFlowDao;
+  private ExecutionJobDao executionJobDao;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -62,8 +69,10 @@ public class ExecutionFlowDaoTest {
   @Before
   public void setup() {
     this.executionFlowDao = new ExecutionFlowDao(dbOperator);
-    this.executorDao= new ExecutorDao(dbOperator);
-    this.assignExecutor= new AssignExecutorDao(dbOperator, this.executorDao);
+    this.executorDao = new ExecutorDao(dbOperator);
+    this.assignExecutor = new AssignExecutorDao(dbOperator, this.executorDao);
+    this.fetchActiveFlowDao = new FetchActiveFlowDao(dbOperator);
+    this.executionJobDao = new ExecutionJobDao(dbOperator);
   }
 
   @After
@@ -225,6 +234,111 @@ public class ExecutionFlowDaoTest {
         .hasMessageContaining("non-existent execution");
   }
 
+
+  @Test
+  public void testFetchActiveFlowsExecutorAssigned() throws Exception {
+
+    // Upload flow1, executor assigned
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.executionFlowDao.uploadExecutableFlow(flow1);
+    final Executor executor = this.executorDao.addExecutor("test", 1);
+    this.assignExecutor.assignExecutor(executor.getId(), flow1.getExecutionId());
+
+    // Upload flow2, executor not assigned
+    final ExecutableFlow flow2 = TestUtils.createExecutableFlow("exectest1", "exec2");
+    this.executionFlowDao.uploadExecutableFlow(flow2);
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
+        this.fetchActiveFlowDao.fetchActiveFlows();
+
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isTrue();
+    assertThat(activeFlows1.containsKey(flow2.getExecutionId())).isFalse();
+    final ExecutableFlow flow1Result =
+        activeFlows1.get(flow1.getExecutionId()).getSecond();
+    assertTwoFlowSame(flow1Result, flow1);
+  }
+
+  @Test
+  public void testFetchActiveFlowsStatusChanged() throws Exception {
+    final ExecutableFlow flow1 = TestUtils.createExecutableFlow("exectest1", "exec1");
+    this.executionFlowDao.uploadExecutableFlow(flow1);
+    final Executor executor = this.executorDao.addExecutor("test", 1);
+    this.assignExecutor.assignExecutor(executor.getId(), flow1.getExecutionId());
+
+    Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
+        this.fetchActiveFlowDao.fetchActiveFlows();
+
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isTrue();
+
+    // When flow status becomes SUCCEEDED/KILLED/FAILED, it should not be in active state
+    flow1.setStatus(Status.SUCCEEDED);
+    this.executionFlowDao.updateExecutableFlow(flow1);
+    activeFlows1 = this.fetchActiveFlowDao.fetchActiveFlows();
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isFalse();
+
+    flow1.setStatus(Status.KILLED);
+    this.executionFlowDao.updateExecutableFlow(flow1);
+    activeFlows1 = this.fetchActiveFlowDao.fetchActiveFlows();
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isFalse();
+
+    flow1.setStatus(Status.FAILED);
+    this.executionFlowDao.updateExecutableFlow(flow1);
+    activeFlows1 = this.fetchActiveFlowDao.fetchActiveFlows();
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isFalse();
+  }
+
+  @Test @Ignore
+  // TODO jamiesjc: Active_execution_flow table is already deprecated. we should remove related
+  // test methods as well.
+  public void testFetchActiveFlowsReferenceChanged() throws Exception {
+  }
+
+  @Test @Ignore
+  // TODO jamiesjc: Active_execution_flow table is already deprecated. we should remove related
+  // test methods as well.
+  public void testFetchActiveFlowByExecId() throws Exception {
+  }
+
+  @Test
+  public void testUploadAndFetchExecutableNode() throws Exception {
+
+    final ExecutableFlow flow = TestUtils.createExecutableFlow("exectest1", "exec1");
+    flow.setExecutionId(10);
+
+    final File jobFile = ExecutionsTestUtil.getFlowFile("exectest1", "job10.job");
+    final Props props = new Props(null, jobFile);
+    props.put("test", "test2");
+    final ExecutableNode oldNode = flow.getExecutableNode("job10");
+    oldNode.setStartTime(System.currentTimeMillis());
+    this.executionJobDao.uploadExecutableNode(oldNode, props);
+
+    final ExecutableJobInfo info = this.executionJobDao.fetchJobInfo(10, "job10", 0);
+    assertThat(flow.getEndTime()).isEqualTo(info.getEndTime());
+    assertThat(flow.getProjectId()).isEqualTo(info.getProjectId());
+    assertThat(flow.getVersion()).isEqualTo(info.getVersion());
+    assertThat(flow.getFlowId()).isEqualTo(info.getFlowId());
+
+    assertThat(oldNode.getId()).isEqualTo(info.getJobId());
+    assertThat(oldNode.getStatus()).isEqualTo(info.getStatus());
+    assertThat(oldNode.getStartTime()).isEqualTo(info.getStartTime());
+
+    // Fetch props
+    final Props outputProps = new Props();
+    outputProps.put("hello", "output");
+    oldNode.setOutputProps(outputProps);
+    oldNode.setEndTime(System.currentTimeMillis());
+    this.executionJobDao.updateExecutableNode(oldNode);
+
+    final Props fInputProps = this.executionJobDao.fetchExecutionJobInputProps(10, "job10");
+    final Props fOutputProps = this.executionJobDao.fetchExecutionJobOutputProps(10, "job10");
+    final Pair<Props, Props> inOutProps = this.executionJobDao.fetchExecutionJobProps(10, "job10");
+
+    assertThat(fInputProps.get("test")).isEqualTo("test2");
+    assertThat(fOutputProps.get("hello")).isEqualTo("output");
+    assertThat(inOutProps.getFirst().get("test")).isEqualTo("test2");
+    assertThat(inOutProps.getSecond().get("hello")).isEqualTo("output");
+  }
+
   private void assertTwoFlowSame(final ExecutableFlow flow1, final ExecutableFlow flow2) {
     assertThat(flow1.getExecutionId()).isEqualTo(flow2.getExecutionId());
     assertThat(flow1.getStatus()).isEqualTo(flow2.getStatus());
@@ -238,4 +352,5 @@ public class ExecutionFlowDaoTest {
         .isEqualTo(flow2.getExecutionOptions().getFailureAction());
     assertThat(new HashSet<>(flow1.getEndNodes())).isEqualTo(new HashSet<>(flow2.getEndNodes()));
   }
+
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionLogsDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionLogsDaoTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import azkaban.db.DatabaseOperator;
+import azkaban.test.Utils;
+import azkaban.test.executions.ExecutionsTestUtil;
+import azkaban.utils.FileIOUtils.LogData;
+import java.io.File;
+import java.sql.SQLException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ExecutionLogsDaoTest {
+
+  private static final String LOG_TEST_DIR_NAME = "logtest";
+  private static DatabaseOperator dbOperator;
+  private ExecutionLogsDao executionLogsDao;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    dbOperator = Utils.initTestDB();
+  }
+
+  @AfterClass
+  public static void destroyDB() throws Exception {
+    try {
+      dbOperator.update("DROP ALL OBJECTS");
+      dbOperator.update("SHUTDOWN");
+    } catch (final SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Before
+  public void setup() {
+    this.executionLogsDao = new ExecutionLogsDao(dbOperator);
+  }
+
+  @After
+  public void clearDB() {
+    try {
+      dbOperator.update("delete from execution_logs");
+    } catch (final SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testSmallUploadLog() throws ExecutorManagerException {
+    final File logDir = ExecutionsTestUtil.getFlowDir(LOG_TEST_DIR_NAME);
+    final File[] smalllog =
+        { new File(logDir, "log1.log"), new File(logDir, "log2.log"),
+            new File(logDir, "log3.log") };
+
+    this.executionLogsDao.uploadLogFile(1, "smallFiles", 0, smalllog);
+
+    final LogData data = this.executionLogsDao.fetchLogs(1, "smallFiles", 0, 0, 50000);
+    assertThat(data).isNotNull();
+    assertThat(data.getLength()).isEqualTo(53);
+    System.out.println(data.toString());
+
+    final LogData data2 = this.executionLogsDao.fetchLogs(1, "smallFiles", 0, 10, 20);
+    System.out.println(data2.toString());
+
+    assertThat(data2).isNotNull();
+    assertThat(data2.getLength()).isEqualTo(20);
+  }
+
+  @Test
+  public void testLargeUploadLog() throws ExecutorManagerException {
+    final File logDir = ExecutionsTestUtil.getFlowDir(LOG_TEST_DIR_NAME);
+
+    // Multiple of 255 for Henry the Eigth
+    final File[] largelog =
+        { new File(logDir, "largeLog1.log"), new File(logDir, "largeLog2.log"),
+            new File(logDir, "largeLog3.log") };
+
+    this.executionLogsDao.uploadLogFile(1, "largeFiles", 0, largelog);
+
+    final LogData logsResult = this.executionLogsDao.fetchLogs(1, "largeFiles", 0, 0, 64000);
+    assertThat(logsResult).isNotNull();
+    assertThat(logsResult.getLength()).isEqualTo(64000);
+
+    final LogData logsResult2 = this.executionLogsDao.fetchLogs(1, "largeFiles", 0, 1000, 64000);
+    assertThat(logsResult2).isNotNull();
+    assertThat(logsResult2.getLength()).isEqualTo(64000);
+
+    final LogData logsResult3 = this.executionLogsDao.fetchLogs(1, "largeFiles", 0, 150000, 250000);
+    assertThat(logsResult3).isNotNull();
+    assertThat(logsResult3.getLength()).isEqualTo(185493);
+  }
+}


### PR DESCRIPTION
Still, this PR is a follow-up of #1345. Last but not least, I'm migrating remained methods in JdbcExecutorloader to use new DB API. This commit should be the last one of the series.