### PR TITLE
adding job logger to credential instance

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -346,17 +346,14 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
         logger.info("custom credential class name: " + credentialClassName);
         final Class credentialClass = Class.forName(credentialClassName);
 
-        final Constructor[] constructors = credentialClass.getConstructors();
-        for (final Constructor constructor : constructors) {
-          if (constructor.getParameterCount() == 3) {
-            final CredentialProvider customCredential = (CredentialProvider) constructors[1]
-                .newInstance(hadoopCred, props, jobLogger);
-            customCredential.register(userToProxy);
-            return;
-          }
-        }
-        logger.error("cannot find the appropriate credential constructor.");
-        throw new Exception("launching credential instance failed.");
+        // The credential class must have a constructor accepting 3 parameters, Credentials,
+        // Props, and Logger in order.
+        Constructor constructor = credentialClass.getConstructor (new Class[]
+            {Credentials.class, Props.class, Logger.class});
+        final CredentialProvider customCredential = (CredentialProvider) constructor
+              .newInstance(hadoopCred, props, jobLogger);
+        customCredential.register(userToProxy);
+
       } catch (final Exception e) {
         logger.error("Encountered error while loading and instantiating "
             + credentialClassName, e);


### PR DESCRIPTION
In order to allow users to debug credential issues easily, this PR proposes adding job logger into the credential instance, so that related log messages will be shown in Azkaban web UI. 

Notice that this PR is backward compatible. In the credential client code side, we have both 2-parameter and 3-parameter constructor. If we need to roll back this commit, it will not fail.

Tested in staging cluster.