### PR TITLE
build: change hadoop gradle dependencies to compileOnly

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     compile deps.fileupload
     compile deps.guava
     compile deps.gson
-    compile deps.hadoopAnnotations
-    compile deps.hadoopAuth
-    compile deps.hadoopCommon
-    compile deps.hadoopHdfs
+    compileOnly deps.hadoopAnnotations
+    compileOnly deps.hadoopAuth
+    compileOnly deps.hadoopCommon
+    compileOnly deps.hadoopHdfs
     compile deps.httpclient
     compile deps.jetty
     compile deps.jettyUtil

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
     testRuntime deps.h2
 
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
     testCompile project(':test')
     testCompile project(path: ':azkaban-db', configuration: 'testOutput')
 }

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -5,14 +5,20 @@ dependencies {
     compile(project(':azkaban-common'))
 
     compile deps.kafkaLog4jAppender
-    compile deps.gobblinKafka
+    compile(deps.gobblinKafka) {
+        exclude group: 'org.apache.hadoop'
+    }
 
     runtime(project(':azkaban-hadoop-security-plugin'))
 
     testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
     testCompile(project(':azkaban-common').sourceSets.test.output)
 
-    testRuntime deps.h2
+    testCompile deps.h2
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
 }
 
 configurations.compile {

--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -7,6 +7,10 @@ dependencies {
     compile(project(':azkaban-exec-server'))
 
     runtime deps.h2
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
 }
 
 installDist.dependsOn ':azkaban-web-server:installDist'


### PR DESCRIPTION
## Issue
#1498 
With change #1069 we introduced hadoop dependencies in azkaban-common/build.gradle which resulted in hadoop jars being present in the lib directory. 
Also with change #1332 we introduced transitive hadoop dependencies through the gobblinKafka dependency. 
When testing against different hadoop versions we noticed azkaban was pulling in its own hadoop jars into the distribution instead of using what's available on the hadoop cluster.

## Fix
For change #1069 
Gradle has a [compileOnly](https://blog.gradle.org/introducing-compile-only-dependencies) dependency option which is a true compile only dependency as opposed to compile which extend into runtime.
We also needed to add the same dependencies as a testCompile dependency tests. 

For change #1332 
we made two changes, the compile has an exclude condition thereby excluding any transitive hadoop dependencies. Similar to the previous change we also needed to add the dependencies as testCompile 

Verified manually that the distribution lib does not contain hadoop jars. 