### PR TITLE
Flow 2.0 design - Convert AzkabanFlow to Flow. Load project YAML file.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -33,7 +33,7 @@ package azkaban;
 public class Constants {
 
   // Azkaban Flow Versions
-  public static final double VERSION_2_0 = 2.0;
+  public static final double AZKABAN_FLOW_VERSION_2_0 = 2.0;
 
   // Flow 2.0 file suffix
   public static final String PROJECT_FILE_SUFFIX = ".project";
@@ -68,8 +68,8 @@ public class Constants {
 
   public static class ConfigurationKeys {
 
-    // Configures Azkaban Flow Version
-    public static final String AZKABAN_FLOW_VERSION = "Azkaban-Flow-Version";
+    // Configures Azkaban Flow Version in project YAML file
+    public static final String AZKABAN_FLOW_VERSION = "azkaban-flow-version";
 
     // These properties are configurable through azkaban.properties
     public static final String AZKABAN_PID_FILENAME = "azkaban.pid.filename";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -33,15 +33,14 @@ package azkaban;
 public class Constants {
 
   // Azkaban Flow Versions
-  public static final String AZKABAN_FLOW_VERSION = "Azkaban-Flow-Version";
-  public static final Double VERSION_2_0 = 2.0;
+  public static final double VERSION_2_0 = 2.0;
 
   // Flow 2.0 file suffix
   public static final String PROJECT_FILE_SUFFIX = ".project";
   public static final String FLOW_FILE_SUFFIX = ".flow";
 
   // Flow 2.0 node type
-  public static final String NODE_TYPE_FLOW = "flow";
+  public static final String FLOW_NODE_TYPE = "flow";
 
   // Names and paths of various file names to configure Azkaban
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
@@ -68,6 +67,9 @@ public class Constants {
   public static final long DEFAULT_SCHEDULE_END_EPOCH_TIME = 2524608000000L;
 
   public static class ConfigurationKeys {
+
+    // Configures Azkaban Flow Version
+    public static final String AZKABAN_FLOW_VERSION = "Azkaban-Flow-Version";
 
     // These properties are configurable through azkaban.properties
     public static final String AZKABAN_PID_FILENAME = "azkaban.pid.filename";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -33,11 +33,15 @@ package azkaban;
 public class Constants {
 
   // Azkaban Flow Versions
-  public static final String AZKABAN_FLOW_VERSION_2_0 = "2.0";
+  public static final String AZKABAN_FLOW_VERSION = "Azkaban-Flow-Version";
+  public static final Double VERSION_2_0 = 2.0;
 
   // Flow 2.0 file suffix
   public static final String PROJECT_FILE_SUFFIX = ".project";
   public static final String FLOW_FILE_SUFFIX = ".flow";
+
+  // Flow 2.0 node type
+  public static final String NODE_TYPE_FLOW = "flow";
 
   // Names and paths of various file names to configure Azkaban
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -17,7 +17,6 @@
 package azkaban.flow;
 
 import azkaban.executor.mail.DefaultMailCreator;
-import azkaban.project.AzkabanFlow;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,8 +47,6 @@ public class Flow {
   private Map<String, Object> metadata = new HashMap<>();
 
   private boolean isLayedOut = false;
-
-  private AzkabanFlow azkabanFlow;
 
   public Flow(final String id) {
     this.id = id;
@@ -411,11 +408,4 @@ public class Flow {
     this.projectId = projectId;
   }
 
-  public AzkabanFlow getAzkabanFlow() {
-    return this.azkabanFlow;
-  }
-
-  public void setAzkabanFlow(final AzkabanFlow azkabanFlow) {
-    this.azkabanFlow = azkabanFlow;
-  }
 }

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanFlow.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanFlow.java
@@ -17,6 +17,7 @@
 
 package azkaban.project;
 
+import azkaban.Constants;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,7 +37,7 @@ public class AzkabanFlow extends AzkabanNode {
 
   private AzkabanFlow(final String name, final Props props,
       final Map<String, AzkabanNode> nodes, final List<String> dependsOn) {
-    super(name, props, dependsOn);
+    super(name, Constants.NODE_TYPE_FLOW, props, dependsOn);
     this.nodes = nodes;
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanFlow.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanFlow.java
@@ -37,7 +37,7 @@ public class AzkabanFlow extends AzkabanNode {
 
   private AzkabanFlow(final String name, final Props props,
       final Map<String, AzkabanNode> nodes, final List<String> dependsOn) {
-    super(name, Constants.NODE_TYPE_FLOW, props, dependsOn);
+    super(name, Constants.FLOW_NODE_TYPE, props, dependsOn);
     this.nodes = nodes;
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanJob.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanJob.java
@@ -28,16 +28,9 @@ import java.util.List;
  */
 public class AzkabanJob extends AzkabanNode {
 
-  private final String type;
-
   private AzkabanJob(final String name, final String type, final Props props,
       final List<String> dependsOn) {
-    super(name, props, dependsOn);
-    this.type = type;
-  }
-
-  public String getType() {
-    return this.type;
+    super(name, type, props, dependsOn);
   }
 
   public static class AzkabanJobBuilder {

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanNode.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanNode.java
@@ -28,17 +28,24 @@ import java.util.List;
 public abstract class AzkabanNode {
 
   protected final String name;
+  protected final String type;
   protected final Props props;
   protected final List<String> dependsOn;
 
-  public AzkabanNode(final String name, final Props props, final List<String> dependsOn) {
+  public AzkabanNode(final String name, final String type, final Props props, final List<String>
+      dependsOn) {
     this.name = requireNonNull(name);
+    this.type = requireNonNull(type);
     this.props = requireNonNull(props);
     this.dependsOn = dependsOn;
   }
 
   public String getName() {
     return this.name;
+  }
+
+  public String getType() {
+    return this.type;
   }
 
   public Props getProps() {

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -193,9 +193,9 @@ class AzkabanProjectLoader {
 
       this.storageManager.uploadProject(project, newVersion, archive, uploader);
 
-      log.info("Uploading flow to db " + archive.getName());
+      log.info("Uploading flow to db for project " + archive.getName());
       this.projectLoader.uploadFlows(project, newVersion, flows.values());
-      log.info("Changing project versions " + archive.getName());
+      log.info("Changing project versions for project " + archive.getName());
       this.projectLoader.changeProjectVersion(project, newVersion,
           uploader.getUserId());
       project.setFlows(flows);

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -83,6 +83,7 @@ public class DirectoryFlowLoader implements FlowLoader {
    *
    * @return Map of flow name to Flow.
    */
+  @Override
   public Map<String, Flow> getFlowMap() {
     return this.flowMap;
   }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -138,7 +138,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     final Node node = new Node(azkabanNode.getName());
     node.setType(azkabanNode.getType());
 
-    if (azkabanNode.getType().equals(Constants.NODE_TYPE_FLOW)) {
+    if (azkabanNode.getType().equals(Constants.FLOW_NODE_TYPE)) {
       node.setEmbeddedFlowId(azkabanNode.getName());
       final Flow flow_node = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode);
       this.flowMap.put(flow_node.getId(), flow_node);

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -17,14 +17,18 @@
 package azkaban.project;
 
 import azkaban.Constants;
+import azkaban.flow.Edge;
 import azkaban.flow.Flow;
+import azkaban.flow.Node;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -40,6 +44,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   private final Props props;
   private final Set<String> errors = new HashSet<>();
   private final Map<String, Flow> flowMap = new HashMap<>();
+  private final Map<String, List<Edge>> edgeMap = new HashMap<>();
 
   /**
    * Creates a new DirectoryYamlFlowLoader.
@@ -55,6 +60,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
    *
    * @return Map of flow name to Flow.
    */
+  @Override
   public Map<String, Flow> getFlowMap() {
     return this.flowMap;
   }
@@ -66,6 +72,15 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
    */
   public Set<String> getErrors() {
     return this.errors;
+  }
+
+  /**
+   * Returns the edge map constructed from the loaded flows.
+   *
+   * @return Map of flow name to all its Edges.
+   */
+  public Map<String, List<Edge>> getEdgeMap() {
+    return this.edgeMap;
   }
 
   /**
@@ -83,7 +98,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   }
 
   private void convertYamlFiles(final File projectDir) {
-    // Todo jamiesjc: convert project yaml file. It will contain properties for all flows.
+    // Todo jamiesjc: convert project yaml file.
 
     final File[] flowFiles = projectDir.listFiles(new SuffixFilter(Constants.FLOW_FILE_SUFFIX));
     for (final File file : flowFiles) {
@@ -91,14 +106,84 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
       try {
         final NodeBean nodeBean = loader.load(file);
         final AzkabanFlow azkabanFlow = (AzkabanFlow) loader.toAzkabanNode(nodeBean);
-        final Flow flow = new Flow(azkabanFlow.getName());
-        flow.setAzkabanFlow(azkabanFlow);
-        this.flowMap.put(azkabanFlow.getName(), flow);
-        final Props flowProps = azkabanFlow.getProps();
-        FlowLoaderUtils.addEmailPropsToFlow(flow, flowProps);
+        final Flow flow = convertAzkabanFlowToFlow(azkabanFlow);
+        this.flowMap.put(flow.getId(), flow);
       } catch (final FileNotFoundException e) {
         logger.error("Error loading flow yaml files", e);
       }
+    }
+  }
+
+  private Flow convertAzkabanFlowToFlow(final AzkabanFlow azkabanFlow) {
+    final Flow flow = new Flow(azkabanFlow.getName());
+    final Props props = azkabanFlow.getProps();
+    FlowLoaderUtils.addEmailPropsToFlow(flow, props);
+
+    // Convert azkabanNodes to nodes inside the flow.
+    azkabanFlow.getNodes().values().stream().map(this::convertAzkabanNodeToNode)
+        .forEach(n -> flow.addNode(n));
+
+    // Add edges for the flow.
+    buildFlowEdges(azkabanFlow);
+    flow.addAllEdges(this.edgeMap.get(flow.getId()));
+
+    // Todo jamiesjc: deprecate startNodes, endNodes and numLevels, and remove below method finally.
+    // Blow method will construct startNodes, endNodes and numLevels for the flow.
+    flow.initialize();
+
+    return flow;
+  }
+
+  private Node convertAzkabanNodeToNode(final AzkabanNode azkabanNode) {
+    final Node node = new Node(azkabanNode.getName());
+    node.setType(azkabanNode.getType());
+
+    if (azkabanNode.getType().equals(Constants.NODE_TYPE_FLOW)) {
+      node.setEmbeddedFlowId(azkabanNode.getName());
+      final Flow flow_node = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode);
+      this.flowMap.put(flow_node.getId(), flow_node);
+    }
+    return node;
+  }
+
+  private void buildFlowEdges(final AzkabanFlow azkabanFlow) {
+    // Recursive stack to record searched nodes. Used for detecting dependency cycles.
+    final HashSet<String> recStack = new HashSet<>();
+    // Nodes that have already been visited and added edges.
+    final HashSet<String> visited = new HashSet<>();
+    for (final AzkabanNode node : azkabanFlow.getNodes().values()) {
+      addEdges(node, azkabanFlow, recStack, visited);
+    }
+  }
+
+  private void addEdges(final AzkabanNode node, final AzkabanFlow azkabanFlow,
+      final HashSet<String> recStack, final HashSet<String> visited) {
+    if (!visited.contains(node.getName())) {
+      recStack.add(node.getName());
+      visited.add(node.getName());
+      final List<String> dependsOnList = node.getDependsOn();
+      for (final String parent : dependsOnList) {
+        final Edge edge = new Edge(parent, node.getName());
+        if (!this.edgeMap.containsKey(azkabanFlow.getName())) {
+          this.edgeMap.put(azkabanFlow.getName(), new ArrayList<>());
+        }
+        this.edgeMap.get(azkabanFlow.getName()).add(edge);
+
+        if (recStack.contains(parent)) {
+          // Cycles found, including self cycle.
+          edge.setError("Cycles found.");
+          this.errors.add("Cycles found at " + edge.getId());
+        } else if (!azkabanFlow.getNodes().containsKey(parent)) {
+          // Dependency not found.
+          edge.setError("Dependency not found.");
+          this.errors.add(node.getName() + " cannot find dependency "
+              + parent);
+        } else {
+          // Valid edge. Continue to process the parent node recursively.
+          addEdges(azkabanFlow.getNode(parent), azkabanFlow, recStack, visited);
+        }
+      }
+      recStack.remove(node.getName());
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoader.java
@@ -16,8 +16,10 @@
 
 package azkaban.project;
 
+import azkaban.flow.Flow;
 import azkaban.project.validator.ValidationReport;
 import java.io.File;
+import java.util.Map;
 
 /**
  * Interface to load project flows.
@@ -32,4 +34,11 @@ public interface FlowLoader {
    * @return the validation report.
    */
   ValidationReport loadProjectFlow(final Project project, final File projectDir);
+
+  /**
+   * Returns the flow map constructed from the loaded flows.
+   *
+   * @return Map of flow name to Flow.
+   */
+  Map<String, Flow> getFlowMap();
 }

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
@@ -75,7 +75,8 @@ public class FlowLoaderFactory {
         throw new ProjectManagerException("Error reading project YAML file.", e);
       }
 
-      if (!azkabanProject.containsKey(Constants.ConfigurationKeys.AZKABAN_FLOW_VERSION)) {
+      if (azkabanProject == null || !azkabanProject
+          .containsKey(Constants.ConfigurationKeys.AZKABAN_FLOW_VERSION)) {
         throw new ProjectManagerException("azkaban-flow-version is not specified in the project "
             + "YAML file.");
       }

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
@@ -19,9 +19,14 @@ package azkaban.project;
 import static java.util.Objects.requireNonNull;
 
 import azkaban.Constants;
+import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.utils.Props;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Map;
 import javax.inject.Inject;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * Factory class to generate flow loaders.
@@ -41,21 +46,41 @@ public class FlowLoaderFactory {
   }
 
   /**
-   * Creates flow loader based on manifest file inside project directory.
+   * Creates flow loader based on project YAML file inside project directory.
    *
    * @param projectDir the project directory
    * @return the flow loader
    */
   public FlowLoader createFlowLoader(final File projectDir) throws ProjectManagerException {
-    // Todo jamiesjc: need to check if manifest file exists in project directory,
-    // and create FlowLoader based on different flow versions specified in the manifest file.
-    final String flowVersion = null;
-    if (flowVersion == null) {
-      return new DirectoryFlowLoader(this.props);
-    } else if (flowVersion.equals(Constants.AZKABAN_FLOW_VERSION_2_0)) {
-      return new DirectoryYamlFlowLoader(this.props);
+
+    final File[] projectFileList = projectDir.listFiles(new SuffixFilter(Constants
+        .PROJECT_FILE_SUFFIX));
+    if (projectFileList != null && projectFileList.length > 0) {
+      if (projectFileList.length > 1) {
+        throw new ProjectManagerException("Duplicate project YAML files found in the project "
+            + "directory. Only one is allowed.");
+      }
+
+      final Map<String, Object> projectYamlParser;
+      try {
+        projectYamlParser = (Map<String, Object>) new Yaml()
+            .load(new FileInputStream(projectFileList[0]));
+      } catch (final FileNotFoundException e) {
+        throw new ProjectManagerException("Error reading project YAML file.", e);
+      }
+
+      if (!projectYamlParser.containsKey(Constants.AZKABAN_FLOW_VERSION)) {
+        throw new ProjectManagerException("Azkaban-Flow-Version is not specified in the project "
+            + "YAML file.");
+      }
+
+      if (projectYamlParser.get(Constants.AZKABAN_FLOW_VERSION).equals(Constants.VERSION_2_0)) {
+        return new DirectoryYamlFlowLoader(this.props);
+      } else {
+        throw new ProjectManagerException("Invalid Azkaban-Flow-Version in the project YAML file.");
+      }
     } else {
-      throw new ProjectManagerException("Flow version " + flowVersion + "is invalid.");
+      return new DirectoryFlowLoader(this.props);
     }
   }
 }

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderFactory.java
@@ -69,12 +69,13 @@ public class FlowLoaderFactory {
         throw new ProjectManagerException("Error reading project YAML file.", e);
       }
 
-      if (!projectYamlParser.containsKey(Constants.AZKABAN_FLOW_VERSION)) {
+      if (!projectYamlParser.containsKey(Constants.ConfigurationKeys.AZKABAN_FLOW_VERSION)) {
         throw new ProjectManagerException("Azkaban-Flow-Version is not specified in the project "
             + "YAML file.");
       }
 
-      if (projectYamlParser.get(Constants.AZKABAN_FLOW_VERSION).equals(Constants.VERSION_2_0)) {
+      if (projectYamlParser.get(Constants.ConfigurationKeys.AZKABAN_FLOW_VERSION).equals
+          (Constants.VERSION_2_0)) {
         return new DirectoryYamlFlowLoader(this.props);
       } else {
         throw new ProjectManagerException("Invalid Azkaban-Flow-Version in the project YAML file.");

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -36,6 +36,7 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String MULTIPLE_FLOW_YAML_DIR = "multipleflowyamltest";
   private static final String EMBEDDED_FLOW_YAML_DIR = "embeddedflowyamltest";
   private static final String INVALID_FLOW_YAML_DIR = "invalidflowyamltest";
+  private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
   private static final String EMBEDDED_FLOW = "embedded_flow";
@@ -88,6 +89,13 @@ public class DirectoryYamlFlowLoaderTest {
     checkFlowProperties(loader, INVALID_FLOW_1, 1, 3, 3, DEPENDENCY_NOT_FOUND_ERROR);
     // Invalid flow 2: Cycles found.
     checkFlowProperties(loader, INVALID_FLOW_2, 1, 4, 4, CYCLE_FOUND_ERROR);
+  }
+
+  @Test
+  public void testLoadNoFlowYamlFile() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(NO_FLOW_YAML_DIR));
+    checkFlowLoaderProperties(loader, 0, 0, 0);
   }
 
   private void checkFlowLoaderProperties(final DirectoryYamlFlowLoader loader, final int numError,

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -16,19 +16,34 @@
 
 package azkaban.project;
 
+import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DirectoryYamlFlowLoaderTest {
 
+  private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoaderTest
+      .class);
+
   private static final String BASIC_FLOW_YAML_DIR = "basicflowyamltest";
   private static final String MULTIPLE_FLOW_YAML_DIR = "multipleflowyamltest";
-  private static final String FLOW_NAME_1 = "basic_flow";
-  private static final String FLOW_NAME_2 = "basic_flow2";
+  private static final String EMBEDDED_FLOW_YAML_DIR = "embeddedflowyamltest";
+  private static final String INVALID_FLOW_YAML_DIR = "invalidflowyamltest";
+  private static final String BASIC_FLOW_1 = "basic_flow";
+  private static final String BASIC_FLOW_2 = "basic_flow2";
+  private static final String EMBEDDED_FLOW = "embedded_flow";
+  private static final String EMBEDDED_FLOW_1 = "embedded_flow1";
+  private static final String EMBEDDED_FLOW_2 = "embedded_flow2";
+  private static final String INVALID_FLOW_1 = "dependency_not_found";
+  private static final String INVALID_FLOW_2 = "cycle_found";
+  private static final String DEPENDENCY_NOT_FOUND_ERROR = "Dependency not found.";
+  private static final String CYCLE_FOUND_ERROR = "Cycles found.";
   private Project project;
 
   @Before
@@ -37,31 +52,136 @@ public class DirectoryYamlFlowLoaderTest {
   }
 
   @Test
-  public void testLoadYamlFileFromDirectory() {
+  public void testLoadBasicYamlFile() {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(BASIC_FLOW_YAML_DIR));
     Assert.assertEquals(0, loader.getErrors().size());
     Assert.assertEquals(1, loader.getFlowMap().size());
-    Assert.assertTrue(loader.getFlowMap().containsKey(FLOW_NAME_1));
-    final Flow flow = loader.getFlowMap().get(FLOW_NAME_1);
-    final AzkabanFlow azkabanFlow = flow.getAzkabanFlow();
-    Assert.assertEquals(FLOW_NAME_1, azkabanFlow.getName());
-    Assert.assertEquals(4, azkabanFlow.getNodes().size());
+    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_1));
+    final Flow flow = loader.getFlowMap().get(BASIC_FLOW_1);
+
+    Assert.assertEquals(4, flow.getNodes().size());
+
+    Assert.assertEquals(1, loader.getEdgeMap().size());
+    Assert.assertEquals(3, loader.getEdgeMap().get(BASIC_FLOW_1).size());
+    Assert.assertEquals(3, flow.getEdges().size());
+    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_1)) {
+      this.logger.info(BASIC_FLOW_1 + " has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
   }
 
   @Test
-  public void testLoadMultipleYamlFilesFromDirectory() {
+  public void testLoadMultipleYamlFiles() {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(MULTIPLE_FLOW_YAML_DIR));
     Assert.assertEquals(0, loader.getErrors().size());
     Assert.assertEquals(2, loader.getFlowMap().size());
-    Assert.assertTrue(loader.getFlowMap().containsKey(FLOW_NAME_1));
-    Assert.assertTrue(loader.getFlowMap().containsKey(FLOW_NAME_2));
-    final Flow flow2 = loader.getFlowMap().get(FLOW_NAME_2);
-    final AzkabanFlow azkabanFlow2 = flow2.getAzkabanFlow();
-    Assert.assertEquals(FLOW_NAME_2, azkabanFlow2.getName());
-    Assert.assertEquals(3, azkabanFlow2.getNodes().size());
+    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_1));
+    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_2));
+    final Flow flow2 = loader.getFlowMap().get(BASIC_FLOW_2);
+    Assert.assertEquals(3, flow2.getNodes().size());
+
+    // Verify flow edges
+    Assert.assertEquals(2, loader.getEdgeMap().size());
+    Assert.assertEquals(3, loader.getEdgeMap().get(BASIC_FLOW_1).size());
+    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_1)) {
+      this.logger.info(BASIC_FLOW_1 + ".flow has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
+
+    Assert.assertEquals(2, loader.getEdgeMap().get(BASIC_FLOW_2).size());
+    Assert.assertEquals(2, flow2.getEdges().size());
+    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_2)) {
+      this.logger.info(BASIC_FLOW_2 + ".flow has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
+  }
+
+  @Test
+  public void testLoadEmbeddedFlowYamlFile() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(EMBEDDED_FLOW_YAML_DIR));
+    Assert.assertEquals(0, loader.getErrors().size());
+    Assert.assertEquals(3, loader.getFlowMap().size());
+    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW));
+    final Flow flow = loader.getFlowMap().get(EMBEDDED_FLOW);
+    Assert.assertEquals(4, flow.getNodes().size());
+
+    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW_1));
+    final Flow flow1 = loader.getFlowMap().get(EMBEDDED_FLOW_1);
+    Assert.assertEquals(4, flow1.getNodes().size());
+
+    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW_2));
+    final Flow flow2 = loader.getFlowMap().get(EMBEDDED_FLOW_2);
+    Assert.assertEquals(2, flow2.getNodes().size());
+
+    // Verify flow edges
+    Assert.assertEquals(3, loader.getEdgeMap().size());
+    Assert.assertEquals(3, loader.getEdgeMap().get(EMBEDDED_FLOW).size());
+    Assert.assertEquals(3, flow.getEdges().size());
+    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW)) {
+      this.logger
+          .info(EMBEDDED_FLOW + ".flow has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
+
+    Assert.assertEquals(3, loader.getEdgeMap().get(EMBEDDED_FLOW_1).size());
+    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW_1)) {
+      this.logger.info(
+          EMBEDDED_FLOW_1 + ".flow has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
+
+    Assert.assertEquals(1, loader.getEdgeMap().get(EMBEDDED_FLOW_2).size());
+    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW_2)) {
+      this.logger.info(EMBEDDED_FLOW_2 + ".flow has edge: " + edge.getId());
+      Assert.assertNull(edge.getError());
+    }
+  }
+
+  @Test
+  public void testLoadInvalidFlowYamlFiles() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(INVALID_FLOW_YAML_DIR));
+    Assert.assertEquals(2, loader.getErrors().size());
+    Assert.assertEquals(2, loader.getFlowMap().size());
+    Assert.assertEquals(2, loader.getEdgeMap().size());
+
+    // Invalid flow 1: Dependency not found.
+    Assert.assertTrue(loader.getFlowMap().containsKey(INVALID_FLOW_1));
+    final Flow flow1 = loader.getFlowMap().get(INVALID_FLOW_1);
+
+    Assert.assertEquals(3, flow1.getNodes().size());
+    Assert.assertEquals(1, flow1.getErrors().size());
+
+    Assert.assertEquals(3, loader.getEdgeMap().get(INVALID_FLOW_1).size());
+    Assert.assertEquals(3, flow1.getEdges().size());
+    for (final Edge edge : loader.getEdgeMap().get(INVALID_FLOW_1)) {
+      this.logger.info(INVALID_FLOW_1 + ".flow has edge: " + edge.getId());
+      if (edge.getError() != null) {
+        Assert.assertEquals(DEPENDENCY_NOT_FOUND_ERROR, edge.getError());
+      }
+    }
+
+    // Invalid flow 2: Cycles found.
+    Assert.assertTrue(loader.getFlowMap().containsKey(INVALID_FLOW_2));
+    final Flow flow2 = loader.getFlowMap().get(INVALID_FLOW_2);
+
+    Assert.assertEquals(4, flow2.getNodes().size());
+    Assert.assertEquals(1, flow2.getErrors().size());
+
+    Assert.assertEquals(4, loader.getEdgeMap().get(INVALID_FLOW_2).size());
+    Assert.assertEquals(4, flow2.getEdges().size());
+    for (final Edge edge : loader.getEdgeMap().get(INVALID_FLOW_2)) {
+      this.logger.info(INVALID_FLOW_2 + ".flow has edge: " + edge.getId());
+      if (edge.getError() != null) {
+        Assert.assertEquals(CYCLE_FOUND_ERROR, edge.getError());
+      }
+    }
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -16,11 +16,12 @@
 
 package azkaban.project;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -56,20 +57,14 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(BASIC_FLOW_YAML_DIR));
-    Assert.assertEquals(0, loader.getErrors().size());
-    Assert.assertEquals(1, loader.getFlowMap().size());
-    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_1));
+    assertThat(loader.getErrors().size()).isEqualTo(0);
+    assertThat(loader.getFlowMap().size()).isEqualTo(1);
+    assertThat(loader.getFlowMap().containsKey(BASIC_FLOW_1)).isTrue();
     final Flow flow = loader.getFlowMap().get(BASIC_FLOW_1);
 
-    Assert.assertEquals(4, flow.getNodes().size());
-
-    Assert.assertEquals(1, loader.getEdgeMap().size());
-    Assert.assertEquals(3, loader.getEdgeMap().get(BASIC_FLOW_1).size());
-    Assert.assertEquals(3, flow.getEdges().size());
-    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_1)) {
-      this.logger.info(BASIC_FLOW_1 + " has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
+    assertThat(flow.getNodes().size()).isEqualTo(4);
+    assertThat(loader.getEdgeMap().size()).isEqualTo(1);
+    assertFlowEdgeNoError(loader, flow, 3, BASIC_FLOW_1);
   }
 
   @Test
@@ -77,27 +72,19 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(MULTIPLE_FLOW_YAML_DIR));
-    Assert.assertEquals(0, loader.getErrors().size());
-    Assert.assertEquals(2, loader.getFlowMap().size());
-    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_1));
-    Assert.assertTrue(loader.getFlowMap().containsKey(BASIC_FLOW_2));
+    assertThat(loader.getErrors().size()).isEqualTo(0);
+    assertThat(loader.getFlowMap().size()).isEqualTo(2);
+    assertThat(loader.getFlowMap().containsKey(BASIC_FLOW_1)).isTrue();
+    assertThat(loader.getFlowMap().containsKey(BASIC_FLOW_2)).isTrue();
+
+    final Flow flow1 = loader.getFlowMap().get(BASIC_FLOW_1);
     final Flow flow2 = loader.getFlowMap().get(BASIC_FLOW_2);
