### PR TITLE
propose bugfix for #1522

### DIFF
--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -155,7 +155,7 @@ public class PropsUtils {
     final Props resolvedProps = new Props();
 
     final LinkedHashSet<String> visitedVariables = new LinkedHashSet<>();
-    for (final String key : props.getKeySet()) {
+    for (final String key : props.getPublicKeySet()) {
       String value = props.get(key);
       if (value == null) {
         logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
@@ -170,7 +170,7 @@ public class PropsUtils {
       resolvedProps.put(key, replacedValue);
     }
 
-    for (final String key : resolvedProps.getKeySet()) {
+    for (final String key : resolvedProps.getPublicKeySet()) {
       final String value = resolvedProps.get(key);
       final String expressedValue = resolveVariableExpression(value);
       resolvedProps.put(key, expressedValue);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestNested.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestNested.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp;
+
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.Status;
+import azkaban.utils.Props;
+import azkaban.utils.PropsUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FlowRunnerTestNested extends FlowRunnerTestBase {
+
+  private FlowRunnerTestUtil testUtil;
+
+  @Before
+  public void setUp() throws Exception {
+    this.testUtil = new FlowRunnerTestUtil("execnested", this.temporaryFolder);
+  }
+
+  @Test
+  public void exec1Normal() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    final FlowRunner runner = this.testUtil.createFromFlowMap("main", flowProps);
+    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    createNodeMap(runner.getExecutableFlow(), nodeMap);
+    final ExecutableFlow flow = runner.getExecutableFlow();
+
+    FlowRunnerTestUtil.startThread(runner);
+    assertStatus(flow, "do-echo-a:echo", Status.RUNNING);
+
+    final Props echoAProps = PropsUtils.resolveProps(nodeMap.get("do-echo-a:echo").getInputProps());
+    Assert.assertEquals("hello world", echoAProps.get("foo"));
+    Assert.assertNull(echoAProps.get("foo.value"));
+
+    final Props echoBProps = PropsUtils.resolveProps(nodeMap.get("do-echo-b:echo").getInputProps());
+    Assert.assertEquals("foo bar", echoBProps.get("foo"));
+    Assert.assertNull(echoBProps.get("foo.value"));
+  }
+
+  private void createNodeMap(final ExecutableFlowBase flow,
+      final Map<String, ExecutableNode> nodeMap) {
+    for (final ExecutableNode node : flow.getExecutableNodes()) {
+      nodeMap.put(node.getNestedId(), node);
+
+      if (node instanceof ExecutableFlowBase) {
+        createNodeMap((ExecutableFlowBase) node, nodeMap);
+      }
+    }
+  }
+}

--- a/test/execution-test-data/execnested/common/echo.job
+++ b/test/execution-test-data/execnested/common/echo.job
@@ -1,0 +1,2 @@
+type=command
+command=echo ${foo}

--- a/test/execution-test-data/execnested/flow-a/default.properties
+++ b/test/execution-test-data/execnested/flow-a/default.properties
@@ -1,0 +1,1 @@
+foo.value=hello world

--- a/test/execution-test-data/execnested/flow-a/do-echo-a.job
+++ b/test/execution-test-data/execnested/flow-a/do-echo-a.job
@@ -1,0 +1,4 @@
+type=flow
+flow.name=echo
+
+foo=${foo.value}

--- a/test/execution-test-data/execnested/flow-b/default.properties
+++ b/test/execution-test-data/execnested/flow-b/default.properties
@@ -1,0 +1,1 @@
+foo.value=foo bar

--- a/test/execution-test-data/execnested/flow-b/do-echo-b.job
+++ b/test/execution-test-data/execnested/flow-b/do-echo-b.job
@@ -1,0 +1,4 @@
+type=flow
+flow.name=echo
+
+foo=${foo.value}

--- a/test/execution-test-data/execnested/main.job
+++ b/test/execution-test-data/execnested/main.job
@@ -1,0 +1,2 @@
+type=noop
+dependencies=do-echo-a,do-echo-b


### PR DESCRIPTION
This required more work than I expected.

Currently for nested flows we totally ignore `.properties` files, due to a `if (!(node instanceof ExecutableFlowBase))`; what we want to achieve instead is to use them when evaluating properties of the flow itself, but to ignore them in inner jobs.

The only way to achieve this is to introduce a level of "visibility" for properties: `.properties` files of a flow will be marked as private, and used only on the flow itself; for inner jobs they will be ignored thanks to the new implementation of `clone` and `resolveProps`.