### PR TITLE
adding db transaction failure metrics

### DIFF
--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -26,10 +26,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.lang.reflect.Constructor;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +62,7 @@ public class MetricsManager {
    */
   public Meter addMeter(final String name) {
     final Meter curr = this.registry.meter(name);
-    this.registry.register(name + "-gauge", (Gauge<Double>) curr::getFifteenMinuteRate);
+    this.registry.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
     return curr;
   }
 

--- a/azkaban-db/src/main/java/azkaban/db/DBMetrics.java
+++ b/azkaban-db/src/main/java/azkaban/db/DBMetrics.java
@@ -32,6 +32,9 @@ public class DBMetrics {
   private final MetricsManager metricsManager;
   private Meter dbConnectionMeter;
   private Meter dbConnectionFailMeter;
+  private Meter queryFailMeter;
+  private Meter updateFailMeter;
+  private Meter transactionFailMeter;
 
   @Inject
   public DBMetrics(final MetricsManager metricsManager) {
@@ -42,13 +45,16 @@ public class DBMetrics {
   private void setupAllMetrics() {
     this.dbConnectionMeter = this.metricsManager.addMeter("DB-Connection-meter");
     this.dbConnectionFailMeter = this.metricsManager.addMeter("DB-Fail-Connection-meter");
+    this.queryFailMeter = this.metricsManager.addMeter("DB-Fail-Query-meter");
+    this.updateFailMeter = this.metricsManager.addMeter("DB-Fail-Update-meter");
+    this.transactionFailMeter = this.metricsManager.addMeter("DB-Fail-Transaction-meter");
     this.metricsManager.addGauge("dbConnectionTime", this.dbConnectionTime::get);
   }
 
   /**
    * Mark the occurrence of an DB query event.
    */
-  public void markDBConnection() {
+  void markDBConnection() {
 
     /*
      * This method should be Thread Safe.
@@ -60,13 +66,35 @@ public class DBMetrics {
   }
 
   /**
+   * Mark the occurrence when DB query step fails
+   */
+  void markDBFailQuery() {
+    this.queryFailMeter.mark();
+  }
+
+  /**
+   * Mark the occurrence when DB update fails.
+   */
+  void markDBFailUpdate() {
+    this.updateFailMeter.mark();
+  }
+
+  /**
+   * Mark the occurrence when AZ DB transaction fails.
+   */
+  void markDBFailTransaction() {
+    this.transactionFailMeter.mark();
+  }
+
+  /**
    * Mark the occurrence when DB get connection fails.
    */
-  public void markDBFailConnection() {
+  void markDBFailConnection() {
     this.dbConnectionFailMeter.mark();
   }
 
-  public void setDBConnectionTime(final long milliseconds) {
+
+  void setDBConnectionTime(final long milliseconds) {
     this.dbConnectionTime.set(milliseconds);
   }
 }

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
@@ -39,6 +39,9 @@ public class DatabaseOperator {
 
   private final QueryRunner queryRunner;
 
+  @Inject
+  private DBMetrics dbMetrics;
+
   /**
    * Note: this queryRunner should include a concrete {@link AzkabanDataSource} inside.
    */
@@ -66,6 +69,9 @@ public class DatabaseOperator {
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
       logger.error("query failed", ex);
+      if (this.dbMetrics != null) {
+        this.dbMetrics.markDBFailQuery();
+      }
       throw ex;
     }
   }
@@ -92,6 +98,9 @@ public class DatabaseOperator {
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
       logger.error("transaction failed", ex);
+      if (this.dbMetrics != null) {
+        this.dbMetrics.markDBFailTransaction();
+      }
       throw ex;
     } finally {
       DbUtils.closeQuietly(conn);
@@ -113,6 +122,9 @@ public class DatabaseOperator {
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
       logger.error("update failed", ex);
+      if (this.dbMetrics != null) {
+        this.dbMetrics.markDBFailUpdate();
+      }
       throw ex;
     }
   }


### PR DESCRIPTION
This PR proposes two changes:
* Originally we use `getFifteenMinuteRate` to get transform meter to gauge. 15 mins was too large, and we'd better change it to 1 minute window to reduce smoothing effect
* Adding database transaction metrics if database throws an exception during the query phase.

Tested on the staging environment.