### PR TITLE
Enable JobRunnerTest#testBasicRun

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/SleepJavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/SleepJavaJob.java
@@ -86,11 +86,13 @@ public class SleepJavaJob {
 
     final int sec = Integer.parseInt(this.seconds);
     System.out.println("Sec " + sec);
-    synchronized (this) {
-      try {
-        this.wait(sec * 1000);
-      } catch (final InterruptedException e) {
-        System.out.println("Interrupted " + this.fail);
+    if (sec > 0) {
+      synchronized (this) {
+        try {
+          this.wait(sec * 1000);
+        } catch (final InterruptedException e) {
+          System.out.println("Interrupted " + this.fail);
+        }
       }
     }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -81,6 +81,7 @@ public class JobRunnerTest {
 
   @After
   public void tearDown() throws IOException {
+    SERVICE_PROVIDER.unsetInjector();
     System.out.println("Teardown temp dir");
     if (this.workingDir != null) {
       FileUtils.deleteDirectory(this.workingDir);


### PR DESCRIPTION
This works, but it seems wrong that `JobRunner` test runs a java job that launches an additional JVM / java process. That should be the responsibility of `JavaProcessJobTest`, and I think it already does that.

If this test case serves any purpose, I think it should be converted to use the `InteractiveTestJob` which is simple and quick and lives within the test process itself.

Any way, the enabled test `testBasicRun` runs in 0,5-1s.

Opinions?