### PR TITLE
#1703 allow azkaban to run in foreground (and possibly replacing the bash process)

### DIFF
--- a/azkaban-common/src/main/bash/internal/startup-shared.sh
+++ b/azkaban-common/src/main/bash/internal/startup-shared.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+#---
+# parse_args:              parses all given args and handles args that control the behavior of
+#                          launching. All other unrecognized args will be sent to the process
+#                          to be launched at the end.
+#                          Note this function is not supposed to be run in a sub shell, otherwise
+#                          the vars won't be correctly exported to the child process, which is why
+#                          it does not attempt to return the value via stdout.
+# args:                    the name of the var to set final command to, the original command
+#---
+function parse_args {
+  local target_arg="$1"
+  shift
+  local final_command=''
+  for arg in "$@"
+  do
+    case "$arg" in
+      -f | --foreground)
+      # azkaban will run as a foreground process
+      export RUN_IN_FOREGROUND='true'
+      ;;
+      --no-fork)
+      # in addition to running in foreground,
+      # this shell process would be replaced by the actual java service
+      # hence all signals would be directly handled by that
+      export NO_FORK='true'
+      export RUN_IN_FOREGROUND='true'
+      ;;
+      -v | --verbose)
+      export VERBOSE='true'
+      ;;
+      *)
+      final_command="${final_command} ${arg}"
+      ;;
+    esac
+  done
+  eval "${target_arg}='${final_command}'"
+}
+
+#---
+# launch:                  this will modify the command such that the output of the launch script
+#                          itself (not the process to be launched) will be written to the log file
+#                          specified
+# returns:                 the exit status of the command
+# args:                    command to be executed, log file path
+#---
+function launch {
+  local log_file="$2"
+  local cmd=''
+  # this will rip off args specific to launch script
+  # and pass others at the end to the callee
+  parse_args 'cmd' $1
+  if [[ ${RUN_IN_FOREGROUND} != 'true' ]]; then
+    if [[ ${VERBOSE} = 'true' ]]; then
+      echo "Launching process in background..."
+      echo "Execution script logs will be written to ${log_file}"
+    fi
+    cmd="${cmd} >${log_file} 2>&1 &"
+  else
+    if [[ ${VERBOSE} = 'true' ]]; then
+      echo "Launching process in foreground..."
+    fi
+    cmd="${cmd} 2>&1"
+  fi
+  run ${cmd}
+}
+
+#---
+# execute:                 this will modify the command such that if it's run in background,
+#                          it will write the pid to a file.
+# returns:                 the exit status of the command
+# args:                    all arguments will be treated as the command to be executed
+#---
+function execute {
+  local cmd="$@"
+  if [[ ${VERBOSE} = 'true' ]]; then
+    echo "Executing ${cmd}"
+  fi
+  if [[ ${RUN_IN_FOREGROUND} != 'true' ]]; then
+    pid_file="${azkaban_dir}/currentpid"
+    if [[ ${VERBOSE} = 'true' ]]; then
+      echo "Pid will be written to $(abs_path ${pid_file})"
+    fi
+    cmd="${cmd} & echo $! > ${pid_file} &"
+  fi
+  run ${cmd}
+}
+
+#---
+# run:                     runs the given command. If NO_FORK is specified,
+#                          the target process will replace the current shell.
+# returns:                 the exit status of the command
+# args:                    all arguments will be treated as the command to be executed
+#---
+function run {
+  local cmd="$@"
+  if [[ ${NO_FORK} != 'true' ]]; then
+    eval ${cmd}
+  else
+    exec ${cmd}
+  fi
+}
+
+function abs_path {
+  echo $(cd "$(dirname '$1')/.." &> /dev/null && printf "%s/%s" "$(pwd)" "${1##*/}")
+}
+
+# exporting util func specific to this file to the callee
+# this is bash specific so we might need to change this later
+# if we want to support general bourne shell
+export -f execute
+export -f abs_path
+export -f run

--- a/azkaban-exec-server/src/main/bash/internal/internal-start-executor.sh
+++ b/azkaban-exec-server/src/main/bash/internal/internal-start-executor.sh
@@ -57,7 +57,6 @@ else
 fi
 AZKABAN_OPTS="$AZKABAN_OPTS -server -Dcom.sun.management.jmxremote -Djava.io.tmpdir=$tmpdir -Dexecutorport=$executorport -Dserverpath=$serverpath"
 
-java $AZKABAN_OPTS $JAVA_LIB_PATH -cp $CLASSPATH azkaban.execapp.AzkabanExecutorServer -conf $conf $@ &
+java_cmd="java $AZKABAN_OPTS $JAVA_LIB_PATH -cp $CLASSPATH azkaban.execapp.AzkabanExecutorServer -conf $conf $@"
 
