### PR TITLE
Fixing regression where JOB_OUTPUT_PROP_FILE was no longer writable by user process

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -387,7 +387,7 @@ public class ProcessJob extends AbstractProcessJob {
 
   /**
    * Changes permissions on file/directory so that the file/directory is owned by the user and
-   * the group remains azkaban.
+   * the group remains the azkaban service account name.
    *
    * Leverages execute-as-user with "root" as the user to run the command.
    *

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -243,7 +243,14 @@ public class ProcessJob extends AbstractProcessJob {
       // Set parent directory permissions to <uid>:azkaban so user can write in their execution directory
       // if the directory is not permissioned correctly already (should happen once per execution)
       if (!canWriteInCurrentWorkingDirectory(effectiveUser)) {
-        assignUserDirOwnership(effectiveUser);
+        info("Changing current working directory ownership");
+        assignUserFileOwnership(effectiveUser, getWorkingDirectory());
+      }
+      // Set property file permissions to <uid>:azkaban so user can write to their prop files
+      // in order to pass properties from one job to another
+      for (final File propFile : propFiles) {
+        info("Changing properties files ownership");
+        assignUserFileOwnership(effectiveUser, propFile.getAbsolutePath());
       }
     }
 
@@ -379,20 +386,22 @@ public class ProcessJob extends AbstractProcessJob {
   }
 
   /**
-   * Changes permission on current working directory so that the directory is owned by the user and
+   * Changes permissions on file/directory so that the file/directory is owned by the user and
    * the group remains azkaban.
    *
    * Leverages execute-as-user with "root" as the user to run the command.
    *
    * @param effectiveUser user/proxy user running the job
+   * @param fileName the name of the file whose permissions will be changed
    */
-  private void assignUserDirOwnership(final String effectiveUser) throws Exception {
+  private void assignUserFileOwnership(final String effectiveUser, final String fileName) throws
+      Exception {
     final ExecuteAsUser executeAsUser = new ExecuteAsUser(
         this.sysProps.getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER));
     final String groupName = this.sysProps.getString(AZKABAN_SERVER_GROUP_NAME, "azkaban");
     final List<String> changeOwnershipCommand = Arrays
-        .asList(CHOWN, effectiveUser + ":" + groupName, getWorkingDirectory());
-    info("Change current working directory ownership to " + effectiveUser + ":" + groupName + ".");
+        .asList(CHOWN, effectiveUser + ":" + groupName, fileName);
+    info("Change ownership of " + fileName + " to " + effectiveUser + ":" + groupName + ".");
     final int result = executeAsUser.execute("root", changeOwnershipCommand);
     if (result != 0) {
       handleError("Failed to change current working directory ownership. Error code: " + Integer


### PR DESCRIPTION
JOB_OUTPUT_PROP_FILE is a file used to pass properties between jobs. You can read about it here: http://azkaban.github.io/azkaban/docs/latest/#job-configuration

#1325 introduced a regression where JOB_OUTPUT_PROP_FILE became no longer writable due to an upgraded execute-as-user executable that stopped user processes from having the azkaban group permission. This file needs to be written to so properties can be passed from one job to another.

This fix assigns ownership of JOB_OUTPUT_PROP_FILE and JOB_PROP_FILE to `<username>:azkaban` to guarantee user ability to write to this file. It is uncertain whether or not JOB_PROP_FILE is intended to be written to, but I believe it's a good idea to do allow it to be in order to prevent regressions.

This is covered by an integration test that simply tries to write to the JOB_OUTPUT_PROP_FILE to confirm that it is doable. This is already in master of azkaban-auto-test.

This change will more drastically take effect when the execute-as-user executable is upgraded to its newest version.

This was tested on solo-server and holdem4.

I'll continue to explore JOB_OUTPUT_PROP_FILE and JOB_PROP_FILE usage and implementation so we can make sure these features are fully covered by tests and can be leveraged successfully by our users.