### PR TITLE
Fixed the UI display issue of same executionOptions for all schedules.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.codehaus.jettison.json.JSONObject;
 
 /**
  * Execution options for submitted flows and scheduled flows
@@ -263,6 +264,10 @@ public class ExecutionOptions {
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
     return flowOptionObj;
+  }
+
+  public JSONObject toJSON() {
+    return new JSONObject(toObject());
   }
 
   public enum FailureAction {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -18,13 +18,14 @@ package azkaban.executor;
 
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.utils.TypedMapWrapper;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.codehaus.jettison.json.JSONObject;
 
 /**
  * Execution options for submitted flows and scheduled flows
@@ -266,8 +267,9 @@ public class ExecutionOptions {
     return flowOptionObj;
   }
 
-  public JSONObject toJSON() {
-    return new JSONObject(toObject());
+  public String toJSON() {
+    final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    return gson.toJson(toObject());
   }
 
   public enum FailureAction {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -18,7 +18,6 @@ package azkaban.executor;
 
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.utils.TypedMapWrapper;
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -268,8 +267,7 @@ public class ExecutionOptions {
   }
 
   public String toJSON() {
-    final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    return gson.toJson(toObject());
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toObject());
   }
 
   public enum FailureAction {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
@@ -40,13 +40,6 @@
     $(document).ready(function () {
       var flowTable = $("#scheduledFlowsTbl");
       flowTable.tablesorter();
-
-    ## Converted the executionOptions to JSON strings for clearer readability purpose.
-      document.querySelectorAll('.executionOptions-json').forEach(
-          function (element) {
-            element.innerHTML = JSON.stringify(JSON.parse(element.innerText), null, 2);
-          });
-
     });
   </script>
 </head>
@@ -141,8 +134,7 @@
                               </div>
                               <div class="modal-body">
                               ## Used <pre> to display text with code format
-                                <pre
-                                    class="executionOptions-json">${sched.executionOptions.toJSON()}</pre>
+                                <pre>${sched.executionOptions.toJSON()}</pre>
                               </div>
                               <div class="modal-footer">
                                   <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
@@ -40,6 +40,13 @@
     $(document).ready(function () {
       var flowTable = $("#scheduledFlowsTbl");
       flowTable.tablesorter();
+
+    ## Converted the executionOptions to JSON strings for clearer readability purpose.
+      document.querySelectorAll('.executionOptions-json').forEach(
+          function (element) {
+            element.innerHTML = JSON.stringify(JSON.parse(element.innerText), null, 2);
+          });
+
     });
   </script>
 </head>
@@ -114,9 +121,18 @@
                 #else
                   <td>Not Applicable</td>
                 #end
-                <td><button type="button" data-toggle="modal" data-target="#executionOptions">show</button></td>
+                <td>
+                ## Changed the style of "Show" button to be consistent with other buttons.
+                  <button type="button" class="btn btn-sm btn-info" data-toggle="modal"
+                          data-target="#executionOptions-${velocityCount}">Show
+                  </button>
+                </td>
 
-                  <div class="modal fade" id="executionOptions" tabindex="-1" role="dialog" aria-labelledby="executionOptionsLabel">
+              ## Distinguished executionOptions of each schedule with unique count number to fix
+              ## the issue of same display for all schedules
+                <div class="modal fade" id="executionOptions-${velocityCount}" tabindex="-1"
+                     role="dialog"
+                     aria-labelledby="executionOptionsLabel">
                       <div class="modal-dialog" role="document">
                           <div class="modal-content">
                               <div class="modal-header">
@@ -124,7 +140,9 @@
                                   <h4 class="modal-title" id="executionOptionsLabel">Execution Options</h4>
                               </div>
                               <div class="modal-body">
-                                  ${sched.executionOptions.toObject()}
+                              ## Used <pre> to display text with code format
+                                <pre
+                                    class="executionOptions-json">${sched.executionOptions.toJSON()}</pre>
                               </div>
                               <div class="modal-footer">
                                   <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
When users click the show button for executionOptions on /scheduling page, it shows the same info for all schedules, which is incorrect. This is related to a recent change in PR https://github.com/azkaban/azkaban/pull/909
The issue happens because the executionOptions id is the same for all schedules when loading the page. I made the change to specify the executionOptions id for each schedule. Also, I changed the display of executionOptions info and the show button style to make it more readable.