-    Assert.assertEquals(3, flow2.getNodes().size());
+    assertThat(flow2.getNodes().size()).isEqualTo(3);
 
     // Verify flow edges
-    Assert.assertEquals(2, loader.getEdgeMap().size());
-    Assert.assertEquals(3, loader.getEdgeMap().get(BASIC_FLOW_1).size());
-    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_1)) {
-      this.logger.info(BASIC_FLOW_1 + ".flow has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
-
-    Assert.assertEquals(2, loader.getEdgeMap().get(BASIC_FLOW_2).size());
-    Assert.assertEquals(2, flow2.getEdges().size());
-    for (final Edge edge : loader.getEdgeMap().get(BASIC_FLOW_2)) {
-      this.logger.info(BASIC_FLOW_2 + ".flow has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
+    assertThat(loader.getEdgeMap().size()).isEqualTo(2);
+    assertFlowEdgeNoError(loader, flow1, 3, BASIC_FLOW_1);
+    assertFlowEdgeNoError(loader, flow2, 2, BASIC_FLOW_2);
   }
 
   @Test
@@ -105,42 +92,26 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(EMBEDDED_FLOW_YAML_DIR));
-    Assert.assertEquals(0, loader.getErrors().size());
-    Assert.assertEquals(3, loader.getFlowMap().size());
-    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW));
+    assertThat(loader.getErrors().size()).isEqualTo(0);
+    assertThat(loader.getFlowMap().size()).isEqualTo(3);
+    assertThat(loader.getFlowMap().containsKey(EMBEDDED_FLOW)).isTrue();
+
     final Flow flow = loader.getFlowMap().get(EMBEDDED_FLOW);
