### PR TITLE
fix bug #1508: fix graph visualisation when exploding nested flows

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/layout.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/layout.js
@@ -212,22 +212,28 @@ function layoutGraph(nodes, edges, hmargin) {
       var destX = nodeMap[dest].x;
 
       var guides = [];
+      var pointArray = new Array();
+      pointArray.push([nodeMap[src].x, nodeMap[src].y]);
       var dummies = edgeDummies[edgeId];
       for (var j = 0; j < dummies.length; ++j) {
         var point = {x: dummies[j].x, y: dummies[j].y};
         guides.push(point);
+        pointArray.push([point.x, point.y]);
 
         var nextX = j == dummies.length - 1 ? destX : dummies[j + 1].x;
         if (point.x != prevX && point.x != nextX) {
           // Add gap
           if ((point.x > prevX) == (point.x > nextX)) {
             guides.push({x: point.x, y: point.y + cornerGap});
+            pointArray.push([point.x, point.y + cornerGap]);
           }
         }
         prevX = point.x;
       }
 
+      pointArray.push([nodeMap[dest].x, nodeMap[dest].y]);
       edge.guides = guides;
+      edge.oldpoints = pointArray;
     }
     else {
       edge.guides = null;


### PR DESCRIPTION
The broken graph attached to the bug #1508 happens because `animatePolylineEdge` fails: it assumes that each `edge` has always a number of `edge.oldpoints` equals to the number of `newPoints`, which sometimes fails.

`newPoints` is fed by the `moveNodeEdges`: it iterates through all the `edge.guides` (the segments composing the lines connecting the graph nodes) and adds the starting and ending points; this makes sense, because the assumption `edge.guides.length == edge.points.length - 2` should always hold.

The bug happens because this assumption is broken: in `layoutGraph` we sometimes add a new segment to `edge.guides` but we forget to update the points accordingly.

This patch fixes the problem: when a new segment is added to an edge (see the code after the `// Add gap` comment) we also add an extra point, therefore assuring the assumption holds, and allowing the `animatePolylineEdge` to work properly.

The result:
![screenshot 2017-09-28 09 41 53](https://user-images.githubusercontent.com/71387/30954667-4f9e353c-a431-11e7-9b61-fc24e84a8a1c.png)
