### PR TITLE
move one method out of PropsUtils [Refactor]

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.flow;
+
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.utils.Props;
+import java.util.UUID;
+import org.joda.time.DateTime;
+
+public class FlowUtils {
+
+  public static Props addCommonFlowProperties(final Props parentProps,
+      final ExecutableFlowBase flow) {
+    final Props props = new Props(parentProps);
+
+    props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
+    props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
+    props.put(CommonJobProperties.PROJECT_ID, flow.getProjectId());
+    props.put(CommonJobProperties.PROJECT_NAME, flow.getProjectName());
+    props.put(CommonJobProperties.PROJECT_VERSION, flow.getVersion());
+    props.put(CommonJobProperties.FLOW_UUID, UUID.randomUUID().toString());
+    props.put(CommonJobProperties.PROJECT_LAST_CHANGED_BY, flow.getLastModifiedByUser());
+    props.put(CommonJobProperties.PROJECT_LAST_CHANGED_DATE, flow.getLastModifiedTimestamp());
+    props.put(CommonJobProperties.SUBMIT_USER, flow.getExecutableFlow().getSubmitUser());
+
+    final DateTime loadTime = new DateTime();
+
+    props.put(CommonJobProperties.FLOW_START_TIMESTAMP, loadTime.toString());
+    props.put(CommonJobProperties.FLOW_START_YEAR, loadTime.toString("yyyy"));
+    props.put(CommonJobProperties.FLOW_START_MONTH, loadTime.toString("MM"));
+    props.put(CommonJobProperties.FLOW_START_DAY, loadTime.toString("dd"));
+    props.put(CommonJobProperties.FLOW_START_HOUR, loadTime.toString("HH"));
+    props.put(CommonJobProperties.FLOW_START_MINUTE, loadTime.toString("mm"));
+    props.put(CommonJobProperties.FLOW_START_SECOND, loadTime.toString("ss"));
+    props.put(CommonJobProperties.FLOW_START_MILLISSECOND,
+        loadTime.toString("SSS"));
+    props.put(CommonJobProperties.FLOW_START_TIMEZONE,
+        loadTime.toString("ZZZZ"));
+
+    return props;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/PropsUtils.java
@@ -16,8 +16,6 @@
 
 package azkaban.utils;
 
-import azkaban.executor.ExecutableFlowBase;
-import azkaban.flow.CommonJobProperties;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -28,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.jexl2.Expression;
@@ -37,7 +34,6 @@ import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.MapContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
 
 public class PropsUtils {
 
@@ -282,37 +278,6 @@ public class PropsUtils {
         value.substring(0, lastIndex) + result.toString()
             + value.substring(nextClosed + 1);
     return resolveVariableExpression(newValue, lastIndex, jexl);
-  }
-
-  public static Props addCommonFlowProperties(final Props parentProps,
-      final ExecutableFlowBase flow) {
-    final Props props = new Props(parentProps);
-
-    props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
-    props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
-    props.put(CommonJobProperties.PROJECT_ID, flow.getProjectId());
-    props.put(CommonJobProperties.PROJECT_NAME, flow.getProjectName());
-    props.put(CommonJobProperties.PROJECT_VERSION, flow.getVersion());
-    props.put(CommonJobProperties.FLOW_UUID, UUID.randomUUID().toString());
-    props.put(CommonJobProperties.PROJECT_LAST_CHANGED_BY, flow.getLastModifiedByUser());
-    props.put(CommonJobProperties.PROJECT_LAST_CHANGED_DATE, flow.getLastModifiedTimestamp());
-    props.put(CommonJobProperties.SUBMIT_USER, flow.getExecutableFlow().getSubmitUser());
-
-    final DateTime loadTime = new DateTime();
-
-    props.put(CommonJobProperties.FLOW_START_TIMESTAMP, loadTime.toString());
-    props.put(CommonJobProperties.FLOW_START_YEAR, loadTime.toString("yyyy"));
-    props.put(CommonJobProperties.FLOW_START_MONTH, loadTime.toString("MM"));
-    props.put(CommonJobProperties.FLOW_START_DAY, loadTime.toString("dd"));
-    props.put(CommonJobProperties.FLOW_START_HOUR, loadTime.toString("HH"));
-    props.put(CommonJobProperties.FLOW_START_MINUTE, loadTime.toString("mm"));
-    props.put(CommonJobProperties.FLOW_START_SECOND, loadTime.toString("ss"));
-    props.put(CommonJobProperties.FLOW_START_MILLISSECOND,
-        loadTime.toString("SSS"));
-    props.put(CommonJobProperties.FLOW_START_TIMEZONE,
-        loadTime.toString("ZZZZ"));
-
-    return props;
   }
 
   public static String toJSONString(final Props props, final boolean localOnly) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -719,6 +719,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     return props;
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void runExecutableNode(final ExecutableNode node) throws IOException {
     // Collect output props from the job's dependencies.
     prepareJobProperties(node);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -37,6 +37,7 @@ import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.flow.FlowProps;
+import azkaban.flow.FlowUtils;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.metric.MetricReportManager;
@@ -46,7 +47,6 @@ import azkaban.sla.SlaOption;
 import azkaban.spi.AzkabanEventReporter;
 import azkaban.spi.EventType;
 import azkaban.utils.Props;
-import azkaban.utils.PropsUtils;
 import azkaban.utils.SwapQueue;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
@@ -245,7 +245,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     final String flowId = this.flow.getFlowId();
 
     // Add a bunch of common azkaban properties
-    Props commonFlowProps = PropsUtils.addCommonFlowProperties(null, this.flow);
+    Props commonFlowProps = FlowUtils.addCommonFlowProperties(null, this.flow);
 
     if (this.flow.getJobSource() != null) {
       final String source = this.flow.getJobSource();
@@ -719,7 +719,6 @@ public class FlowRunner extends EventHandler implements Runnable {
     return props;
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
   private void runExecutableNode(final ExecutableNode node) throws IOException {
     // Collect output props from the job's dependencies.
     prepareJobProperties(node);


### PR DESCRIPTION
In order to move metrics foundation class to a common place, I am creating `az-core` sub module. Since Metrics relies on some utils class in `azkaban-common`, the first step of this series of refactor is to clean up some methods in `azkaban-common', and it facilitate me to do those refactor in the following PRs.

In this code patch:
* I move `addCommonFlowProperties` out of PropsUtils, so that we can move PropsUtil to az-core in the next PR easily. 
* Also, this method is not suitable to stay in `PropsUtils`.