-    Assert.assertEquals(4, flow.getNodes().size());
+    assertThat(flow.getNodes().size()).isEqualTo(4);
 
-    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW_1));
+    assertThat(loader.getFlowMap().containsKey(EMBEDDED_FLOW_1)).isTrue();
     final Flow flow1 = loader.getFlowMap().get(EMBEDDED_FLOW_1);
-    Assert.assertEquals(4, flow1.getNodes().size());
+    assertThat(flow1.getNodes().size()).isEqualTo(4);
 
-    Assert.assertTrue(loader.getFlowMap().containsKey(EMBEDDED_FLOW_2));
+    assertThat(loader.getFlowMap().containsKey(EMBEDDED_FLOW_2)).isTrue();
     final Flow flow2 = loader.getFlowMap().get(EMBEDDED_FLOW_2);
-    Assert.assertEquals(2, flow2.getNodes().size());
+    assertThat(flow2.getNodes().size()).isEqualTo(2);
 
     // Verify flow edges
-    Assert.assertEquals(3, loader.getEdgeMap().size());
-    Assert.assertEquals(3, loader.getEdgeMap().get(EMBEDDED_FLOW).size());
-    Assert.assertEquals(3, flow.getEdges().size());
-    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW)) {
-      this.logger
-          .info(EMBEDDED_FLOW + ".flow has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
-
-    Assert.assertEquals(3, loader.getEdgeMap().get(EMBEDDED_FLOW_1).size());
-    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW_1)) {
-      this.logger.info(
-          EMBEDDED_FLOW_1 + ".flow has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
-
-    Assert.assertEquals(1, loader.getEdgeMap().get(EMBEDDED_FLOW_2).size());
-    for (final Edge edge : loader.getEdgeMap().get(EMBEDDED_FLOW_2)) {
-      this.logger.info(EMBEDDED_FLOW_2 + ".flow has edge: " + edge.getId());
-      Assert.assertNull(edge.getError());
-    }
+    assertThat(loader.getEdgeMap().size()).isEqualTo(3);
+    assertFlowEdgeNoError(loader, flow, 3, EMBEDDED_FLOW);
+    assertFlowEdgeNoError(loader, flow1, 3, EMBEDDED_FLOW_1);
+    assertFlowEdgeNoError(loader, flow2, 1, EMBEDDED_FLOW_2);
   }
 
   @Test
@@ -148,39 +119,47 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
 
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(INVALID_FLOW_YAML_DIR));
-    Assert.assertEquals(2, loader.getErrors().size());
-    Assert.assertEquals(2, loader.getFlowMap().size());
-    Assert.assertEquals(2, loader.getEdgeMap().size());
+    assertThat(loader.getErrors().size()).isEqualTo(2);
+    assertThat(loader.getFlowMap().size()).isEqualTo(2);
+    assertThat(loader.getEdgeMap().size()).isEqualTo(2);
 
     // Invalid flow 1: Dependency not found.
