### PR TITLE
Build: remove eclipse gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,6 @@ ext.deps = [
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'eclipse'
     apply plugin: 'net.ltgt.errorprone'
 
     // Set the same version for all sub-projects to root project version


### PR DESCRIPTION
The dev setup now depends on Intellij specific plugins, styles etc.