### PR TITLE
add onKilled to callback interface

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyCheck.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyCheck.java
@@ -40,7 +40,7 @@ public interface DependencyCheck {
    * Initialize the dependency plugin.
    *
    * @param config dependency plugin config.
-   * @param successCallback callback to invoke when the check succeeds.
+   * @param callback callback to invoke when the check succeeds.
    */
-  void init(DependencyPluginConfig config, SuccessCallback successCallback);
+  void init(DependencyPluginConfig config, DependencyInstanceCallback callback);
 }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyInstanceCallback.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyInstanceCallback.java
@@ -16,13 +16,15 @@
 
 package azkaban.flowtrigger;
 
-/**
- * Defines the action to take when dependency check instance is successfully finished.
- */
-public interface SuccessCallback {
+public interface DependencyInstanceCallback {
 
   /**
    * action to invoke when dependency check instance is successfully finished.
    */
   void onSuccess(DependencyInstanceContext dependencyInstance);
+
+  /**
+   * action to invoke when dependency check instance is successfully killed.
+   */
+  void onKilled(DependencyInstanceContext dependencyInstance);
 }


### PR DESCRIPTION
onKilled will be called when dependency context is killed successfully. Before that, dependency context is in "Killing" status.