### PR TITLE
Fix not being able to change tab after pulling a note banner

### DIFF
--- a/azkaban-web-server/src/main/less/base.less
+++ b/azkaban-web-server/src/main/less/base.less
@@ -24,6 +24,11 @@
   }
 }
 
+div#graphView.container-fill {
+  position: static;
+  height: 750px;
+}
+
 .alert-default {
   color: #a0a0a0;
   background-color: #f5f5f5;


### PR DESCRIPTION
#1335 brought a feature that AZ admins can publish messages in banner bar on the top of AZ UI. There exists an issue reported by the user: 

>I cannot click on the "Job List", "Flow Log", and "Stats" tabs until the orange message banner disappears after about 30 seconds.

The cause is that `container-fill` (css class) uses absolute position, when the top div elements moves down, it will override the div beneath. I figured out there are a number of places using `container-fill`. So I'd like not change the [original place](https://github.com/kunkun-tang/azkaban/blob/e188e943680f7721d9d4ecb677e15ce686880d66/azkaban-web-server/src/main/less/base.less#L9). The proposed fix is that we just let flow view page's div to be `static`, such that it will move downward along with top div.

Basically, we only fix the below occurrence:
https://github.com/azkaban/azkaban/blob/9858f634d578ab194a293267a420d9d1462a3783/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm#L19

Tested locally.