### PR TITLE
Customize code style template. Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ project. You can import it into your IDE using the `build.gradle` file in the ro
 Project from the Quick Start box or choose Open from the File menu and select the root `build.gradle` file.
 
 ### Code Style
-Azkaban follows a slightly modified [Google code style](http://google.github.io/styleguide/). The template file, 
-`az-intellij-style.xml`, can be found in the root directory.
+Azkaban follows [Google code style](http://google.github.io/styleguide/). The template file, 
+`az-intellij-style.xml`, can be found in the root directory. It's based on the 
+[intellij-java-google-style.xml config file](https://github.com/google/styleguide/blob/75c289f1d33836d1ff4bd94e6c9033673e320b58/intellij-java-google-style.xml) from the google/styleguide project.
 
 Follow [the Intellij's code style help](https://www.jetbrains.com/help/idea/2017.1/code-style.html) 
 to import and set up the style. Make sure to activate the AzkabanStyle by

--- a/README.md
+++ b/README.md
@@ -36,19 +36,15 @@ project. You can import it into your IDE using the `build.gradle` file in the ro
 Project from the Quick Start box or choose Open from the File menu and select the root `build.gradle` file.
 
 ### Code Style
-Azkaban follows Google code style. The template file, `intellij-java-google-style.xml`, can be found in the root 
-directory.
+Azkaban follows a slightly modified [Google code style](http://google.github.io/styleguide/). The template file, 
+`az-intellij-style.xml`, can be found in the root directory.
 
 Follow [the Intellij's code style help](https://www.jetbrains.com/help/idea/2017.1/code-style.html) 
-to import and set up the style.
- 
-Note: 
-To use different styles for different projects try
- "You can copy the IDE scheme to the current project, using the Copy to Project... command."
+to import and set up the style. Make sure to activate the AzkabanStyle by
+ "copy the IDE scheme to the current project, using the Copy to Project... command."
 
-
-We also recommend 
-intellij's [save actions plugin](https://github.com/dubreuia/intellij-plugin-save-actions) to 
+Install and enable the intellij's [save actions plugin](https://github
+.com/dubreuia/intellij-plugin-save-actions) to 
 reformat/refactor code automatically:
 
 Please turn on all the options except 

--- a/az-intellij-style.xml
+++ b/az-intellij-style.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<code_scheme name="GoogleStyle">
+<code_scheme name="AzkabanStyle">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
       <option name="INDENT_SIZE" value="2"/>
@@ -26,12 +26,14 @@
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100"/>
+  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true"/>
   <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
   <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
   <option name="JD_P_AT_EMPTY_LINES" value="false"/>
   <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
   <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
   <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+  <option name="JD_PRESERVE_LINE_FEEDS" value="true"/>
   <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
   <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
   <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>


### PR DESCRIPTION
- Modify the style template to preserve line feeds in the Javadoc. This
makes it easier to preserve the Javadoc format in the source file. This
is especially helpful given this IntelliJ issue
"Formatting doesn't apply to an existing Javadoc "
https://youtrack.jetbrains.com/issue/IDEA-178073

- Change the name of the style config file and the style name
to reflect that it is now a customized style config for the project.
And it contains styles for other languages such as JavaScript as well.

- Update the README to reference the new style file. Make it clear that
the new style needs to be activated after it is imported.

- Update the README to require SaveAction plugin. We have finished
auto formatting all the source files.