### PR TITLE
Fix NullPointerException in fetchflowgraph API

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -778,6 +778,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private void fillFlowInfo(final Project project, final String flowId,
       final HashMap<String, Object> ret) {
     final Flow flow = project.getFlow(flowId);
+    if (flow == null) {
+      ret.put("error",
+              "Flow " + flowId + " not found in project " + project.getName());
+      return;
+    }
 
     final ArrayList<Map<String, Object>> nodeList =
         new ArrayList<>();


### PR DESCRIPTION
If you execute the fetchflowgraph API in already deleted project, the following error occurs.

I think that null check is necessary.

azkaban 3.37.0 log
```
java.lang.NullPointerException
        at azkaban.webapp.servlet.ProjectManagerServlet.fillFlowInfo(ProjectManagerServlet.java:781)
        at azkaban.webapp.servlet.ProjectManagerServlet.ajaxFetchFlowGraph(ProjectManagerServlet.java:772)
        at azkaban.webapp.servlet.ProjectManagerServlet.handleAJAXAction(ProjectManagerServlet.java:240)
        at azkaban.webapp.servlet.ProjectManagerServlet.handleGet(ProjectManagerServlet.java:142)
        at azkaban.webapp.servlet.LoginAbstractAzkabanServlet.doGet(LoginAbstractAzkabanServlet.java:123)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:668)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:770)
        at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
        at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:401)
        at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
        at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:766)
        at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
        at org.mortbay.jetty.Server.handle(Server.java:326)
        at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
        at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:928)
        at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:549)
        at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:212)
        at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
        at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
        at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
```