### PR TITLE
Temporary fix for startup failure (#1569)

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
@@ -39,6 +39,10 @@ import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+/**
+ * @deprecated in favor of {@link azkaban.db.DatabaseSetup}.
+ */
+@Deprecated
 public class AzkabanDatabaseSetup {
 
   public static final String DATABASE_CHECK_VERSION = "database.check.version";

--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
@@ -229,6 +229,14 @@ public class AzkabanDatabaseSetup {
         final String[] nameSplit = name.split("\\.");
         final String tableName = nameSplit[1];
 
+        // TODO temporary fix for Issue #1569:
+        // "Startup fails: missing tables that need to be installed: quartz-tables-all"
+        // this doesn't work because the file actually contains multiple tables and the file name
+        // pattern doesn't match with any of those. Until this new file the convention has been that
+        // each file has a single table and the file name matches the table name.
+        if ("quartz-tables-all".equals(tableName)) {
+          continue;
+        }
         if (!this.tables.containsKey(tableName)) {
           this.missingTables.add(tableName);
         }


### PR DESCRIPTION
https://github.com/azkaban/azkaban/issues/1569

Issue #1569: "Startup fails: missing tables that need to be installed: quartz-tables-all"

This fix allows `AzkabanSingleServer` to start, and I was also able to run jobs after that.