### PR TITLE
Fix flaky JobRunnerTest > testDelayedExecutionCancelledJob

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext.versions = [
 ext.deps = [
         // External dependencies
         assertj             : 'org.assertj:assertj-core:3.8.0',
+        awaitility          : 'org.awaitility:awaitility:3.0.0',
         collections         : 'commons-collections:commons-collections:3.2.2',
         commonsLang         : 'commons-lang:commons-lang:2.6',
         dbcp2               : 'org.apache.commons:commons-dbcp2:2.1.1',
@@ -149,6 +150,7 @@ subprojects {
             testCompile deps.assertj
             testCompile deps.junit
             testCompile deps.mockito
+            testCompile deps.awaitility
         }
 
         test {


### PR DESCRIPTION
(Part of fixing https://github.com/azkaban/azkaban/issues/1389)

- Now instead of fixed 1s sleep we wait for max 10s for the node update count to be 2.
- This lets us use the luxury of additional sleep time (1s->2s) before killing the flow, so that there's a better chance for job getting inside its delayExecution() block.

Test failure was:

```
azkaban.execapp.JobRunnerTest > testDelayedExecutionCancelledJob FAILED
    java.lang.AssertionError: expected:<2> but was:<1>
```

It was faithfully reproduced when I removed the 1s sleep before assert on getNodeUpdateCount().