### PR TITLE
Fix bug in killed quick finish

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -405,7 +405,7 @@ public class JobRunner extends EventHandler implements Runnable {
         nodeStatus = changeStatus(Status.SKIPPED, time);
         quickFinish = true;
       } else if (this.isKilled()) {
-        nodeStatus = changeStatus(Status.KILLING, time);
+        nodeStatus = changeStatus(Status.KILLED, time);
         quickFinish = true;
       }
 


### PR DESCRIPTION
If a job is actually not run at all, but it has been marked as killed, the right thing to do is set the status to KILLED. Otherwise the flow would get stuck because this job would send the JOB_FINISHED event with the unfinished status: KILLING.

This was caught by a unit test on a failed Travis. Details can be found in https://github.com/azkaban/azkaban/pull/1509#issuecomment-333196277.