### PR TITLE
Add debug logging for upload project issue.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -213,6 +213,7 @@ public class ProjectManager {
       fetchedProject = this.projectsByName.get(name);
     } else {
       try {
+        logger.info("Project " + name + " doesn't exist in cache, fetching from DB now.");
         fetchedProject = this.projectLoader.fetchProjectByName(name);
       } catch (final ProjectManagerException e) {
         logger.error("Could not load project from store.", e);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1295,6 +1295,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     Flow flow = null;
     try {
       project = this.projectManager.getProject(projectName);
+      logger.info("JobPage: project " + projectName + " version is " + project.getVersion()
+          + ", reference is " + System.identityHashCode(project));
       if (project == null) {
         page.add("errorMsg", "Project " + projectName + " not found.");
         page.render();
@@ -1644,6 +1646,9 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final User user = session.getUser();
     final String projectName = (String) multipart.get("project");
     final Project project = this.projectManager.getProject(projectName);
+    logger.info(
+        "Upload: reference of project " + projectName + " is " + System.identityHashCode(project));
+
     final String autoFix = (String) multipart.get("fix");
     final Props props = new Props();
     if (autoFix != null && autoFix.equals("off")) {
@@ -1764,6 +1769,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         }
       }
 
+      logger.info("Upload: project " + projectName + " version is " + project.getVersion()
+          + ", reference is " + System.identityHashCode(project));
       ret.put("version", String.valueOf(project.getVersion()));
     }
   }

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -62,6 +62,8 @@ public class ProjectManagerResource extends ResourceContextHolder {
     final User user = ResourceUtils.getUserFromSessionId(sessionId);
     final ProjectManager projectManager = getAzkaban().getProjectManager();
     final Project project = projectManager.getProject(projectName);
+    logger.info("Deploy: reference of project " + projectName + " is " + System.identityHashCode
+        (project));
     if (project == null) {
       final String errorMsg = "Project '" + projectName + "' not found.";
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, errorMsg);
@@ -115,6 +117,8 @@ public class ProjectManagerResource extends ResourceContextHolder {
       final Map<String, ValidationReport> reports = projectManager
           .uploadProject(project, archiveFile, "zip", user, props);
       checkReports(reports);
+      logger.info("Deploy: project " + projectName + " version is " + project.getVersion()
+          + ", reference is " + System.identityHashCode(project));
       return Integer.toString(project.getVersion());
     } catch (final ProjectManagerException e) {
       final String errorMsg = "Upload of project " + project + " from " + archiveFile + " failed";


### PR DESCRIPTION
User reported intermittent issues that they sometimes could not get job properties after successfully deploying their project. When they executed the flow, it still picked the old project version and run. Project info like lastModifiedTime was not updated on the web UI after CRT deployment.
This issue could not be reproduced locally and it only happened to certain projects occasionally. Suspect some issue with updating project cache. Add some log messages to help debug the issue.
Related issues: LIHADOOP-33098, LIHADOOP-34114, TOOLS-170605