### PR TITLE
Fix issue #1559: Error writing out logs for job on a retry attempt

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -63,7 +63,7 @@ public class ExecutableNode {
   private Set<String> outNodes = new HashSet<>();
   private Props inputProps;
   private Props outputProps;
-  private int attempt = 0;
+  private volatile int attempt = 0;
   private long delayExecution = 0;
   private ArrayList<ExecutionAttempt> pastAttempts = null;
 
@@ -235,7 +235,9 @@ public class ExecutableNode {
 
   public void resetForRetry() {
     final ExecutionAttempt pastAttempt = new ExecutionAttempt(this.attempt, this);
-    this.attempt++;
+    synchronized (this) {
+      this.attempt++;
+    }
 
     synchronized (this) {
       if (this.pastAttempts == null) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -20,7 +20,6 @@ import azkaban.flow.Node;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.TypedMapWrapper;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -228,11 +227,6 @@ public class ExecutableNode {
 
   public int getAttempt() {
     return this.attempt.get();
-  }
-
-  @VisibleForTesting
-  public void setAttempt(final int attempt) {
-    this.attempt.set(attempt);
   }
 
   public void resetForRetry() {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
@@ -282,7 +282,9 @@ public class ExecutableFlowTest {
 
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
     exFlow.setExecutionId(101);
-    exFlow.setAttempt(2);
+    // reset twice so that attempt = 2
+    exFlow.resetForRetry();
+    exFlow.resetForRetry();
     exFlow.setDelayedExecution(1000);
 
     final ExecutionOptions options = new ExecutionOptions();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -609,11 +609,15 @@ public class JobRunner extends EventHandler implements Runnable {
         "Finishing job " + this.jobId + getNodeRetryLog() + " at " + this.node.getEndTime()
             + " with status " + this.node.getStatus());
 
-    fireEvent(Event.create(this, EventType.JOB_FINISHED,
-        new EventData(finalStatus, this.node.getNestedId())), false);
-    finalizeLogFile(this.node.getAttempt());
-    finalizeAttachmentFile();
-    writeStatus();
+    try {
+      finalizeLogFile(this.node.getAttempt());
+      finalizeAttachmentFile();
+      writeStatus();
+    } finally {
+      // note that FlowRunner thread does node.attempt++ when it receives the JOB_FINISHED event
+      fireEvent(Event.create(this, EventType.JOB_FINISHED,
+          new EventData(finalStatus, this.node.getNestedId())), false);
+    }
   }
 
   private String getNodeRetryLog() {


### PR DESCRIPTION
Fix https://github.com/azkaban/azkaban/issues/1559.

After making `attempt` volatile, `attempt++` had to be synchronized because of this check:
http://errorprone.info/bugpattern/NonAtomicVolatileUpdate