-echo $! > $azkaban_dir/currentpid
-
+execute ${java_cmd}

--- a/azkaban-exec-server/src/main/bash/start-exec.sh
+++ b/azkaban-exec-server/src/main/bash/start-exec.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-
 script_dir=$(dirname $0)
 
-# pass along command line arguments to the internal launch script.
-${script_dir}/internal/internal-start-executor.sh "$@" >executorServerLog__`date +%F+%T`.out 2>&1 &
+source "${script_dir}/internal/startup-shared.sh"
 
+# pass along command line arguments to the internal launch script.
+log_file="executorServerLog__$(date +%F+%T).out"
+startup_cmd="${script_dir}/internal/internal-start-executor.sh $@"
+
+launch "${startup_cmd}" "${log_file}"

--- a/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
+++ b/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
@@ -56,8 +56,8 @@ if [[ -f "${conf}/log4j.properties" ]]; then
       -Dlog4j.log.dir=${installdir}/logs"
 fi
 
-java ${AZKABAN_OPTS} -cp ${CLASSPATH} azkaban.soloserver.AzkabanSingleServer -conf ${conf} $@ &
+java_cmd="java ${AZKABAN_OPTS} -cp ${CLASSPATH} azkaban.soloserver.AzkabanSingleServer -conf ${conf} $@"
 
-echo $! > $currentpidfile
+execute ${java_cmd}
 
 

--- a/azkaban-solo-server/src/main/bash/start-solo.sh
+++ b/azkaban-solo-server/src/main/bash/start-solo.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 script_dir=$(dirname $0)
+source "${script_dir}/internal/startup-shared.sh"
 
-${script_dir}/internal/internal-start-solo-server.sh "$@" > soloServerLog__`date +%F+%T`.out 2>&1 &
+log_file="soloServerLog__$(date +%F+%T).out"
+startup_cmd="${script_dir}/internal/internal-start-solo-server.sh $@"
+
+launch "${startup_cmd}" "${log_file}"

--- a/azkaban-web-server/src/main/bash/internal/internal-start-web.sh
+++ b/azkaban-web-server/src/main/bash/internal/internal-start-web.sh
@@ -56,7 +56,6 @@ else
 fi
 AZKABAN_OPTS="$AZKABAN_OPTS -server -Dcom.sun.management.jmxremote -Djava.io.tmpdir=$tmpdir -Dexecutorport=$executorport -Dserverpath=$serverpath"
 
-java $AZKABAN_OPTS $JAVA_LIB_PATH -cp $CLASSPATH azkaban.webapp.AzkabanWebServer -conf $conf $@ &
+java_cmd="java $AZKABAN_OPTS $JAVA_LIB_PATH -cp $CLASSPATH azkaban.webapp.AzkabanWebServer -conf $conf $@"
 
-echo $! > $azkaban_dir/currentpid
-
+execute ${java_cmd}

--- a/azkaban-web-server/src/main/bash/start-web.sh
+++ b/azkaban-web-server/src/main/bash/start-web.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 script_dir=$(dirname $0)
+source "${script_dir}/internal/startup-shared.sh"
 
-${script_dir}/internal/internal-start-web.sh >webServerLog_`date +%F+%T`.out 2>&1 &
+log_file="webServerLog__$(date +%F+%T).out"
+startup_cmd="${script_dir}/internal/internal-start-web.sh $@"
+
+launch "${startup_cmd}" "${log_file}"


### PR DESCRIPTION
Issue: #1703 

This is useful when running in docker or other containerized environments:
1. Running in background is only useful if service is supposed to run directly on a machine (either bare metal or cloud instance). If run in background inside a containerized environment, docker daemon would assume it’s already done and thus killing the container.
2. Simply running it in foreground might not be enough as docker shuts down containers through signals. If we fork the java process as usual, the signals will be received by shell process rather than java, thus the server itself is unable to perform graceful shutdown and will be forcefully killed at the end.

This PR introduces:
* allowing user to run azkaban in foreground (`-f` or `--foreground`), in which case we will fork the java process as usual but script logs will go to stdout rather than a file. No pid will be written.
* in addition to that, user can specify `--no-fork` such that the java process will replace the shell one, allowing the server to be directly responding to the control signals.
* `-v` will allow user to see the command that will be run by script for debugging purpose
* fix the missing _ in web server log file name to make it consistent with others

Discussion: I generally doubt why we need to split the original single script to external/internal. That doesn’t seem to provide much benefit but increases the complexity to modify the launch scripts. Users should be able to control the behavior of the scripts on their own (i.e. if they want to redirect output to somewhere rather than being forced to do so). With that said, that’s outside of the scope of this PR.

TODO: documentation?