### PR TITLE
No eviction, alert email instead

### DIFF
--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -16,6 +16,8 @@
 
 package azkaban.viewer.reportal;
 
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorManagerException;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -101,6 +103,20 @@ public class ReportalMailCreator implements MailCreator {
 
     return createEmail(flow, emailList, message, "Success", azkabanName,
         scheme, clientHostname, clientPortNumber, true);
+  }
+
+  @Override
+  public boolean createFailedUpdateMessage(List<ExecutableFlow> flows, Executor executor,
+      ExecutorManagerException updateException, EmailMessage message, String azkabanName,
+      String scheme, String clientHostname, String clientPortNumber) {
+
+    ExecutableFlow flow = flows.get(0);
+
+    ExecutionOptions option = flow.getExecutionOptions();
+    Set<String> emailList = new HashSet<String>(option.getFailureEmails());
+
+    return createEmail(flow, emailList, message, "FailedUpdate", azkabanName,
+        scheme, clientHostname, clientPortNumber, false);
   }
 
   private boolean createEmail(ExecutableFlow flow, Set<String> emailList,

--- a/azkaban-common/src/main/java/azkaban/alert/Alerter.java
+++ b/azkaban-common/src/main/java/azkaban/alert/Alerter.java
@@ -17,7 +17,10 @@
 package azkaban.alert;
 
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorManagerException;
 import azkaban.sla.SlaOption;
+import java.util.List;
 
 public interface Alerter {
 
@@ -28,4 +31,7 @@ public interface Alerter {
   void alertOnFirstError(ExecutableFlow exflow) throws Exception;
 
   void alertOnSla(SlaOption slaOption, String slaMessage) throws Exception;
+
+  void alertOnFailedUpdate(Executor executor, List<ExecutableFlow> executions,
+      ExecutorManagerException e);
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1535,8 +1535,10 @@ public class ExecutorManager extends EventHandler implements
 
     private final int waitTimeIdleMs = 2000;
     private final int waitTimeMs = 500;
-    // When we have an http error, for that flow, we'll check every 10 secs, 6
-    // times (1 mins) before we send an email about unresponsive executor.
+    // When we have an http error, for that flow, we'll check every 10 secs, 360
+    // times (3600 seconds = 1 hour) before we send an email about unresponsive executor.
+    private final int numErrorsBetweenUnresponsiveEmail = 360;
+    // First email is sent after 1 minute of unresponsiveness
     private final int numErrorsBeforeUnresponsiveEmail = 6;
     private final long errorThreshold = 10000;
     private boolean shutdown = false;
@@ -1615,7 +1617,8 @@ public class ExecutorManager extends EventHandler implements
                   final ExecutionReference ref = pair.getFirst();
                   ref.setNextCheckTime(System.currentTimeMillis() + this.errorThreshold);
                   ref.setNumErrors(ref.getNumErrors() + 1);
-                  if (ref.getNumErrors() % this.numErrorsBeforeUnresponsiveEmail == 0) {
+                  if (ref.getNumErrors() == this.numErrorsBeforeUnresponsiveEmail
+                      || ref.getNumErrors() % this.numErrorsBetweenUnresponsiveEmail == 0) {
                     // if any of the executions has failed many enough updates, alert
                     sendUnresponsiveEmail = true;
                   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1610,6 +1610,7 @@ public class ExecutorManager extends EventHandler implements
                 for (final ExecutableFlow flow : entry.getValue()) {
                   final Pair<ExecutionReference, ExecutableFlow> pair =
                       ExecutorManager.this.runningFlows.get(flow.getExecutionId());
+                  // TODO can runningFlows.get ever return null, causing NPE below?
 
                   ExecutorManager.this.updaterStage =
                       "Failed to get update for flow " + pair.getSecond().getExecutionId();

--- a/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
@@ -20,6 +20,8 @@ import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutionOptions.FailureAction;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.utils.EmailMessage;
 import azkaban.utils.Utils;
@@ -29,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.lang.exception.ExceptionUtils;
 
 public class DefaultMailCreator implements MailCreator {
 
@@ -251,6 +254,53 @@ public class DefaultMailCreator implements MailCreator {
           + " Execution Link</a>");
       return true;
     }
+    return false;
+  }
+
+  @Override
+  public boolean createFailedUpdateMessage(final List<ExecutableFlow> flows,
+      final Executor executor, final ExecutorManagerException updateException,
+      final EmailMessage message, final String azkabanName,
+      final String scheme, final String clientHostname, final String clientPortNumber) {
+
+    final ExecutionOptions option = flows.get(0).getExecutionOptions();
+    final List<String> emailList = option.getFailureEmails();
+
+    if (emailList != null && !emailList.isEmpty()) {
+      message.addAllToAddress(emailList);
+      message.setMimeType("text/html");
+      message.setSubject(
+          "Flow status could not be updated from " + executor.getHost() + " on " + azkabanName);
+
+      message.println(
+          "<h2 style=\"color:#FF0000\"> Flow status could not be updated from " + executor.getHost()
+              + " on " + azkabanName + "</h2>");
+
+      message.println("The actual status of these executions is unknown, "
+          + "because getting status update from azkaban executor is failing");
+
+      message.println("");
+      message.println("<h3>Error detail</h3>");
+      message.println("<pre>" + ExceptionUtils.getStackTrace(updateException) + "</pre>");
+
+      message.println("");
+      message.println("<h3>Affected executions</h3>");
+      message.println("<ul>");
+      for (final ExecutableFlow flow : flows) {
+        final int execId = flow.getExecutionId();
+        final String executionUrl =
+            scheme + "://" + clientHostname + ":" + clientPortNumber + "/"
+                + "executor?" + "execid=" + execId;
+
+        message.println("<li>Execution '" + flow.getExecutionId() + "' of flow '" + flow.getFlowId()
+            + "' of project '" + flow.getProjectName() + "' - " +
+            " <a href=\"" + executionUrl + "\">Execution Link</a></li>");
+      }
+
+      message.println("</ul>");
+      return true;
+    }
+
     return false;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
@@ -17,6 +17,8 @@
 package azkaban.executor.mail;
 
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorManagerException;
 import azkaban.utils.EmailMessage;
 import java.util.List;
 
@@ -33,4 +35,9 @@ public interface MailCreator {
   public boolean createSuccessEmail(ExecutableFlow flow, EmailMessage message,
       String azkabanName, String scheme, String clientHostname,
       String clientPortNumber, String... vars);
+
+  public boolean createFailedUpdateMessage(List<ExecutableFlow> flows, Executor executor,
+      ExecutorManagerException updateException, EmailMessage message,
+      String azkabanName, String scheme, String clientHostname,
+      String clientPortNumber);
 }

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -189,7 +189,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   }
 
   /**
-   * Sends a single email.
+   * Sends a single email about failed updates.
    */
   private void sendFailedUpdateEmail(final Executor executor,
       final ExecutorManagerException exception, final MailCreator mailCreator,

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -22,18 +22,25 @@ import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.alert.Alerter;
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.Executor;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.executor.mail.MailCreator;
 import azkaban.metrics.CommonMetrics;
 import azkaban.sla.SlaOption;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimaps;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.mail.internet.AddressException;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
 @Singleton
@@ -144,6 +151,55 @@ public class Emailer extends AbstractMailer implements Alerter {
     final boolean mailCreated = mailCreator.createSuccessEmail(flow, message, this.azkabanName,
         this.scheme, this.clientHostname, this.clientPortNumber);
     sendEmail(message, mailCreated, "success email message for execution" + flow.getExecutionId());
+  }
+
+  /**
+   * Sends as many emails as there are unique combinations of:
+   *
+   * [mail creator] x [failure email address list]
+   *
+   * Executions with the same combo are grouped into a single message.
+   */
+  @Override
+  public void alertOnFailedUpdate(final Executor executor, List<ExecutableFlow> flows,
+      final ExecutorManagerException updateException) {
+
+    flows = flows.stream()
+        .filter(flow -> flow.getExecutionOptions() != null)
+        .filter(flow -> CollectionUtils.isNotEmpty(flow.getExecutionOptions().getFailureEmails()))
+        .collect(Collectors.toList());
+
+    // group by mail creator in case some flows use different creators
+    final ImmutableListMultimap<String, ExecutableFlow> creatorsToFlows = Multimaps
+        .index(flows, flow -> flow.getExecutionOptions().getMailCreator());
+
+    for (final String mailCreatorName : creatorsToFlows.keySet()) {
+
+      final ImmutableList<ExecutableFlow> creatorFlows = creatorsToFlows.get(mailCreatorName);
+      final MailCreator mailCreator = getMailCreator(mailCreatorName);
+
+      // group by recipients in case some flows have different failure email addresses
+      final ImmutableListMultimap<List<String>, ExecutableFlow> emailsToFlows = Multimaps
+          .index(creatorFlows, flow -> flow.getExecutionOptions().getFailureEmails());
+
+      for (final List<String> emailList : emailsToFlows.keySet()) {
+        sendFailedUpdateEmail(executor, updateException, mailCreator, emailsToFlows.get(emailList));
+      }
+    }
+  }
+
+  /**
+   * Sends a single email.
+   */
+  private void sendFailedUpdateEmail(final Executor executor,
+      final ExecutorManagerException exception, final MailCreator mailCreator,
+      final ImmutableList<ExecutableFlow> flows) {
+    final EmailMessage message = this.messageCreator.createMessage();
+    final boolean mailCreated = mailCreator
+        .createFailedUpdateMessage(flows, executor, exception, message,
+            this.azkabanName, this.scheme, this.clientHostname, this.clientPortNumber);
+    final List<Integer> executionIds = Lists.transform(flows, ExecutableFlow::getExecutionId);
+    sendEmail(message, mailCreated, "failed update email message for executions " + executionIds);
   }
 
   private MailCreator getMailCreator(final ExecutableFlow flow) {

--- a/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutionOptions;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.flow.Flow;
 import azkaban.flow.Node;
@@ -16,6 +18,7 @@ import azkaban.utils.EmailMessageCreator;
 import azkaban.utils.TestUtils;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
 import org.joda.time.DateTimeUtils;
@@ -34,6 +37,7 @@ public class DefaultMailCreatorTest {
 
   private DefaultMailCreator mailCreator;
 
+  private Executor executor;
   private ExecutableFlow executableFlow;
   private Flow flow;
   private Project project;
@@ -45,6 +49,15 @@ public class DefaultMailCreatorTest {
   private String clientPortNumber;
   private TimeZone defaultTz;
 
+  public static ExecutorManagerException createTestStracktrace() {
+    final ExecutorManagerException exception = new ExecutorManagerException("mocked failure");
+    // set custom stacktrace to have deterministic string for comparison
+    exception.setStackTrace(new StackTraceElement[]{new StackTraceElement(
+        DefaultMailCreatorTest.class.getCanonicalName(), "createFailedUpdateMessage",
+        "DefaultMailCreatorTest.java", 135)});
+    return exception;
+  }
+
   @Before
   public void setUp() throws Exception {
     this.defaultTz = TimeZone.getDefault();
@@ -55,6 +68,7 @@ public class DefaultMailCreatorTest {
 
     this.mailCreator = new DefaultMailCreator();
 
+    this.executor = new Executor(1, "executor1-host", 1234, true);
     this.flow = new Flow("mail-creator-test");
     this.project = new Project(1, "test-project");
     this.options = new ExecutionOptions();
@@ -142,6 +156,19 @@ public class DefaultMailCreatorTest {
         this.clientPortNumber));
     assertEquals("Flow 'mail-creator-test' has succeeded on unit-tests", this.message.getSubject());
     assertThat(TestUtils.readResource("successEmail.html", this))
+        .isEqualToIgnoringWhitespace(this.message.getBody());
+  }
+
+  @Test
+  public void createFailedUpdateMessage() throws Exception {
+    final ExecutorManagerException exception = createTestStracktrace();
+    assertTrue(this.mailCreator
+        .createFailedUpdateMessage(Arrays.asList(this.executableFlow, this.executableFlow),
+            this.executor, exception, this.message, this.azkabanName, this.scheme,
+            this.clientHostname, this.clientPortNumber));
+    assertEquals("Flow status could not be updated from executor1-host on unit-tests",
+        this.message.getSubject());
+    assertThat(TestUtils.readResource("failedUpdateMessage.html", this))
         .isEqualToIgnoringWhitespace(this.message.getBody());
   }
 

--- a/azkaban-common/src/test/resources/azkaban/executor/mail/failedUpdateMessage.html
+++ b/azkaban-common/src/test/resources/azkaban/executor/mail/failedUpdateMessage.html
@@ -1,0 +1,13 @@
+<h2 style="color:#FF0000"> Flow status could not be updated from executor1-host on unit-tests</h2>
+The actual status of these executions is unknown, because getting status update from azkaban executor is failing
+<h3>Error detail</h3>
+<pre>azkaban.executor.ExecutorManagerException: mocked failure
+  at azkaban.executor.mail.DefaultMailCreatorTest.createFailedUpdateMessage(DefaultMailCreatorTest.java:135)
+</pre>
+<h3>Affected executions</h3>
+<ul>
+  <li>Execution '-1' of flow 'mail-creator-test' of project 'test-project' - <a
+      href="http://localhost:8081/executor?execid=-1"> Execution Link</a></li>
+  <li>Execution '-1' of flow 'mail-creator-test' of project 'test-project' - <a
+      href="http://localhost:8081/executor?execid=-1"> Execution Link</a></li>
+</ul>

--- a/azkaban-common/src/test/resources/azkaban/utils/failedUpdateMessage2.html
+++ b/azkaban-common/src/test/resources/azkaban/utils/failedUpdateMessage2.html
@@ -1,0 +1,12 @@
+<h2 style="color:#FF0000"> Flow status could not be updated from executor1-host on
+  azkaban</h2>The actual status of these executions is unknown, because getting status update from azkaban executor is failing
+<h3>Error detail</h3>
+<pre>azkaban.executor.ExecutorManagerException: mocked failure
+	at azkaban.executor.mail.DefaultMailCreatorTest.createFailedUpdateMessage(DefaultMailCreatorTest.java:135)
+</pre><h3>Affected executions</h3>
+<ul>
+  <li>Execution '-1' of flow 'jobe' of project 'myTestProject' - <a
+      href="http://localhost:8786/executor?execid=-1">Execution Link</a></li>
+  <li>Execution '-1' of flow 'jobe' of project 'myTestProject' - <a
+      href="http://localhost:8786/executor?execid=-1">Execution Link</a></li>
+</ul>


### PR DESCRIPTION
Not evicting executions, sending an email instead.

This is to fix https://github.com/azkaban/azkaban/issues/1653 instead of https://github.com/azkaban/azkaban/pull/1654.

In practice it's always better to let the executions remain in running state if the assigned executor can't be reached. If azkaban-web is evicting executions without knowing the actual state, azkaban-web will start new scheduled executions and execution concurrency options (skip/pipeline) can be violated (if the same jobs are still running on an unreachable executor).