### PR TITLE
Call executor servlet with POST

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
@@ -118,10 +118,9 @@ public class ExecutorApiGateway {
     }
 
     @SuppressWarnings("unchecked") final URI uri =
-        ExecutorApiClient.buildUri(host, port, path, true,
-            paramList.toArray(new Pair[0]));
+        ExecutorApiClient.buildUri(host, port, path, true);
 
-    return this.apiClient.httpGet(uri, null);
+    return this.apiClient.httpPost(uri, paramList);
   }
 
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
@@ -29,8 +29,16 @@ public class ExecutorApiGatewaySystemTest {
 
   @Test
   public void update300Executions() throws Exception {
-    // this fails because the URL is too long
+    // used to fail because the URL is too long
+    // works after switching to HTTP POST
     updateExecutions(300);
+  }
+
+  @Test
+  public void update100kExecutions() throws Exception {
+    // used to fail because the URL is too long
+    // works after switching to HTTP POST
+    updateExecutions(100_000);
   }
 
   private void updateExecutions(int count) throws ExecutorManagerException {
@@ -54,7 +62,12 @@ public class ExecutorApiGatewaySystemTest {
     Map<String, Object> results = apiGateway.callWithExecutionId("localhost", 12321,
         ConnectorParams.UPDATE_ACTION, null, null, executionIds, updateTimes);
 
-    Assert.assertTrue(results != null && !results.isEmpty());
+    Assert.assertTrue(results != null);
+    final List<Map<String, Object>> executionUpdates =
+        (List<Map<String, Object>>) results
+            .get(ConnectorParams.RESPONSE_UPDATED_FLOWS);
+    Assert.assertEquals(count, executionUpdates.size());
+    System.out.println("executionUpdates.get(count - 1): " + executionUpdates.get(count - 1));
   }
 
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
@@ -1,0 +1,60 @@
+package azkaban.executor;
+
+import azkaban.utils.JSONUtils;
+import azkaban.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Requires azkaban server running -> run AzkabanSingleServer first")
+public class ExecutorApiGatewaySystemTest {
+
+  private ExecutorApiGateway apiGateway;
+
+  @Before
+  public void setUp() throws Exception {
+    ExecutorApiClient client = new ExecutorApiClient();
+    apiGateway = new ExecutorApiGateway(client);
+  }
+
+  @Test
+  public void update100Executions() throws Exception {
+    updateExecutions(100);
+  }
+
+  @Test
+  public void update300Executions() throws Exception {
+    // this fails because the URL is too long
+    updateExecutions(300);
+  }
+
+  private void updateExecutions(int count) throws ExecutorManagerException {
+    final List<Integer> executionIdsList = new ArrayList<>();
+    final List<Long> updateTimesList = new ArrayList<>();
+
+    for (int i = 100000; i < 100000 + count; i++) {
+      executionIdsList.add(i);
+      updateTimesList.add(0L);
+    }
+
+    final Pair<String, String> executionIds =
+        new Pair<>(ConnectorParams.EXEC_ID_LIST_PARAM,
+            JSONUtils.toJSON(executionIdsList));
+
+    final Pair<String, String> updateTimes =
+        new Pair<>(
+            ConnectorParams.UPDATE_TIME_LIST_PARAM,
+            JSONUtils.toJSON(updateTimesList));
+
+    Map<String, Object> results = apiGateway.callWithExecutionId("localhost", 12321,
+        ConnectorParams.UPDATE_ACTION, null, null, executionIds, updateTimes);
+
+    Assert.assertTrue(results != null && !results.isEmpty());
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
@@ -40,7 +40,7 @@ public class ExecutorApiGatewayTest {
     final ExecutorInfo exeInfo = new ExecutorInfo(99.9, 14095, 50, System.currentTimeMillis(), 89,
         10);
     final String json = JSONUtils.toJSON(exeInfo);
-    when(this.client.httpGet(Mockito.any(), Mockito.any())).thenReturn(json);
+    when(this.client.httpPost(Mockito.any(), Mockito.any())).thenReturn(json);
     final ExecutorInfo exeInfo2 = this.gateway
         .callForJsonType("localhost", 1234, "executor", null, ExecutorInfo.class);
     Assert.assertTrue(exeInfo.equals(exeInfo2));

--- a/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/RestfulApiClientTest.java
@@ -18,58 +18,25 @@ package azkaban.utils;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import org.apache.http.Header;
+import java.util.Collections;
+import java.util.List;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseFactory;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
-import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.DefaultHttpResponseFactory;
-import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- *
- */
 public class RestfulApiClientTest {
-
-  @Test
-  public void testHttpGet() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final String result = mockClient.httpGet(uri, null);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("METHOD = GET"));
-  }
-
-  @Test
-  public void testHttpGetWithHeaderItems() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final ArrayList<NameValuePair> headerItems = new ArrayList<>();
-    headerItems.add(new BasicNameValuePair("h1", "v1"));
-    headerItems.add(new BasicNameValuePair("h2", "v2"));
-
-    final String result = mockClient.httpGet(uri, headerItems);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("METHOD = GET"));
-    Assert.assertTrue(result.contains("h1 = v1"));
-    Assert.assertTrue(result.contains("h2 = v2"));
-  }
 
   @Test
   public void testHttpPost() throws Exception {
@@ -77,103 +44,21 @@ public class RestfulApiClientTest {
     final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
         new Pair<>("Entry1", "Value1"));
 
-    final ArrayList<NameValuePair> headerItems = new ArrayList<>();
-    headerItems.add(new BasicNameValuePair("h1", "v1"));
-    headerItems.add(new BasicNameValuePair("h2", "v2"));
-
     final String content = "123456789";
 
-    final String result = mockClient.httpPost(uri, headerItems, content);
+    final String result = mockClient.httpPost(uri, toPairList(content));
     Assert.assertTrue(result != null && result.contains(uri.toString()));
     Assert.assertTrue(result.contains("METHOD = POST"));
-    Assert.assertTrue(result.contains("h1 = v1"));
-    Assert.assertTrue(result.contains("h2 = v2"));
-    Assert.assertTrue(result.contains(String.format("%s = %s;", "BODY", content)));
+    Assert.assertTrue(result.contains(String.format("%s = value=%s;", "BODY", content)));
   }
 
-  @Test
-  public void testHttpPostWOBody() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final String result = mockClient.httpPost(uri, null, null);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("METHOD = POST"));
-    Assert.assertFalse(result.contains("BODY_EXISTS"));
-    Assert.assertFalse(result.contains("HEADER_EXISTS"));
-  }
-
-  @Test
-  public void testHttpPut() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final ArrayList<NameValuePair> headerItems = new ArrayList<>();
-    headerItems.add(new BasicNameValuePair("h1", "v1"));
-    headerItems.add(new BasicNameValuePair("h2", "v2"));
-
-    final String content = "123456789";
-
-    final String result = mockClient.httpPut(uri, headerItems, content);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("METHOD = PUT"));
-    Assert.assertTrue(result.contains("h1 = v1"));
-    Assert.assertTrue(result.contains("h2 = v2"));
-    Assert.assertTrue(result.contains(String.format("%s = %s;", "BODY", content)));
-  }
-
-  @Test
-  public void testContentLength() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final String content = "123456789";
-
-    final String result = mockClient.httpPut(uri, null, content);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("Content-Length = " + Integer.toString(content.length())));
-  }
-
-  @Test
-  public void testContentLengthOverride() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final ArrayList<NameValuePair> headerItems = new ArrayList<>();
-    headerItems.add(new BasicNameValuePair("Content-Length", "0"));
-
-    final String content = "123456789";
-
-    final String result = mockClient.httpPut(uri, headerItems, content);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertEquals(result.lastIndexOf("Content-Length"), result.indexOf("Content-Length"));
-    Assert.assertTrue(result.contains("Content-Length = " + Integer.toString(content.length())));
-  }
-
-  @Test
-  public void testHttpDelete() throws Exception {
-    final MockRestfulApiClient mockClient = new MockRestfulApiClient();
-    final URI uri = MockRestfulApiClient.buildUri("test.com", 80, "test", true,
-        new Pair<>("Entry1", "Value1"));
-
-    final ArrayList<NameValuePair> headerItems = new ArrayList<>();
-    headerItems.add(new BasicNameValuePair("h1", "v1"));
-    headerItems.add(new BasicNameValuePair("h2", "v2"));
-
-    final String result = mockClient.httpDelete(uri, headerItems);
-    Assert.assertTrue(result != null && result.contains(uri.toString()));
-    Assert.assertTrue(result.contains("METHOD = DELETE"));
-    Assert.assertTrue(result.contains("h1 = v1"));
-    Assert.assertTrue(result.contains("h2 = v2"));
+  private List<Pair<String, String>> toPairList(final String content) {
+    return Collections.singletonList(new Pair<>("value", content));
   }
 
   static class MockRestfulApiClient extends RestfulApiClient<String> {
 
-    private int status = HttpStatus.SC_OK;
+    private final int status = HttpStatus.SC_OK;
 
     @Override
     protected String parseResponse(final HttpResponse response) throws IOException {
@@ -182,16 +67,7 @@ public class RestfulApiClientTest {
         throw new HttpResponseException(statusLine.getStatusCode(),
             statusLine.getReasonPhrase());
       }
-      final HttpEntity entity = response.getEntity();
-      return entity == null ? null : EntityUtils.toString(entity);
-    }
-
-    public void setReturnStatus(final int newStatus) {
-      this.status = newStatus;
-    }
-
-    public void resetReturnStatus() {
-      this.status = HttpStatus.SC_OK;
+      return EntityUtils.toString(response.getEntity());
     }
 
     @Override
@@ -205,21 +81,8 @@ public class RestfulApiClientTest {
       sb.append(String.format("%s = %s;", "METHOD", request.getMethod()));
       sb.append(String.format("%s = %s;", "URI", request.getURI()));
 
-      if (request.getAllHeaders().length > 0) {
-        sb.append("HEADER_EXISTS");
-      }
-
-      for (final Header h : request.getAllHeaders()) {
-        sb.append(String.format("%s = %s;", h.getName(), h.getValue()));
-      }
-
-      if (request instanceof HttpEntityEnclosingRequestBase) {
-        final HttpEntity entity = ((HttpEntityEnclosingRequestBase) request).getEntity();
-        if (entity != null) {
-          sb.append("BODY_EXISTS");
-          sb.append(String.format("%s = %s;", "BODY", EntityUtils.toString(entity)));
-        }
-      }
+      final HttpEntity entity = ((HttpEntityEnclosingRequestBase) request).getEntity();
+      sb.append(String.format("%s = %s;", "BODY", EntityUtils.toString(entity)));
 
       response.setEntity(new StringEntity(sb.toString()));
       return parseResponse(response);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -78,11 +78,25 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
     mapper.writeValue(stream, obj);
   }
 
+  /**
+   * @deprecated GET available for seamless upgrade. azkaban-web now uses POST.
+   */
+  @Deprecated
   @Override
   public void doGet(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
+    handleRequest(req, resp);
+  }
+
+  @Override
+  public void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    handleRequest(req, resp);
+  }
+
+  public void handleRequest(final HttpServletRequest req, final HttpServletResponse resp)
+      throws IOException {
     final HashMap<String, Object> respMap = new HashMap<>();
-    // logger.info("ExecutorServer called by " + req.getRemoteAddr());
     try {
       if (!hasParam(req, ACTION_PARAM)) {
         logger.error("Parameter action not set");
@@ -90,7 +104,6 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
       } else {
         final String action = getParam(req, ACTION_PARAM);
         if (action.equals(UPDATE_ACTION)) {
-          // logger.info("Updated called");
           handleAjaxUpdateRequest(req, respMap);
         } else if (action.equals(PING_ACTION)) {
           respMap.put("status", "alive");
@@ -412,12 +425,6 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
       logger.error(e.getMessage(), e);
       respMap.put(RESPONSE_ERROR, e.getMessage());
     }
-  }
-
-  @Override
-  public void doPost(final HttpServletRequest req, final HttpServletResponse resp)
-      throws ServletException, IOException {
-
   }
 
   /**


### PR DESCRIPTION
Fix for #1653.

Switch to using POST with form params instead of GET with URL params, so that the number of execution ids passed can be longer.

Also deleting some unused code.

Tested manually that it works like this:
- run AzkabanSingleServer in IDEA with debugger
- start a flow via the UI (http://localhost:8081/)
- set breakpoint to check that requests come to `azkaban.execapp.ExecutorServlet` and are handled successfully
- set breakpoint to check that `ExecutorManager` can get the execution updates

(initial PR & discussion in https://github.com/azkaban/azkaban/pull/1655)

Builds on https://github.com/azkaban/azkaban/pull/1707 to validate the fix.