### PR TITLE
Enable all in JobRunnerTest

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/SleepJavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/SleepJavaJob.java
@@ -86,11 +86,13 @@ public class SleepJavaJob {
 
     final int sec = Integer.parseInt(this.seconds);
     System.out.println("Sec " + sec);
-    synchronized (this) {
-      try {
-        this.wait(sec * 1000);
-      } catch (final InterruptedException e) {
-        System.out.println("Interrupted " + this.fail);
+    if (sec > 0) {
+      synchronized (this) {
+        try {
+          this.wait(sec * 1000);
+        } catch (final InterruptedException e) {
+          System.out.println("Interrupted " + this.fail);
+        }
       }
     }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -80,6 +80,7 @@ public class JobRunnerTest {
 
   @After
   public void tearDown() throws IOException {
+    SERVICE_PROVIDER.unsetInjector();
     System.out.println("Teardown temp dir");
     if (this.workingDir != null) {
       FileUtils.deleteDirectory(this.workingDir);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -43,7 +43,6 @@ import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class JobRunnerTest {
@@ -119,7 +118,6 @@ public class JobRunnerTest {
     eventCollector.assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
-  @Ignore
   @Test
   public void testFailedRun() {
     final MockExecutorLoader loader = new MockExecutorLoader();
@@ -210,7 +208,6 @@ public class JobRunnerTest {
     eventCollector.assertEvents(Type.JOB_STARTED, Type.JOB_FINISHED);
   }
 
-  @Ignore
   @Test
   // todo: HappyRay investigate if it is worth fixing this test. If not, remove it.
   // The change history doesn't mention why this test was ignored.
@@ -249,7 +246,6 @@ public class JobRunnerTest {
     eventCollector.assertEvents(Type.JOB_STARTED, Type.JOB_STATUS_CHANGED, Type.JOB_FINISHED);
   }
 
-  @Ignore
   @Test
   public void testDelayedExecutionJob() {
     final MockExecutorLoader loader = new MockExecutorLoader();


### PR DESCRIPTION
Enable all in `JobRunnerTest`. First commit separately in https://github.com/azkaban/azkaban/pull/1445.

This works but is a bit slow with all the sleeps in place:

<img width="322" alt="nayttokuva 2017-09-09 kello 12 09 47" src="https://user-images.githubusercontent.com/4446608/30238872-cbe21e8e-9558-11e7-90be-f0cbc5f8ad05.png">

I think this can be made run quickly, but I wonder if these tests are useful or not :)