### PR TITLE
Clarify the ELK instruction logging message

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -294,7 +294,9 @@ public class JobRunner extends EventHandler implements Runnable {
         .getExternalLogViewer(this.azkabanProps, this.jobId,
             this.props);
     if (!externalViewer.isEmpty()) {
-      this.logger.info("See logs at: " + externalViewer);
+      this.logger.info("If you want to leverage AZ ELK logging support, you need to follow the "
+          + "instructions: http://azkaban.github.io/azkaban/docs/latest/#how-to");
+      this.logger.info("If you did the above step, see logs at: " + externalViewer);
     }
   }
 


### PR DESCRIPTION
People always get confused when they read 
> See logs at: https://blahblahXXX://

This PR adds another log message before this message, in order to instruct users how to set job ELK logger.