### PR TITLE
flow trigger max wait time validation error message improvement

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -110,8 +110,8 @@ public class NodeBeanLoader {
   private void validateFlowTriggerBean(final FlowTriggerBean flowTriggerBean) {
     // validate max wait mins
     Preconditions.checkArgument(flowTriggerBean.getMaxWaitMins() >= Constants
-        .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes(), "max wait min must be longer than " + Constants
-        .MIN_FLOW_TRIGGER_WAIT_TIME + " min ");
+        .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes(), "max wait min must be at least " + Constants
+        .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes() + " min(s) ");
 
     validateSchedule(flowTriggerBean);
     validateTriggerDependencies(flowTriggerBean.getTriggerDependencies());

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -111,7 +111,7 @@ public class NodeBeanLoader {
     // validate max wait mins
     Preconditions.checkArgument(flowTriggerBean.getMaxWaitMins() >= Constants
         .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes(), "max wait min must be at least " + Constants
-        .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes() + " min(s) ");
+        .MIN_FLOW_TRIGGER_WAIT_TIME.toMinutes() + " min(s)");
 
     validateSchedule(flowTriggerBean);
     validateTriggerDependencies(flowTriggerBean.getTriggerDependencies());

--- a/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
@@ -223,7 +223,8 @@ public class NodeBeanLoaderTest {
         TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_zero_max_wait_min.flow"));
 
     assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean2.getTrigger()))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class).hasMessage("max wait min must be at least 1"
+        + " min(s)");
   }
 
   @Test


### PR DESCRIPTION
changed error message from "max wait min must be longer than X min" 
to "max wait min must be at least X min(s)"