### PR TITLE
use java lib instead of external sh commands to do recursive hard linking

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -105,16 +107,18 @@ public class FileIOUtils {
     final Set<String> paths = new HashSet<>();
     createDirsFindFiles(sourceDir, sourceDir, destDir, paths);
 
-    final StringBuffer buffer = new StringBuffer();
     for (String path : paths) {
       final File sourceLink = new File(sourceDir, path);
-      path = "." + path;
+      path = destDir + path;
 
-      buffer.append("ln ").append(sourceLink.getAbsolutePath()).append("/*")
-          .append(" ").append(path).append(";");
+      final File[] targetFiles = sourceLink.listFiles();
+      for (final File targetFile : targetFiles) {
+        if (targetFile.isFile()) {
+          final File linkFile = new File(path, targetFile.getName());
+          Files.createLink(linkFile.toPath(), Paths.get(targetFile.getAbsolutePath()));
+        }
+      }
     }
-
-    runShellCommand(buffer.toString(), destDir);
   }
 
   private static void runShellCommand(final String command, final File workingDir)
@@ -151,6 +155,7 @@ public class FileIOUtils {
     }
 
   }
+
 
   private static void createDirsFindFiles(final File baseDir, final File sourceDir,
       final File destDir, final Set<String> paths) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -89,7 +89,7 @@ public class FileIOUtils {
   }
 
   /**
-   * Run a unix command that will hard link files and recurse into directories.
+   * Hard link files and recurse into directories.
    */
 
   public static void createDeepHardlink(final File sourceDir, final File destDir)
@@ -120,42 +120,6 @@ public class FileIOUtils {
       }
     }
   }
-
-  private static void runShellCommand(final String command, final File workingDir)
-      throws IOException {
-    final ProcessBuilder builder = new ProcessBuilder().command("sh", "-c", command);
-    builder.directory(workingDir);
-
-    // XXX what about stopping threads ??
-    final Process process = builder.start();
-    try {
-      final NullLogger errorLogger = new NullLogger(process.getErrorStream());
-      final NullLogger inputLogger = new NullLogger(process.getInputStream());
-      errorLogger.start();
-      inputLogger.start();
-
-      try {
-        if (process.waitFor() < 0) {
-          // Assume that the error will be in standard out. Otherwise it'll be
-          // in standard in.
-          String errorMessage = errorLogger.getLastMessages();
-          if (errorMessage.isEmpty()) {
-            errorMessage = inputLogger.getLastMessages();
-          }
-
-          throw new IOException(errorMessage);
-        }
-      } catch (final InterruptedException e) {
-        logger.error(e);
-      }
-    } finally {
-      IOUtils.closeQuietly(process.getInputStream());
-      IOUtils.closeQuietly(process.getOutputStream());
-      IOUtils.closeQuietly(process.getErrorStream());
-    }
-
-  }
-
 
   private static void createDirsFindFiles(final File baseDir, final File sourceDir,
       final File destDir, final Set<String> paths) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -88,10 +88,10 @@ public class FileIOUtils {
     }
   }
 
+
   /**
    * Hard link files and recurse into directories.
    */
-
   public static void createDeepHardlink(final File sourceDir, final File destDir)
       throws IOException {
     if (!sourceDir.exists()) {

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -79,7 +79,6 @@ public class FileIOUtilsTest {
     file5.createNewFile();
     file6.createNewFile();
     file7.createNewFile();
-    createBigDir(this.baseDir.getAbsolutePath());
 
     byte[] fileData = new byte[]{1, 2, 3};
     FileOutputStream out = new FileOutputStream(file1);
@@ -112,6 +111,18 @@ public class FileIOUtilsTest {
     assertThat(areDirsEqual(this.sourceDir, this.destDir, true)).isTrue();
     FileUtils.deleteDirectory(this.destDir);
     assertThat(areDirsEqual(this.baseDir, this.sourceDir, true)).isTrue();
+  }
+
+  @Test
+  public void testHardlinkCopyOfBigDir() throws IOException {
+    final File bigDir = new File(this.baseDir.getAbsolutePath() + "/bigdir");
+    bigDir.mkdir();
+    createBigDir(bigDir.getAbsolutePath());
+
+    FileIOUtils.createDeepHardlink(bigDir, this.destDir);
+    assertThat(areDirsEqual(this.destDir, bigDir, true)).isTrue();
+    FileUtils.deleteDirectory(bigDir);
+
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -24,6 +24,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.comparator.NameFileComparator;
@@ -50,11 +53,11 @@ public class FileIOUtilsTest {
             + "11231312312312312312313121111111111111111111111111111111111111111111111111";
 
     for (int i = 1; i <= 400; i++) {
-      final File tmpDir = new File(path + "/" + verylongprefix + "dir" + i);
-      tmpDir.mkdir();
+      final Path tmpDirPath = Paths.get(path, verylongprefix + "dir" + i);
+      Files.createDirectory(tmpDirPath);
       for (int j = 1; j <= 100; j++) {
-        final File tmp = new File(tmpDir.getAbsolutePath() + "/" + j);
-        tmp.createNewFile();
+        final Path tmp = Paths.get(tmpDirPath.toAbsolutePath().toString(), String.valueOf(j));
+        Files.createFile(tmp);
       }
     }
   }

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -43,12 +43,12 @@ public class FileIOUtilsTest {
     final String verylongprefix =
         "123123123123123123123123123123123113123111111111111111111111111111111111111111111111111111"
             + "111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-            + "1123131231231231231231312";
+            + "11231312312312312312313121111111111111111111111111111111111111111111111111";
 
-    for (int i = 1; i <= 50; i++) {
+    for (int i = 1; i <= 400; i++) {
       final File tmpDir = new File(path + "/" + verylongprefix + "dir" + i);
       tmpDir.mkdir();
-      for (int j = 1; j <= 50; j++) {
+      for (int j = 1; j <= 100; j++) {
         final File tmp = new File(tmpDir.getAbsolutePath() + "/" + j);
         tmp.createNewFile();
       }

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -39,6 +39,10 @@ public class FileIOUtilsTest {
   public TemporaryFolder temp = new TemporaryFolder();
   private File sourceDir, destDir, baseDir;
 
+  /**
+   * Create a very big dir which would cause linux shell command to hard link the dir to
+   * exceed the allowed limit.
+   */
   private void createBigDir(final String path) throws IOException {
     final String verylongprefix =
         "123123123123123123123123123123123113123111111111111111111111111111111111111111111111111111"


### PR DESCRIPTION
Linux has restriction on shell argument length, it's likely the command to do hard linking project dir of a lot of subdir and files will exceed the restriction, causing flow setup failure. The fix is replacing the logic with java native file API.