-    Assert.assertTrue(loader.getFlowMap().containsKey(INVALID_FLOW_1));
+    assertThat(loader.getFlowMap().containsKey(INVALID_FLOW_1)).isTrue();
     final Flow flow1 = loader.getFlowMap().get(INVALID_FLOW_1);
 
-    Assert.assertEquals(3, flow1.getNodes().size());
-    Assert.assertEquals(1, flow1.getErrors().size());
-
-    Assert.assertEquals(3, loader.getEdgeMap().get(INVALID_FLOW_1).size());
-    Assert.assertEquals(3, flow1.getEdges().size());
-    for (final Edge edge : loader.getEdgeMap().get(INVALID_FLOW_1)) {
-      this.logger.info(INVALID_FLOW_1 + ".flow has edge: " + edge.getId());
-      if (edge.getError() != null) {
-        Assert.assertEquals(DEPENDENCY_NOT_FOUND_ERROR, edge.getError());
-      }
-    }
+    assertThat(flow1.getNodes().size()).isEqualTo(3);
+    assertThat(flow1.getErrors().size()).isEqualTo(1);
+    assertFlowEdgeHasError(loader, flow1, 3, INVALID_FLOW_1, DEPENDENCY_NOT_FOUND_ERROR);
 
     // Invalid flow 2: Cycles found.
