### PR TITLE
start the flow trigger service first then flow trigger scheduler

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -540,8 +540,10 @@ public class AzkabanWebServer extends AzkabanServer {
     }
 
     if (this.props.getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false)) {
-      this.scheduler.start();
+      // flowTriggerService needs to be started first before scheduler starts to schedule
+      // existing flow triggers
       this.flowTriggerService.start();
+      this.scheduler.start();
     }
 
     try {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -542,7 +542,9 @@ public class AzkabanWebServer extends AzkabanServer {
     if (this.props.getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false)) {
       // flowTriggerService needs to be started first before scheduler starts to schedule
       // existing flow triggers
+      logger.info("starting flow trigger service");
       this.flowTriggerService.start();
+      logger.info("starting flow trigger scheduler");
       this.scheduler.start();
     }
 


### PR DESCRIPTION
flow trigger service needs to be started first before scheduler starts to schedule existing flow triggers. This PR puts starting flow trigger service before starting flow trigger scheduler and adds more logging when starting flow trigger service/scheduler.