### PR TITLE
Enforce using Singleton Annotation rather than binding statement

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -20,7 +20,6 @@ package azkaban.execapp;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.JdbcExecutorLoader;
 import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
 
 /**
  * This Guice module is currently a one place container for all bindings in the current module. This
@@ -33,8 +32,5 @@ public class AzkabanExecServerModule extends AbstractModule {
   protected void configure() {
     install(new ExecJettyServerModule());
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class);
-    bind(AzkabanExecutorServer.class).in(Scopes.SINGLETON);
-    bind(TriggerManager.class).in(Scopes.SINGLETON);
-    bind(FlowRunnerManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -48,7 +48,6 @@ import azkaban.utils.Props;
 import azkaban.utils.StdOutErrRedirect;
 import azkaban.utils.Utils;
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -64,7 +63,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -75,6 +76,7 @@ import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 
+@Singleton
 public class AzkabanExecutorServer {
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -44,7 +44,6 @@ import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.ThreadPoolExecutingListener;
 import azkaban.utils.TrackingThreadPool;
-import com.google.inject.Inject;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -62,6 +61,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
@@ -83,6 +84,7 @@ import org.apache.log4j.Logger;
  * flows that are in the Status.PREPARING status. The entries in this map is removed once the flow
  * execution is completed.
  */
+@Singleton
 public class FlowRunnerManager implements EventListener,
     ThreadPoolExecutingListener {
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
@@ -25,7 +25,6 @@ import azkaban.trigger.TriggerAction;
 import azkaban.trigger.builtin.SlaAlertAction;
 import azkaban.trigger.builtin.SlaChecker;
 import azkaban.utils.Utils;
-import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,10 +32,13 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.log4j.Logger;
 import org.joda.time.ReadablePeriod;
 
 
+@Singleton
 public class TriggerManager {
 
   private static final int SCHEDULED_THREAD_POOL_SIZE = 4;

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
@@ -17,6 +17,7 @@
 
 package azkaban.execapp;
 
+import static azkaban.ServiceProviderTest.assertSingleton;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.junit.Assert.assertNotNull;
@@ -89,8 +90,11 @@ public class AzkabanExecutorServerTest {
         new AzkabanExecServerModule()
     );
 
-    assertNotNull(injector.getInstance(AzkabanExecutorServer.class));
     assertNotNull(injector.getInstance(Emailer.class));
     assertNotNull(injector.getInstance(AlerterHolder.class));
+
+    assertSingleton(TriggerManager.class, injector);
+    assertSingleton(FlowRunnerManager.class, injector);
+    assertSingleton(AzkabanExecutorServer.class, injector);
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -62,7 +62,6 @@ import azkaban.webapp.servlet.StatsServlet;
 import azkaban.webapp.servlet.StatusServlet;
 import azkaban.webapp.servlet.TriggerManagerServlet;
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.linkedin.restli.server.RestliServlet;
 import java.io.File;
@@ -80,6 +79,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.management.MBeanInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -112,6 +113,7 @@ import org.mortbay.thread.QueuedThreadPool;
  * jetty.keystore - Jetty keystore . jetty.keypassword - Jetty keystore password jetty.truststore -
  * Jetty truststore jetty.trustpassword - Jetty truststore password
  */
+@Singleton
 public class AzkabanWebServer extends AzkabanServer {
 
   public static final String DEFAULT_CONF_PATH = "conf";

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -25,7 +25,6 @@ import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import java.lang.reflect.Constructor;
 import org.apache.log4j.Logger;
@@ -49,7 +48,6 @@ public class AzkabanWebServerModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(Server.class).toProvider(WebServerProvider.class);
-    bind(AzkabanWebServer.class).in(Scopes.SINGLETON);
     bind(ScheduleLoader.class).to(TriggerBasedScheduleLoader.class);
   }
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -127,7 +127,6 @@ public class AzkabanWebServerTest {
     executor.setActive(true);
     executorLoader.updateExecutor(executor);
 
-    assertNotNull(injector.getInstance(AzkabanWebServer.class));
     assertNotNull(injector.getInstance(ExecutionFlowDao.class));
 
     //Test if triggermanager is singletonly guiced. If not, the below test will fail.
@@ -148,6 +147,7 @@ public class AzkabanWebServerTest {
     assertSingleton(ExecutorEventsDao.class, injector);
     assertSingleton(ActiveExecutingFlowsDao.class, injector);
     assertSingleton(FetchActiveFlowDao.class, injector);
+    assertSingleton(AzkabanWebServer.class, injector);
 
     SERVICE_PROVIDER.unsetInjector();
   }


### PR DESCRIPTION
There still exists a few places where we bind class to singleton in guice module class. As discussed a few weeks ago, we decided to enforce using `@Singleton` annotation, rather than the binding statement. The benefit is to manage and view singleton class easily.

This code patch tries to fix/replace this issue.