### PR TITLE
fix NPE when shutting flow trigger scheduler

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -241,7 +241,7 @@ public class AzkabanWebServer extends AzkabanServer {
             webServer.scheduler.shutdown();
           }
         } catch (final Exception e) {
-          logger.error(("Exception while shutting down flow trigger service."), e);
+          logger.error("Exception while shutting down flow trigger service.", e);
         }
 
         try {
@@ -250,7 +250,7 @@ public class AzkabanWebServer extends AzkabanServer {
             webServer.flowTriggerService.shutdown();
           }
         } catch (final Exception e) {
-          logger.error(("Exception while shutting down flow trigger service."), e);
+          logger.error("Exception while shutting down flow trigger service.", e);
         }
 
         try {
@@ -261,7 +261,7 @@ public class AzkabanWebServer extends AzkabanServer {
           webServer.close();
 
         } catch (final Exception e) {
-          logger.error(("Exception while shutting down web server."), e);
+          logger.error("Exception while shutting down web server.", e);
         }
 
         logger.info("kk thx bye.");

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -235,13 +235,18 @@ public class AzkabanWebServer extends AzkabanServer {
 
       @Override
       public void run() {
-        if (webServer.scheduler != null) {
-          logger.info("Shutting down flow trigger scheduler...");
-          webServer.scheduler.shutdown();
+        try {
+          if (webServer.props.getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false)) {
+            logger.info("Shutting down flow trigger scheduler...");
+            webServer.scheduler.shutdown();
+          }
+        } catch (final Exception e) {
+          logger.error(("Exception while shutting down flow trigger service."), e);
         }
 
         try {
-          if (webServer.flowTriggerService != null) {
+          if (webServer.props.getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false)) {
+            logger.info("Shutting down flow trigger service...");
             webServer.flowTriggerService.shutdown();
           }
         } catch (final Exception e) {


### PR DESCRIPTION
Issue description: https://github.com/azkaban/azkaban/issues/1681

Since webServer.scheduler and webServer.flowTriggerService are injected and always non null, even if quartz is disabled, in old code webServer.scheduler.shutdown() will be still executed throwing NPE if quart is disabled.