### PR TITLE
schema change for execution_jobs

### DIFF
--- a/azkaban-db/src/main/sql/create.execution_jobs.sql
+++ b/azkaban-db/src/main/sql/create.execution_jobs.sql
@@ -11,12 +11,8 @@ CREATE TABLE execution_jobs (
   input_params  LONGBLOB,
   output_params LONGBLOB,
   attachments   LONGBLOB,
-  PRIMARY KEY (exec_id, job_id, attempt)
+  PRIMARY KEY (exec_id, job_id, flow_id, attempt)
 );
 
-CREATE INDEX exec_job
-  ON execution_jobs (exec_id, job_id);
-CREATE INDEX exec_id
-  ON execution_jobs (exec_id);
 CREATE INDEX ex_job_id
   ON execution_jobs (project_id, job_id);


### PR DESCRIPTION
1. add flow_id to key set of execution_jobs table
2. drop two unnecessary indexes.

Previously primary key set of execution_jobs is (execution_id, job_id, attempt).
This is under the assumption where no job shares the same name within a flow. However this is not the case when embedded flow comes into picture, which allows user to embed a smaller flow into multiple places inside a bigger flow.

with new keyset, two indexes becomes a subset of the key set, so we can drop them. 
