### PR TITLE
build: run Travis build with --info flag to get more detailed output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build --no-daemon
+script: ./gradlew clean build --no-daemon --info
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:


### PR DESCRIPTION
It's useful to see additional information. It's currently difficult to
debug a flaky test that only fails in Travis since there is no easy way
to see the test's console output.