### PR TITLE
Enforcing num of concurrent runs quota given a Flow Executable

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -67,6 +67,8 @@ public class ExecutorManager extends EventHandler implements
 
   public static final String AZKABAN_USE_MULTIPLE_EXECUTORS =
       "azkaban.use.multiple.executors";
+  public static final String AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW =
+      "azkaban.max.concurrent.runs.oneflow";
   static final String AZKABAN_EXECUTOR_SELECTOR_FILTERS =
       "azkaban.executorselector.filters";
   static final String AZKABAN_EXECUTOR_SELECTOR_COMPARATOR_PREFIX =
@@ -79,8 +81,6 @@ public class ExecutorManager extends EventHandler implements
       "azkaban.activeexecutor.refresh.milisecinterval";
   private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
       "azkaban.activeexecutor.refresh.flowinterval";
-  private static final String AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW =
-      "azkaban.max.concurrent.runs.oneflow";
   private static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
   private static final String AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS =
       "azkaban.executorinfo.refresh.maxThreads";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -80,7 +80,7 @@ public class ExecutorManager extends EventHandler implements
   private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
       "azkaban.activeexecutor.refresh.flowinterval";
   private static final String AZKABAN_MAX_NUM_CONCURRENT_FLOW =
-      "azkaban.max.concurrent.num.oneflow";
+      "azkaban.max.concurrent.runs.oneflow";
   private static final String AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS =
       "azkaban.executorinfo.refresh.maxThreads";
   private static final String AZKABAN_MAX_DISPATCHING_ERRORS_PERMITTED =

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -79,8 +79,9 @@ public class ExecutorManager extends EventHandler implements
       "azkaban.activeexecutor.refresh.milisecinterval";
   private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
       "azkaban.activeexecutor.refresh.flowinterval";
-  private static final String AZKABAN_MAX_NUM_CONCURRENT_FLOW =
+  private static final String AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW =
       "azkaban.max.concurrent.runs.oneflow";
+  private static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
   private static final String AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS =
       "azkaban.executorinfo.refresh.maxThreads";
   private static final String AZKABAN_MAX_DISPATCHING_ERRORS_PERMITTED =
@@ -130,7 +131,8 @@ public class ExecutorManager extends EventHandler implements
 
     // The default threshold is set to 30 for now, in case some users are affected. We may
     // decrease this number in future, to better prevent DDos attacks.
