### PR TITLE
Dynamically generate job link URL.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -195,6 +195,16 @@ public class Constants {
 
     // dir to keep dependency plugins
     public static final String DEPENDENCY_PLUGIN_DIR = "azkaban.dependency.plugin.dir";
+
+    /*
+     * Prefix used to construct Hadoop/Spark user job link.
+     * a) RM: resource manager
+     * b) JHS: Hadoop job history server
+     * c) SHS: spark job history server
+     * */
+    public static final String AZKABAN_RM_JOB_LINK = "azkaban.rm.job.link";
+    public static final String AZKABAN_JHS_JOB_LINK = "azkaban.jhs.job.link";
+    public static final String AZKABAN_SHS_JOB_LINK = "azkaban.shs.job.link";
   }
 
   public static class FlowProperties {

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -197,14 +197,15 @@ public class Constants {
     public static final String DEPENDENCY_PLUGIN_DIR = "azkaban.dependency.plugin.dir";
 
     /*
-     * Prefix used to construct Hadoop/Spark user job link.
-     * a) RM: resource manager
-     * b) JHS: Hadoop job history server
-     * c) SHS: spark job history server
+     * Hadoop/Spark user job link.
+     * Example:
+     * a) azkaban.server.external.resource_manager_job_url=http://***rm***:8088/cluster/app/application_${application.id}
+     * b) azkaban.server.external.history_server_job_url=http://***jh***:19888/jobhistory/job/job_${application.id}
+     * c) azkaban.server.external.spark_history_server_job_url=http://***sh***:18080/history/application_${application.id}/1/jobs
      * */
-    public static final String AZKABAN_RM_JOB_LINK = "azkaban.rm.job.link";
-    public static final String AZKABAN_JHS_JOB_LINK = "azkaban.jhs.job.link";
-    public static final String AZKABAN_SHS_JOB_LINK = "azkaban.shs.job.link";
+    public static final String RESOURCE_MANAGER_JOB_URL = "azkaban.server.external.resource_manager_job_url";
+    public static final String HISTORY_SERVER_JOB_URL = "azkaban.server.external.history_server_job_url";
+    public static final String SPARK_HISTORY_SERVER_JOB_URL = "azkaban.server.external.spark_history_server_job_url";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -87,6 +87,8 @@ public interface ExecutorManagerAdapter {
   public List<Object> getExecutionJobStats(ExecutableFlow exflow, String jobId,
       int attempt) throws ExecutorManagerException;
 
+  public String getJobLinkUrl(ExecutableFlow exFlow, String jobId, int attempt);
+
   public JobMetaData getExecutionJobMetaData(ExecutableFlow exFlow,
       String jobId, int offset, int length, int attempt)
       throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/utils/AuthenticationUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/AuthenticationUtils.java
@@ -1,0 +1,62 @@
+/*
+* Copyright 2018 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the “License”); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package azkaban.utils;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL.Token;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The util class for hadoop authentication.
+ */
+public class AuthenticationUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(AuthenticationUtils.class);
+
+  public static HttpURLConnection loginAuthenticatedURL(final URL url, final String keytabPrincipal,
+      final String keytabPath) throws Exception {
+    final List<URL> resources = new ArrayList<>();
+    resources.add(url);
+
+    final URLClassLoader ucl = new URLClassLoader(resources.toArray(new URL[resources.size()]));
+    final Configuration conf = new Configuration();
+    conf.setClassLoader(ucl);
+    UserGroupInformation.setConfiguration(conf);
+
+    logger.info(
+        "Logging in URL: " + url.toString() + " using Principal: " + keytabPrincipal + ", Keytab: "
+            + keytabPath);
+
+    UserGroupInformation.loginUserFromKeytab(keytabPrincipal, keytabPath);
+
+    final HttpURLConnection connection = UserGroupInformation.getLoginUser().doAs(
+        (PrivilegedExceptionAction<HttpURLConnection>) () -> {
+          final Token token = new Token();
+          return new AuthenticatedURL().openConnection(url, token);
+        });
+
+    return connection;
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -291,6 +291,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
     ExecutableFlow flow = null;
     ExecutableNode node = null;
+    final String jobLinkUrl;
     try {
       flow = this.executorManager.getExecutableFlow(execId);
       if (flow == null) {
@@ -306,6 +307,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
             "Job " + jobId + " doesn't exist in " + flow.getExecutionId());
         return;
       }
+
+      jobLinkUrl = this.executorManager.getJobLinkUrl(flow, jobId, attempt);
 
       final List<ViewerPlugin> jobViewerPlugins =
           PluginRegistry.getRegistry().getViewerPluginsForJobType(
@@ -329,6 +332,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("flowid", flow.getId());
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
+    page.add("jobLinkUrl", jobLinkUrl);
+    page.add("jobType", node.getType());
 
     page.render();
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -335,6 +335,12 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("jobLinkUrl", jobLinkUrl);
     page.add("jobType", node.getType());
 
+    if (node.getStatus() == Status.FAILED || node.getStatus() == Status.KILLED) {
+      page.add("jobFailed", true);
+    } else {
+      page.add("jobFailed", false);
+    }
+
     page.render();
   }
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -28,10 +28,11 @@
         <div class="pull-right header-form">
           #if ($jobLinkUrl)
             #if ($jobType == "spark")
-              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm">Spark Job Log</a>
+              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm"
+                 id="jobLinkUrl">Spark Job Log</a>
             #else
-              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm">Hadoop Job
-                Log</a>
+              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm"
+                 id="jobLinkUrl">Hadoop Job Log</a>
             #end
           #end
           <a href="${context}/manager?project=${projectName}&flow=${parentflowid}&job=$jobname"

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -26,6 +26,14 @@
       </div>
       <div class="header-control">
         <div class="pull-right header-form">
+          #if ($jobLinkUrl)
+            #if ($jobType == "spark")
+              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm">Spark Job Log</a>
+            #else
+              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm">Hadoop Job
+                Log</a>
+            #end
+          #end
           <a href="${context}/manager?project=${projectName}&flow=${parentflowid}&job=$jobname"
              class="btn btn-info btn-sm">Job Properties</a>
         </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -37,6 +37,13 @@
     var jobId = "${jobid}";
     var attempt = ${attempt};
   </script>
+  <script type="text/javascript">
+    $(document).ready(function () {
+      #if ($jobFailed == "true")
+        $("#jobLinkUrl").removeClass("btn-primary").addClass("btn-danger");
+      #end
+    });
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
For Hadoop/Spark jobs, the job log first stays in resource manager, after some time, it will be moved to job history server. The current web proxy job link in Azkaban user logs doesn't always work properly. When user click the link, it often expires. Users have to search for the application_id and then manually type the RM or JH link to find the actual job log.

I've added a new button on job log page to provide the dynamic job link. See attached images for the UI change. When user click the "Hadoop Job Log" or "Spark Job Log" button, it first logins to RM using authenticated keytab files, then parses the web content to determine whether the job log has expired on RM and been moved to JHS. It constructs the correct job link URL and returns to the user. If the job fails or is killed, the button color will turn red to attract users' attention to click the button and debug their jobs.

To enable this feature, we need configuration changes in azkaban.properties for all clusters. Here is an example:
```
# Hadoop/Spark Job link url
azkaban.server.external.resource_manager_job_url=http://***rm***:8088/cluster/app/application_${application.id}
azkaban.server.external.history_server_job_url=http://***jh***:19888/jobhistory/job/job_${application.id}
azkaban.server.external.spark_history_server_job_url=http://***sh***:18080/history/application_${application.id}/1/jobs
```
Note: ${application.id} will be replaced at run time.

I've enabled the configuration and tested on our testing cluster.