### PR TITLE
build: reduce gradle build memory usage on the Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,8 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+env:
+  global:
+    # Reduce the memory pressure on Travis CI to reduce build failures.
+    - GRADLE_OPTS="-Xms128m"

--- a/build.gradle
+++ b/build.gradle
@@ -199,3 +199,13 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.0.2'
     distributionType('ALL')
 }
+
+if (System.env.TRAVIS == 'true') {
+    allprojects {
+        tasks.withType(Test) {
+            // Reduce the memory pressure on the Travis CI to reduce build failures.
+            maxParallelForks = 2
+            minHeapSize = '128m'
+        }
+    }
+}


### PR DESCRIPTION
## Issue
Travis CI builds sometimes fail with the following error
```
Process 'Gradle Test Executor 6' finished with non-zero exit value 137 travis
```

## Fix

See
https://discuss.gradle.org/t/gradle-travis-ci/11928/9
https://discuss.gradle.org/t/travis-ci-org-gradle-launcher-daemon-client-daemondisappearedexception-gradle-build-daemon-disappeared-unexpectedly-it-may-have-been-killed-or-may-have-crashed/13106/3