### PR TITLE
retrieve running trigger from db instead of cache in flow trigger service

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -163,12 +162,14 @@ public class FlowTriggerService {
    * @return the list of running trigger instances
    */
   public Collection<TriggerInstance> getRunningTriggers() {
+    final List<TriggerInstance> triggerInstanceList = new ArrayList<>();
     final Future future = this.executorService.submit(
-        (Callable) () -> FlowTriggerService.this.runningTriggers);
+        () -> FlowTriggerService.this.runningTriggers.stream()
+            .filter(inst -> !Status.isDone(inst.getStatus())).forEach(triggerInstanceList::add)
+    );
 
-    List<TriggerInstance> triggerInstanceList = new ArrayList<>();
     try {
-      triggerInstanceList = (List<TriggerInstance>) future.get();
+      future.get();
     } catch (final Exception ex) {
       logger.error("error in getting running triggers", ex);
     }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -165,8 +165,25 @@ public class FlowTriggerService {
     logger.info("chengren get running triggers1");
     final List<TriggerInstance> triggerInstanceList = new ArrayList<>();
     final Future future = this.executorService.submit(
-        () -> FlowTriggerService.this.runningTriggers.stream()
-            .filter(inst -> !Status.isDone(inst.getStatus())).forEach(triggerInstanceList::add)
+        () -> {
+          for (final TriggerInstance inst : FlowTriggerService.this.runningTriggers) {
+            if (!Status.isDone(inst.getStatus())) {
+              final List<DependencyInstance> dependencyInstancesCopy = new ArrayList<>();
+              for (final DependencyInstance depInst : inst.getDepInstances()) {
+                final DependencyInstance depInstCopy = new DependencyInstance(depInst.getDepName(),
+                    new Date(depInst.getStartTime().getTime()),
+                    new Date(depInst.getEndTime().getTime()),
+                    depInst.getContext(), depInst.getStatus(), depInst.getCancellationCause());
+                dependencyInstancesCopy.add(depInstCopy);
+              }
+
+              final TriggerInstance copy = new TriggerInstance(inst.getId(), inst.getFlowTrigger
+                  (), inst.getFlowId(), inst.getFlowVersion(), inst.getSubmitUser(), inst
+                  .getDepInstances(), inst.getFlowExecId(), inst.getProject());
+              triggerInstanceList.add(copy);
+            }
+          }
+        }
     );
 
     try {

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -162,38 +162,7 @@ public class FlowTriggerService {
    * @return the list of running trigger instances
    */
   public Collection<TriggerInstance> getRunningTriggers() {
-    logger.info("chengren get running triggers1");
-    final List<TriggerInstance> triggerInstanceList = new ArrayList<>();
-    final Future future = this.executorService.submit(
-        () -> {
-          for (final TriggerInstance inst : FlowTriggerService.this.runningTriggers) {
-            if (!Status.isDone(inst.getStatus())) {
-              final List<DependencyInstance> dependencyInstancesCopy = new ArrayList<>();
-              for (final DependencyInstance depInst : inst.getDepInstances()) {
-                final DependencyInstance depInstCopy = new DependencyInstance(depInst.getDepName(),
-                    new Date(depInst.getStartTime().getTime()),
-                    new Date(depInst.getEndTime().getTime()),
-                    depInst.getContext(), depInst.getStatus(), depInst.getCancellationCause());
-                dependencyInstancesCopy.add(depInstCopy);
-              }
-
-              final TriggerInstance copy = new TriggerInstance(inst.getId(), inst.getFlowTrigger
-                  (), inst.getFlowId(), inst.getFlowVersion(), inst.getSubmitUser(), inst
-                  .getDepInstances(), inst.getFlowExecId(), inst.getProject());
-              triggerInstanceList.add(copy);
-            }
-          }
-        }
-    );
-
-    try {
-      logger.info("chengren get running triggers2");
-      future.get();
-      logger.info("chengren get running triggers3");
-    } catch (final Exception ex) {
-      logger.error("error in getting running triggers", ex);
-    }
-    return triggerInstanceList;
+    return this.flowTriggerInstanceLoader.getRunning();
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +72,7 @@ public class FlowTriggerService {
   private static final String START_TIME = "starttime";
   private static final Logger logger = LoggerFactory.getLogger(FlowTriggerService.class);
   private final ExecutorService executorService;
+  //todo chengren311: remove runningTriggers
   private final List<TriggerInstance> runningTriggers;
   private final ScheduledExecutorService timeoutService;
   private final FlowTriggerDependencyPluginManager triggerPluginManager;
@@ -363,18 +363,7 @@ public class FlowTriggerService {
   }
 
   public TriggerInstance findRunningTriggerInstById(final String triggerInstId) {
-    //todo chengren311: make the method single threaded
-    final Future<TriggerInstance> future = this.executorService.submit(
-        () -> this.runningTriggers.stream()
-            .filter(triggerInst -> triggerInst.getId().equals(triggerInstId)).findFirst()
-            .orElse(null)
-    );
-    try {
-      return future.get();
-    } catch (final Exception e) {
-      logger.error("exception when finding trigger instance by id" + triggerInstId, e);
-      return null;
-    }
+    return this.flowTriggerInstanceLoader.getTriggerInstanceById(triggerInstId);
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -162,6 +162,7 @@ public class FlowTriggerService {
    * @return the list of running trigger instances
    */
   public Collection<TriggerInstance> getRunningTriggers() {
+    logger.info("chengren get running triggers1");
     final List<TriggerInstance> triggerInstanceList = new ArrayList<>();
     final Future future = this.executorService.submit(
         () -> FlowTriggerService.this.runningTriggers.stream()
@@ -169,7 +170,9 @@ public class FlowTriggerService {
     );
 
     try {
+      logger.info("chengren get running triggers2");
       future.get();
+      logger.info("chengren get running triggers3");
     } catch (final Exception ex) {
       logger.error("error in getting running triggers", ex);
     }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/FlowTriggerInstanceLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/FlowTriggerInstanceLoader.java
@@ -52,6 +52,11 @@ public interface FlowTriggerInstanceLoader {
    */
   Collection<TriggerInstance> getRecentlyFinished(int limit);
 
+  /**
+   * Retrieve running trigger instances.
+   */
+  Collection<TriggerInstance> getRunning();
+
   TriggerInstance getTriggerInstanceById(String triggerInstanceId);
 
 }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/JdbcFlowTriggerInstanceLoaderImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/JdbcFlowTriggerInstanceLoaderImpl.java
@@ -267,6 +267,9 @@ public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoa
   @Override
   public Collection<TriggerInstance> getRunning() {
     try {
+      //todo chengren311:
+      // 1. add index for the execution_dependencies table to accelerate selection.
+      // 2. implement purging mechanism to keep reasonable amount of historical executions in db.
       return this.dbOperator.query(SELECT_ALL_RUNNING_EXECUTIONS, new TriggerInstanceHandler());
     } catch (final SQLException ex) {
       handleSQLException(ex);

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/MockFlowTriggerInstanceLoader.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/MockFlowTriggerInstanceLoader.java
@@ -86,6 +86,17 @@ public class MockFlowTriggerInstanceLoader implements FlowTriggerInstanceLoader 
   }
 
   @Override
+  public Collection<TriggerInstance> getRunning() {
+    final List<TriggerInstance> res = new ArrayList<>();
+    for (final TriggerInstance inst : this.triggerInstances) {
+      if (!Status.isDone(inst.getStatus())) {
+        res.add(inst);
+      }
+    }
+    return res;
+  }
+
+  @Override
   public TriggerInstance getTriggerInstanceById(final String triggerInstanceId) {
     for (final TriggerInstance inst : this.triggerInstances) {
       if (inst.getId().equals(triggerInstanceId)) {


### PR DESCRIPTION
Flow trigger service currently maintains an in memory list of running trigger instances for fast retrieval of the list of currently running trigger instances. However, it also introduces some issues like race condition and threads being created per request of getting running trigger instances. Removing the dependency on running trigger instances and retrieving directly from DB is a simpler and less error prone option. If retrieval of running triggers starts to have performance concern, we will reconsider it. 

But this PR doesn't remove the running trigger entirely from flow trigger service since the mapping between running trigger instance and and its DependencyInstanceContext still needs to be kept in memory in case where users want to cancel a running trigger instance.

follow up:
1. Add index to execution_dependencies table for faster retrieval. 
2. As execution_dependencies table keeps growing, we will need to implement purging mechanism to keep reasonable amount of historical executions.