### PR TITLE
Add user.to.proxy validation before reportal uploads the user zip to AZ

### DIFF
--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -900,6 +900,15 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
         proxyUser = variable.name;
       }
 
+      if (variable.title.equals("reportal.config.user.to.proxy")) {
+        String userToProxy = variable.name;
+        final UserManager userManager = getApplication().getUserManager();
+        if (!userManager.validateProxyUser(userToProxy, user)) {
+          errors.add("User " + user.getUserId() + " has no permission to add " + userToProxy
+              + " as proxy user.");
+        }
+      }
+
       variableList.add(variable);
     }
 

--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -900,6 +900,8 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
         proxyUser = variable.name;
       }
 
+      // Validate if the session user (who interact with UI) is part of specified user.to.proxy
+      // user. If not, reportal can not be saved and warn users.
       if (variable.title.equals("reportal.config.user.to.proxy")) {
         String userToProxy = variable.name;
         final UserManager userManager = getApplication().getUserManager();


### PR DESCRIPTION
A user is able to `user.to.proxy` any user in Reportal today. This has been a security vulnerability issue for long time. This PR proposes a fix to validate user.to.proxy configuration before the zip being uploaded to AZ. If the session user is not part of userToProxy user, error is returned to browser to prevent users saving the Reportal.