### PR TITLE
fix upload package bug

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -112,7 +112,7 @@ class AzkabanProjectLoader {
     }
 
     // Upload the project to DB and storage.
-    persistProject(project, loader, archive, uploader);
+    persistProject(project, loader, archive, uploader, fileType);
 
     // Clean up project old installations after new project is uploaded successfully.
     cleanUpProjectOldInstallations(project);
@@ -182,7 +182,7 @@ class AzkabanProjectLoader {
   }
 
   private void persistProject(final Project project, final FlowLoader loader, final File archive,
-      final User uploader) throws ProjectManagerException {
+      final User uploader, final String fileType) throws ProjectManagerException {
     synchronized (project) {
       if (loader instanceof DirectoryFlowLoader) {
         final DirectoryFlowLoader directoryFlowLoader = (DirectoryFlowLoader) loader;
@@ -193,7 +193,7 @@ class AzkabanProjectLoader {
           flow.setVersion(newVersion);
         }
 
-        this.storageManager.uploadProject(project, newVersion, archive, uploader);
+        this.storageManager.uploadProject(project, newVersion, archive, uploader, fileType);
 
         log.info("Uploading flow to db " + archive.getName());
         this.projectLoader.uploadFlows(project, newVersion, flows.values());

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -95,7 +95,7 @@ public interface ProjectLoader {
   /**
    * Will upload the files and return the version number of the file uploaded.
    */
-  void uploadProjectFile(int projectId, int version, File localFile, String user)
+  void uploadProjectFile(int projectId, int version, File localFile, String user, String fileType)
       throws ProjectManagerException;
 
   /**
@@ -103,7 +103,7 @@ public interface ProjectLoader {
    * for each uploaded version of the project
    */
   void addProjectVersion(int projectId, int version, File localFile, String uploader, byte[] md5,
-      String resourceId)
+      String resourceId,final String fileType)
       throws ProjectManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/DatabaseStorage.java
@@ -54,11 +54,12 @@ public class DatabaseStorage implements Storage {
   }
 
   @Override
-  public String put(final StorageMetadata metadata, final File localFile) {
+  public String put(final StorageMetadata metadata, final File localFile, final String fileType) {
     this.projectLoader.uploadProjectFile(
         metadata.getProjectId(),
         metadata.getVersion(),
-        localFile, metadata.getUploader());
+        localFile, metadata.getUploader(),
+        fileType);
 
     return null;
   }

--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -64,7 +64,7 @@ public class HdfsStorage implements Storage {
   }
 
   @Override
-  public String put(final StorageMetadata metadata, final File localFile) {
+  public String put(final StorageMetadata metadata, final File localFile, final String fileType) {
     this.hdfsAuth.authorize();
     final Path projectsPath = new Path(this.rootUri.getPath(),
         String.valueOf(metadata.getProjectId()));

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -78,7 +78,7 @@ public class LocalStorage implements Storage {
   }
 
   @Override
-  public String put(final StorageMetadata metadata, final File localFile) {
+  public String put(final StorageMetadata metadata, final File localFile, final String fileType) {
     final File projectDir = new File(this.rootDirectory, String.valueOf(metadata.getProjectId()));
     if (projectDir.mkdir()) {
       log.info("Created project dir: " + projectDir.getAbsolutePath());

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -89,7 +89,8 @@ public class StorageManager {
       final Project project,
       final int version,
       final File localFile,
-      final User uploader) {
+      final User uploader,
+      final String fileType) {
     byte[] md5 = null;
     if (!(this.storage instanceof DatabaseStorage)) {
       md5 = computeHash(localFile);
@@ -103,7 +104,7 @@ public class StorageManager {
         metadata, localFile.getName(), localFile.length()));
 
     /* upload to storage */
-    final String resourceId = this.storage.put(metadata, localFile);
+    final String resourceId = this.storage.put(metadata, localFile, fileType);
 
     /* Add metadata to db */
     // TODO spyne: remove hack. Database storage should go through the same flow
@@ -114,7 +115,8 @@ public class StorageManager {
           localFile,
           uploader.getUserId(),
           requireNonNull(md5),
-          requireNonNull(resourceId)
+          requireNonNull(resourceId),
+          fileType
       );
       log.info(String.format("Added project metadata to DB. Meta:%s File: %s[%d bytes] URI: %s",
           metadata, localFile.getName(), localFile.length(), resourceId));

--- a/azkaban-common/src/test/java/azkaban/project/AzkabanProjectLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/AzkabanProjectLoaderTest.java
@@ -83,7 +83,7 @@ public class AzkabanProjectLoaderTest {
         validationReportMap.get(DIRECTORY_FLOW_REPORT_KEY).getStatus());
 
     verify(this.storageManager)
-        .uploadProject(this.project, this.VERSION + 1, projectZipFile, uploader);
+        .uploadProject(this.project, this.VERSION + 1, projectZipFile, uploader, "zip");
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -122,7 +122,7 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     final File testFile = new File(getClass().getClassLoader().getResource(SAMPLE_FILE).getFile());
     final int newVersion = this.loader.getLatestProjectVersion(project) + 1;
-    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1");
+    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1","zip");
 
     final ProjectFileHandler fileHandler = this.loader.getUploadedFile(project.getId(), newVersion);
     Assert.assertEquals(fileHandler.getFileName(), SAMPLE_FILE);
@@ -135,8 +135,8 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     final File testFile = new File(getClass().getClassLoader().getResource(SAMPLE_FILE).getFile());
     final int newVersion = this.loader.getLatestProjectVersion(project) + 1;
-    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1");
-    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1");
+    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1", "zip");
+    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1", "zip");
   }
 
   private byte[] computeHash(final File localFile) {
@@ -156,7 +156,7 @@ public class JdbcProjectImplTest {
     final File testFile = new File(getClass().getClassLoader().getResource(SAMPLE_FILE).getFile());
     final int newVersion = this.loader.getLatestProjectVersion(project) + 1;
     this.loader.addProjectVersion(project.getId(), newVersion, testFile, "uploadUser1",
-        computeHash(testFile), "resourceId1");
+        computeHash(testFile), "resourceId1", "zip");
     final int currVersion = this.loader.getLatestProjectVersion(project);
     Assert.assertEquals(currVersion, newVersion);
   }
@@ -167,7 +167,7 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     final File testFile = new File(getClass().getClassLoader().getResource(SAMPLE_FILE).getFile());
     final int newVersion = this.loader.getLatestProjectVersion(project) + 1;
-    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1");
+    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1", "zip");
     final ProjectFileHandler pfh = this.loader.fetchProjectMetaData(project.getId(), newVersion);
     Assert.assertEquals(pfh.getVersion(), newVersion);
   }
@@ -330,7 +330,7 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     final File testFile = new File(getClass().getClassLoader().getResource(SAMPLE_FILE).getFile());
     final int newVersion = this.loader.getLatestProjectVersion(project) + 1;
-    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1");
+    this.loader.uploadProjectFile(project.getId(), newVersion, testFile, "uploadUser1", "zip");
 
     final ProjectFileHandler fileHandler = this.loader.getUploadedFile(project.getId(), newVersion);
     Assert.assertEquals(fileHandler.getNumChunks(), 1);

--- a/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/DatabaseStorageTest.java
@@ -38,7 +38,7 @@ public class DatabaseStorageTest {
     final int version = 1;
     final String uploader = "testuser";
     final StorageMetadata metadata = new StorageMetadata(projectId, version, uploader, null);
-    this.databaseStorage.put(metadata, file);
-    verify(this.projectLoader).uploadProjectFile(projectId, version, file, uploader);
+    this.databaseStorage.put(metadata, file,"zip");
+    verify(this.projectLoader).uploadProjectFile(projectId, version, file, uploader,"zip");
   }
 }

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -66,7 +66,7 @@ public class HdfsStorageTest {
     when(this.hdfs.exists(any(Path.class))).thenReturn(false);
 
     final StorageMetadata metadata = new StorageMetadata(1, 2, "uploader", Md5Hasher.md5Hash(file));
-    final String key = this.hdfsStorage.put(metadata, file);
+    final String key = this.hdfsStorage.put(metadata, file, "zip");
 
     final String expectedName = String.format("1/1-%s.zip", hash);
     Assert.assertEquals(expectedName, key);

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -65,7 +65,7 @@ public class LocalStorageTest {
 
     final StorageMetadata metadata = new StorageMetadata(
         1, 1, "testuser", Md5Hasher.md5Hash(testFile));
-    final String key = this.localStorage.put(metadata, testFile);
+    final String key = this.localStorage.put(metadata, testFile, "zip");
     assertNotNull(key);
     log.info("Key URI: " + key);
 

--- a/azkaban-spi/src/main/java/azkaban/spi/Storage.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/Storage.java
@@ -49,7 +49,7 @@ public interface Storage {
    * @param localFile Read data from a local file
    * @return Key associated with the current object on successful put
    */
-  String put(StorageMetadata metadata, File localFile);
+  String put(StorageMetadata metadata, File localFile, String fileType);
 
   /**
    * Delete an object from Storage.


### PR DESCRIPTION
when i upload a zip format package and the file extension is not zip. This will cause the database to generate an incorrect record in the project_versions table. 

Code for determining file type in azkaban.webapp.servlet.ProjectManagerServlet # ajaxHandleUpload is:

    if (contentType != null
          && (contentType.startsWith(APPLICATION_ZIP_MIME_TYPE)
          || contentType.startsWith("application/x-zip-compressed") || contentType
          .startsWith("application/octet-stream"))) {
        type = "zip";
      }

But when inserting project_versions only according to the file extension to determine the type (azkaban.project.JdbcProjectImpl#addProjectToProjectVersions)

    final String INSERT_PROJECT_VERSION = "INSERT INTO project_versions "
        + "(project_id, version, upload_time, uploader, file_type, file_name, md5, num_chunks, resource_id) values "
        + "(?,?,?,?,?,?,?,?,?)";

    try {
      /*
       * As we don't know the num_chunks before uploading the file, we initialize it to 0,
       * and will update it after uploading completes.
       */
      transOperator.update(INSERT_PROJECT_VERSION, projectId, version, updateTime, uploader,
          Files.getFileExtension(localFile.getName()), localFile.getName(), md5, 0, resourceId);
    } catch (final SQLException e) {
      final String msg = String
          .format("Error initializing project id: %d version: %d ", projectId, version);
      logger.error(msg, e);
      throw new ProjectManagerException(msg, e);
    }
