### PR TITLE
format: properly format the javadoc for the azkaban.Constants class

### DIFF
--- a/azkaban-common/src/main/java/azkaban/Constants.java
+++ b/azkaban-common/src/main/java/azkaban/Constants.java
@@ -18,12 +18,17 @@
 package azkaban;
 
 /**
- * Constants
+ * Constants used in configuration files or shared among classes.
  *
- * Global place for storing constants. Conventions: <p> - All internal constants to be put in the
- * root level ie. {@link Constants} class <p> - All Configuration keys to be put in {@link
- * ConfigurationKeys} class <p> - Flow level Properties keys go to {@link FlowProperties} <p> - Job
- * level Properties keys go to {@link JobProperties} <p>
+ * <p>Conventions:
+ *
+ * <p>Internal constants to be put in the {@link Constants} class
+ *
+ * <p>Configuration keys to be put in the {@link ConfigurationKeys} class
+ *
+ * <p>Flow level properties keys to be put in the {@link FlowProperties} class
+ *
+ * <p>Job level Properties keys to be put in the {@link JobProperties} class
  */
 public class Constants {
 


### PR DESCRIPTION
Adjust `<p>` tags placements to conform to the Google style guide.

Describe more details in the class summary line.

See
https://google.github.io/styleguide/javaguide.html#s7.1.2-javadoc-paragraphs

Also see
http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html
http://blog.joda.org/2012/11/javadoc-coding-standards.html

Note that the Google style places `<p>` after the empty line. It's
different from the Oracle style.