-    this.maxConcurrentRunsOneFlow = azkProps.getInt(AZKABAN_MAX_NUM_CONCURRENT_FLOW, 30);
+    this.maxConcurrentRunsOneFlow = azkProps.getInt(AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW,
+        DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
     this.loadQueuedFlows();
 
     this.cacheDir = new File(azkProps.getString("cache.directory", "cache"));

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -79,6 +79,7 @@ public class ExecutorManager extends EventHandler implements
       "azkaban.activeexecutor.refresh.milisecinterval";
   private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
       "azkaban.activeexecutor.refresh.flowinterval";
+  private static final int AZKABAN_MAX_NUM_CONCURRENT_FLOW = 30;
   private static final String AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS =
       "azkaban.executorinfo.refresh.maxThreads";
   private static final String AZKABAN_MAX_DISPATCHING_ERRORS_PERMITTED =
@@ -951,6 +952,7 @@ public class ExecutorManager extends EventHandler implements
         exflow.setSubmitUser(userId);
         exflow.setSubmitTime(System.currentTimeMillis());
 
+        // Get collection of running flows given a project and a specific flow name
         final List<Integer> running = getRunningFlows(projectId, flowId);
 
         ExecutionOptions options = exflow.getExecutionOptions();
@@ -977,6 +979,10 @@ public class ExecutorManager extends EventHandler implements
               ExecutionOptions.CONCURRENT_OPTION_SKIP)) {
             throw new ExecutorManagerException("Flow " + flowId
                 + " is already running. Skipping execution.",
+                ExecutorManagerException.Reason.SkippedExecution);
+          } else if (running.size() > AZKABAN_MAX_NUM_CONCURRENT_FLOW) {
+            throw new ExecutorManagerException("Flow " + flowId
+                + " has more than 30 concurrent runs. Skipping",
                 ExecutorManagerException.Reason.SkippedExecution);
           } else {
             // The settings is to run anyways.

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -303,7 +303,9 @@ public class ExecutorManagerTest {
   public void testSubmitFlows() throws Exception {
     testSetUpForRunningFlows();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    this.manager.submitExecutableFlow(flow2, this.user.getUserId());
     verify(this.loader).uploadExecutableFlow(flow1);
     verify(this.loader).addActiveExecutableReference(any());
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -303,11 +303,33 @@ public class ExecutorManagerTest {
   public void testSubmitFlows() throws Exception {
     testSetUpForRunningFlows();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
-    this.manager.submitExecutableFlow(flow2, this.user.getUserId());
     verify(this.loader).uploadExecutableFlow(flow1);
     verify(this.loader).addActiveExecutableReference(any());
+  }
+
+  // Too many concurrent flows will fail job submission
+  @Test(expected = ExecutorManagerException.class)
+  public void testTooManySubmitFlows() throws Exception {
+    testSetUpForRunningFlows();
+    final ExecutableFlow flow1 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow1.setExecutionId(101);
+    final ExecutableFlow flow2 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow2.setExecutionId(102);
+    final ExecutableFlow flow3 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow3.setExecutionId(103);
+    final ExecutableFlow flow4 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow4.setExecutionId(104);
+    this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow1);
+    this.manager.submitExecutableFlow(flow2, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow2);
+    this.manager.submitExecutableFlow(flow3, this.user.getUserId());
+    this.manager.submitExecutableFlow(flow4, this.user.getUserId());
   }
 
   @Ignore
@@ -366,6 +388,9 @@ public class ExecutorManagerTest {
     //To test runningFlows, AZKABAN_QUEUEPROCESSING_ENABLED should be set to true
     //so that flows will be dispatched to executors.
     this.props.put(ExecutorManager.AZKABAN_QUEUEPROCESSING_ENABLED, "true");
+
+    // allow two concurrent runs give one Flow
+    this.props.put("azkaban.max.concurrent.num.oneflow", 2);
 
     final List<Executor> executors = new ArrayList<>();
     final Executor executor1 = new Executor(1, "localhost", 12345, true);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -390,7 +390,7 @@ public class ExecutorManagerTest {
     this.props.put(ExecutorManager.AZKABAN_QUEUEPROCESSING_ENABLED, "true");
 
     // allow two concurrent runs give one Flow
-    this.props.put("azkaban.max.concurrent.runs.oneflow", 2);
+    this.props.put(ExecutorManager.AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW, 2);
 
     final List<Executor> executors = new ArrayList<>();
     final Executor executor1 = new Executor(1, "localhost", 12345, true);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -390,7 +390,7 @@ public class ExecutorManagerTest {
     this.props.put(ExecutorManager.AZKABAN_QUEUEPROCESSING_ENABLED, "true");
 
     // allow two concurrent runs give one Flow
-    this.props.put("azkaban.max.concurrent.num.oneflow", 2);
+    this.props.put("azkaban.max.concurrent.runs.oneflow", 2);
 
     final List<Executor> executors = new ArrayList<>();
     final Executor executor1 = new Executor(1, "localhost", 12345, true);

--- a/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
+++ b/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
@@ -18,6 +18,7 @@ package azkaban.utils;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.flow.Flow;
+import azkaban.project.DirectoryYamlFlowLoader;
 import azkaban.project.Project;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.user.User;
@@ -51,6 +52,20 @@ public class TestUtils {
     final ExecutableFlow execFlow = new ExecutableFlow(project, flow);
 
     return execFlow;
+  }
+
+  /* Helper method to create an ExecutableFlow from Yaml */
+  public static ExecutableFlow createTestExecutableFlowFromYaml(final String projectName,
+      final String flowName) throws IOException {
+
+    final Project project = new Project(11, projectName);
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(project, ExecutionsTestUtil.getFlowDir(projectName));
+    project.setFlows(loader.getFlowMap());
+    project.setVersion(123);
+
+    final Flow flow = project.getFlow(flowName);
+    return new ExecutableFlow(project, flow);
   }
 
   /* Helper method to create an XmlUserManager from XML_FILE_PARAM file */

--- a/test/execution-test-data/basicyamlshelltest/bashSleep.flow
+++ b/test/execution-test-data/basicyamlshelltest/bashSleep.flow
@@ -1,0 +1,20 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_sleep
+      - shell_echo
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_sleep
+    type: command
+    config:
+      command: sleep 5

--- a/test/execution-test-data/basicyamlshelltest/bashSleep.project
+++ b/test/execution-test-data/basicyamlshelltest/bashSleep.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0


### PR DESCRIPTION
A couple of production issues warned us that we should enforce the MAX number of concurrent executions given a flow executable. In case people accidentally schedule flows per minute or endlessly submit flows from the client side, this PR proposes to implement a simple quota to prevent it happening.

Unit Test is added.  
  