### PR TITLE
3.34.x hotfix branch with cherry picks

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -42,10 +42,10 @@ dependencies {
     compile deps.fileupload
     compile deps.guava
     compile deps.gson
-    compile deps.hadoopAnnotations
-    compile deps.hadoopAuth
-    compile deps.hadoopCommon
-    compile deps.hadoopHdfs
+    compileOnly deps.hadoopAnnotations
+    compileOnly deps.hadoopAuth
+    compileOnly deps.hadoopCommon
+    compileOnly deps.hadoopHdfs
     compile deps.httpclient
     compile deps.io
     compile deps.jacksonCoreAsl
@@ -66,6 +66,10 @@ dependencies {
 
     testRuntime deps.h2
 
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
     testCompile project(':test')
     testCompile project(path: ':azkaban-db', configuration: 'testOutput')
 }

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -4,13 +4,23 @@ dependencies {
     compile(project(':azkaban-common'))
 
     compile deps.kafkaLog4jAppender
+<<<<<<< HEAD
+=======
+    compile(deps.gobblinKafka) {
+        exclude group: 'org.apache.hadoop'
+    }
+>>>>>>> 59cce4e9... build: change hadoop gradle dependencies to compileOnly (#1499)
 
     runtime(project(':azkaban-hadoop-security-plugin'))
 
     testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
     testCompile(project(':azkaban-common').sourceSets.test.output)
 
-    testRuntime deps.h2
+    testCompile deps.h2
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
 }
 
 distributions {

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -4,12 +4,6 @@ dependencies {
     compile(project(':azkaban-common'))
 
     compile deps.kafkaLog4jAppender
-<<<<<<< HEAD
-=======
-    compile(deps.gobblinKafka) {
-        exclude group: 'org.apache.hadoop'
-    }
->>>>>>> 59cce4e9... build: change hadoop gradle dependencies to compileOnly (#1499)
 
     runtime(project(':azkaban-hadoop-security-plugin'))
 

--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -7,10 +7,10 @@ dependencies {
     compile(project(':azkaban-exec-server'))
 
     runtime deps.h2
-    testCompile deps.hadoopAnnotations
-    testCompile deps.hadoopAuth
-    testCompile deps.hadoopCommon
-    testCompile deps.hadoopHdfs
+    compile deps.hadoopAnnotations
+    compile deps.hadoopAuth
+    compile deps.hadoopCommon
+    compile deps.hadoopHdfs
 }
 
 installDist.dependsOn ':azkaban-web-server:installDist'

--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -7,6 +7,10 @@ dependencies {
     compile(project(':azkaban-exec-server'))
 
     runtime deps.h2
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
 }
 
 installDist.dependsOn ':azkaban-web-server:installDist'


### PR DESCRIPTION
Creating a 3.34.x hot fix branch with changes to remove hadoop dependencies cherry picked from master. 

Tested by building and bringing up the solo-server.
Also verified that no hadoop dependencies exist in the distribution outside of the solo sever. 