### PR TITLE
fix JDBC test failure reported in #1614

### DIFF
--- a/azkaban-common/src/test/java/azkaban/trigger/JdbcTriggerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/JdbcTriggerImplTest.java
@@ -18,24 +18,19 @@ package azkaban.trigger;
 
 import static org.junit.Assert.assertTrue;
 
-import azkaban.database.AzkabanConnectionPoolTest;
-import azkaban.database.AzkabanDataSource;
-import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.db.DatabaseOperator;
 import azkaban.executor.ExecutionOptions;
 import azkaban.trigger.builtin.BasicTimeChecker;
 import azkaban.trigger.builtin.ExecuteFlowAction;
-import azkaban.utils.Props;
 import azkaban.utils.Utils;
-import java.io.File;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.dbutils.QueryRunner;
 import org.joda.time.DateTime;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,20 +38,12 @@ import org.junit.Test;
 
 public class JdbcTriggerImplTest {
 
-  public static AzkabanDataSource dataSource = new AzkabanConnectionPoolTest.EmbeddedH2BasicDataSource();
-  TriggerLoader loader;
-  DatabaseOperator dbOperator;
+  private static DatabaseOperator dbOperator;
+  private TriggerLoader loader;
 
   @BeforeClass
   public static void prepare() throws Exception {
-    final Props props = new Props();
-
-    final String sqlScriptsDir = new File("../azkaban-db/src/main/sql/").getCanonicalPath();
-    props.put("database.sql.scripts.dir", sqlScriptsDir);
-
-    final AzkabanDatabaseSetup setup = new AzkabanDatabaseSetup(dataSource, props);
-    setup.loadTableInfo();
-    setup.updateDatabase(true, false);
+    dbOperator = azkaban.test.Utils.initTestDB();
 
     final CheckerTypeLoader checkerTypeLoader = new CheckerTypeLoader();
     final ActionTypeLoader actionTypeLoader = new ActionTypeLoader();
@@ -75,11 +62,19 @@ public class JdbcTriggerImplTest {
     actionTypeLoader.registerActionType(ExecuteFlowAction.type, ExecuteFlowAction.class);
   }
 
+  @AfterClass
+  public static void destroyDB() throws Exception {
+    try {
+      dbOperator.update("DROP ALL OBJECTS");
+      dbOperator.update("SHUTDOWN");
+    } catch (final SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
   @Before
   public void setUp() {
-
-    this.dbOperator = new DatabaseOperator(new QueryRunner(dataSource));
-    this.loader = new JdbcTriggerImpl(this.dbOperator);
+    this.loader = new JdbcTriggerImpl(dbOperator);
   }
 
   @Test
@@ -149,21 +144,18 @@ public class JdbcTriggerImplTest {
             "azkaban", new ExecutionOptions(), null);
     actions.add(action);
 
-    final Trigger t = new Trigger.TriggerBuilder("azkaban",
+    return new Trigger.TriggerBuilder("azkaban",
         source,
         triggerCond,
         expireCond,
         actions)
         .build();
-
-    return t;
   }
 
   @After
   public void clearDB() {
     try {
-      this.dbOperator.update("DELETE FROM triggers");
-
+      dbOperator.update("DELETE FROM triggers");
     } catch (final SQLException e) {
       e.printStackTrace();
       return;


### PR DESCRIPTION
This PR is mainly a refactor, in order to fix JDBC intermittent test failure reported in #1614. Looks like JdbcTriggerImplTest uses a deprecated class to construct h2 test db. The fix is to replace it with the one which all XXXDaoTest currently are depending on.