### PR TITLE
Add boolean property for evicting executions

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -196,6 +196,22 @@ public class Constants {
 
     // dir to keep dependency plugins
     public static final String DEPENDENCY_PLUGIN_DIR = "azkaban.dependency.plugin.dir";
+
+    public static final String USE_MULTIPLE_EXECUTORS = "azkaban.use.multiple.executors";
+    public static final String MAX_CONCURRENT_RUNS_ONEFLOW = "azkaban.max.concurrent.runs.oneflow";
+    public static final String WEBSERVER_QUEUE_SIZE = "azkaban.webserver.queue.size";
+    public static final String ACTIVE_EXECUTOR_REFRESH_IN_MS =
+        "azkaban.activeexecutor.refresh.milisecinterval";
+    public static final String ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
+        "azkaban.activeexecutor.refresh.flowinterval";
+    public static final String EXECUTORINFO_REFRESH_MAX_THREADS =
+        "azkaban.executorinfo.refresh.maxThreads";
+    public static final String MAX_DISPATCHING_ERRORS_PERMITTED = "azkaban.maxDispatchingErrors";
+    public static final String EVICT_EXECUTIONS = "azkaban.evictExecutions";
+    public static final String EXECUTOR_SELECTOR_FILTERS = "azkaban.executorselector.filters";
+    public static final String EXECUTOR_SELECTOR_COMPARATOR_PREFIX =
+        "azkaban.executorselector.comparator.";
+    public static final String QUEUEPROCESSING_ENABLED = "azkaban.queueprocessing.enabled";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -66,29 +66,7 @@ import java.util.concurrent.TimeoutException;
 public class ExecutorManager extends EventHandler implements
     ExecutorManagerAdapter {
 
-  public static final String AZKABAN_USE_MULTIPLE_EXECUTORS =
-      "azkaban.use.multiple.executors";
-  public static final String AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW =
-      "azkaban.max.concurrent.runs.oneflow";
-  static final String AZKABAN_EXECUTOR_SELECTOR_FILTERS =
-      "azkaban.executorselector.filters";
-  static final String AZKABAN_EXECUTOR_SELECTOR_COMPARATOR_PREFIX =
-      "azkaban.executorselector.comparator.";
-  static final String AZKABAN_QUEUEPROCESSING_ENABLED =
-      "azkaban.queueprocessing.enabled";
-  private static final String AZKABAN_WEBSERVER_QUEUE_SIZE =
-      "azkaban.webserver.queue.size";
-  private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_MS =
-      "azkaban.activeexecutor.refresh.milisecinterval";
-  private static final String AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW =
-      "azkaban.activeexecutor.refresh.flowinterval";
   private static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
-  private static final String AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS =
-      "azkaban.executorinfo.refresh.maxThreads";
-  private static final String AZKABAN_MAX_DISPATCHING_ERRORS_PERMITTED =
-      "azkaban.maxDispatchingErrors";
-  private static final String AZKABAN_EVICT_EXECUTIONS =
-      "azkaban.evictExecutions";
   // 12 weeks
   private static final long DEFAULT_EXECUTION_LOGS_RETENTION_MS = 3 * 4 * 7
       * 24 * 60 * 60 * 1000L;
@@ -130,12 +108,14 @@ public class ExecutorManager extends EventHandler implements
     this.setupExecutors();
     this.loadRunningFlows();
 
-    this.queuedFlows = new QueuedExecutions(azkProps.getLong(AZKABAN_WEBSERVER_QUEUE_SIZE, 100000));
+    this.queuedFlows = new QueuedExecutions(
+        azkProps.getLong(Constants.ConfigurationKeys.WEBSERVER_QUEUE_SIZE, 100000));
 
     // The default threshold is set to 30 for now, in case some users are affected. We may
     // decrease this number in future, to better prevent DDos attacks.
-    this.maxConcurrentRunsOneFlow = azkProps.getInt(AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW,
-        DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
+    this.maxConcurrentRunsOneFlow = azkProps
+        .getInt(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW,
+            DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
     this.loadQueuedFlows();
 
     this.cacheDir = new File(azkProps.getString("cache.directory", "cache"));
@@ -147,9 +127,8 @@ public class ExecutorManager extends EventHandler implements
       setupMultiExecutorMode();
     }
 
-    final long executionLogsRetentionMs =
-        azkProps.getLong("execution.logs.retention.ms",
-            DEFAULT_EXECUTION_LOGS_RETENTION_MS);
+    final long executionLogsRetentionMs = azkProps
+        .getLong("execution.logs.retention.ms", DEFAULT_EXECUTION_LOGS_RETENTION_MS);
 
     this.cleanerThread = new CleanerThread(executionLogsRetentionMs);
     this.cleanerThread.start();
@@ -158,15 +137,16 @@ public class ExecutorManager extends EventHandler implements
 
   private void setupMultiExecutorMode() {
     // initliatize hard filters for executor selector from azkaban.properties
-    final String filters = this.azkProps.getString(AZKABAN_EXECUTOR_SELECTOR_FILTERS, "");
+    final String filters = this.azkProps
+        .getString(Constants.ConfigurationKeys.EXECUTOR_SELECTOR_FILTERS, "");
     if (filters != null) {
       this.filterList = Arrays.asList(StringUtils.split(filters, ","));
     }
 
     // initliatize comparator feature weights for executor selector from
     // azkaban.properties
-    final Map<String, String> compListStrings =
-        this.azkProps.getMapByPrefix(AZKABAN_EXECUTOR_SELECTOR_COMPARATOR_PREFIX);
+    final Map<String, String> compListStrings = this.azkProps
+        .getMapByPrefix(Constants.ConfigurationKeys.EXECUTOR_SELECTOR_COMPARATOR_PREFIX);
     if (compListStrings != null) {
       this.comparatorWeightsMap = new TreeMap<>();
       for (final Map.Entry<String, String> entry : compListStrings.entrySet()) {
@@ -176,15 +156,16 @@ public class ExecutorManager extends EventHandler implements
 
     this.executorInforRefresherService =
         Executors.newFixedThreadPool(this.azkProps.getInt(
-            AZKABAN_EXECUTORINFO_REFRESH_MAX_THREADS, 5));
+            Constants.ConfigurationKeys.EXECUTORINFO_REFRESH_MAX_THREADS, 5));
 
     // configure queue processor
     this.queueProcessor =
         new QueueProcessorThread(this.azkProps.getBoolean(
-            AZKABAN_QUEUEPROCESSING_ENABLED, true), this.azkProps.getLong(
-            AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_MS, 50000), this.azkProps.getInt(
-            AZKABAN_ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW, 5), this.azkProps.getInt(
-            AZKABAN_MAX_DISPATCHING_ERRORS_PERMITTED, this.activeExecutors.size()));
+            Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, true), this.azkProps.getLong(
+            Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_MS, 50000), this.azkProps.getInt(
+            Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW, 5),
+            this.azkProps.getInt(Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED,
+                this.activeExecutors.size()));
 
     this.queueProcessor.start();
   }
@@ -235,11 +216,11 @@ public class ExecutorManager extends EventHandler implements
   }
 
   private boolean isMultiExecutorMode() {
-    return this.azkProps.getBoolean(AZKABAN_USE_MULTIPLE_EXECUTORS, false);
+    return this.azkProps.getBoolean(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, false);
   }
 
   private boolean isEvictExecutions() {
-    return this.azkProps.getBoolean(AZKABAN_EVICT_EXECUTIONS, true);
+    return this.azkProps.getBoolean(Constants.ConfigurationKeys.EVICT_EXECUTIONS, true);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import azkaban.Constants;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.user.User;
@@ -85,8 +86,8 @@ public class ExecutorManagerTest {
    * Helper method to create a ExecutorManager Instance
    */
   private ExecutorManager createMultiExecutorManagerInstance() throws Exception {
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
-    this.props.put(ExecutorManager.AZKABAN_QUEUEPROCESSING_ENABLED, "false");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, "false");
     this.loader.addExecutor("localhost", 12345);
     this.loader.addExecutor("localhost", 12346);
     return createExecutorManager();
@@ -98,7 +99,7 @@ public class ExecutorManagerTest {
    */
   @Test(expected = ExecutorManagerException.class)
   public void testNoExecutorScenario() throws Exception {
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     @SuppressWarnings("unused") final ExecutorManager manager = createExecutorManager();
   }
 
@@ -125,7 +126,7 @@ public class ExecutorManagerTest {
    */
   @Test
   public void testMultipleExecutorScenario() throws Exception {
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     final Executor executor1 = this.loader.addExecutor("localhost", 12345);
     final Executor executor2 = this.loader.addExecutor("localhost", 12346);
 
@@ -147,7 +148,7 @@ public class ExecutorManagerTest {
    */
   @Test
   public void testSetupExecutorsSucess() throws Exception {
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     final Executor executor1 = this.loader.addExecutor("localhost", 12345);
     final ExecutorManager manager = createExecutorManager();
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
@@ -170,7 +171,7 @@ public class ExecutorManagerTest {
    */
   @Test(expected = ExecutorManagerException.class)
   public void testSetupExecutorsException() throws Exception {
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     final Executor executor1 = this.loader.addExecutor("localhost", 12345);
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
@@ -384,13 +385,13 @@ public class ExecutorManagerTest {
     this.loader = mock(ExecutorLoader.class);
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.user = TestUtils.getTestUser();
-    this.props.put(ExecutorManager.AZKABAN_USE_MULTIPLE_EXECUTORS, "true");
+    this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     //To test runningFlows, AZKABAN_QUEUEPROCESSING_ENABLED should be set to true
     //so that flows will be dispatched to executors.
-    this.props.put(ExecutorManager.AZKABAN_QUEUEPROCESSING_ENABLED, "true");
+    this.props.put(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, "true");
 
     // allow two concurrent runs give one Flow
-    this.props.put(ExecutorManager.AZKABAN_MAX_CONCURRENT_RUNS_ONEFLOW, 2);
+    this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 2);
 
     final List<Executor> executors = new ArrayList<>();
     final Executor executor1 = new Executor(1, "localhost", 12345, true);


### PR DESCRIPTION
New boolean property `azkaban.evictExecutions`. Default: `true` (to match existing behaviour).

This can be used to decide whether Azkaban should ever give up on getting a response from executor.

As before, an eventual successful response may still indicate that an execution is not running on that executor any more, which will cause cleaning it up as usual.

In practice the automatic evicting has caused more trouble than benefit in our case. It's really surprising to see that executions are disappearing from the _Executing_ list in UI while they are still running on azkaban-executor side. I would recommend setting this to `false` even by default, but of course evicting may still be needed in some use cases that I can't really imagine - so I wouldn't dare to change it without users' own consideration.

This is related to #1653 - which needs to be fixed though, before it makes sense for anyone to set `azkaban.evictExecutions=false`