### PR TITLE
Rename assertFlowStatus method to waitForAndAssertFlowStatus

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 LinkedIn Corp.
+ * Copyright 2017 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -83,7 +83,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     startThread(this.runner);
     succeedJobs("job3", "job4", "job6");
 
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
     compareFinishedRuntime(this.runner);
 
@@ -117,7 +117,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     this.runner = createFlowRunner(exFlow, this.loader, eventCollector);
 
     Assert.assertTrue(!this.runner.isKilled());
-    assertFlowStatus(Status.READY);
+    waitForAndAssertFlowStatus(Status.READY);
 
     startThread(this.runner);
     succeedJobs("job3", "job4");
@@ -125,7 +125,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertThreadShutDown();
     compareFinishedRuntime(this.runner);
 
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
 
     assertStatus("job1", Status.SKIPPED);
     assertStatus("job2", Status.SUCCEEDED);
@@ -154,7 +154,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     succeedJobs("job6");
 
     Assert.assertTrue(!this.runner.isKilled());
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
 
     assertStatus("job1", Status.SUCCEEDED);
     assertStatus("job2d", Status.FAILED);
@@ -187,7 +187,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
 
     Assert.assertTrue(this.runner.isKilled());
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
 
     assertStatus("job1", Status.SUCCEEDED);
     assertStatus("job2d", Status.FAILED);
@@ -217,7 +217,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     startThread(this.runner);
     succeedJobs("job3");
 
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
 
     assertStatus("job1", Status.SUCCEEDED);
     assertStatus("job2d", Status.FAILED);
@@ -259,7 +259,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job6", Status.KILLED);
     assertThreadShutDown();
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
 
     eventCollector.assertEvents(Type.FLOW_STARTED, Type.FLOW_FINISHED);
   }
