### PR TITLE
WIP: call executor /update with POST

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -32,6 +32,12 @@ import azkaban.utils.JSONUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.lang.Thread.State;
@@ -52,11 +58,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
 
 /**
  * Executor manager used to manage the client side job.
@@ -1080,7 +1081,7 @@ public class ExecutorManager extends EventHandler implements
         .add(new Pair<>(ConnectorParams.ACTION_PARAM, action));
 
     return this.apiGateway.callForJsonObjectMap(executor.getHost(), executor.getPort(),
-        "/stats", paramList);
+        "GET", "/stats", paramList);
   }
 
 
@@ -1097,7 +1098,7 @@ public class ExecutorManager extends EventHandler implements
 
     final String[] hostPortSplit = hostPort.split(":");
     return this.apiGateway.callForJsonObjectMap(hostPortSplit[0],
-        Integer.valueOf(hostPortSplit[1]), "/jmx", paramList);
+        Integer.valueOf(hostPortSplit[1]), "GET", "/jmx", paramList);
   }
 
   @Override
@@ -1473,7 +1474,7 @@ public class ExecutorManager extends EventHandler implements
               Map<String, Object> results = null;
               try {
                 results =
-                    ExecutorManager.this.apiGateway.callWithExecutionId(executor.getHost(),
+                    ExecutorManager.this.apiGateway.postWithExecutionId(executor.getHost(),
                         executor.getPort(), ConnectorParams.UPDATE_ACTION,
                         null, null, executionIds, updateTimes);
               } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
+++ b/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
@@ -21,11 +21,13 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
@@ -33,9 +35,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 
 /**
@@ -138,11 +140,13 @@ public abstract class RestfulApiClient<T> {
   private static HttpEntityEnclosingRequestBase completeRequest(
       final HttpEntityEnclosingRequestBase request,
       final List<NameValuePair> headerEntries,
-      final String postingBody) throws UnsupportedEncodingException {
+      final List<Pair<String, String>> params) throws UnsupportedEncodingException {
     if (null != completeRequest(request, headerEntries)) {
-      // dump the post body UTF-8 will be used as the default encoding type.
-      if (null != postingBody && postingBody.length() > 0) {
-        final HttpEntity entity = new ByteArrayEntity(postingBody.getBytes("UTF-8"));
+      if (null != params && !params.isEmpty()) {
+        final List<NameValuePair> formParams = params.stream()
+            .map(pair -> new BasicNameValuePair(pair.getFirst(), pair.getSecond()))
+            .collect(Collectors.toList());
+        final HttpEntity entity = new UrlEncodedFormEntity(formParams, "UTF-8");
         request.setHeader("Content-Length", Long.toString(entity.getContentLength()));
         request.setEntity(entity);
       }
@@ -182,13 +186,13 @@ public abstract class RestfulApiClient<T> {
    *
    * @param uri the URI of the request.
    * @param headerEntries extra entries to be added to request header.
-   * @param postingBody the content to be posted , optional.
+   * @param params the form params to be posted, optional.
    * @return the response object type of which is specified by user.
    * @throws UnsupportedEncodingException, IOException
    */
   public T httpPost(final URI uri,
       final List<NameValuePair> headerEntries,
-      final String postingBody) throws UnsupportedEncodingException, IOException {
+      final List<Pair<String, String>> params) throws UnsupportedEncodingException, IOException {
     // shortcut if the passed url is invalid.
     if (null == uri) {
       logger.error(" unable to perform httpPost as the passed uri is null.");
@@ -196,7 +200,7 @@ public abstract class RestfulApiClient<T> {
     }
 
     final HttpPost post = new HttpPost(uri);
-    return this.sendAndReturn(completeRequest(post, headerEntries, postingBody));
+    return this.sendAndReturn(completeRequest(post, headerEntries, params));
   }
 
   /**
@@ -222,12 +226,12 @@ public abstract class RestfulApiClient<T> {
    *
    * @param uri the URI of the request.
    * @param headerEntries extra entries to be added to request header.
-   * @param postingBody the content to be posted , optional.
+   * @param params the content to be posted , optional.
    * @return the response object type of which is specified by user.
    * @throws UnsupportedEncodingException, IOException
    */
   public T httpPut(final URI uri, final List<NameValuePair> headerEntries,
-      final String postingBody) throws UnsupportedEncodingException, IOException {
+      final List<Pair<String, String>> params) throws UnsupportedEncodingException, IOException {
     // shortcut if the passed url is invalid.
     if (null == uri) {
       logger.error(" unable to perform httpPut as the passed url is null or empty.");
@@ -235,7 +239,7 @@ public abstract class RestfulApiClient<T> {
     }
 
     final HttpPut put = new HttpPut(uri);
-    return this.sendAndReturn(completeRequest(put, headerEntries, postingBody));
+    return this.sendAndReturn(completeRequest(put, headerEntries, params));
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -291,7 +291,7 @@ public class ExecutorManagerTest {
   @SuppressWarnings("unchecked")
   private void mockUpdateResponse(
       final Map<String, List<Map<String, Object>>> map) throws Exception {
-    doReturn(map).when(this.apiGateway).callWithExecutionId(
+    doReturn(map).when(this.apiGateway).postWithExecutionId(
         any(), anyInt(), eq(ConnectorParams.UPDATE_ACTION), any(), any(), any(), any());
   }
 

--- a/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
@@ -19,6 +19,8 @@ package azkaban.utils;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -38,9 +40,6 @@ import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- *
- */
 public class RestfulApiClientTest {
 
   @Test
@@ -83,12 +82,12 @@ public class RestfulApiClientTest {
 
     final String content = "123456789";
 
-    final String result = mockClient.httpPost(uri, headerItems, content);
+    final String result = mockClient.httpPost(uri, headerItems, toPairList(content));
     Assert.assertTrue(result != null && result.contains(uri.toString()));
     Assert.assertTrue(result.contains("METHOD = POST"));
     Assert.assertTrue(result.contains("h1 = v1"));
     Assert.assertTrue(result.contains("h2 = v2"));
-    Assert.assertTrue(result.contains(String.format("%s = %s;", "BODY", content)));
+    Assert.assertTrue(result.contains(String.format("%s = value=%s;", "BODY", content)));
   }
 
   @Test
@@ -116,12 +115,12 @@ public class RestfulApiClientTest {
 
     final String content = "123456789";
 
-    final String result = mockClient.httpPut(uri, headerItems, content);
+    final String result = mockClient.httpPut(uri, headerItems, toPairList(content));
     Assert.assertTrue(result != null && result.contains(uri.toString()));
     Assert.assertTrue(result.contains("METHOD = PUT"));
     Assert.assertTrue(result.contains("h1 = v1"));
     Assert.assertTrue(result.contains("h2 = v2"));
-    Assert.assertTrue(result.contains(String.format("%s = %s;", "BODY", content)));
+    Assert.assertTrue(result.contains(String.format("%s = value=%s;", "BODY", content)));
   }
 
   @Test
@@ -132,9 +131,9 @@ public class RestfulApiClientTest {
 
     final String content = "123456789";
 
-    final String result = mockClient.httpPut(uri, null, content);
+    final String result = mockClient.httpPut(uri, null, toPairList(content));
     Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("Content-Length = " + Integer.toString(content.length())));
+    Assert.assertTrue(result.contains("Content-Length = " + getExpectedLength(content)));
   }
 
   @Test
@@ -148,10 +147,10 @@ public class RestfulApiClientTest {
 
     final String content = "123456789";
 
-    final String result = mockClient.httpPut(uri, headerItems, content);
+    final String result = mockClient.httpPut(uri, headerItems, toPairList(content));
     Assert.assertTrue(result != null && result.contains(uri.toString()));
     Assert.assertEquals(result.lastIndexOf("Content-Length"), result.indexOf("Content-Length"));
-    Assert.assertTrue(result.contains("Content-Length = " + Integer.toString(content.length())));
+    Assert.assertTrue(result.contains("Content-Length = " + getExpectedLength(content)));
   }
 
   @Test
@@ -169,6 +168,14 @@ public class RestfulApiClientTest {
     Assert.assertTrue(result.contains("METHOD = DELETE"));
     Assert.assertTrue(result.contains("h1 = v1"));
     Assert.assertTrue(result.contains("h2 = v2"));
+  }
+
+  private List<Pair<String, String>> toPairList(final String content) {
+    return Collections.singletonList(new Pair<>("value", content));
+  }
+
+  private String getExpectedLength(final String content) {
+    return Integer.toString("value=".length() + content.length());
   }
 
   static class MockRestfulApiClient extends RestfulApiClient<String> {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/RequestProcessor.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/RequestProcessor.java
@@ -1,0 +1,12 @@
+package azkaban.execapp;
+
+import java.io.IOException;
+import java.util.HashMap;
+import javax.servlet.ServletException;
+
+@FunctionalInterface
+public interface RequestProcessor {
+
+  void process(HashMap<String, Object> respMap, String action) throws ServletException, IOException;
+
+}


### PR DESCRIPTION
This is a candidate fix for https://github.com/azkaban/azkaban/issues/1653.

The idea here is to use POST with form params instead of GET with URL params, so that the number of execution ids passed can be longer.

This implementation is basically ready, but not sure if this works yet, untested end to end.