### PR TITLE
Update errorprone to latest version 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ subprojects {
 
     configurations.errorprone {
         dependencies {
-            errorprone 'com.google.errorprone:error_prone_core:2.0.15'
+            errorprone 'com.google.errorprone:error_prone_core:2.1.0'
         }
     }
 


### PR DESCRIPTION
This is a follow-up PR for the previous errorprone version change [PR #1382](https://github.com/azkaban/azkaban/pull/1382).
We've updated the errorprone version in artifactory to 2.1.0. We can update the version in Azkaban accordingly.