### PR TITLE
Edit the comments for job URL examples.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -109,13 +109,13 @@ public class Constants {
     // Designates one of the external link topics to correspond to a job log viewer
     public static final String AZKABAN_SERVER_EXTERNAL_LOGVIEWER_TOPIC = "azkaban.server.external.logviewer.topic";
     public static final String AZKABAN_SERVER_EXTERNAL_LOGVIEWER_LABEL = "azkaban.server.external.logviewer.label";
-    
+
     /*
      * Hadoop/Spark user job link.
      * Example:
-     * a) azkaban.server.external.resource_manager_job_url=http://***rm***:8088/cluster/app/application_${application.id}
-     * b) azkaban.server.external.history_server_job_url=http://***jh***:19888/jobhistory/job/job_${application.id}
-     * c) azkaban.server.external.spark_history_server_job_url=http://***sh***:18080/history/application_${application.id}/1/jobs
+     * a) azkaban.server.external.resource_manager_job_url=http://resource-manager-http-address:port/cluster/app/application_${application.id}
+     * b) azkaban.server.external.history_server_job_url=http://history-server-http-address:port/jobhistory/job/job_${application.id}
+     * c) azkaban.server.external.spark_history_server_job_url=http://spark-history-server-http-address:port/history/application_${application.id}/1/jobs
      * */
     public static final String RESOURCE_MANAGER_JOB_URL = "azkaban.server.external.resource_manager_job_url";
     public static final String HISTORY_SERVER_JOB_URL = "azkaban.server.external.history_server_job_url";


### PR DESCRIPTION
Followed the example in below document to clarify the job URL examples in comments.
https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/HistoryServerRest.html