### PR TITLE
Refactor Emailer.java

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -121,10 +121,10 @@ public class Emailer extends AbstractMailer implements Alerter {
       if (!this.testMode) {
         try {
           message.sendEmail();
-          logger.info("Sent SLA email message " + body);
+          logger.info("Sent email message " + body);
           this.commonMetrics.markSendEmailSuccess();
         } catch (final Exception e) {
-          logger.error("Failed to send SLA email message " + body, e);
+          logger.error("Failed to send email message " + body, e);
           this.commonMetrics.markSendEmailFail();
         }
       }

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -74,16 +74,20 @@ public class Emailer extends AbstractMailer implements Alerter {
 
     EmailMessage.setTotalAttachmentMaxSize(getAttachmentMaxSize());
 
-    this.clientHostname = props.getString(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME, props.getString("jetty.hostname", "localhost"));
+    this.clientHostname = props.getString(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME,
+        props.getString("jetty.hostname", "localhost"));
 
     if (props.getBoolean("jetty.use.ssl", true)) {
       this.scheme = HTTPS;
-      this.clientPortNumber = Integer.toString(props.getInt(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_SSL_PORT, props.getInt("jetty.ssl.port",
-          Constants.DEFAULT_SSL_PORT_NUMBER)));
+      this.clientPortNumber = Integer.toString(props
+          .getInt(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_SSL_PORT,
+              props.getInt("jetty.ssl.port",
+                  Constants.DEFAULT_SSL_PORT_NUMBER)));
     } else {
       this.scheme = HTTP;
-      this.clientPortNumber = Integer.toString(props.getInt(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_PORT, props.getInt("jetty.port",
-          Constants.DEFAULT_PORT_NUMBER)));
+      this.clientPortNumber = Integer.toString(
+          props.getInt(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_PORT, props.getInt("jetty.port",
+              Constants.DEFAULT_PORT_NUMBER)));
     }
 
     this.testMode = props.getBoolean("test.mode", false);
@@ -100,10 +104,14 @@ public class Emailer extends AbstractMailer implements Alerter {
   }
 
   private void sendSlaAlertEmail(final SlaOption slaOption, final String slaMessage) {
-    final String subject = "SLA violation for " + getJobOrFlowName(slaOption) + " on " + getAzkabanName();
-    final String body = slaMessage;
+    final String subject =
+        "SLA violation for " + getJobOrFlowName(slaOption) + " on " + getAzkabanName();
     final List<String> emailList =
         (List<String>) slaOption.getInfo().get(SlaOption.INFO_EMAIL_LIST);
+    sendEmail(emailList, subject, slaMessage);
+  }
+
+  public void sendEmail(final List<String> emailList, final String subject, final String body) {
     if (emailList != null && !emailList.isEmpty()) {
       final EmailMessage message =
           super.createEmailMessage(subject, "text/html", emailList);
@@ -113,10 +121,10 @@ public class Emailer extends AbstractMailer implements Alerter {
       if (!this.testMode) {
         try {
           message.sendEmail();
-          logger.info("Sent SLA email message " + slaMessage);
+          logger.info("Sent SLA email message " + body);
           this.commonMetrics.markSendEmailSuccess();
         } catch (final Exception e) {
-          logger.error("Failed to send SLA email message " + slaMessage, e);
+          logger.error("Failed to send SLA email message " + body, e);
           this.commonMetrics.markSendEmailFail();
         }
       }

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -108,6 +108,7 @@ public class Emailer extends AbstractMailer implements Alerter {
         "SLA violation for " + getJobOrFlowName(slaOption) + " on " + getAzkabanName();
     final List<String> emailList =
         (List<String>) slaOption.getInfo().get(SlaOption.INFO_EMAIL_LIST);
+    logger.info("Sending SLA email " + slaMessage);
     sendEmail(emailList, subject, slaMessage);
   }
 

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -111,6 +111,9 @@ public class Emailer extends AbstractMailer implements Alerter {
     sendEmail(emailList, subject, slaMessage);
   }
 
+  /**
+   * Send an email to the specified email list
+   */
   public void sendEmail(final List<String> emailList, final String subject, final String body) {
     if (emailList != null && !emailList.isEmpty()) {
       final EmailMessage message =


### PR DESCRIPTION
Create a sendEmail method to be used more generally not just limited to failure/success/sla emails. This method will be used by Flow trigger to alert user on flow trigger failure with customized email subject/body.
Since currently Emailer.java can only be tested via integration test, I didn't write unit test but verified by sending a email with the new method in local mode.  