### PR TITLE
Fix deleting job properties issue on web UI.

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1321,17 +1321,12 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         return;
       }
 
-      final Props jobProp = this.projectManager
-          .getProperties(project, flow, jobName, node.getJobSource());
-      Props overrideProp =
-          this.projectManager.getJobOverrideProperty(project, flow, jobName, node.getJobSource());
-      if (overrideProp == null) {
-        overrideProp = new Props();
+      Props jobProp = this.projectManager
+          .getJobOverrideProperty(project, flow, jobName, node.getJobSource());
+      if (jobProp == null) {
+        jobProp = this.projectManager.getProperties(project, flow, jobName, node.getJobSource());
       }
-      final Props comboProp = new Props(jobProp);
-      for (final String key : overrideProp.getKeySet()) {
-        comboProp.put(key, overrideProp.get(key));
-      }
+
       page.add("jobid", node.getId());
       page.add("jobtype", node.getType());
 
@@ -1375,8 +1370,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       final ArrayList<Pair<String, String>> parameters =
           new ArrayList<>();
       // Parameter
-      for (final String key : comboProp.getKeySet()) {
-        final String value = comboProp.get(key);
+      for (final String key : jobProp.getKeySet()) {
+        final String value = jobProp.get(key);
         parameters.add(new Pair<>(key, value));
       }
 


### PR DESCRIPTION
This is to fix issue: https://github.com/azkaban/azkaban/issues/1597

On job properties page, the properties are a combination of original job properties and jobOverride properties. This does not work when we delete the property from original ones. In project_properties DB table, the jobOverride properties (.jor) contains all the job properties instead of just the delta of changed properties.
It makes more sense to display the jobOverride properties if there is any. Otherwise, we just display the original job properties.
  