### PR TITLE
Adding missing datasource singleton annoataion

### DIFF
--- a/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
+++ b/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
@@ -21,6 +21,8 @@ import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import azkaban.db.DatabaseOperator;
+import azkaban.db.H2FileDataSource;
+import azkaban.db.MySQLDataSource;
 import azkaban.project.JdbcProjectImpl;
 import azkaban.spi.Storage;
 import azkaban.storage.DatabaseStorage;
@@ -73,5 +75,8 @@ public class ServiceProviderTest {
     assertThat(injector.getInstance(LocalStorage.class)).isNotNull();
     assertThat(injector.getInstance(Storage.class)).isNotNull();
     assertThat(injector.getInstance(DatabaseOperator.class)).isNotNull();
+
+    assertSingleton(MySQLDataSource.class, injector);
+    assertSingleton(H2FileDataSource.class, injector);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
+++ b/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
@@ -21,8 +21,6 @@ import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import azkaban.db.DatabaseOperator;
-import azkaban.db.H2FileDataSource;
-import azkaban.db.MySQLDataSource;
 import azkaban.project.JdbcProjectImpl;
 import azkaban.spi.Storage;
 import azkaban.storage.DatabaseStorage;
@@ -75,8 +73,5 @@ public class ServiceProviderTest {
     assertThat(injector.getInstance(LocalStorage.class)).isNotNull();
     assertThat(injector.getInstance(Storage.class)).isNotNull();
     assertThat(injector.getInstance(DatabaseOperator.class)).isNotNull();
-
-    assertSingleton(MySQLDataSource.class, injector);
-    assertSingleton(H2FileDataSource.class, injector);
   }
 }

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
@@ -34,7 +33,6 @@ import org.apache.log4j.Logger;
  *
  * @see org.apache.commons.dbutils.QueryRunner
  */
-@Singleton
 public class DatabaseOperator {
 
   private static final Logger logger = Logger.getLogger(DatabaseOperator.class);

--- a/azkaban-db/src/main/java/azkaban/db/H2FileDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/H2FileDataSource.java
@@ -19,8 +19,9 @@ import azkaban.utils.Props;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
-
+@Singleton
 public class H2FileDataSource extends AzkabanDataSource {
 
   @Inject

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -21,9 +21,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.log4j.Logger;
 
+@Singleton
 public class MySQLDataSource extends AzkabanDataSource {
 
   private static final Logger logger = Logger.getLogger(MySQLDataSource.class);

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -148,7 +148,9 @@ public class AzkabanWebServerTest {
     assertSingleton(ExecutorEventsDao.class, injector);
     assertSingleton(ActiveExecutingFlowsDao.class, injector);
     assertSingleton(FetchActiveFlowDao.class, injector);
+    assertSingleton(AzkabanWebServer.class, injector);
     assertSingleton(H2FileDataSource.class, injector);
+
     SERVICE_PROVIDER.unsetInjector();
   }
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -28,6 +28,7 @@ import azkaban.AzkabanCommonModule;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.database.AzkabanDatabaseUpdater;
 import azkaban.db.DatabaseOperator;
+import azkaban.db.H2FileDataSource;
 import azkaban.executor.ActiveExecutingFlowsDao;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutionFlowDao;
@@ -147,8 +148,7 @@ public class AzkabanWebServerTest {
     assertSingleton(ExecutorEventsDao.class, injector);
     assertSingleton(ActiveExecutingFlowsDao.class, injector);
     assertSingleton(FetchActiveFlowDao.class, injector);
-    assertSingleton(AzkabanWebServer.class, injector);
-
+    assertSingleton(H2FileDataSource.class, injector);
     SERVICE_PROVIDER.unsetInjector();
   }
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -128,6 +128,7 @@ public class AzkabanWebServerTest {
     executorLoader.updateExecutor(executor);
 
     assertNotNull(injector.getInstance(ExecutionFlowDao.class));
+    assertNotNull(injector.getInstance(DatabaseOperator.class));
 
     //Test if triggermanager is singletonly guiced. If not, the below test will fail.
     assertSingleton(ExecutorLoader.class, injector);
@@ -135,7 +136,6 @@ public class AzkabanWebServerTest {
     assertSingleton(ProjectLoader.class, injector);
     assertSingleton(ProjectManager.class, injector);
     assertSingleton(Storage.class, injector);
-    assertSingleton(DatabaseOperator.class, injector);
     assertSingleton(TriggerLoader.class, injector);
     assertSingleton(TriggerManager.class, injector);
     assertSingleton(AlerterHolder.class, injector);


### PR DESCRIPTION
Both `H2FileDataSource ` and `MySQLDataSource ` should be singleton. The reason behind is that We would like all database operations to share the same connection pool to guarantee performance. 

Besides, removing singleton from `DatabaseOperator` as no states exist there. It is safe to have multiple DatabaseOperator instances.