### PR TITLE
build: Enable gradle scans on travis CI to debug #1448

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ languages: java
 jdk:
   - oraclejdk8
 sudo: false
-script: ./gradlew clean build --no-daemon --info
+script: ./gradlew clean build --scan --no-daemon --info
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,15 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.gradle.build-scan' version '1.9'
+}
+
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
+}
+
 apply plugin: 'com.cinnober.gradle.semver-git'
 
 apply plugin: 'compare-gradle-builds'


### PR DESCRIPTION
## Issue
#1448 
Travis CI builds sometimes fail with the following error

> Process 'Gradle Test Executor 6' finished with non-zero exit value 137 travis

@HappyRay alleviated some of the resource issues with #1402 but we are still seeing sporadic failures. 

## Fix
Gradle has a tool to investigate builds including metrics like memory, threads GC etc called [scans](https://scans.gradle.com/get-started) .This change enables build scans on travis to help debug failures and also provide insight into our builds. 