### PR TITLE
Add UI colors for FAILED_SUCCEEDED

### DIFF
--- a/azkaban-web-server/src/main/less/azkaban-graph.less
+++ b/azkaban-web-server/src/main/less/azkaban-graph.less
@@ -103,6 +103,15 @@
   fill: #FFF;
 }
 
+.FAILED_SUCCEEDED > g > rect {
+  fill: #FF9999;
+  stroke: #FF9999;
+}
+
+.FAILED_SUCCEEDED > g > text {
+  fill: #FFF;
+}
+
 .FAILED_FINISHING > g > rect {
   fill: #ed9c28;
   stroke: #ed9c28;

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -83,6 +83,10 @@
   &.CANCELLED {
     background-color: @flow-cancelled-color;
   }
+
+  &.FAILED_SUCCEEDED {
+    background-color: @flow-failed-succeeded-color;
+  }
 }
 
 td {
@@ -141,6 +145,10 @@ td {
     &.CANCELLED {
       background-color: @flow-cancelled-color;
     }
+
+    &.FAILED_SUCCEEDED {
+      background-color: @flow-failed-succeeded-color;
+    }
   }
 }
 
@@ -171,6 +179,10 @@ td {
 
   &.CANCELLED {
     color: @flow-cancelled-color;
+  }
+
+  &.FAILED_SUCCEEDED {
+    color: @flow-failed-succeeded-color;
   }
 
   &.FAILED_FINISHING {
@@ -311,6 +323,11 @@ li.tree-list-item {
     }
 
     &.CANCELLED .icon {
+      background-position: 0px 0px;
+      opacity: 0.5;
+    }
+
+    &.FAILED_SUCCEEDED .icon {
       background-position: 0px 0px;
       opacity: 0.5;
     }

--- a/azkaban-web-server/src/main/less/variables.less
+++ b/azkaban-web-server/src/main/less/variables.less
@@ -6,6 +6,7 @@
 @flow-running-color: #3398cc;
 @flow-failed-finishing-color: #f19153;
 @flow-cancelled-color: #ff9999;
+@flow-failed-succeeded-color: #ff9999;
 @flow-queued-color: #009fc9;
 @flow-disabled-color: #aaa;
 @flow-default-color: #ccc;

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -251,6 +251,8 @@
                     <option value=90>Skipped</option>
                     <option value=100>Disabled</option>
                     <option value=110>Queued</option>
+                    <option value=120>Failed, treated as success</option>
+                    <option value=125>Cancelled</option>
                   </select>
                 </div>
               </div>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -16,7 +16,7 @@
 
 var statusList = ["FAILED", "FAILED_FINISHING", "SUCCEEDED", "RUNNING",
   "WAITING", "KILLED", "DISABLED", "READY", "CANCELLED", "UNKNOWN", "PAUSED",
-  "SKIPPED", "QUEUED"];
+  "SKIPPED", "QUEUED", "FAILED_SUCCEEDED"];
 var statusStringMap = {
   "QUEUED": "Queued",
   "SKIPPED": "Skipped",
@@ -31,5 +31,6 @@ var statusStringMap = {
   "DISABLED": "Disabled",
   "READY": "Ready",
   "UNKNOWN": "Unknown",
-  "PAUSED": "Paused"
+  "PAUSED": "Paused",
+  "FAILED_SUCCEEDED": "Failed, treated as success"
 };


### PR DESCRIPTION
FAILED_SUCCEEDED status was missing color in the UI, so add it.

The issue https://github.com/azkaban/azkaban/issues/1451 has some further details.

<img width="882" alt="nayttokuva 2017-09-19 kello 22 37 04" src="https://user-images.githubusercontent.com/4446608/30611795-2d20f9ec-9d8b-11e7-9944-faef4ccf8b26.png">

<img width="538" alt="nayttokuva 2017-09-19 kello 22 43 14" src="https://user-images.githubusercontent.com/4446608/30612038-fac59f56-9d8b-11e7-959a-ea6c7753e991.png">

<img width="569" alt="nayttokuva 2017-09-19 kello 22 37 25" src="https://user-images.githubusercontent.com/4446608/30611820-38716f84-9d8b-11e7-8ec5-55998051da69.png">
