### PR TITLE
Flow 2.0 design - Get props from flow YAML file.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -42,6 +42,9 @@ public class Constants {
   // Flow 2.0 node type
   public static final String FLOW_NODE_TYPE = "flow";
 
+  // Flow 2.0 flow and job path delimiter
+  public static final String PATH_DELIMITER = ":";
+
   // Names and paths of various file names to configure Azkaban
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
   public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -47,6 +47,7 @@ public class Flow {
   private Map<String, Object> metadata = new HashMap<>();
 
   private boolean isLayedOut = false;
+  private boolean isEmbeddedFlow = false;
 
   public Flow(final String id) {
     this.id = id;
@@ -57,10 +58,16 @@ public class Flow {
 
     final String id = (String) flowObject.get("id");
     final Boolean layedout = (Boolean) flowObject.get("layedout");
+    final Boolean isEmbeddedFlow = (Boolean) flowObject.get("embeddedFlow");
     final Flow flow = new Flow(id);
     if (layedout != null) {
       flow.setLayedOut(layedout);
     }
+
+    if (isEmbeddedFlow != null) {
+      flow.setEmbeddedFlow(isEmbeddedFlow);
+    }
+
     final int projId = (Integer) flowObject.get("project.id");
     flow.setProjectId(projId);
 
@@ -320,6 +327,7 @@ public class Flow {
     flowObj.put("success.email", this.successEmail);
     flowObj.put("mailCreator", this.mailCreator);
     flowObj.put("layedout", this.isLayedOut);
+    flowObj.put("embeddedFlow", this.isEmbeddedFlow);
     if (this.errors != null) {
       flowObj.put("errors", this.errors);
     }
@@ -367,6 +375,14 @@ public class Flow {
 
   public void setLayedOut(final boolean layedOut) {
     this.isLayedOut = layedOut;
+  }
+
+  public boolean isEmbeddedFlow() {
+    return this.isEmbeddedFlow;
+  }
+
+  public void setEmbeddedFlow(final boolean embeddedFlow) {
+    this.isEmbeddedFlow = embeddedFlow;
   }
 
   public Map<String, Object> getMetadata() {

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -24,6 +24,7 @@ import azkaban.flow.Node;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.Props;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -121,9 +122,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     FlowLoaderUtils.addEmailPropsToFlow(flow, props);
     props.setSource(flowFile.getName());
 
-    final List<FlowProps> flowPropsList = new ArrayList<>();
-    flowPropsList.add(new FlowProps(props));
-    flow.addAllFlowProperties(flowPropsList);
+    flow.addAllFlowProperties(ImmutableList.of(new FlowProps(props)));
 
     // Convert azkabanNodes to nodes inside the flow.
     azkabanFlow.getNodes().values().stream()
@@ -151,10 +150,10 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     if (azkabanNode.getType().equals(Constants.FLOW_NODE_TYPE)) {
       final String embeddedFlowId = flowName + Constants.PATH_DELIMITER + node.getId();
       node.setEmbeddedFlowId(embeddedFlowId);
-      final Flow flow_node = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode, embeddedFlowId,
+      final Flow flowNode = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode, embeddedFlowId,
           flowFile);
-      flow_node.setEmbeddedFlow(true);
-      this.flowMap.put(flow_node.getId(), flow_node);
+      flowNode.setEmbeddedFlow(true);
+      this.flowMap.put(flowNode.getId(), flowNode);
     }
     return node;
   }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -19,6 +19,7 @@ package azkaban.project;
 import azkaban.Constants;
 import azkaban.flow.Edge;
 import azkaban.flow.Flow;
+import azkaban.flow.FlowProps;
 import azkaban.flow.Node;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
@@ -100,13 +101,12 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   private void convertYamlFiles(final File projectDir) {
     // Todo jamiesjc: convert project yaml file.
 
-    final File[] flowFiles = projectDir.listFiles(new SuffixFilter(Constants.FLOW_FILE_SUFFIX));
-    for (final File file : flowFiles) {
+    for (final File file : projectDir.listFiles(new SuffixFilter(Constants.FLOW_FILE_SUFFIX))) {
       final NodeBeanLoader loader = new NodeBeanLoader();
       try {
         final NodeBean nodeBean = loader.load(file);
         final AzkabanFlow azkabanFlow = (AzkabanFlow) loader.toAzkabanNode(nodeBean);
-        final Flow flow = convertAzkabanFlowToFlow(azkabanFlow);
+        final Flow flow = convertAzkabanFlowToFlow(azkabanFlow, azkabanFlow.getName(), file);
         this.flowMap.put(flow.getId(), flow);
       } catch (final FileNotFoundException e) {
         logger.error("Error loading flow yaml files", e);
@@ -114,18 +114,25 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     }
   }
 
-  private Flow convertAzkabanFlowToFlow(final AzkabanFlow azkabanFlow) {
-    final Flow flow = new Flow(azkabanFlow.getName());
+  private Flow convertAzkabanFlowToFlow(final AzkabanFlow azkabanFlow, final String flowName,
+      final File flowFile) {
+    final Flow flow = new Flow(flowName);
     final Props props = azkabanFlow.getProps();
     FlowLoaderUtils.addEmailPropsToFlow(flow, props);
+    props.setSource(flowFile.getName());
+
+    final List<FlowProps> flowPropsList = new ArrayList<>();
+    flowPropsList.add(new FlowProps(props));
+    flow.addAllFlowProperties(flowPropsList);
 
     // Convert azkabanNodes to nodes inside the flow.
-    azkabanFlow.getNodes().values().stream().map(this::convertAzkabanNodeToNode)
+    azkabanFlow.getNodes().values().stream()
+        .map(n -> convertAzkabanNodeToNode(n, flowName, flowFile))
         .forEach(n -> flow.addNode(n));
 
     // Add edges for the flow.
-    buildFlowEdges(azkabanFlow);
-    flow.addAllEdges(this.edgeMap.get(flow.getId()));
+    buildFlowEdges(azkabanFlow, flowName);
+    flow.addAllEdges(this.edgeMap.get(flowName));
 
     // Todo jamiesjc: deprecate startNodes, endNodes and numLevels, and remove below method finally.
     // Blow method will construct startNodes, endNodes and numLevels for the flow.
@@ -134,40 +141,46 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     return flow;
   }
 
-  private Node convertAzkabanNodeToNode(final AzkabanNode azkabanNode) {
+  private Node convertAzkabanNodeToNode(final AzkabanNode azkabanNode, final String flowName,
+      final File flowFile) {
     final Node node = new Node(azkabanNode.getName());
     node.setType(azkabanNode.getType());
+    node.setPropsSource(flowFile.getName());
+    node.setJobSource(flowFile.getName());
 
     if (azkabanNode.getType().equals(Constants.FLOW_NODE_TYPE)) {
-      node.setEmbeddedFlowId(azkabanNode.getName());
-      final Flow flow_node = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode);
+      final String embeddedFlowId = flowName + Constants.PATH_DELIMITER + node.getId();
+      node.setEmbeddedFlowId(embeddedFlowId);
+      final Flow flow_node = convertAzkabanFlowToFlow((AzkabanFlow) azkabanNode, embeddedFlowId,
+          flowFile);
+      flow_node.setEmbeddedFlow(true);
       this.flowMap.put(flow_node.getId(), flow_node);
     }
     return node;
   }
 
-  private void buildFlowEdges(final AzkabanFlow azkabanFlow) {
+  private void buildFlowEdges(final AzkabanFlow azkabanFlow, final String flowName) {
     // Recursive stack to record searched nodes. Used for detecting dependency cycles.
     final HashSet<String> recStack = new HashSet<>();
     // Nodes that have already been visited and added edges.
     final HashSet<String> visited = new HashSet<>();
     for (final AzkabanNode node : azkabanFlow.getNodes().values()) {
-      addEdges(node, azkabanFlow, recStack, visited);
+      addEdges(node, azkabanFlow, flowName, recStack, visited);
     }
   }
 
   private void addEdges(final AzkabanNode node, final AzkabanFlow azkabanFlow,
-      final HashSet<String> recStack, final HashSet<String> visited) {
+      final String flowName, final HashSet<String> recStack, final HashSet<String> visited) {
     if (!visited.contains(node.getName())) {
       recStack.add(node.getName());
       visited.add(node.getName());
       final List<String> dependsOnList = node.getDependsOn();
       for (final String parent : dependsOnList) {
         final Edge edge = new Edge(parent, node.getName());
-        if (!this.edgeMap.containsKey(azkabanFlow.getName())) {
-          this.edgeMap.put(azkabanFlow.getName(), new ArrayList<>());
+        if (!this.edgeMap.containsKey(flowName)) {
+          this.edgeMap.put(flowName, new ArrayList<>());
         }
-        this.edgeMap.get(azkabanFlow.getName()).add(edge);
+        this.edgeMap.get(flowName).add(edge);
 
         if (recStack.contains(parent)) {
           // Cycles found, including self cycle.
@@ -180,7 +193,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
               + parent);
         } else {
           // Valid edge. Continue to process the parent node recursively.
-          addEdges(azkabanFlow.getNode(parent), azkabanFlow, recStack, visited);
+          addEdges(azkabanFlow.getNode(parent), azkabanFlow, flowName, recStack, visited);
         }
       }
       recStack.remove(node.getName());

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -85,6 +85,10 @@ public class NodeBeanLoader {
     }
   }
 
+  public Props getNodeProps(final NodeBean nodeBean) {
+    return new Props(null, nodeBean.getConfig());
+  }
+
   public String getFlowName(final File flowFile) {
     checkArgument(flowFile.exists());
     checkArgument(flowFile.getName().endsWith(Constants.FLOW_FILE_SUFFIX));

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -18,6 +18,7 @@ package azkaban.project;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import azkaban.Constants;
 import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.test.executions.ExecutionsTestUtil;
@@ -35,13 +36,23 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String BASIC_FLOW_YAML_DIR = "basicflowyamltest";
   private static final String MULTIPLE_FLOW_YAML_DIR = "multipleflowyamltest";
   private static final String EMBEDDED_FLOW_YAML_DIR = "embeddedflowyamltest";
+  private static final String MULTIPLE_EMBEDDED_FLOW_YAML_DIR = "multipleembeddedflowyamltest";
   private static final String INVALID_FLOW_YAML_DIR = "invalidflowyamltest";
   private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
   private static final String EMBEDDED_FLOW = "embedded_flow";
-  private static final String EMBEDDED_FLOW_1 = "embedded_flow1";
-  private static final String EMBEDDED_FLOW_2 = "embedded_flow2";
+  private static final String EMBEDDED_FLOW_1 = "embedded_flow" + Constants.PATH_DELIMITER +
+      "embedded_flow1";
+  private static final String EMBEDDED_FLOW_2 =
+      "embedded_flow" + Constants.PATH_DELIMITER + "embedded_flow1" + Constants.PATH_DELIMITER
+          + "embedded_flow2";
+  private static final String EMBEDDED_FLOW_B = "embedded_flow_b";
+  private static final String EMBEDDED_FLOW_B1 =
+      "embedded_flow_b" + Constants.PATH_DELIMITER + "embedded_flow1";
+  private static final String EMBEDDED_FLOW_B2 =
+      "embedded_flow_b" + Constants.PATH_DELIMITER + "embedded_flow1" + Constants.PATH_DELIMITER
+          + "embedded_flow2";
   private static final String INVALID_FLOW_1 = "dependency_not_found";
   private static final String INVALID_FLOW_2 = "cycle_found";
   private static final String DEPENDENCY_NOT_FOUND_ERROR = "Dependency not found.";
@@ -58,7 +69,7 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(BASIC_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 1, 1);
-    checkFlowProperties(loader, BASIC_FLOW_1, 0, 4, 3, null);
+    checkFlowProperties(loader, BASIC_FLOW_1, 0, 4, 1, 3, null);
   }
 
   @Test
@@ -66,8 +77,8 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(MULTIPLE_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 2, 2);
-    checkFlowProperties(loader, BASIC_FLOW_1, 0, 4, 3, null);
-    checkFlowProperties(loader, BASIC_FLOW_2, 0, 3, 2, null);
+    checkFlowProperties(loader, BASIC_FLOW_1, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, BASIC_FLOW_2, 0, 3, 1, 2, null);
   }
 
   @Test
@@ -75,9 +86,23 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(EMBEDDED_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 3, 3);
-    checkFlowProperties(loader, EMBEDDED_FLOW, 0, 4, 3, null);
-    checkFlowProperties(loader, EMBEDDED_FLOW_1, 0, 4, 3, null);
-    checkFlowProperties(loader, EMBEDDED_FLOW_2, 0, 2, 1, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_1, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_2, 0, 2, 1, 1, null);
+  }
+
+  @Test
+  public void testLoadMultipleEmbeddedFlowYamlFiles() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(this.project,
+        ExecutionsTestUtil.getFlowDir(MULTIPLE_EMBEDDED_FLOW_YAML_DIR));
+    checkFlowLoaderProperties(loader, 0, 6, 6);
+    checkFlowProperties(loader, EMBEDDED_FLOW, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_1, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_2, 0, 2, 1, 1, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_B, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_B1, 0, 4, 1, 3, null);
+    checkFlowProperties(loader, EMBEDDED_FLOW_B2, 0, 2, 1, 1, null);
   }
 
   @Test
@@ -86,9 +111,9 @@ public class DirectoryYamlFlowLoaderTest {
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(INVALID_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 2, 2, 2);
     // Invalid flow 1: Dependency not found.
-    checkFlowProperties(loader, INVALID_FLOW_1, 1, 3, 3, DEPENDENCY_NOT_FOUND_ERROR);
+    checkFlowProperties(loader, INVALID_FLOW_1, 1, 3, 1, 3, DEPENDENCY_NOT_FOUND_ERROR);
     // Invalid flow 2: Cycles found.
-    checkFlowProperties(loader, INVALID_FLOW_2, 1, 4, 4, CYCLE_FOUND_ERROR);
+    checkFlowProperties(loader, INVALID_FLOW_2, 1, 4, 1, 4, CYCLE_FOUND_ERROR);
   }
 
   @Test
@@ -106,13 +131,15 @@ public class DirectoryYamlFlowLoaderTest {
   }
 
   private void checkFlowProperties(final DirectoryYamlFlowLoader loader, final String flowName,
-      final int numError, final int numNode, final int numEdge, final String edgeError) {
+      final int numError, final int numNode, final int numFlowProps, final int numEdge, final
+  String edgeError) {
     assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();
     final Flow flow = loader.getFlowMap().get(flowName);
     if (numError != 0) {
       assertThat(flow.getErrors().size()).isEqualTo(numError);
     }
     assertThat(flow.getNodes().size()).isEqualTo(numNode);
+    assertThat(flow.getAllFlowProps().size()).isEqualTo(numFlowProps);
 
     // Verify flow edges
     assertThat(loader.getEdgeMap().get(flowName).size()).isEqualTo(numEdge);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -757,9 +757,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final ArrayList<Map<String, Object>> flowList =
         new ArrayList<>();
     for (final Flow flow : project.getFlows()) {
-      final HashMap<String, Object> flowObj = new HashMap<>();
-      flowObj.put("flowId", flow.getId());
-      flowList.add(flowObj);
+      if (!flow.isEmbeddedFlow()) {
+        final HashMap<String, Object> flowObj = new HashMap<>();
+        flowObj.put("flowId", flow.getId());
+        flowList.add(flowObj);
+      }
     }
 
     ret.put("flows", flowList);
@@ -1585,7 +1587,12 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           page.add("exec", false);
         }
 
-        final List<Flow> flows = project.getFlows();
+        final List<Flow> flows = new ArrayList<>();
+        for (final Flow flow : project.getFlows()) {
+          if (!flow.isEmbeddedFlow()) {
+            flows.add(flow);
+          }
+        }
         if (!flows.isEmpty()) {
           Collections.sort(flows, FLOW_ID_COMPARATOR);
           page.add("flows", flows);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -1587,12 +1588,9 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           page.add("exec", false);
         }
 
-        final List<Flow> flows = new ArrayList<>();
-        for (final Flow flow : project.getFlows()) {
-          if (!flow.isEmbeddedFlow()) {
-            flows.add(flow);
-          }
-        }
+        final List<Flow> flows = project.getFlows().stream().filter(flow -> !flow.isEmbeddedFlow())
+            .collect(Collectors.toList());
+
         if (!flows.isEmpty()) {
           Collections.sort(flows, FLOW_ID_COMPARATOR);
           page.add("flows", flows);

--- a/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow.flow
+++ b/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow.flow
@@ -1,0 +1,61 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - embedded_flow1
+
+  - name: shell_pwd
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: embedded_flow1
+    type: flow
+    config:
+      flow-level-parameter: value
+
+    nodes:
+      - name: shell_end
+        type: noop
+        dependsOn:
+          - shell_echo
+          - embedded_flow2
+
+      - name: shell_echo
+        type: command
+        config:
+          command: echo "This is an echoed text from embedded_flow1."
+
+      - name: embedded_flow2
+        type: flow
+        config:
+          flow-level-parameter: value
+        dependsOn:
+            - shell_bash
+
+        nodes:
+          - name: shell_end
+            type: noop
+            dependsOn:
+              - shell_pwd
+
+          - name: shell_pwd
+            type: command
+            config:
+              command: pwd
+
+      - name: shell_bash
+        type: command
+        config:
+          command: bash ./sample_script.sh

--- a/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow.project
+++ b/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow_b.flow
+++ b/test/execution-test-data/multipleembeddedflowyamltest/embedded_flow_b.flow
@@ -1,0 +1,61 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - embedded_flow1
+
+  - name: shell_pwd
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: embedded_flow1
+    type: flow
+    config:
+      flow-level-parameter: value
+
+    nodes:
+      - name: shell_end
+        type: noop
+        dependsOn:
+          - shell_echo
+          - embedded_flow2
+
+      - name: shell_echo
+        type: command
+        config:
+          command: echo "This is an echoed text from embedded_flow1."
+
+      - name: embedded_flow2
+        type: flow
+        config:
+          flow-level-parameter: value
+        dependsOn:
+            - shell_bash
+
+        nodes:
+          - name: shell_end
+            type: noop
+            dependsOn:
+              - shell_pwd
+
+          - name: shell_pwd
+            type: command
+            config:
+              command: pwd
+
+      - name: shell_bash
+        type: command
+        config:
+          command: bash ./sample_script.sh


### PR DESCRIPTION
1. Support API to get flows and job properties from flow YAML file. This is needed when executing the flows and jobs.
2. With the new YAML file format, there is no need to specify the parent flow name as a prefix for the jobs. YAML format provides a structured way to distinguish sub-flows or jobs with same names between different parent flows. To achieve that, we choose to adopt ":" as the delimiter for job path. For example, the job path in an embedded flow could have the internal naming as "flow1: subflow2: subflow3: job4".  As a result, ":" will be restricted for use in the flow or job names. We will add validation to that later.
3. Today we are showing sub-flows in the project UI page together with the parent flow. This is not ideal because sub-flows should not be treated as independent flows and exposed for executing separately. This breaks the concept of a sub-flow. As an improvement, we will not display sub-flows as individual flows in the project UI page. 