### PR TITLE
added new runtime parameter (azkaban.flow.execution.dir).

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -106,6 +106,11 @@ public class CommonJobProperties {
   public static final String EXEC_ID = "azkaban.flow.execid";
 
   /**
+   * Root directory of the the flow execution.
+   */
+  public static final String FLOW_EXECUTION_DIR = "azkaban.flow.execution.dir";
+
+  /**
    * The numerical project id identifier.
    */
   public static final String PROJECT_ID = "azkaban.flow.projectid";

--- a/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
@@ -30,15 +30,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.joda.time.DateTime;
+import java.io.File;
 
 public class FlowUtils {
 
   public static Props addCommonFlowProperties(final Props parentProps,
-      final ExecutableFlowBase flow) {
+      final ExecutableFlow flow) {
     final Props props = new Props(parentProps);
 
     props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
     props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
+    props.put(CommonJobProperties.FLOW_EXECUTION_DIR , new File(flow.getExecutionPath()).getAbsolutePath());
     props.put(CommonJobProperties.PROJECT_ID, flow.getProjectId());
     props.put(CommonJobProperties.PROJECT_NAME, flow.getProjectName());
     props.put(CommonJobProperties.PROJECT_VERSION, flow.getVersion());


### PR DESCRIPTION
added new run time parameter `azkaban.flow.execution.dir` which will be set to root directory of execution.
we need this parameter when we are executing a job which is not in same folder as job. with this parameter its going to be more easy to reference a job regardless of location. 

- myfolder/myjobs/myscript
- myworkflows/myjob/myscript.job
- usage  `commad=${azkaban.flow.execution.dir}/myfolder/myjobs/myscript`

-- test run
`echo ${azkaban.flow.execution.dir}`
```
09-03-2018 05:10:16 PST my_etl1 INFO - 1 commands to execute.
09-03-2018 05:10:16 PST my_etl1 INFO - cwd=/Users/myuser/development/azkaban/azkaban-solo-server/build/install/azkaban-solo-server/executions/4/workflows/DWH
09-03-2018 05:10:16 PST my_etl1 INFO - effective user is: azkaban
**09-03-2018 05:10:16 PST my_etl1 INFO - Command: echo /Users/myuser/development/azkaban/azkaban-solo-server/build/install/azkaban-solo-server/executions/4**

```
