### PR TITLE
Move execute-as-user c program to its own module

### DIFF
--- a/az-exec-util/build.gradle
+++ b/az-exec-util/build.gradle
@@ -13,15 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-rootProject.name = 'azkaban'
-
-include 'az-exec-util'
-include 'azkaban-spi'
-include 'azkaban-db'
-include 'azkaban-common'
-include 'azkaban-exec-server'
-include 'azkaban-hadoop-security-plugin'
-include 'azkaban-solo-server'
-include 'azkaban-web-server'
-include 'test'
+apply plugin: 'c'
+model {
+    components {
+        main(NativeExecutableSpec) {
+            sources {
+                c {
+                    source {
+                        srcDir "src/main"
+                        include "**/*.c"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/az-exec-util/src/main/c/execute-as-user.c
+++ b/az-exec-util/src/main/c/execute-as-user.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 LinkedIn Corp.
+ * Copyright 2017 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -12,24 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
  */
-
-apply plugin: 'c'
-model {
-    components {
-        main(NativeExecutableSpec) {
-            sources {
-                c {
-                    source {
-                        srcDir "src/main"
-                        include "**/*.c"
-                    }
-                }
-            }
-        }
-    }
-}
 
 dependencies {
     compile project(':azkaban-spi')


### PR DESCRIPTION
This module doesn't belong to the common module.
It also helps speeding up the build a bit by taking better advantage of
the gradle cache and project dependency management.

Fixes #1227