### PR TITLE
fix bug #1481: avoid duplicate properties when closing/reopening dialog

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -162,7 +162,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
       $('#queueLevel').val(queueLevel);
     }
 
-    if (flowParams) {
+    if (flowParams && $(".editRow").length == 0) {
       for (var key in flowParams) {
         editTableView.handleAddRow({
           paramkey: key,

--- a/azkaban-web-server/src/web/js/azkaban/view/job-edit.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-edit.js
@@ -86,12 +86,14 @@ azkaban.JobEditView = Backbone.View.extend({
       mythis.overrideParams = overrideParams;
       mythis.generalParams = generalParams;
 
-      for (var okey in overrideParams) {
-        if (okey != 'type' && okey != 'dependencies') {
-          var row = handleAddRow();
-          var td = $(row).find('span');
-          $(td[0]).text(okey);
-          $(td[1]).text(overrideParams[okey]);
+      if (overrideParams && $(".editRow").length == 0)  {
+        for (var okey in overrideParams) {
+          if (okey != 'type' && okey != 'dependencies') {
+            var row = handleAddRow();
+            var td = $(row).find('span');
+            $(td[0]).text(okey);
+            $(td[1]).text(overrideParams[okey]);
+          }
         }
       }
     };


### PR DESCRIPTION
Fix duplicate properties in flow execution and job edit when dialog is closed and reopened.