### PR TITLE
Fix azkaban-solo-server by including hadoop dependencies in build.gradle

### DIFF
--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -7,10 +7,10 @@ dependencies {
     compile(project(':azkaban-exec-server'))
 
     runtime deps.h2
-    testCompile deps.hadoopAnnotations
-    testCompile deps.hadoopAuth
-    testCompile deps.hadoopCommon
-    testCompile deps.hadoopHdfs
+    compile deps.hadoopAnnotations
+    compile deps.hadoopAuth
+    compile deps.hadoopCommon
+    compile deps.hadoopHdfs
 }
 
 installDist.dependsOn ':azkaban-web-server:installDist'


### PR DESCRIPTION
## Issue
#1502
With #1499 we broke azkaban-solo-server due to missing hadoop dependencies in solo server which were being transitively included.
## Fix
Include hadoop dependencies for azkaban-solo-server
Verified by bringing up azkaban-solo-server locally and running flows against it. 

