### PR TITLE
Flow trigger service enhancement

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -248,13 +248,34 @@ public class FlowTriggerService {
   public void recoverIncompleteTriggerInstances() {
     final Collection<TriggerInstance> unfinishedTriggerInstances = this.flowTriggerInstanceLoader
         .getIncompleteTriggerInstances();
-    //todo chengren311: what if flow trigger is not found?
     for (final TriggerInstance triggerInstance : unfinishedTriggerInstances) {
       if (triggerInstance.getFlowTrigger() != null) {
         recover(triggerInstance);
       } else {
-        logger.error(String.format("cannot recover the trigger instance %s, flow trigger is null ",
-            triggerInstance.getId()));
+        logger.error(String.format("cannot recover the trigger instance %s, flow trigger is null,"
+            + " cancelling it ", triggerInstance.getId()));
+
+        //finalize unrecoverable trigger instances
+        // the following situation would cause trigger instances unrecoverable:
+        // 1. project A with flow A associated with flow trigger A is uploaded
+        // 2. flow trigger A starts to run
+        // 3. project A with flow B without any flow trigger is uploaded
+        // 4. web server restarts
+        // in this case, flow trigger instance of flow trigger A will be equipped with latest
+        // project, thus failing to find the flow trigger since new project doesn't contain flow
+        // trigger at all
+        if (isDoneButFlowNotExecuted(triggerInstance)) {
+          triggerInstance.setFlowExecId(Constants.FAILED_EXEC_ID);
+          this.flowTriggerInstanceLoader.updateAssociatedFlowExecId(triggerInstance);
+        } else {
+          for (final DependencyInstance depInst : triggerInstance.getDepInstances()) {
+            if (!Status.isDone(depInst.getStatus())) {
+              processStatusAndCancelCauseUpdate(depInst, Status.CANCELLED,
+                  CancellationCause.FAILURE);
+              this.triggerProcessor.processTermination(depInst.getTriggerInstance());
+            }
+          }
+        }
       }
     }
   }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/FlowTriggerService.java
@@ -537,6 +537,7 @@ public class FlowTriggerService {
     this.singleThreadExecutorService.shutdownNow(); // Cancel currently executing tasks
     this.multiThreadsExecutorService.shutdown();
     this.multiThreadsExecutorService.shutdownNow();
+    this.triggerProcessor.shutdown();
     this.triggerPluginManager.shutdown();
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstance.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstance.java
@@ -38,8 +38,9 @@ public class TriggerInstance {
 
   //todo chengren311: convert it to builder
   public TriggerInstance(final String id, final FlowTrigger flowTrigger, final String flowId,
-      final int flowVersion, final String submitUser, final List<DependencyInstance> depInstances,
-      final int flowExecId, final Project project) {
+      final int flowVersion, final String submitUser, final List<DependencyInstance>
+      depInstances, final int flowExecId, final Project project) {
+
     this.depInstances = ImmutableList.copyOf(depInstances);
     this.id = id;
     this.flowTrigger = flowTrigger;

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
@@ -60,6 +60,11 @@ public class TriggerInstanceProcessor {
     this.executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
   }
 
+  public void shutdown() {
+    this.executorService.shutdown();
+    this.executorService.shutdownNow();
+  }
+
   private void executeFlowAndUpdateExecID(final TriggerInstance triggerInst) {
     try {
       final Project project = triggerInst.getProject();


### PR DESCRIPTION
The PR consists of following fix/enhancement around flow trigger service:

1. Cancel non-recoverable trigger instances after web server restarts:
 the following situation would cause trigger instances unrecoverable:
 1.1. project A with flow A associated with flow trigger A is uploaded
 1.2. flow trigger A starts to run
 1.3. project A with flow B without any flow trigger is uploaded
 1.4. web server restarts
 In this case, flow trigger instance of flow trigger A will be equipped with latest project, thus failing to find the flow trigger since new project doesn't contain flow trigger at all.

2. fix edge cases in getIncompleteTriggerInstances

3. shutdown executor service of TriggerInstanceProcessor when shutting down FlowTriggerService.