### PR TITLE
mysql table for flow trigger dependency instance

### DIFF
--- a/azkaban-db/src/main/sql/create.execution_dependencies.sql
+++ b/azkaban-db/src/main/sql/create.execution_dependencies.sql
@@ -1,0 +1,16 @@
+CREATE TABLE execution_dependencies(
+  trigger_instance_id varchar(64),
+  dep_name varchar(128),
+  starttime datetime not null,
+  endtime datetime,
+  dep_status tinyint not null,
+  cancelleation_cause tinyint not null,
+
+  project_id INT not null,
+  project_version INT not null,
+  flow_id varchar(128) not null,
+  flow_version INT not null,
+  project_json MEDIUMTEXT not null,
+  flow_exec_id INT not null,
+  primary key(trigger_instance_id, dep_name)
+);


### PR DESCRIPTION
added sql script to create table to keep execution of all dependency instances. There will be no table specifically for trigger instance since trigger instance is nothing but the collection of dependency instances, which can be easily constructed from dependency instances. The table will be used to keep the historic executions for users to query in the UI and to recover the running triggers from web server restart. 
