### PR TITLE
use bigint to keep the timestamp of flow trigger dependency instance in db.

### DIFF
--- a/azkaban-db/src/main/sql/create.execution_dependencies.sql
+++ b/azkaban-db/src/main/sql/create.execution_dependencies.sql
@@ -1,8 +1,8 @@
 CREATE TABLE execution_dependencies(
   trigger_instance_id varchar(64),
   dep_name varchar(128),
-  starttime timestamp not null,
-  endtime timestamp,
+  starttime bigint(20) not null,
+  endtime bigint(20),
   dep_status tinyint not null,
   cancelleation_cause tinyint not null,
 

--- a/azkaban-db/src/main/sql/create.execution_dependencies.sql
+++ b/azkaban-db/src/main/sql/create.execution_dependencies.sql
@@ -1,8 +1,8 @@
 CREATE TABLE execution_dependencies(
   trigger_instance_id varchar(64),
   dep_name varchar(128),
-  starttime datetime not null,
-  endtime datetime,
+  starttime timestamp not null,
+  endtime timestamp,
   dep_status tinyint not null,
   cancelleation_cause tinyint not null,
 

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyInstance.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/DependencyInstance.java
@@ -16,21 +16,20 @@
 
 package azkaban.flowtrigger;
 
-import java.util.Date;
 
 public class DependencyInstance {
 
-  private final Date startTime;
+  private final long startTime;
   private final String depName;
   private TriggerInstance triggerInstance;
   private DependencyInstanceContext context;
-  private volatile Date endTime;
+  private volatile long endTime;
   private volatile Status status;
   private volatile CancellationCause cause;
 
   //todo chengren311: convert it to builder
-  public DependencyInstance(final String depName, final Date startTime,
-      final Date endTime, final DependencyInstanceContext context, final Status status,
+  public DependencyInstance(final String depName, final long startTime,
+      final long endTime, final DependencyInstanceContext context, final Status status,
       final CancellationCause cause) {
     this.status = status;
     this.depName = depName;
@@ -43,10 +42,10 @@ public class DependencyInstance {
   @Override
   public String toString() {
     return "DependencyInstance{" +
-        "startTime=" + this.startTime.getTime() +
+        "startTime=" + this.startTime +
         ", depName='" + this.depName + '\'' +
         ", context=" + this.context +
-        ", endTime=" + (this.endTime == null ? null : this.endTime.getTime()) +
+        ", endTime=" + this.endTime +
         ", status=" + this.status +
         ", cause=" + this.cause +
         '}';
@@ -72,15 +71,15 @@ public class DependencyInstance {
     this.context = context;
   }
 
-  public Date getStartTime() {
+  public long getStartTime() {
     return this.startTime;
   }
 
-  public Date getEndTime() {
+  public long getEndTime() {
     return this.endTime;
   }
 
-  public void setEndTime(final Date endTime) {
+  public void setEndTime(final long endTime) {
     this.endTime = endTime;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -28,7 +28,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -122,7 +121,6 @@ public class FlowTriggerService {
     final List<DependencyInstance> depInstList = new ArrayList<>();
     for (final FlowTriggerDependency dep : flowTrigger.getDependencies()) {
       final String depName = dep.getName();
-      final Date startDate = new Date(startTime);
       DependencyInstanceContext context = null;
       try {
         context = createDepContext(dep, startTime);
@@ -135,8 +133,8 @@ public class FlowTriggerService {
       final Status status = context == null ? Status.CANCELLED : Status.RUNNING;
       final CancellationCause cause =
           context == null ? CancellationCause.FAILURE : CancellationCause.NONE;
-      final Date endTime = context == null ? new Date() : null;
-      final DependencyInstance depInst = new DependencyInstance(depName, startDate, endTime,
+      final long endTime = context == null ? System.currentTimeMillis() : 0;
+      final DependencyInstance depInst = new DependencyInstance(depName, startTime, endTime,
           context, status, cause);
       depInstList.add(depInst);
     }
@@ -202,7 +200,7 @@ public class FlowTriggerService {
         DependencyInstanceContext context = null;
         try {
           //recreate dependency instance context
-          context = createDepContext(dependency, depInst.getStartTime().getTime());
+          context = createDepContext(dependency, depInst.getStartTime());
         } catch (final Exception ex) {
           logger
               .error(
@@ -307,7 +305,7 @@ public class FlowTriggerService {
   private void updateDepInstStatus(final DependencyInstance depInst, final Status newStatus) {
     depInst.setStatus(newStatus);
     if (Status.isDone(depInst.getStatus())) {
-      depInst.setEndTime(new Date());
+      depInst.setEndTime(System.currentTimeMillis());
     }
   }
 
@@ -327,8 +325,9 @@ public class FlowTriggerService {
 
   private long remainingTimeBeforeTimeout(final TriggerInstance triggerInst) {
     final long now = System.currentTimeMillis();
-    return Math.max(0, triggerInst.getFlowTrigger().getMaxWaitDuration().toMillis() - (now -
-        triggerInst.getStartTime().getTime()));
+    return Math.max(0,
+        triggerInst.getFlowTrigger().getMaxWaitDuration().toMillis() - (now - triggerInst
+            .getStartTime()));
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstance.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstance.java
@@ -20,7 +20,6 @@ import azkaban.project.FlowTrigger;
 import azkaban.project.Project;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -57,14 +56,14 @@ public class TriggerInstance {
   @Override
   public String toString() {
     return "TriggerInstance{" +
-        "depInstances=" + depInstances +
-        ", id='" + id + '\'' +
-        ", submitUser='" + submitUser + '\'' +
-        ", project=" + project +
-        ", flowId='" + flowId + '\'' +
-        ", flowVersion=" + flowVersion +
-        ", flowTrigger=" + flowTrigger +
-        ", flowExecId=" + flowExecId +
+        "depInstances=" + this.depInstances +
+        ", id='" + this.id + '\'' +
+        ", submitUser='" + this.submitUser + '\'' +
+        ", project=" + this.project +
+        ", flowId='" + this.flowId + '\'' +
+        ", flowVersion=" + this.flowVersion +
+        ", flowTrigger=" + this.flowTrigger +
+        ", flowExecId=" + this.flowExecId +
         '}';
   }
 
@@ -170,20 +169,20 @@ public class TriggerInstance {
     }
   }
 
-  public Date getStartTime() {
-    final List<Date> startTimeList = this.depInstances.stream()
+  public long getStartTime() {
+    final List<Long> startTimeList = this.depInstances.stream()
         .map(DependencyInstance::getStartTime).collect(Collectors.toList());
-    return startTimeList.isEmpty() ? null : Collections.min(startTimeList);
+    return startTimeList.isEmpty() ? 0 : Collections.min(startTimeList);
   }
 
-  public Date getEndTime() {
+  public long getEndTime() {
     if (Status.isDone(this.getStatus())) {
-      final List<Date> endTimeList = this.depInstances.stream()
-          .map(DependencyInstance::getEndTime).filter(endTime -> endTime != null)
+      final List<Long> endTimeList = this.depInstances.stream()
+          .map(DependencyInstance::getEndTime).filter(endTime -> endTime != 0)
           .collect(Collectors.toList());
-      return endTimeList.isEmpty() ? null : Collections.max(endTimeList);
+      return endTimeList.isEmpty() ? 0 : Collections.max(endTimeList);
     } else {
-      return null;
+      return 0;
     }
   }
 }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
@@ -154,7 +154,7 @@
             #*todo chengren311: verify utils.formatDate will convert to user's timezone *#
               <td>$utils.formatDate(${trigger.getStartTime().getTime()})</td>
               #if (${trigger.getEndTime()})
-                <td>${trigger.getEndTime()}</td>
+                <td>$utils.formatDate(${trigger.getEndTime()})</td>
               #else
                 <td>-</td>
               #end
@@ -205,7 +205,7 @@
                 <td>${dep.getDepName()}</td>
                 <td>$utils.formatDate(${dep.getStartTime().getTime()})</td>
                 #if (${dep.getEndTime()})
-                  <td>${dep.getEndTime()}</td>
+                  <td>$utils.formatDate(${dep.getEndTime().getTime()})</td>
                 #else
                   <td>-</td>
                 #end
@@ -299,7 +299,7 @@
             #*todo chengren311: verify utils.formatDate will convert to user's timezone *#
               <td>$utils.formatDate(${trigger.getStartTime().getTime()})</td>
               #if (${trigger.getEndTime()})
-                <td>${trigger.getEndTime()}</td>
+                <td>$utils.formatDate(${trigger.getEndTime().getTime()})</td>
               #else
                 <td>-</td>
               #end
@@ -346,7 +346,7 @@
                 <td>${dep.getDepName()}</td>
                 <td>$utils.formatDate(${dep.getStartTime().getTime()})</td>
                 #if (${dep.getEndTime()})
-                  <td>${dep.getEndTime()}</td>
+                  <td>$utils.formatDate(${dep.getEndTime().getTime()})</td>
                 #else
                   <td>-</td>
                 #end

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
@@ -152,18 +152,18 @@
 
               <td>${trigger.getSubmitUser()}</td>
             #*todo chengren311: verify utils.formatDate will convert to user's timezone *#
-              <td>$utils.formatDate(${trigger.getStartTime().getTime()})</td>
-              #if (${trigger.getEndTime()})
+              <td>$utils.formatDate(${trigger.getStartTime()})</td>
+              #if (${trigger.getEndTime()} != "0")
                 <td>$utils.formatDate(${trigger.getEndTime()})</td>
               #else
                 <td>-</td>
               #end
               <td>${trigger.getStatus()}</td>
               #if (${trigger.getStatus()} != "RUNNING" && ${trigger.getStatus()} != "CANCELLING")
-                <td>$utils.formatDuration(${trigger.getStartTime().getTime()}, ${trigger.getEndTime().getTime()})
+                <td>$utils.formatDuration(${trigger.getStartTime()}, ${trigger.getEndTime()})
                 </td>
               #else
-                <td>$utils.formatDuration(${trigger.getStartTime().getTime()}, ${utils.currentTimestamp()})
+                <td>$utils.formatDuration(${trigger.getStartTime()}, ${utils.currentTimestamp()})
                 </td>
               #end
               #if (${trigger.getFlowExecId()} != "-1")
@@ -203,18 +203,18 @@
               <tr class="child-${trigger.getId()}">
                 <td>&nbsp;</td>
                 <td>${dep.getDepName()}</td>
-                <td>$utils.formatDate(${dep.getStartTime().getTime()})</td>
-                #if (${dep.getEndTime()})
-                  <td>$utils.formatDate(${dep.getEndTime().getTime()})</td>
+                <td>$utils.formatDate(${dep.getStartTime()})</td>
+                #if (${dep.getEndTime()} != "0")
+                  <td>$utils.formatDate(${dep.getEndTime()})</td>
                 #else
                   <td>-</td>
                 #end
                 <td>${dep.getStatus()}</td>
-                #if (${dep.getEndTime()})
-                  <td>$utils.formatDuration(${dep.getStartTime().getTime()}, ${dep.getEndTime().getTime()})
+                #if (${dep.getEndTime()} != "0")
+                  <td>$utils.formatDuration(${dep.getStartTime()}, ${dep.getEndTime()})
                   </td>
                 #else
-                  <td>$utils.formatDuration(${dep.getStartTime().getTime()}, ${utils.currentTimestamp()})
+                  <td>$utils.formatDuration(${dep.getStartTime()}, ${utils.currentTimestamp()})
                   </td>
                 #end
               </tr>
@@ -297,18 +297,18 @@
 
               <td>${trigger.getSubmitUser()}</td>
             #*todo chengren311: verify utils.formatDate will convert to user's timezone *#
-              <td>$utils.formatDate(${trigger.getStartTime().getTime()})</td>
-              #if (${trigger.getEndTime()})
-                <td>$utils.formatDate(${trigger.getEndTime().getTime()})</td>
+              <td>$utils.formatDate(${trigger.getStartTime()})</td>
+              #if (${trigger.getEndTime()} != "0")
+                <td>$utils.formatDate(${trigger.getEndTime()})</td>
               #else
                 <td>-</td>
               #end
               <td>${trigger.getStatus()}</td>
               #if (${trigger.getStatus()} != "RUNNING" && ${trigger.getStatus()} != "CANCELLING")
-                <td>$utils.formatDuration(${trigger.getStartTime().getTime()}, ${trigger.getEndTime().getTime()})
+                <td>$utils.formatDuration(${trigger.getStartTime()}, ${trigger.getEndTime()})
                 </td>
               #else
-                <td>$utils.formatDuration(${trigger.getStartTime().getTime()}, ${utils.currentTimestamp()})
+                <td>$utils.formatDuration(${trigger.getStartTime()}, ${utils.currentTimestamp()})
                 </td>
               #end
               #if (${trigger.getFlowExecId()} != "-1")
@@ -344,19 +344,19 @@
               <tr class="child-${trigger.getId()}">
                 <td>&nbsp;</td>
                 <td>${dep.getDepName()}</td>
-                <td>$utils.formatDate(${dep.getStartTime().getTime()})</td>
-                #if (${dep.getEndTime()})
-                  <td>$utils.formatDate(${dep.getEndTime().getTime()})</td>
+                <td>$utils.formatDate(${dep.getStartTime()})</td>
+                #if (${dep.getEndTime()} != "0")
+                  <td>$utils.formatDate(${dep.getEndTime()})</td>
                 #else
                   <td>-</td>
                 #end
                 <td>${dep.getStatus()}</td>
                 <td>${dep.getCancellationCause()}</td>
-                #if (${dep.getEndTime()})
-                  <td>$utils.formatDuration(${dep.getStartTime().getTime()}, ${dep.getEndTime().getTime()})
+                #if (${dep.getEndTime()} != "0")
+                  <td>$utils.formatDuration(${dep.getStartTime()}, ${dep.getEndTime()})
                   </td>
                 #else
-                  <td>$utils.formatDuration(${dep.getStartTime().getTime()}, ${utils.currentTimestamp()})
+                  <td>$utils.formatDuration(${dep.getStartTime()}, ${utils.currentTimestamp()})
                   </td>
                 #end
               </tr>

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/DependencyInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/DependencyInstanceProcessorTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
-import java.util.Date;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -42,8 +41,8 @@ public class DependencyInstanceProcessorTest {
 
   @Test
   public void testStatusUpdate() {
-    final DependencyInstance depInst = new DependencyInstance("dep1", new Date(), null, null, Status
-        .RUNNING, CancellationCause.NONE);
+    final DependencyInstance depInst = new DependencyInstance("dep1", System.currentTimeMillis()
+        , 0, null, Status.RUNNING, CancellationCause.NONE);
     processor.processStatusUpdate(depInst);
     verify(triggerInstLoader).updateDependencyExecutionStatus(depInst);
   }

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
@@ -107,13 +107,11 @@ public class FlowTriggerInstanceLoaderTest {
     final List<DependencyInstance> depInstList = new ArrayList<>();
     for (final FlowTriggerDependency dep : flowTrigger.getDependencies()) {
       final String depName = dep.getName();
-      final Date startDate = new Date(startTime);
       final DependencyInstanceContext context = new TestDependencyInstanceContext(null, null, null);
       final Status status = Status.RUNNING;
       final CancellationCause cause = CancellationCause.NONE;
-      final Date endTime = null;
-      final DependencyInstance depInst = new DependencyInstance(depName, startDate, endTime,
-          context, status, cause);
+      final DependencyInstance depInst = new DependencyInstance(depName, startTime, 0, context,
+          status, cause);
       depInstList.add(depInst);
     }
 
@@ -184,7 +182,7 @@ public class FlowTriggerInstanceLoaderTest {
     this.triggerInstLoader.uploadTriggerInstance(expectedTriggerInst);
     for (final DependencyInstance depInst : expectedTriggerInst.getDepInstances()) {
       depInst.setStatus(Status.CANCELLED);
-      depInst.setEndTime(new Date());
+      depInst.setEndTime(System.currentTimeMillis());
       depInst.setCancellationCause(CancellationCause.MANUAL);
       this.triggerInstLoader.updateDependencyExecutionStatus(depInst);
     }
@@ -199,7 +197,7 @@ public class FlowTriggerInstanceLoaderTest {
     for (final DependencyInstance depInst : triggerInst.getDepInstances()) {
       depInst.setStatus(Status.SUCCEEDED);
       depInst.getTriggerInstance().setFlowExecId(associateFlowExecId);
-      depInst.setEndTime(new Date());
+      depInst.setEndTime(System.currentTimeMillis());
     }
   }
 
@@ -207,7 +205,7 @@ public class FlowTriggerInstanceLoaderTest {
     for (final DependencyInstance depInst : triggerInst.getDepInstances()) {
       depInst.setStatus(Status.CANCELLED);
       depInst.setCancellationCause(CancellationCause.TIMEOUT);
-      depInst.setEndTime(new Date());
+      depInst.setEndTime(System.currentTimeMillis());
     }
   }
 
@@ -338,7 +336,7 @@ public class FlowTriggerInstanceLoaderTest {
     this.shuffleAndUpload(all);
 
     final List<TriggerInstance> finished = all.subList(0, 7);
-    finished.sort((o1, o2) -> -1 * (o1.getEndTime().compareTo(o2.getEndTime())));
+    finished.sort((o1, o2) -> ((Long) o2.getEndTime()).compareTo(o1.getEndTime()));
 
     List<TriggerInstance> expected = new ArrayList<>(finished);
     expected.sort(Comparator.comparing(TriggerInstance::getStartTime));

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceTest.java
@@ -40,7 +40,7 @@ public class TriggerInstanceTest {
 
   private DependencyInstance createTestDependencyInstance(final Status status,
       final CancellationCause killingCause) {
-    final DependencyInstance depInst = new DependencyInstance(null, null, null, null, null,
+    final DependencyInstance depInst = new DependencyInstance(null, 0, 0, null, null,
         null);
     depInst.setStatus(status);
     depInst.setCancellationCause(killingCause);
@@ -49,8 +49,8 @@ public class TriggerInstanceTest {
 
   private DependencyInstance createTestDependencyInstance(final Status status,
       final CancellationCause cancelCause, final Date startTime, final Date endTime) {
-    final DependencyInstance depInst = new DependencyInstance(null, startTime, endTime, null,
-        status, cancelCause);
+    final DependencyInstance depInst = new DependencyInstance(null, startTime.getTime(), endTime
+        == null ? 0 : endTime.getTime(), null, status, cancelCause);
     depInst.setStatus(status);
     depInst.setCancellationCause(cancelCause);
     return depInst;
@@ -67,12 +67,12 @@ public class TriggerInstanceTest {
     TriggerInstance ti = null;
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getStartTime()).isEqualTo(expectedStartTime);
+    assertThat(ti.getStartTime()).isEqualTo(expectedStartTime.getTime());
     dependencyInstanceList.clear();
 
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getStartTime()).isNull();
+    assertThat(ti.getStartTime()).isEqualTo(0);
     dependencyInstanceList.clear();
 
     expectedStartTime = getDate(2, 2, 2);
@@ -90,7 +90,7 @@ public class TriggerInstanceTest {
 
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getStartTime()).isEqualTo(expectedStartTime);
+    assertThat(ti.getStartTime()).isEqualTo(expectedStartTime.getTime());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class TriggerInstanceTest {
     TriggerInstance ti = null;
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getEndTime()).isEqualTo(expectedEndTime);
+    assertThat(ti.getEndTime()).isEqualTo(expectedEndTime.getTime());
     dependencyInstanceList.clear();
 
     dependencyInstanceList
@@ -117,7 +117,7 @@ public class TriggerInstanceTest {
 
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getEndTime()).isNull();
+    assertThat(ti.getEndTime()).isEqualTo(0);
     dependencyInstanceList.clear();
 
     expectedEndTime = getDate(3, 2, 3);
@@ -134,12 +134,12 @@ public class TriggerInstanceTest {
             2), expectedEndTime));
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getEndTime()).isEqualTo(expectedEndTime);
+    assertThat(ti.getEndTime()).isEqualTo(expectedEndTime.getTime());
     dependencyInstanceList.clear();
 
     ti = new TriggerInstance("1", null, "1", 1,
         "test", dependencyInstanceList, -1, null);
-    assertThat(ti.getEndTime()).isNull();
+    assertThat(ti.getEndTime()).isEqualTo(0);
     dependencyInstanceList.clear();
   }
 


### PR DESCRIPTION
This PR switched column mysql data type from datetime to bigint to keep the start/end time of dependency instance. The reason is datetime is not timezone agnostic(https://dev.mysql.com/doc/refman/5.5/en/datetime.html). It's less error-prone to keep UTC timestamp(System.currentTimeMillis()) in db.