@@ -281,7 +281,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertAttempts("job-pass", 0);
     assertAttempts("job-retry-fail", 2);
 
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
   }
 
   private void startThread(final FlowRunner runner) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -266,7 +266,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
     assertStatus("jobf", Status.SUCCEEDED);
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
   }
 
   /**
@@ -321,7 +321,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobf").succeedJob();
     assertStatus("jobf", Status.SUCCEEDED);
 
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
   }
 
@@ -344,7 +344,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     // 2. JOB A COMPLETES SUCCESSFULLY, others should be skipped
     InteractiveTestJob.getTestJob("joba").failJob();
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
     assertStatus("joba", Status.FAILED);
     assertStatus("joba1", Status.RUNNING);
     assertStatus("jobb", Status.CANCELLED);
@@ -360,7 +360,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     /// innerJobA completes
     InteractiveTestJob.getTestJob("joba1").succeedJob();
     assertStatus("jobf", Status.CANCELLED);
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -392,7 +392,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("joba1").failJob();
     assertStatus("joba1", Status.FAILED);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     // 3. joba completes, everything is killed
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
@@ -405,13 +405,13 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobd:innerFlow2", Status.CANCELLED);
     assertStatus("jobb", Status.KILLED);
     assertStatus("jobd", Status.KILLED);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobc").succeedJob();
     assertStatus("jobc", Status.SUCCEEDED);
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -447,7 +447,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
     assertStatus("jobb", Status.FAILED_FINISHING);
     assertStatus("jobb:innerJobB", Status.FAILED);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
@@ -463,7 +463,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobc", Status.SUCCEEDED);
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -505,7 +505,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
     assertStatus("jobb", Status.FAILED_FINISHING);
     assertStatus("jobb:innerJobB", Status.FAILED);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     InteractiveTestJob.getTestJob("jobb:innerJobC").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
@@ -524,7 +524,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobc", Status.SUCCEEDED);
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -577,7 +577,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
 
     assertThreadShutDown();
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
   }
 
   /**
@@ -619,7 +619,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobd:innerJobA", Status.SUCCEEDED);
     assertStatus("jobd:innerFlow2", Status.CANCELLED);
     assertStatus("jobd", Status.KILLED);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     final ExecutableNode node = this.runner.getExecutableFlow()
         .getExecutableNodePath("jobd:innerFlow2");
@@ -638,7 +638,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobd", Status.RUNNING);
     assertStatus("jobb:innerFlow", Status.DISABLED);
     assertStatus("jobd:innerFlow2", Status.RUNNING);
-    assertFlowStatus(Status.RUNNING);
+    waitForAndAssertFlowStatus(Status.RUNNING);
     assertThreadRunning();
 
     InteractiveTestJob.getTestJob("jobb:innerJobB").succeedJob();
@@ -663,7 +663,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
     assertStatus("jobf", Status.SUCCEEDED);
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
   }
 
@@ -714,7 +714,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
   }
 
@@ -753,7 +753,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobb:innerJobB").failJob();
     assertStatus("jobb:innerJobB", Status.FAILED);
     assertStatus("jobb", Status.FAILED_FINISHING);
-    assertFlowStatus(Status.FAILED_FINISHING);
+    waitForAndAssertFlowStatus(Status.FAILED_FINISHING);
 
     this.runner.kill("me");
 
@@ -767,7 +767,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
   }
 
@@ -790,11 +790,11 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("joba").succeedJob();
     // 2.1 JOB A COMPLETES SUCCESSFULLY AFTER PAUSE
     assertStatus("joba", Status.SUCCEEDED);
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
 
     // 2.2 Flow is unpaused
     this.runner.resume("test");
-    assertFlowStatus(Status.RUNNING);
+    waitForAndAssertFlowStatus(Status.RUNNING);
     assertStatus("joba", Status.SUCCEEDED);
     assertStatus("joba1", Status.RUNNING);
     assertStatus("jobb", Status.RUNNING);
@@ -850,7 +850,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("jobf").succeedJob();
     assertStatus("jobf", Status.SUCCEEDED);
-    assertFlowStatus(Status.SUCCEEDED);
+    waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
   }
 
@@ -881,7 +881,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobA", Status.RUNNING);
 
     this.runner.pause("me");
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").succeedJob();
     assertStatus("jobb:innerJobA", Status.SUCCEEDED);
@@ -899,7 +899,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
   }
 
@@ -931,7 +931,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobA", Status.RUNNING);
 
     this.runner.pause("me");
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
     assertStatus("jobd:innerJobA", Status.FAILED);
@@ -942,7 +942,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     // If we would resume before the job failure has been completely processed, FlowRunner would be
     // able to start some new jobs instead of cancelling everything.
     waitEventFired("jobd:innerJobA", Status.FAILED);
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
 
     this.runner.resume("me");
     assertStatus("jobb:innerJobB", Status.CANCELLED);
@@ -959,7 +959,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     assertStatus("jobe", Status.CANCELLED);
 
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -992,7 +992,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobA", Status.RUNNING);
 
     this.runner.pause("me");
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobb:innerJobA").succeedJob();
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
     assertStatus("jobd:innerJobA", Status.FAILED);
@@ -1018,7 +1018,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
 
-    assertFlowStatus(Status.FAILED);
+    waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
   }
 
@@ -1043,7 +1043,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
       }
     }
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
   }
 
@@ -1074,7 +1074,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobb:innerJobA", Status.RUNNING);
 
     this.runner.pause("me");
-    assertFlowStatus(Status.PAUSED);
+    waitForAndAssertFlowStatus(Status.PAUSED);
     InteractiveTestJob.getTestJob("jobd:innerJobA").failJob();
     assertStatus("jobd:innerJobA", Status.FAILED);
     assertStatus("jobd:innerFlow2", Status.CANCELLED);
@@ -1089,7 +1089,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     assertStatus("joba1", Status.KILLED);
 
-    assertFlowStatus(Status.KILLED);
+    waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.execapp;
 
 import static org.junit.Assert.assertEquals;
@@ -101,7 +117,7 @@ public class FlowRunnerTestBase {
     return true;
   }
 
-  protected void assertFlowStatus(final Status status) {
+  protected void waitForAndAssertFlowStatus(final Status status) {
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     StatusTestUtils.waitForStatus(flow, status);
     printStatuses(status, flow);


### PR DESCRIPTION
This method is only used in tests.
Make the name more descriptive.
This is particularly helpful when doing code reviews.