### PR TITLE
Create a job setting to enable leveraging custom credential provider

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -207,6 +207,9 @@ public class Constants {
     @Deprecated
     public static final String EXTRA_HCAT_LOCATION = "other_hcat_location";
 
+    // If true, AZ will fetches the jobs' certificate from remote Certificate Authority.
+    public static final String ENABLE_JOB_SSL = "azkaban.job.enable.ssl";
+
     // Job properties that indicate maximum memory size
     public static final String JOB_MAX_XMS = "job.max.Xms";
     public static final String MAX_XMS_DEFAULT = "1G";

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -342,7 +342,7 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
     String credentialClassName = "unknown class";
       try {
         credentialClassName = props
-            .get(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
+            .getString(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
         logger.info("custom credential class name: " + credentialClassName);
         final Class metricsClass = Class.forName(credentialClassName);
 

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -341,9 +341,6 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
   String userToProxy) {
     String credentialClassName = "unknown class";
       try {
-        if (!props.containsKey(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME)) {
-          throw new Exception("can not find settings for credential class");
-        }
         credentialClassName = props
             .get(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
         logger.info("custom credential class name: " + credentialClassName);

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -339,11 +339,13 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
 
   private void registerCustomCredential(final Props props, final Credentials hadoopCred, final
   String userToProxy) {
-    if (props.containsKey(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME)) {
-      // new custom Credential object here.
-      final String credentialClassName = props
-          .get(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
+    String credentialClassName = "unknown class";
       try {
+        if (!props.containsKey(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME)) {
+          throw new Exception("can not find settings for credential class");
+        }
+        credentialClassName = props
+            .get(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
         logger.info("custom credential class name: " + credentialClassName);
         final Class metricsClass = Class.forName(credentialClassName);
 
@@ -357,7 +359,6 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
         throw new IllegalStateException("Encountered error while loading and instantiating "
             + credentialClassName, e);
       }
-    }
   }
 
   @Override
@@ -637,7 +638,7 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
               + props.getBoolean(OBTAIN_NAMENODE_TOKEN));
 
           // Register user secrets by custom credential Object
-          if (props.containsKey(JobProperties.ENABLE_JOB_SSL)) {
+          if (props.getBoolean(JobProperties.ENABLE_JOB_SSL, false)) {
             registerCustomCredential(props, cred, userToProxy);
           }
 

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -21,6 +21,8 @@ import static azkaban.Constants.JobProperties.EXTRA_HCAT_CLUSTERS;
 import static azkaban.Constants.JobProperties.EXTRA_HCAT_LOCATION;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
 
+import azkaban.Constants;
+import azkaban.Constants.JobProperties;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.ExecuteAsUser;
@@ -30,6 +32,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.PrivilegedAction;
@@ -334,6 +337,29 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
     return this.shouldProxy;
   }
 
+  private void registerCustomCredential(final Props props, final Credentials hadoopCred, final
+  String userToProxy) {
+    if (props.containsKey(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME)) {
+      // new custom Credential object here.
+      final String credentialClassName = props
+          .get(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
+      try {
+        logger.info("custom credential class name: " + credentialClassName);
+        final Class metricsClass = Class.forName(credentialClassName);
+
+        final Constructor[] constructors = metricsClass.getConstructors();
+        final CredentialProvider customCredential = (CredentialProvider) constructors[0]
+            .newInstance(hadoopCred, props);
+        customCredential.register(userToProxy);
+      } catch (final Exception e) {
+        logger.error("Encountered error while loading and instantiating "
+            + credentialClassName, e);
+        throw new IllegalStateException("Encountered error while loading and instantiating "
+            + credentialClassName, e);
+      }
+    }
+  }
+
   @Override
   public boolean isHadoopSecurityEnabled() {
     return this.securityEnabled;
@@ -609,6 +635,12 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
             IOException, HadoopSecurityManagerException {
           logger.info("Here is the props for " + OBTAIN_NAMENODE_TOKEN + ": "
               + props.getBoolean(OBTAIN_NAMENODE_TOKEN));
+
+          // Register user secrets by custom credential Object
+          if (props.containsKey(JobProperties.ENABLE_JOB_SSL)) {
+            registerCustomCredential(props, cred, userToProxy);
+          }
+
           if (props.getBoolean(OBTAIN_NAMENODE_TOKEN, false)) {
             final FileSystem fs = FileSystem.get(HadoopSecurityManager_H_2_0.this.conf);
             // check if we get the correct FS, and most importantly, the


### PR DESCRIPTION
This PR is a follow-up of #1552 . We create a job setting "azkaban.job.enable.ssl". When it is enabled, we use Java reflection to initialize the credential provider object, and run the method.