### PR TITLE
Ignore white space differences when comparing html outputs in tests

### DIFF
--- a/azkaban-web-server/src/test/java/azkaban/fixture/FileAssertion.java
+++ b/azkaban-web-server/src/test/java/azkaban/fixture/FileAssertion.java
@@ -1,10 +1,11 @@
 package azkaban.fixture;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import org.junit.Assert;
 
 
 /**
@@ -15,6 +16,8 @@ public class FileAssertion {
   /**
    * Assert the given string equals the given file's content.
    *
+   * The white space differences are ignored.
+   *
    * @param expectedFilePath the expected file path
    * @param actual the actual string
    * @throws IOException the io exception
@@ -24,7 +27,7 @@ public class FileAssertion {
       throws IOException {
     final String expected = new String(Files.readAllBytes(Paths.get(expectedFilePath)),
         StandardCharsets.UTF_8);
-    Assert.assertEquals(expected, actual);
+    assertThat(actual).isEqualToIgnoringWhitespace(expected);
   }
 
   /**


### PR DESCRIPTION
This function is currently only used in the testProjectSideBarView test.
 This is to make it easier to auto format html files and velocity
 templates.