### PR TITLE
replace unknown concurrent option

### DIFF
--- a/_includes/docs/latest/ajax-api.html
+++ b/_includes/docs/latest/ajax-api.html
@@ -885,7 +885,7 @@ by disabling all other jobs in the same flow.
       <td>concurrentOption (Optional)</td>
       <td>
         <p>Concurrent choices. Use ignore if nothing specifical is required. </p>
-        <p> <strong> Possible Values: </strong> ignore, pipeline, queue </p>
+        <p> <strong> Possible Values: </strong> ignore, pipeline, skip</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
We don't have `queue` option for concurrent settings.

Take a look at code:
https://github.com/azkaban/azkaban/blob/9e89d362b604926e2c087efebc6f429e2f2295c9/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java#L33-L35