### PR TITLE
Reproduce flaky tests: FlowRunnerTest2 > testNormalFailure2 & FlowRunnerTest > exec1FailedKillAll

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1385,6 +1385,9 @@ public class ExecutorManager extends EventHandler implements
     // move from flow to running flows
     this.runningFlows.put(exflow.getExecutionId(),
         new Pair<>(reference, exflow));
+    synchronized (this) {
+      this.notifyAll();
+    }
 
     logger.info(String.format(
         "Successfully dispatched exec %d with error count %d",
@@ -1521,12 +1524,12 @@ public class ExecutorManager extends EventHandler implements
 
           ExecutorManager.this.updaterStage = "Updated all active flows. Waiting for next round.";
 
-          synchronized (this) {
+          synchronized (ExecutorManager.this) {
             try {
               if (ExecutorManager.this.runningFlows.size() > 0) {
-                this.wait(this.waitTimeMs);
+                ExecutorManager.this.wait(this.waitTimeMs);
               } else {
-                this.wait(this.waitTimeIdleMs);
+                ExecutorManager.this.wait(this.waitTimeIdleMs);
               }
             } catch (final InterruptedException e) {
             }

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -32,8 +32,8 @@ public class InteractiveTestJob extends AbstractProcessJob {
       new ConcurrentHashMap<>();
   private static volatile boolean quickSuccess = false;
   private Props generatedProperties = new Props();
-  private boolean isWaiting = true;
-  private boolean succeed = true;
+  private volatile boolean isWaiting = true;
+  private volatile boolean succeed = true;
 
   public InteractiveTestJob(final String jobId, final Props sysProps, final Props jobProps,
       final Logger log) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -608,7 +608,15 @@ public class JobRunner extends EventHandler implements Runnable {
     logInfo(
         "Finishing job " + this.jobId + getNodeRetryLog() + " at " + this.node.getEndTime()
             + " with status " + this.node.getStatus());
-
+    if (finalStatus == Status.FAILED) {
+      this.logger.warn("SLEEPING BEFORE fireEvent :)");
+      try {
+        Thread.sleep(1000L);
+      } catch (final InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      this.logger.warn("NOW -> fireEvent");
+    }
     fireEvent(Event.create(this, Type.JOB_FINISHED,
         new EventData(finalStatus, this.node.getNestedId())), false);
     finalizeLogFile(this.node.getAttempt());

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -392,6 +392,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("joba1").failJob();
     assertStatus("joba1", Status.FAILED);
+    assertFlowStatus(Status.FAILED_FINISHING);
 
     // 3. joba completes, everything is killed
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -398,6 +398,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
     assertStatus("jobb:innerJobA", Status.SUCCEEDED);
     assertStatus("jobd:innerJobA", Status.SUCCEEDED);
+    // the happens failure on this line
     assertStatus("jobb:innerJobB", Status.CANCELLED);
     assertStatus("jobb:innerJobC", Status.CANCELLED);
     assertStatus("jobb:innerFlow", Status.CANCELLED);

--- a/test/execution-test-data/exectest1/job6.job
+++ b/test/execution-test-data/exectest1/job6.job
@@ -1,4 +1,4 @@
 type=test
 dependencies=job1
-seconds=1
+seconds=10
 fail=false


### PR DESCRIPTION
The test failure is:

```
azkaban.execapp.FlowRunnerTest2 > testNormalFailure2 FAILED
    java.lang.AssertionError: Wrong status for [jobb:innerJobB] expected:<CANCELLED> but was:<RUNNING>

azkaban.execapp.FlowRunnerTest2 > testNormalFailure2 STANDARD_ERROR
    testJob: joba1 FAILED
    testJob: jobd:innerJobA SUCCEEDED
    testJob: jobd:innerFlow2 RUNNING
    testJob: joba SUCCEEDED
    testJob: jobc RUNNING
    testJob: jobb:innerJobB RUNNING
    testJob: jobb:innerJobC RUNNING
    testJob: jobb:innerJobA SUCCEEDED
    ExecutableFlow: jobf FAILED_FINISHING
    ExecutableNode: joba1 FAILED
    ExecutableFlow: jobb RUNNING
    ExecutableNode: jobb:innerFlow READY
    ExecutableNode: jobb:innerJobB RUNNING
    ExecutableNode: jobb:innerJobA SUCCEEDED
    ExecutableNode: jobb:innerJobC RUNNING
    ExecutableNode: joba SUCCEEDED
    ExecutableFlow: jobd RUNNING
    ExecutableNode: jobd:innerJobA SUCCEEDED
    ExecutableNode: jobd:innerFlow2 RUNNING
    ExecutableNode: jobc RUNNING
    ExecutableNode: jobf READY
    ExecutableNode: jobe READY
```

 Analysis: when a job finishes, an event is fired about its status. The events are handled asynchronously in FlowRunner's progressGraph() loop. This test case is flaky because before ("jobb:innerJobA").succeedJob() and ("jobd:innerJobA").succeedJob() it waits for the node status of "joba1" to be FAILED, but it doesn't wait for that event to have been processed.