### PR TITLE
All executor servlets to use POST

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -56,8 +56,18 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
     return HttpRequestUtils.getParam(request, name);
   }
 
+  /**
+   * @deprecated GET available for seamless upgrade. azkaban-web now uses POST.
+   */
+  @Deprecated
   @Override
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    doPost(req, resp);
+  }
+
+  @Override
+  protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
     final Map<String, Object> ret = new HashMap<>();
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -47,13 +47,20 @@ public class ServerStatisticsServlet extends HttpServlet {
   protected static ExecutorInfo cachedstats = null;
 
   /**
-   * Handle all get request to Statistics Servlet {@inheritDoc}
-   *
-   * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
-   * javax.servlet.http.HttpServletResponse)
+   * @deprecated GET available for seamless upgrade. azkaban-web now uses POST.
    */
+  @Deprecated
   @Override
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    doPost(req, resp);
+  }
+
+  /**
+   * Handle all requests to Statistics Servlet {@inheritDoc}
+   */
+  @Override
+  protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
 
     final boolean noCache = null != req && Boolean.valueOf(req.getParameter(noCacheParamName));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
@@ -69,13 +69,20 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
   }
 
   /**
-   * Handle all get request to Stats Servlet {@inheritDoc}
-   *
-   * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
-   * javax.servlet.http.HttpServletResponse)
+   * @deprecated GET available for seamless upgrade. azkaban-web now uses POST.
    */
+  @Deprecated
   @Override
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+      throws ServletException, IOException {
+    doPost(req, resp);
+  }
+
+  /**
+   * Handle all requests to Stats Servlet {@inheritDoc}
+   */
+  @Override
+  protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
       throws ServletException, IOException {
     final Map<String, Object> ret = new HashMap<>();
 


### PR DESCRIPTION
`ExecutorApiGateway` was changed to use `POST` for all requests, but I missed that azkaban-web also makes calls to `/serverStatistics`, `/jmx` & `/stats` via the gateway, not just `/executor`.

The problem wasn't seen in manual tests with AzkabanSingleServer because it doesn't use multi-executor mode.

Bug was reported by @chengren311 at https://github.com/azkaban/azkaban/pull/1659#issuecomment-376768014.