### PR TITLE
Add an API to allow Props to load both current and parent properties 

### DIFF
--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -667,7 +667,9 @@ public class Props {
   }
 
   /**
-   * Returns a java.util.Properties file populated with the stuff in here.
+   * Returns a java.util.Properties file populated with the current Properties in here.
+   * Note: if you want to import parent properties (e.g., database credentials), please use
+   * toAllProperties
    */
   public Properties toProperties() {
     final Properties p = new Properties();
@@ -676,6 +678,21 @@ public class Props {
     }
 
     return p;
+  }
+
+  /**
+   * Returns a java.util.Properties file populated with both current and parent properties.
+   */
+  public Properties toAllProperties() {
+    Properties allProp = new Properties();
+    // import local properties
+    allProp.putAll(toProperties());
+
+    // import parent properties
+    if(_parent != null)
+      allProp.putAll(_parent.toProperties());
+
+    return allProp;
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -55,7 +55,7 @@ public class QuartzScheduler {
       return;
     }
     final StdSchedulerFactory schedulerFactory =
-        new StdSchedulerFactory(azProps.toProperties());
+        new StdSchedulerFactory(azProps.toAllProperties());
     this.scheduler = schedulerFactory.getScheduler();
 
     // Currently Quartz only support internal job schedules. When we migrate to User Production

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -54,6 +54,9 @@ public class QuartzScheduler {
     if (!azProps.getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false)) {
       return;
     }
+    // TODO kunkun-tang: Many quartz properties should be defaulted such that not necessarily being
+    // checked into azkaban.properties. Also, we need to only assemble Quartz related properties
+    // here, which should be done in Azkaban WebServer Guice Module.
     final StdSchedulerFactory schedulerFactory =
         new StdSchedulerFactory(azProps.toAllProperties());
     this.scheduler = schedulerFactory.getScheduler();


### PR DESCRIPTION
Today `toProperties` in Props API doesn't include parent properties. In this PR, we add an API to import both current and parent properties. 

Tested locally.