### PR TITLE
javaprocess classpath improvements

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
@@ -59,7 +59,7 @@ public class JavaProcessJob extends ProcessJob {
     command += getJVMArguments() + " ";
     command += "-Xms" + getInitialMemorySize() + " ";
     command += "-Xmx" + getMaxMemorySize() + " ";
-    command += "-cp " + createArguments(getClassPaths(), ":") + " ";
+    command += getClassPathParam();
     command += getJavaClass() + " ";
     command += getMainArguments();
 
@@ -73,7 +73,8 @@ public class JavaProcessJob extends ProcessJob {
   protected String getClassPathParam() {
     final List<String> classPath = getClassPaths();
     if (classPath == null || classPath.size() == 0) {
-      return "";
+      throw new IllegalArgumentException(
+          "No classpath defined and no .jar files found in job directory. Can't run java command.");
     }
 
     return "-cp " + createArguments(classPath, ":") + " ";
@@ -94,7 +95,7 @@ public class JavaProcessJob extends ProcessJob {
       }
     }
 
-    if (classPaths == null) {
+    if (classPaths == null || classPaths.isEmpty()) {
       final File path = new File(getPath());
       // File parent = path.getParentFile();
       getLog().info(

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -198,7 +198,7 @@ public class ProcessJob extends AbstractProcessJob {
     try {
       commands = getCommandList();
     } catch (final Exception e) {
-      handleError("Job set up failed " + e.getCause(), e);
+      handleError("Job set up failed: " + e.getMessage(), e);
     }
 
     final long startMs = System.currentTimeMillis();
@@ -386,8 +386,8 @@ public class ProcessJob extends AbstractProcessJob {
   }
 
   /**
-   * Changes permissions on file/directory so that the file/directory is owned by the user and
-   * the group remains the azkaban service account name.
+   * Changes permissions on file/directory so that the file/directory is owned by the user and the
+   * group remains the azkaban service account name.
    *
    * Leverages execute-as-user with "root" as the user to run the command.
    *


### PR DESCRIPTION
(relates to issue https://github.com/azkaban/azkaban/issues/1566)

Classpath improvements for the `javaprocess` job type:

- Tests for `javaprocess` job with empty or non-existing `classpath` property
- Fail the job with a helpful message if there's nothing to add as `-cp` arg (instead of trying to run `java` command that's doomed to fail)
- If `classpath` property exists, but has an empty value, try to scan the folder for `.jar` files (as was already the case when `classpath` property doesn't exist)
- Improve error message when `ProcessJob` setup fails: print the top-level exception message first, not the cause of it
- For some reason `getClassPathParam()` method wasn't being used. Now it is used again, with a small modification, though.