### PR TITLE
Issue #1433 part 1: Remove code duplication in FlowRunner tests

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 
 public class InteractiveTestJob extends AbstractProcessJob {
 
+  public static final String JOB_ID_PREFIX = "InteractiveTestJob.jobIdPrefix";
   private static final ConcurrentHashMap<String, InteractiveTestJob> testJobs =
       new ConcurrentHashMap<>();
   private static volatile boolean quickSuccess = false;
@@ -83,10 +84,10 @@ public class InteractiveTestJob extends AbstractProcessJob {
   public void run() throws Exception {
     final String nestedFlowPath =
         this.getJobProps().get(CommonJobProperties.NESTED_FLOW_PATH);
-    final String groupName = this.getJobProps().getString("group", null);
+    final String jobIdPrefix = this.getJobProps().getString(JOB_ID_PREFIX, null);
     String id = nestedFlowPath == null ? this.getId() : nestedFlowPath;
-    if (groupName != null) {
-      id = groupName + ":" + id;
+    if (jobIdPrefix != null) {
+      id = jobIdPrefix + ":" + id;
     }
     testJobs.put(id, this);
     synchronized (testJobs) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -16,30 +16,16 @@
 
 package azkaban.execapp;
 
-import static org.mockito.Mockito.mock;
-
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
-import azkaban.executor.ExecutorLoader;
 import azkaban.executor.InteractiveTestJob;
-import azkaban.executor.JavaJob;
-import azkaban.executor.MockExecutorLoader;
-import azkaban.flow.Flow;
-import azkaban.jobtype.JobTypeManager;
-import azkaban.project.Project;
-import azkaban.project.ProjectLoader;
-import azkaban.spi.AzkabanEventReporter;
+import azkaban.executor.Status;
 import azkaban.utils.Props;
-import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -57,70 +43,36 @@ import org.junit.Test;
  *
  * job2 and 4 are in nested directories so should have different shared properties than other jobs.
  */
-public class FlowRunnerPropertyResolutionTest {
+public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
-  private static int id = 101;
-  private final AzkabanEventReporter azkabanEventReporter = null;
-  private File workingDir;
-  private JobTypeManager jobtypeManager;
-  private ExecutorLoader fakeExecutorLoader;
-  private Project project;
-  private Map<String, Flow> flowMap;
+  private FlowRunnerTestUtil testUtil;
 
   @Before
   public void setUp() throws Exception {
-    System.out.println("Create temp dir");
-    this.workingDir = new File("_AzkabanTestDir_" + System.currentTimeMillis());
-    if (this.workingDir.exists()) {
-      FileUtils.deleteDirectory(this.workingDir);
-    }
-    this.workingDir.mkdirs();
-    this.jobtypeManager =
-        new JobTypeManager(null, null, this.getClass().getClassLoader());
-    this.jobtypeManager.getJobTypePluginSet().addPluginClass("java", JavaJob.class);
-    this.jobtypeManager.getJobTypePluginSet().addPluginClass("test",
-        InteractiveTestJob.class);
-    this.fakeExecutorLoader = new MockExecutorLoader();
-    this.project = new Project(1, "testProject");
-
-    final File dir = new File("unit/executions/execpropstest");
-    this.flowMap = FlowRunnerTestUtil
-        .prepareProject(this.project, dir, this.workingDir);
-
-    InteractiveTestJob.clearTestJobs();
-  }
-
-  @After
-  public void tearDown() throws IOException {
-    System.out.println("Teardown temp dir");
-    if (this.workingDir != null) {
-      FileUtils.deleteDirectory(this.workingDir);
-      this.workingDir = null;
-    }
+    this.testUtil = new FlowRunnerTestUtil("execpropstest", this.temporaryFolder);
   }
 
   /**
    * Tests the basic flow resolution. Flow is defined in execpropstest
    */
-  @Ignore
   @Test
   public void testPropertyResolution() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     flowProps.put("props7", "flow7");
     flowProps.put("props6", "flow6");
     flowProps.put("props5", "flow5");
-    final FlowRunner runner = createFlowRunner("job3", flowProps);
+    final FlowRunner runner = this.testUtil.createFromFlowMap("job3", flowProps);
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
+    final ExecutableFlow flow = runner.getExecutableFlow();
 
     // 1. Start flow. Job 2 should start
-    runFlowRunnerInThread(runner);
-    pause(250);
+    FlowRunnerTestUtil.startThread(runner);
+    assertStatus(flow, "job2", Status.RUNNING);
 
     // Job 2 is a normal job.
     // Only the flow overrides and the shared properties matter
-    ExecutableNode node = nodeMap.get("job2");
-    final Props job2Props = node.getInputProps();
+    final Props job2Props = nodeMap.get("job2").getInputProps();
     Assert.assertEquals("shared1", job2Props.get("props1"));
     Assert.assertEquals("job2", job2Props.get("props2"));
     Assert.assertEquals("moo3", job2Props.get("props3"));
@@ -138,9 +90,9 @@ public class FlowRunnerPropertyResolutionTest {
     job2Generated.put("props9", "gjob9");
     job2Generated.put("props10", "gjob10");
     InteractiveTestJob.getTestJob("job2").succeedJob(job2Generated);
-    pause(250);
-    node = nodeMap.get("innerflow:job1");
-    final Props job1Props = node.getInputProps();
+    assertStatus(flow, "innerflow:job1", Status.RUNNING);
+
+    final Props job1Props = nodeMap.get("innerflow:job1").getInputProps();
     Assert.assertEquals("job1", job1Props.get("props1"));
     Assert.assertEquals("job2", job1Props.get("props2"));
     Assert.assertEquals("job8", job1Props.get("props8"));
@@ -161,9 +113,8 @@ public class FlowRunnerPropertyResolutionTest {
     job1GeneratedProps.put("props7", "g2job7");
     InteractiveTestJob.getTestJob("innerflow:job1").succeedJob(
         job1GeneratedProps);
-    pause(250);
-    node = nodeMap.get("innerflow:job4");
-    final Props job4Props = node.getInputProps();
+    assertStatus(flow, "innerflow:job4", Status.RUNNING);
+    final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
     Assert.assertEquals("job8", job4Props.get("props8"));
     Assert.assertEquals("job9", job4Props.get("props9"));
     Assert.assertEquals("g2job7", job4Props.get("props7"));
@@ -183,9 +134,8 @@ public class FlowRunnerPropertyResolutionTest {
     job4GeneratedProps.put("props6", "g4job6");
     InteractiveTestJob.getTestJob("innerflow:job4").succeedJob(
         job4GeneratedProps);
-    pause(250);
-    node = nodeMap.get("job3");
-    final Props job3Props = node.getInputProps();
+    assertStatus(flow, "job3", Status.RUNNING);
+    final Props job3Props = nodeMap.get("job3").getInputProps();
     Assert.assertEquals("job3", job3Props.get("props3"));
     Assert.assertEquals("g4job6", job3Props.get("props6"));
     Assert.assertEquals("g4job9", job3Props.get("props9"));
@@ -196,30 +146,6 @@ public class FlowRunnerPropertyResolutionTest {
     Assert.assertEquals("moo4", job3Props.get("props4"));
   }
 
-  private FlowRunner createFlowRunner(final String flowName,
-      final HashMap<String, String> flowParams) throws Exception {
-    return createFlowRunner(flowName, flowParams, new Props());
-  }
-
-  private FlowRunner createFlowRunner(final String flowName,
-      final HashMap<String, String> flowParams, final Props azkabanProps) throws Exception {
-    final Flow flow = this.flowMap.get(flowName);
-
-    final int exId = id++;
-    final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
-    exFlow.setExecutionPath(this.workingDir.getPath());
-    exFlow.setExecutionId(exId);
-
-    exFlow.getExecutionOptions().addAllFlowParameters(flowParams);
-    this.fakeExecutorLoader.uploadExecutableFlow(exFlow);
-
-    final FlowRunner runner =
-        new FlowRunner(this.fakeExecutorLoader.fetchExecutableFlow(exId),
-            this.fakeExecutorLoader, mock(ProjectLoader.class), this.jobtypeManager, azkabanProps,
-            this.azkabanEventReporter);
-    return runner;
-  }
-
   private void createNodeMap(final ExecutableFlowBase flow,
       final Map<String, ExecutableNode> nodeMap) {
     for (final ExecutableNode node : flow.getExecutableNodes()) {
@@ -228,19 +154,6 @@ public class FlowRunnerPropertyResolutionTest {
       if (node instanceof ExecutableFlowBase) {
         createNodeMap((ExecutableFlowBase) node, nodeMap);
       }
-    }
-  }
-
-  private Thread runFlowRunnerInThread(final FlowRunner runner) {
-    final Thread thread = new Thread(runner);
-    thread.start();
-    return thread;
-  }
-
-  private void pause(final long millisec) {
-    try {
-      Thread.sleep(millisec);
-    } catch (final InterruptedException e) {
     }
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -16,62 +16,24 @@
 
 package azkaban.execapp;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.when;
-
-import azkaban.execapp.jmx.JmxJobMBeanManager;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
+import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutionOptions.FailureAction;
-import azkaban.executor.ExecutorLoader;
 import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.Status;
-import azkaban.jobExecutor.AllJobExecutorTests;
-import azkaban.jobtype.JobTypeManager;
-import azkaban.jobtype.JobTypePluginSet;
-import azkaban.project.ProjectLoader;
-import azkaban.spi.AzkabanEventReporter;
 import azkaban.spi.EventType;
-import azkaban.test.Utils;
-import azkaban.test.executions.ExecutionsTestUtil;
-import azkaban.utils.Props;
-import java.io.File;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class FlowRunnerTest extends FlowRunnerTestBase {
 
-  private static final File TEST_DIR = ExecutionsTestUtil.getFlowDir("exectest1");
-  private final AzkabanEventReporter azkabanEventReporter = null;
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  private File workingDir;
-  private JobTypeManager jobtypeManager;
-  @Mock
-  private ProjectLoader fakeProjectLoader;
-  @Mock
-  private ExecutorLoader loader;
+  private FlowRunnerTestUtil testUtil;
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    when(this.loader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
-    this.workingDir = this.temporaryFolder.newFolder();
-    this.jobtypeManager =
-        new JobTypeManager(null, null, this.getClass().getClassLoader());
-    final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();
-    pluginSet.setCommonPluginLoadProps(AllJobExecutorTests.setUpCommonProps());
-    pluginSet.addPluginClass("test", InteractiveTestJob.class);
-    Utils.initServiceProvider();
-    JmxJobMBeanManager.getInstance().initialize(new Props());
-
-    InteractiveTestJob.clearTestJobs();
+    this.testUtil = new FlowRunnerTestUtil("exectest1", this.temporaryFolder);
   }
 
   @Test
@@ -79,9 +41,9 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec1");
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     succeedJobs("job3", "job4", "job6");
 
     waitForAndAssertFlowStatus(Status.SUCCEEDED);
@@ -106,8 +68,9 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    final ExecutableFlow exFlow = FlowRunnerTestUtil
-        .prepareExecDir(this.workingDir, TEST_DIR, "exec1", 1);
+
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec1");
+    final ExecutableFlow exFlow = this.runner.getExecutableFlow();
 
     // Disable couple in the middle and at the end.
     exFlow.getExecutableNode("job1").setStatus(Status.DISABLED);
@@ -115,12 +78,10 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     exFlow.getExecutableNode("job5").setStatus(Status.DISABLED);
     exFlow.getExecutableNode("job10").setStatus(Status.DISABLED);
 
-    this.runner = createFlowRunner(exFlow, this.loader, eventCollector);
-
     Assert.assertTrue(!this.runner.isKilled());
     waitForAndAssertFlowStatus(Status.READY);
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     succeedJobs("job3", "job4");
 
     assertThreadShutDown();
@@ -146,12 +107,10 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    final ExecutableFlow flow = FlowRunnerTestUtil
-        .prepareExecDir(this.workingDir, TEST_DIR, "exec2", 1);
 
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec2");
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     succeedJobs("job6");
 
     Assert.assertTrue(!this.runner.isKilled());
@@ -177,13 +136,12 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    final ExecutableFlow flow = FlowRunnerTestUtil
-        .prepareExecDir(this.workingDir, TEST_DIR, "exec2", 1);
-    flow.getExecutionOptions().setFailureAction(FailureAction.CANCEL_ALL);
+    final ExecutionOptions options = new ExecutionOptions();
+    options.setFailureAction(FailureAction.CANCEL_ALL);
 
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    this.runner = this.testUtil.createFromFlowFile("exec2", eventCollector, options);
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     assertThreadShutDown();
 
     Assert.assertTrue(this.runner.isKilled());
@@ -209,13 +167,11 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    final ExecutableFlow flow = FlowRunnerTestUtil
-        .prepareExecDir(this.workingDir, TEST_DIR, "exec3", 1);
-    flow.getExecutionOptions().setFailureAction(
-        FailureAction.FINISH_ALL_POSSIBLE);
-    this.runner = createFlowRunner(flow, this.loader, eventCollector);
+    final ExecutionOptions options = new ExecutionOptions();
+    options.setFailureAction(FailureAction.FINISH_ALL_POSSIBLE);
+    this.runner = this.testUtil.createFromFlowFile("exec3", eventCollector, options);
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     succeedJobs("job3");
 
     waitForAndAssertFlowStatus(Status.FAILED);
@@ -240,9 +196,9 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec1");
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec1");
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
 
     assertStatus("job1", Status.SUCCEEDED);
     assertStatus("job2", Status.SUCCEEDED);
@@ -275,9 +231,9 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final EventCollectorListener eventCollector = new EventCollectorListener();
     eventCollector.setEventFilterOut(EventType.JOB_FINISHED,
         EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED);
-    this.runner = createFlowRunner(this.loader, eventCollector, "exec4-retry");
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec4-retry");
 
-    startThread(this.runner);
+    FlowRunnerTestUtil.startThread(this.runner);
     assertThreadShutDown();
 
     assertStatus("job-retry", Status.SUCCEEDED);
@@ -288,12 +244,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertAttempts("job-retry-fail", 2);
 
     waitForAndAssertFlowStatus(Status.FAILED);
-  }
-
-  private void startThread(final FlowRunner runner) {
-    Assert.assertTrue(!runner.isKilled());
-    final Thread thread = new Thread(runner);
-    thread.start();
   }
 
   private void assertAttempts(final String name, final int attempt) {
@@ -332,47 +282,5 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
       final ExecutableNode childNode = flow.getExecutableNode(outNode);
       compareStartFinishTimes(flow, childNode, endTime);
     }
-  }
-
-  private FlowRunner createFlowRunner(final ExecutableFlow flow,
-      final ExecutorLoader loader, final EventCollectorListener eventCollector) throws Exception {
-    return createFlowRunner(flow, loader, eventCollector, new Props());
-  }
-
-  private FlowRunner createFlowRunner(final ExecutableFlow flow,
-      final ExecutorLoader loader, final EventCollectorListener eventCollector,
-      final Props azkabanProps)
-      throws Exception {
-
-    loader.uploadExecutableFlow(flow);
-    final FlowRunner runner =
-        new FlowRunner(flow, loader, this.fakeProjectLoader, this.jobtypeManager, azkabanProps,
-            this.azkabanEventReporter);
-
-    runner.addListener(eventCollector);
-
-    return runner;
-  }
-
-  private FlowRunner createFlowRunner(final ExecutorLoader loader,
-      final EventCollectorListener eventCollector, final String flowName) throws Exception {
-    return createFlowRunner(loader, eventCollector, flowName, new Props());
-  }
-
-  private FlowRunner createFlowRunner(final ExecutorLoader loader,
-      final EventCollectorListener eventCollector, final String flowName, final Props azkabanProps)
-      throws Exception {
-    final ExecutableFlow exFlow = FlowRunnerTestUtil
-        .prepareExecDir(this.workingDir, TEST_DIR, flowName, 1);
-
-    loader.uploadExecutableFlow(exFlow);
-
-    final FlowRunner runner =
-        new FlowRunner(exFlow, loader, this.fakeProjectLoader, this.jobtypeManager, azkabanProps,
-            this.azkabanEventReporter);
-
-    runner.addListener(eventCollector);
-
-    return runner;
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -28,8 +28,13 @@ import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.Status;
 import java.util.function.Function;
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class FlowRunnerTestBase {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   protected FlowRunner runner;
   protected EventCollectorListener eventCollector;

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -16,19 +16,67 @@
 
 package azkaban.execapp;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import azkaban.execapp.jmx.JmxJobMBeanManager;
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutionOptions;
+import azkaban.executor.ExecutionOptions.FailureAction;
+import azkaban.executor.ExecutorLoader;
+import azkaban.executor.InteractiveTestJob;
 import azkaban.flow.Flow;
+import azkaban.jobtype.JobTypeManager;
+import azkaban.jobtype.JobTypePluginSet;
 import azkaban.project.DirectoryFlowLoader;
 import azkaban.project.Project;
+import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManagerException;
+import azkaban.test.Utils;
+import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
 
 public class FlowRunnerTestUtil {
+
+  private static int id = 101;
+  private final Map<String, Flow> flowMap;
+  private final Project project;
+  private final File workingDir;
+  private final ExecutorLoader fakeExecutorLoader;
+  private final JobTypeManager jobtypeManager;
+  private final File projectDir;
+
+  public FlowRunnerTestUtil(final String flowName, final TemporaryFolder temporaryFolder)
+      throws Exception {
+
+    this.projectDir = ExecutionsTestUtil.getFlowDir(flowName);
+    this.workingDir = temporaryFolder.newFolder();
+    this.project = new Project(1, "testProject");
+
+    this.flowMap = FlowRunnerTestUtil
+        .prepareProject(this.project, ExecutionsTestUtil.getFlowDir(flowName), this.workingDir);
+
+    this.fakeExecutorLoader = mock(ExecutorLoader.class);
+    when(this.fakeExecutorLoader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
+
+    Utils.initServiceProvider();
+    JmxJobMBeanManager.getInstance().initialize(new Props());
+
+    InteractiveTestJob.clearTestJobs();
+
+    this.jobtypeManager = new JobTypeManager(null, null, this.getClass().getClassLoader());
+    final JobTypePluginSet pluginSet = this.jobtypeManager.getJobTypePluginSet();
+    pluginSet.addPluginClass("test", InteractiveTestJob.class);
+  }
 
   /**
    * Initialize the project with the flow definitions stored in the given source directory. Also
@@ -58,7 +106,6 @@ public class FlowRunnerTestUtil {
     final Map<String, Flow> flowMap = loader.getFlowMap();
     project.setFlows(flowMap);
     FileUtils.copyDirectory(sourceDir, workingDir);
-
     return flowMap;
   }
 
@@ -75,4 +122,84 @@ public class FlowRunnerTestUtil {
     return execFlow;
   }
 
+  public static void startThread(final FlowRunner runner) {
+    new Thread(runner).start();
+  }
+
+  public FlowRunner createFromFlowFile(final EventCollectorListener eventCollector,
+      final String flowName) throws Exception {
+    return createFromFlowFile(flowName, eventCollector, new ExecutionOptions());
+  }
+
+  public FlowRunner createFromFlowFile(final String flowName,
+      final EventCollectorListener eventCollector,
+      final ExecutionOptions options) throws Exception {
+    final ExecutableFlow exFlow = FlowRunnerTestUtil
+        .prepareExecDir(this.workingDir, this.projectDir, flowName, 1);
+    return createFromExecutableFlow(eventCollector, exFlow, options, new HashMap<>(), new Props());
+  }
+
+  public FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
+      final String flowName, final String jobIdPrefix) throws Exception {
+    return createFromFlowMap(eventCollector, flowName, jobIdPrefix,
+        new ExecutionOptions(), new Props());
+  }
+
+  public FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
+      final String flowName, final String jobIdPrefix, final ExecutionOptions options)
+      throws Exception {
+    return createFromFlowMap(eventCollector, flowName, jobIdPrefix,
+        options, new Props());
+  }
+
+  public FlowRunner createFromFlowMap(final String flowName,
+      final HashMap<String, String> flowParams) throws Exception {
+    return createFromFlowMap(null, flowName, null, flowParams, new Props());
+  }
+
+  public FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
+      final String flowName, final ExecutionOptions options,
+      final Map<String, String> flowParams, final Props azkabanProps)
+      throws Exception {
+    final Flow flow = this.flowMap.get(flowName);
+    final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    return createFromExecutableFlow(eventCollector, exFlow, options, flowParams, azkabanProps);
+  }
+
+  public FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
+      final String flowName, final FailureAction action)
+      throws Exception {
+    final ExecutionOptions options = new ExecutionOptions();
+    options.setFailureAction(action);
+    return createFromFlowMap(eventCollector, flowName, options, new HashMap<>(), new Props());
+  }
+
+  private FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
+      final String flowName, final String jobIdPrefix, final ExecutionOptions options,
+      final Props azkabanProps)
+      throws Exception {
+    final Map<String, String> flowParams = new HashMap<>();
+    flowParams.put(InteractiveTestJob.JOB_ID_PREFIX, jobIdPrefix);
+    return createFromFlowMap(eventCollector, flowName, options, flowParams, azkabanProps);
+  }
+
+  private FlowRunner createFromExecutableFlow(final EventCollectorListener eventCollector,
+      final ExecutableFlow exFlow, final ExecutionOptions options,
+      final Map<String, String> flowParams, final Props azkabanProps)
+      throws Exception {
+    final int exId = id++;
+    exFlow.setExecutionPath(this.workingDir.getPath());
+    exFlow.setExecutionId(exId);
+    if (options != null) {
+      exFlow.setExecutionOptions(options);
+    }
+    exFlow.getExecutionOptions().addAllFlowParameters(flowParams);
+    final FlowRunner runner =
+        new FlowRunner(exFlow, this.fakeExecutorLoader, mock(ProjectLoader.class),
+            this.jobtypeManager, azkabanProps, null);
+    if (eventCollector != null) {
+      runner.addListener(eventCollector);
+    }
+    return runner;
+  }
 }


### PR DESCRIPTION
This resolves most of issue #1433 _Remove code duplication in tests: createFlowRunner_.

The FlowWatcher tests are slightly different so I thought to leave them for later – can be done once this has been merged.