### PR TITLE
move project json out of execution_dependencies table

### DIFF
--- a/azkaban-db/src/main/sql/create.execution_dependencies.sql
+++ b/azkaban-db/src/main/sql/create.execution_dependencies.sql
@@ -10,7 +10,6 @@ CREATE TABLE execution_dependencies(
   project_version INT not null,
   flow_id varchar(128) not null,
   flow_version INT not null,
-  project_json MEDIUMTEXT not null,
   flow_exec_id INT not null,
   primary key(trigger_instance_id, dep_name)
 );

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
@@ -16,10 +16,10 @@
 
 package azkaban.flowtrigger.quartz;
 
-import azkaban.flow.FlowUtils;
 import azkaban.flowtrigger.FlowTriggerService;
 import azkaban.project.FlowTrigger;
 import azkaban.project.Project;
+import azkaban.project.ProjectManager;
 import azkaban.scheduler.AbstractQuartzJob;
 import javax.inject.Inject;
 import org.quartz.JobDataMap;
@@ -29,24 +29,26 @@ import org.quartz.JobExecutionContext;
 public class FlowTriggerQuartzJob extends AbstractQuartzJob {
 
   public static final String SUBMIT_USER = "SUBMIT_USER";
-  public static final String PROJECT = "PROJECT";
+  public static final String PROJECT_ID = "PROJECT_ID";
   public static final String FLOW_TRIGGER = "FLOW_TRIGGER";
   public static final String FLOW_ID = "FLOW_ID";
   public static final String FLOW_VERSION = "FLOW_VERSION";
 
   private final FlowTriggerService triggerService;
+  private final ProjectManager projectManager;
 
   @Inject
-  public FlowTriggerQuartzJob(final FlowTriggerService service) {
+  public FlowTriggerQuartzJob(final FlowTriggerService service,
+      final ProjectManager projectManager) {
     this.triggerService = service;
+    this.projectManager = projectManager;
   }
 
   @Override
   public void execute(final JobExecutionContext context) {
     final JobDataMap data = context.getMergedJobDataMap();
-    final String projectJson = data.getString(PROJECT);
-    final Project project = FlowUtils.toProject(projectJson);
-
+    final int projectId = data.getInt(PROJECT_ID);
+    final Project project = this.projectManager.getProject(projectId);
     final String flowId = data.getString(FLOW_ID);
     final int flowVersion = data.getInt(FLOW_VERSION);
     final String submitUser = data.getString(SUBMIT_USER);

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -19,11 +19,11 @@ package azkaban.flowtrigger.quartz;
 import static java.util.Objects.requireNonNull;
 
 import azkaban.flow.Flow;
-import azkaban.flow.FlowUtils;
 import azkaban.project.FlowLoaderUtils;
 import azkaban.project.FlowTrigger;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
+import azkaban.project.ProjectManager;
 import azkaban.project.ProjectManagerException;
 import azkaban.scheduler.QuartzJobDescription;
 import azkaban.scheduler.QuartzScheduler;
@@ -51,11 +51,14 @@ public class FlowTriggerScheduler {
   private static final Logger logger = LoggerFactory.getLogger(FlowTriggerScheduler.class);
   private final ProjectLoader projectLoader;
   private final QuartzScheduler scheduler;
+  private final ProjectManager projectManager;
 
   @Inject
-  public FlowTriggerScheduler(final ProjectLoader projectLoader, final QuartzScheduler scheduler) {
+  public FlowTriggerScheduler(final ProjectLoader projectLoader, final QuartzScheduler scheduler,
+      final ProjectManager projectManager) {
     this.projectLoader = requireNonNull(projectLoader);
     this.scheduler = requireNonNull(scheduler);
+    this.projectManager = requireNonNull(projectManager);
   }
 
   /**
@@ -86,13 +89,12 @@ public class FlowTriggerScheduler {
           final FlowTrigger flowTrigger = FlowLoaderUtils.getFlowTriggerFromYamlFile(flowFile);
 
           if (flowTrigger != null) {
-            final String projectJson = FlowUtils.toJson(project);
             final Map<String, Object> contextMap = ImmutableMap
                 .of(FlowTriggerQuartzJob.SUBMIT_USER, submitUser,
                     FlowTriggerQuartzJob.FLOW_TRIGGER, flowTrigger,
                     FlowTriggerQuartzJob.FLOW_ID, flow.getId(),
                     FlowTriggerQuartzJob.FLOW_VERSION, latestFlowVersion,
-                    FlowTriggerQuartzJob.PROJECT, projectJson);
+                    FlowTriggerQuartzJob.PROJECT_ID, project.getId());
             logger.info("scheduling flow " + flow.getProjectId() + "." + flow.getId());
             this.scheduler
                 .registerJob(flowTrigger.getSchedule().getCronExpression(), new QuartzJobDescription
@@ -124,15 +126,13 @@ public class FlowTriggerScheduler {
           final JobDataMap jobDataMap = job.getJobDataMap();
 
           final String flowId = jobDataMap.getString(FlowTriggerQuartzJob.FLOW_ID);
-
-          final String projectJson = jobDataMap.getString(FlowTriggerQuartzJob.PROJECT);
-          final Project project = FlowUtils.toProject(projectJson);
+          final int projectId = jobDataMap.getInt(FlowTriggerQuartzJob.PROJECT_ID);
           final FlowTrigger flowTrigger = (FlowTrigger) jobDataMap
               .get(FlowTriggerQuartzJob.FLOW_TRIGGER);
           final String submitUser = jobDataMap.getString(FlowTriggerQuartzJob.SUBMIT_USER);
           final List<? extends Trigger> quartzTriggers = quartzScheduler.getTriggersOfJob(jobKey);
           scheduledFlowTrigger = new ScheduledFlowTrigger(
-              project.getName(),
+              this.projectManager.getProject(projectId).getName(),
               flowId, flowTrigger, submitUser, quartzTriggers.isEmpty() ? null
               : quartzTriggers.get(0));
         } catch (final Exception ex) {

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
@@ -16,6 +16,8 @@
 package azkaban.flowtrigger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
 import azkaban.db.DatabaseOperator;
@@ -29,6 +31,7 @@ import azkaban.project.JdbcProjectImpl;
 import azkaban.project.JdbcProjectImplTest;
 import azkaban.project.Project;
 import azkaban.project.ProjectLoader;
+import azkaban.project.ProjectManager;
 import azkaban.test.Utils;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
@@ -67,6 +70,7 @@ public class FlowTriggerInstanceLoaderTest {
   private static FlowTrigger flowTrigger;
   private static FlowTriggerInstanceLoader triggerInstLoader;
   private static Project project;
+  private static ProjectManager projManager;
 
   @AfterClass
   public static void destroyDB() {
@@ -83,8 +87,10 @@ public class FlowTriggerInstanceLoaderTest {
   public static void setup() throws Exception {
     dbOperator = Utils.initTestDB();
     projLoader = new JdbcProjectImpl(props, dbOperator);
-    triggerInstLoader = new JdbcFlowTriggerInstanceLoaderImpl(dbOperator, projLoader);
+    projManager = mock(ProjectManager.class);
+    triggerInstLoader = new JdbcFlowTriggerInstanceLoaderImpl(dbOperator, projLoader, projManager);
     project = new Project(project_id, project_name);
+
     final DirectoryYamlFlowLoader yamlFlowLoader = new DirectoryYamlFlowLoader(new Props());
     yamlFlowLoader
         .loadProjectFlow(project, ExecutionsTestUtil.getFlowDir(test_project_zip_dir));
@@ -94,6 +100,8 @@ public class FlowTriggerInstanceLoaderTest {
 
     final File flowFile = new File(JdbcProjectImplTest.class.getClassLoader().getResource
         (test_flow_file).getFile());
+
+    when(projManager.getProject(project_id)).thenReturn(project);
 
     projLoader
         .uploadFlowFile(project_id, project_version, flowFile, flow_version);


### PR DESCRIPTION
The initial motivation of keeping project object as part of trigger instance and persist it into db is for consistency purpose - when a new project zip is uploaded, even if web server restarts after that, the running trigger instance would still pick up the old version of the flow to execute for consistency. 

However due to the huge size of project object, the cost of keeping project object for each dependency instance/flow trigger in db is extremely high(suppose a big project containing hundreds of flows, one of which are using flow trigger, then each row of execution_dependencies will contain a large blob field of project json, rendering deserialization costly when recovering incomplete trigger instances before web server restarts).  

So we decided to only keep the project id instead of the project object in database. And we will populate the project object of dependency instance by looking up the id from project database. The downside is we might compromise consistency as we mentioned above since looking up by project id will always fetch the latest-uploaded project.
