### PR TITLE
Fix Advanced Filter search bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ For help, please visit the [Azkaban Google Group](https://groups.google.com/foru
 ## Developer Guide
 
 See [the contribution guide](https://github.com/azkaban/azkaban/blob/master/CONTRIBUTING.md).
+

--- a/README.md
+++ b/README.md
@@ -50,4 +50,3 @@ For help, please visit the [Azkaban Google Group](https://groups.google.com/foru
 ## Developer Guide
 
 See [the contribution guide](https://github.com/azkaban/azkaban/blob/master/CONTRIBUTING.md).
-

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -268,7 +268,7 @@ public class ExecutionFlowDao {
       ResultSetHandler<List<ExecutableFlow>> {
 
     static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows ";
+        "SELECT exec_id, ef.enc_type, flow_data FROM execution_flows ";
     static String FETCH_EXECUTABLE_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE exec_id=?";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -142,7 +142,7 @@ public class ExecutionFlowDao {
 
     boolean first = true;
     if (projContain != null && !projContain.isEmpty()) {
-      query += " ef JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?";
+      query += " JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?";
       params.add('%' + projContain + '%');
       first = false;
     }
@@ -268,7 +268,7 @@ public class ExecutionFlowDao {
       ResultSetHandler<List<ExecutableFlow>> {
 
     static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
-        "SELECT exec_id, ef.enc_type, flow_data FROM execution_flows ";
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef";
     static String FETCH_EXECUTABLE_FLOW =
         "SELECT exec_id, enc_type, flow_data FROM execution_flows "
             + "WHERE exec_id=?";

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -138,6 +138,18 @@ public class ExecutionFlowDaoTest {
   }
 
   @Test
+  public void testAdvancedFilter() throws Exception {
+    final ExecutableFlow flow = createTestFlow();
+    this.executionFlowDao.uploadExecutableFlow(flow);
+    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory("exectest1", "", "", 0, -1, -1, 0, 16);
+    assertThat(flowList1.size()).isEqualTo(1);
+
+    final ExecutableFlow fetchFlow =
+            this.executionFlowDao.fetchExecutableFlow(flow.getExecutionId());
+    assertTwoFlowSame(flowList1.get(0), fetchFlow);
+  }
+
+  @Test
   public void testFetchRecentlyFinishedFlows() throws Exception {
     final ExecutableFlow flow1 = createTestFlow();
     this.executionFlowDao.uploadExecutableFlow(flow1);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -20,8 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.db.DatabaseOperator;
+import azkaban.project.JdbcProjectImpl;
+import azkaban.project.ProjectLoader;
 import azkaban.test.Utils;
 import azkaban.test.executions.ExecutionsTestUtil;
+import azkaban.user.User;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
@@ -50,6 +53,8 @@ public class ExecutionFlowDaoTest {
   private AssignExecutorDao assignExecutor;
   private FetchActiveFlowDao fetchActiveFlowDao;
   private ExecutionJobDao executionJobDao;
+  private static final Props props = new Props();
+  private ProjectLoader loader;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -73,6 +78,7 @@ public class ExecutionFlowDaoTest {
     this.assignExecutor = new AssignExecutorDao(dbOperator, this.executorDao);
     this.fetchActiveFlowDao = new FetchActiveFlowDao(dbOperator);
     this.executionJobDao = new ExecutionJobDao(dbOperator);
+    this.loader = new JdbcProjectImpl(props, dbOperator);
   }
 
   @After
@@ -80,6 +86,7 @@ public class ExecutionFlowDaoTest {
     try {
       dbOperator.update("DELETE FROM execution_flows");
       dbOperator.update("DELETE FROM executors");
+      dbOperator.update("DELETE FROM projects");
     } catch (final SQLException e) {
       e.printStackTrace();
     }
@@ -87,6 +94,13 @@ public class ExecutionFlowDaoTest {
 
   private ExecutableFlow createTestFlow() throws Exception {
     return TestUtils.createTestExecutableFlow("exectest1", "exec1");
+  }
+
+  private void createTestProject() {
+    String projectName = "flow";
+    String projectDescription = "This is my new project";
+    User user = new User("testUser1");
+    this.loader.createNewProject(projectName, projectDescription, user);
   }
 
   @Test
@@ -139,9 +153,10 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testAdvancedFilter() throws Exception {
+    createTestProject();
     final ExecutableFlow flow = createTestFlow();
     this.executionFlowDao.uploadExecutableFlow(flow);
-    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory("exectest1", "", "", 0, -1, -1, 0, 16);
+    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory("flow", "", "",0, -1, -1, 0, 16);
     assertThat(flowList1.size()).isEqualTo(1);
 
     final ExecutableFlow fetchFlow =

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -97,7 +97,7 @@ public class ExecutionFlowDaoTest {
   }
 
   private void createTestProject() {
-    String projectName = "flow";
+    String projectName = "exectest1";
     String projectDescription = "This is my new project";
     User user = new User("testUser1");
     this.loader.createNewProject(projectName, projectDescription, user);
@@ -156,7 +156,7 @@ public class ExecutionFlowDaoTest {
     createTestProject();
     final ExecutableFlow flow = createTestFlow();
     this.executionFlowDao.uploadExecutableFlow(flow);
-    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory("flow", "", "",0, -1, -1, 0, 16);
+    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory("exectest1", "", "",0, -1, -1, 0, 16);
     assertThat(flowList1.size()).isEqualTo(1);
 
     final ExecutableFlow fetchFlow =


### PR DESCRIPTION
If I fill in project field and push Filter button in Advanced Filter, search doesn't work.
![](https://gyazo.com/f55436b73f22d79501a62b9f572b9141.png)

Here is azkaban web server log
```
java.sql.SQLException: Column 'enc_type' in field list is ambiguous Query: SELECT exec_id, enc_type, flow_data FROM execution_flows  ef JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?  ORDER BY exec_id DESC LIMIT ?, ? Parameters: [%hoge%, 0, 16]
        at org.apache.commons.dbutils.AbstractQueryRunner.rethrow(AbstractQueryRunner.java:363)
        at org.apache.commons.dbutils.QueryRunner.query(QueryRunner.java:350)
        at org.apache.commons.dbutils.QueryRunner.query(QueryRunner.java:288)
        at azkaban.db.DatabaseOperator.query(DatabaseOperator.java:65)
        at azkaban.executor.ExecutionFlowDao.fetchFlowHistory(ExecutionFlowDao.java:213)
        at azkaban.executor.JdbcExecutorLoader.fetchFlowHistory(JdbcExecutorLoader.java:152)
        at azkaban.executor.ExecutorManager.getExecutableFlows(ExecutorManager.java:659)
        at azkaban.webapp.servlet.HistoryServlet.handleHistoryPage(HistoryServlet.java:114)
        at azkaban.webapp.servlet.HistoryServlet.handleGet(HistoryServlet.java:60)
        at azkaban.webapp.servlet.LoginAbstractAzkabanServlet.doGet(LoginAbstractAzkabanServlet.java:123)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:668)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:770)
        at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
        at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:401)
        at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
        at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:766)
        at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
        at org.mortbay.jetty.Server.handle(Server.java:326)
        at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
        at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:928)
        at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:549)
        at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:212)
        at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
        at org.mortbay.jetty.bio.SocketConnector$Connection.run(SocketConnector.java:228)
        at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
```