-    Assert.assertTrue(loader.getFlowMap().containsKey(INVALID_FLOW_2));
+    assertThat(loader.getFlowMap().containsKey(INVALID_FLOW_2)).isTrue();
     final Flow flow2 = loader.getFlowMap().get(INVALID_FLOW_2);
 
-    Assert.assertEquals(4, flow2.getNodes().size());
-    Assert.assertEquals(1, flow2.getErrors().size());
+    assertThat(flow2.getNodes().size()).isEqualTo(4);
+    assertThat(flow2.getErrors().size()).isEqualTo(1);
+    assertFlowEdgeHasError(loader, flow2, 4, INVALID_FLOW_2, CYCLE_FOUND_ERROR);
+  }
 
-    Assert.assertEquals(4, loader.getEdgeMap().get(INVALID_FLOW_2).size());
-    Assert.assertEquals(4, flow2.getEdges().size());
-    for (final Edge edge : loader.getEdgeMap().get(INVALID_FLOW_2)) {
-      this.logger.info(INVALID_FLOW_2 + ".flow has edge: " + edge.getId());
+  /* Helper method to verify there is no error in the flow edge. */
+  private void assertFlowEdgeNoError(final DirectoryYamlFlowLoader loader, final Flow flow,
+      final int num_edge, final String flow_name) {
+    assertThat(loader.getEdgeMap().get(flow_name).size()).isEqualTo(num_edge);
+    assertThat(flow.getEdges().size()).isEqualTo(num_edge);
+    for (final Edge edge : loader.getEdgeMap().get(flow_name)) {
+      this.logger.info(flow_name + ".flow has edge: " + edge.getId());
+      assertThat(edge.getError()).isNull();
+    }
+  }
+
+  /* Helper method to verify there is an error in the flow edge. */
+  private void assertFlowEdgeHasError(final DirectoryYamlFlowLoader loader, final Flow flow,
+      final int num_edge, final String flow_name, final String error) {
+    assertThat(loader.getEdgeMap().get(flow_name).size()).isEqualTo(num_edge);
+    assertThat(flow.getEdges().size()).isEqualTo(num_edge);
+    for (final Edge edge : loader.getEdgeMap().get(flow_name)) {
+      this.logger.info(flow_name + ".flow has edge: " + edge.getId());
       if (edge.getError() != null) {
-        Assert.assertEquals(CYCLE_FOUND_ERROR, edge.getError());
+        assertThat(edge.getError()).isEqualTo(error);
       }
     }
   }

--- a/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
@@ -63,6 +63,6 @@ public class FlowLoaderFactoryTest {
     final File projectDir = ExecutionsTestUtil.getFlowDir(INVALID_FLOW_VERSION_DIRECTORY);
     assertThatThrownBy(() -> loaderFactory.createFlowLoader(projectDir))
         .isInstanceOf(ProjectManagerException.class)
-        .hasMessageContaining("Invalid Azkaban-Flow-Version in the project YAML file.");
+        .hasMessageContaining("Invalid azkaban-flow-version in the project YAML file.");
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
@@ -16,10 +16,12 @@
 
 package azkaban.project;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import java.io.File;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class FlowLoaderFactoryTest {
@@ -34,7 +36,7 @@ public class FlowLoaderFactoryTest {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(FLOW_10_TEST_DIRECTORY);
     final FlowLoader loader = loaderFactory.createFlowLoader(projectDir);
-    Assert.assertTrue(loader instanceof DirectoryFlowLoader);
+    assertThat(loader instanceof DirectoryFlowLoader).isTrue();
   }
 
   @Test
@@ -42,20 +44,25 @@ public class FlowLoaderFactoryTest {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(FLOW_20_TEST_DIRECTORY);
     final FlowLoader loader = loaderFactory.createFlowLoader(projectDir);
-    Assert.assertTrue(loader instanceof DirectoryYamlFlowLoader);
+    assertThat(loader instanceof DirectoryYamlFlowLoader).isTrue();
   }
 
-  @Test(expected = ProjectManagerException.class)
+  @Test
   public void testDuplicateProjectYamlFilesException() {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(DUPLICATE_PROJECT_DIRECTORY);
-    loaderFactory.createFlowLoader(projectDir);
+    assertThatThrownBy(() -> loaderFactory.createFlowLoader(projectDir))
+        .isInstanceOf(ProjectManagerException.class)
+        .hasMessageContaining(
+            "Duplicate project YAML files found in the project directory. Only one is allowed.");
   }
 
-  @Test(expected = ProjectManagerException.class)
+  @Test
   public void testInvalidFlowVersionException() {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(INVALID_FLOW_VERSION_DIRECTORY);
-    loaderFactory.createFlowLoader(projectDir);
+    assertThatThrownBy(() -> loaderFactory.createFlowLoader(projectDir))
+        .isInstanceOf(ProjectManagerException.class)
+        .hasMessageContaining("Invalid Azkaban-Flow-Version in the project YAML file.");
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
@@ -30,6 +30,7 @@ public class FlowLoaderFactoryTest {
   private static final String FLOW_20_TEST_DIRECTORY = "basicflowyamltest";
   private static final String DUPLICATE_PROJECT_DIRECTORY = "duplicateprojectyamltest";
   private static final String INVALID_FLOW_VERSION_DIRECTORY = "invalidflowversiontest";
+  private static final String NO_FLOW_VERSION_DIRECTORY = "noflowversiontest";
 
   @Test
   public void testCreateDirectoryFlowLoader() {
@@ -55,6 +56,15 @@ public class FlowLoaderFactoryTest {
         .isInstanceOf(ProjectManagerException.class)
         .hasMessageContaining(
             "Duplicate project YAML files found in the project directory. Only one is allowed.");
+  }
+
+  @Test
+  public void testNoFlowVersionException() {
+    final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
+    final File projectDir = ExecutionsTestUtil.getFlowDir(NO_FLOW_VERSION_DIRECTORY);
+    assertThatThrownBy(() -> loaderFactory.createFlowLoader(projectDir))
+        .isInstanceOf(ProjectManagerException.class)
+        .hasMessageContaining("azkaban-flow-version is not specified in the project YAML file.");
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
@@ -20,20 +20,14 @@ import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import java.io.File;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FlowLoaderFactoryTest {
 
   private static final String FLOW_10_TEST_DIRECTORY = "exectest1";
   private static final String FLOW_20_TEST_DIRECTORY = "basicflowyamltest";
-  private Project project;
-
-  @Before
-  public void setUp() throws Exception {
-    this.project = new Project(13, "myTestProject");
-  }
+  private static final String DUPLICATE_PROJECT_DIRECTORY = "duplicateprojectyamltest";
+  private static final String INVALID_FLOW_VERSION_DIRECTORY = "invalidflowversiontest";
 
   @Test
   public void testCreateDirectoryFlowLoader() {
@@ -43,13 +37,25 @@ public class FlowLoaderFactoryTest {
     Assert.assertTrue(loader instanceof DirectoryFlowLoader);
   }
 
-  // Todo jamiesjc: add the manifest file with flow version 2.0 and enable this test
   @Test
-  @Ignore
   public void testCreateDirectoryYamlFlowLoader() {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(FLOW_20_TEST_DIRECTORY);
     final FlowLoader loader = loaderFactory.createFlowLoader(projectDir);
     Assert.assertTrue(loader instanceof DirectoryYamlFlowLoader);
+  }
+
+  @Test(expected = ProjectManagerException.class)
+  public void testDuplicateProjectYamlFilesException() {
+    final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
+    final File projectDir = ExecutionsTestUtil.getFlowDir(DUPLICATE_PROJECT_DIRECTORY);
+    loaderFactory.createFlowLoader(projectDir);
+  }
+
+  @Test(expected = ProjectManagerException.class)
+  public void testInvalidFlowVersionException() {
+    final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
+    final File projectDir = ExecutionsTestUtil.getFlowDir(INVALID_FLOW_VERSION_DIRECTORY);
+    loaderFactory.createFlowLoader(projectDir);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
@@ -19,6 +19,7 @@ package azkaban.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import azkaban.Constants;
 import azkaban.test.executions.ExecutionsTestUtil;
 import org.junit.Test;
 
@@ -41,7 +42,6 @@ public class NodeBeanLoaderTest {
   private static final String EMBEDDED_FLOW2 = "embedded_flow2";
   private static final String TYPE_NOOP = "noop";
   private static final String TYPE_COMMAND = "command";
-  private static final String TYPE_FLOW = "flow";
 
   @Test
   public void testLoadNodeBeanForBasicFlow() throws Exception {
@@ -51,7 +51,7 @@ public class NodeBeanLoaderTest {
         BASIC_FLOW_YML_TEST_DIR, BASIC_FLOW_YML_FILE));
 
     assertThat(nodeBean.getName()).isEqualTo(BASIC_FLOW_NAME);
-    assertThat(nodeBean.getType()).isEqualTo(TYPE_FLOW);
+    assertThat(nodeBean.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
     assertThat(nodeBean.getConfig().get(FLOW_CONFIG_KEY)).isEqualTo(FLOW_CONFIG_VALUE);
     assertThat(nodeBean.getNodes().size()).isEqualTo(4);
 
@@ -74,7 +74,7 @@ public class NodeBeanLoaderTest {
         EMBEDDED_FLOW_YML_TEST_DIR, EMBEDDED_FLOW_YML_FILE));
 
     assertThat(nodeBean.getName()).isEqualTo(EMBEDDED_FLOW_NAME);
-    assertThat(nodeBean.getType()).isEqualTo(TYPE_FLOW);
+    assertThat(nodeBean.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
     assertThat(nodeBean.getConfig().get(FLOW_CONFIG_KEY)).isEqualTo(FLOW_CONFIG_VALUE);
     assertThat(nodeBean.getNodes().size()).isEqualTo(4);
 
@@ -91,7 +91,7 @@ public class NodeBeanLoaderTest {
 
     final NodeBean node3 = nodeBean.getNodes().get(3);
     assertThat(node3.getName()).isEqualTo(EMBEDDED_FLOW1);
-    assertThat(node3.getType()).isEqualTo(TYPE_FLOW);
+    assertThat(node3.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
     assertThat(node3.getNodes().size()).isEqualTo(4);
 
     // Verify nodes in embedded_flow1 are loaded correctly.
@@ -103,7 +103,7 @@ public class NodeBeanLoaderTest {
 
     final NodeBean node3_2 = node3.getNodes().get(2);
     assertThat(node3_2.getName()).isEqualTo(EMBEDDED_FLOW2);
-    assertThat(node3_2.getType()).isEqualTo(TYPE_FLOW);
+    assertThat(node3_2.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
     assertThat(node3_2.getDependsOn()).contains(SHELL_BASH);
     assertThat(node3_2.getNodes().size()).isEqualTo(2);
 

--- a/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
@@ -51,7 +51,7 @@ public class NodeBeanLoaderTest {
         BASIC_FLOW_YML_TEST_DIR, BASIC_FLOW_YML_FILE));
 
     assertThat(nodeBean.getName()).isEqualTo(BASIC_FLOW_NAME);
-    assertThat(nodeBean.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
+    assertThat(nodeBean.getType()).isEqualTo(Constants.FLOW_NODE_TYPE);
     assertThat(nodeBean.getConfig().get(FLOW_CONFIG_KEY)).isEqualTo(FLOW_CONFIG_VALUE);
     assertThat(nodeBean.getNodes().size()).isEqualTo(4);
 
@@ -74,7 +74,7 @@ public class NodeBeanLoaderTest {
         EMBEDDED_FLOW_YML_TEST_DIR, EMBEDDED_FLOW_YML_FILE));
 
     assertThat(nodeBean.getName()).isEqualTo(EMBEDDED_FLOW_NAME);
-    assertThat(nodeBean.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
+    assertThat(nodeBean.getType()).isEqualTo(Constants.FLOW_NODE_TYPE);
     assertThat(nodeBean.getConfig().get(FLOW_CONFIG_KEY)).isEqualTo(FLOW_CONFIG_VALUE);
     assertThat(nodeBean.getNodes().size()).isEqualTo(4);
 
@@ -91,7 +91,7 @@ public class NodeBeanLoaderTest {
 
     final NodeBean node3 = nodeBean.getNodes().get(3);
     assertThat(node3.getName()).isEqualTo(EMBEDDED_FLOW1);
-    assertThat(node3.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
+    assertThat(node3.getType()).isEqualTo(Constants.FLOW_NODE_TYPE);
     assertThat(node3.getNodes().size()).isEqualTo(4);
 
     // Verify nodes in embedded_flow1 are loaded correctly.
@@ -103,7 +103,7 @@ public class NodeBeanLoaderTest {
 
     final NodeBean node3_2 = node3.getNodes().get(2);
     assertThat(node3_2.getName()).isEqualTo(EMBEDDED_FLOW2);
-    assertThat(node3_2.getType()).isEqualTo(Constants.NODE_TYPE_FLOW);
+    assertThat(node3_2.getType()).isEqualTo(Constants.FLOW_NODE_TYPE);
     assertThat(node3_2.getDependsOn()).contains(SHELL_BASH);
     assertThat(node3_2.getNodes().size()).isEqualTo(2);
 

--- a/test/execution-test-data/basicflowyamltest/basic_flow.project
+++ b/test/execution-test-data/basicflowyamltest/basic_flow.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/basicflowyamltest/basic_flow.project
+++ b/test/execution-test-data/basicflowyamltest/basic_flow.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/duplicateprojectyamltest/basic_flow.flow
+++ b/test/execution-test-data/duplicateprojectyamltest/basic_flow.flow
@@ -1,0 +1,41 @@
+---
+# All flow level properties here
+config:
+  flow-level-parameter: value
+
+# This section defines the list of jobs
+# A node can be a job or a flow
+# In this example, all nodes are jobs
+nodes:
+  # Job definition
+  # The job definition is like a YAMLified version of properties file
+  # with one major difference. All custom properties are now clubbed together
+  # in a config section in the definition.
+  # The first line describes the name of the job
+  - name: shell_end
+    # Describe the type of the job
+    type: noop
+
+    # List the dependencies of the job
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - shell_bash
+
+  - name: shell_echo
+    # Describe the type of the job
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    # Describe the type of the job
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_bash
+    # Describe the type of the job
+    type: command
+    config:
+      command: bash ./sample_script.sh

--- a/test/execution-test-data/duplicateprojectyamltest/basic_flow.project
+++ b/test/execution-test-data/duplicateprojectyamltest/basic_flow.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/duplicateprojectyamltest/basic_flow.project
+++ b/test/execution-test-data/duplicateprojectyamltest/basic_flow.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/duplicateprojectyamltest/basic_flow2.project
+++ b/test/execution-test-data/duplicateprojectyamltest/basic_flow2.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/duplicateprojectyamltest/basic_flow2.project
+++ b/test/execution-test-data/duplicateprojectyamltest/basic_flow2.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/embeddedflowyamltest/embedded_flow.project
+++ b/test/execution-test-data/embeddedflowyamltest/embedded_flow.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/embeddedflowyamltest/embedded_flow.project
+++ b/test/execution-test-data/embeddedflowyamltest/embedded_flow.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/invalidflowversiontest/basic_flow.flow
+++ b/test/execution-test-data/invalidflowversiontest/basic_flow.flow
@@ -1,0 +1,41 @@
+---
+# All flow level properties here
+config:
+  flow-level-parameter: value
+
+# This section defines the list of jobs
+# A node can be a job or a flow
+# In this example, all nodes are jobs
+nodes:
+  # Job definition
+  # The job definition is like a YAMLified version of properties file
+  # with one major difference. All custom properties are now clubbed together
+  # in a config section in the definition.
+  # The first line describes the name of the job
+  - name: shell_end
+    # Describe the type of the job
+    type: noop
+
+    # List the dependencies of the job
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - shell_bash
+
+  - name: shell_echo
+    # Describe the type of the job
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    # Describe the type of the job
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_bash
+    # Describe the type of the job
+    type: command
+    config:
+      command: bash ./sample_script.sh

--- a/test/execution-test-data/invalidflowversiontest/basic_flow.project
+++ b/test/execution-test-data/invalidflowversiontest/basic_flow.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 1.0

--- a/test/execution-test-data/invalidflowversiontest/basic_flow.project
+++ b/test/execution-test-data/invalidflowversiontest/basic_flow.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 1.0
+azkaban-flow-version: 1.0

--- a/test/execution-test-data/invalidflowyamltest/cycle_found.flow
+++ b/test/execution-test-data/invalidflowyamltest/cycle_found.flow
@@ -1,0 +1,30 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_echo
+
+  - name: shell_echo
+    type: command
+    dependsOn:
+      - shell_pwd
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    type: command
+    dependsOn:
+      - shell_bash
+    config:
+      command: pwd
+
+  - name: shell_bash
+    type: command
+    dependsOn:
+      - shell_echo
+    config:
+      command: bash ./sample_script.sh

--- a/test/execution-test-data/invalidflowyamltest/dependency_not_found.flow
+++ b/test/execution-test-data/invalidflowyamltest/dependency_not_found.flow
@@ -1,0 +1,21 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - shell_bash
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    type: command
+    config:
+      command: pwd

--- a/test/execution-test-data/invalidflowyamltest/invalid_flow.project
+++ b/test/execution-test-data/invalidflowyamltest/invalid_flow.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/invalidflowyamltest/invalid_flow.project
+++ b/test/execution-test-data/invalidflowyamltest/invalid_flow.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/multipleflowyamltest/multiple_flows.project
+++ b/test/execution-test-data/multipleflowyamltest/multiple_flows.project
@@ -1,0 +1,1 @@
+Azkaban-Flow-Version: 2.0

--- a/test/execution-test-data/multipleflowyamltest/multiple_flows.project
+++ b/test/execution-test-data/multipleflowyamltest/multiple_flows.project
@@ -1,1 +1,1 @@
-Azkaban-Flow-Version: 2.0
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/noflowversiontest/basic_flow.flow
+++ b/test/execution-test-data/noflowversiontest/basic_flow.flow
@@ -1,0 +1,41 @@
+---
+# All flow level properties here
+config:
+  flow-level-parameter: value
+
+# This section defines the list of jobs
+# A node can be a job or a flow
+# In this example, all nodes are jobs
+nodes:
+  # Job definition
+  # The job definition is like a YAMLified version of properties file
+  # with one major difference. All custom properties are now clubbed together
+  # in a config section in the definition.
+  # The first line describes the name of the job
+  - name: shell_end
+    # Describe the type of the job
+    type: noop
+
+    # List the dependencies of the job
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - shell_bash
+
+  - name: shell_echo
+    # Describe the type of the job
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    # Describe the type of the job
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_bash
+    # Describe the type of the job
+    type: command
+    config:
+      command: bash ./sample_script.sh

--- a/test/execution-test-data/noflowyamltest/no_flow.project
+++ b/test/execution-test-data/noflowyamltest/no_flow.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0


### PR DESCRIPTION
1. In Flow 2.0 design, we load project flows from flow YAML files and convert them to azkabanFlow objects. In order to display the flow graph in the UI correctly, we need to further convert azkabanFlow to Flow object with all the necessary parameters filled in, like nodes and edges. 
2. With the flow level definition, we don't need to rely on an endNode to resolve the DAG. The new design will be able to resolve the DAG even without an endNode.
3. Project YAML file is also introduced in the Flow 2.0 design. It contains azkaban flow version. Only when "Azkaban-Flow-Version: 2.0" is specified in the project YAML file, then we treat it as Flow 2.0 design. If the project YAML file does not exist, we just keep the current way of loading project flows from job and properties files.