### PR TITLE
fix reportal regression bug introduced by security fix #1325

### DIFF
--- a/az-reportal/src/main/java/azkaban/jobtype/ReportalPigRunner.java
+++ b/az-reportal/src/main/java/azkaban/jobtype/ReportalPigRunner.java
@@ -47,10 +47,12 @@ public class ReportalPigRunner extends ReportalAbstractRunner {
   public static final String PIG_SCRIPT = "reportal.pig.script";
   public static final String UDF_IMPORT_LIST = "udf.import.list";
   public static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
+  private final String jobName;
   Props prop;
 
   public ReportalPigRunner(final String jobName, final Properties props) {
     super(props);
+    this.jobName = jobName;
     this.prop = new Props();
     this.prop.put(props);
   }
@@ -218,7 +220,8 @@ public class ReportalPigRunner extends ReportalAbstractRunner {
     // Inject variables into the script
     System.out.println("Reportal Pig: Replacing variables");
     final File inputFile = new File(file);
-    final File outputFile = new File(file + ".bak");
+    final File outputFile = new File(this.jobName + ".bak");
+
     final InputStream scriptInputStream =
         new BufferedInputStream(new FileInputStream(inputFile));
     final Scanner rowScanner = new Scanner(scriptInputStream, StandardCharsets.UTF_8.toString());

--- a/az-reportal/src/main/java/azkaban/jobtype/ReportalPigRunner.java
+++ b/az-reportal/src/main/java/azkaban/jobtype/ReportalPigRunner.java
@@ -220,6 +220,9 @@ public class ReportalPigRunner extends ReportalAbstractRunner {
     // Inject variables into the script
     System.out.println("Reportal Pig: Replacing variables");
     final File inputFile = new File(file);
+
+    // Creating a bak file under the root working directory, in order to copy the original pig
+    // script to here with injected variables.
     final File outputFile = new File(this.jobName + ".bak");
 
     final InputStream scriptInputStream =


### PR DESCRIPTION
We found a security hole in #1325 that any job is able to leverage execute-as-user to impersonate any unix account. when we tryied rolling out this fix to Reportal server, we run into an exception for all ReportalPig jobs:

> 13-04-2018 16:54:13 PDT test-pig INFO - Exception in thread "main" java.lang.reflect.UndeclaredThrowableException
13-04-2018 16:54:13 PDT test-pig INFO - 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1769)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain.runMethodAsUser(HadoopJavaJobRunnerMain.java:221)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain.(HadoopJavaJobRunnerMain.java:174)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain.main(HadoopJavaJobRunnerMain.java:80)
13-04-2018 16:54:13 PDT test-pig INFO - Caused by: java.lang.reflect.InvocationTargetException
13-04-2018 16:54:13 PDT test-pig INFO - 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
13-04-2018 16:54:13 PDT test-pig INFO - 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
13-04-2018 16:54:13 PDT test-pig INFO - 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.lang.reflect.Method.invoke(Method.java:498)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain.runMethod(HadoopJavaJobRunnerMain.java:240)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain.access$000(HadoopJavaJobRunnerMain.java:51)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain$2.run(HadoopJavaJobRunnerMain.java:231)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.HadoopJavaJobRunnerMain$2.run(HadoopJavaJobRunnerMain.java:221)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.security.AccessController.doPrivileged(Native Method)
13-04-2018 16:54:13 PDT test-pig INFO - 	at javax.security.auth.Subject.doAs(Subject.java:422)
13-04-2018 16:54:13 PDT test-pig INFO - 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1754)
13-04-2018 16:54:13 PDT test-pig INFO - 	... 3 more
13-04-2018 16:54:13 PDT test-pig INFO - Caused by: java.io.FileNotFoundException: res/test-pig.pig.bak (Permission denied)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.io.FileOutputStream.open0(Native Method)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.io.FileOutputStream.open(FileOutputStream.java:270)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.io.FileOutputStream.(FileOutputStream.java:213)
13-04-2018 16:54:13 PDT test-pig INFO - 	at java.io.FileOutputStream.(FileOutputStream.java:162)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.ReportalPigRunner.injectAllVariables(ReportalPigRunner.java:217)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.ReportalPigRunner.runReportal(ReportalPigRunner.java:59)
13-04-2018 16:54:13 PDT test-pig INFO - 	at azkaban.jobtype.ReportalAbstractRunner.run(ReportalAbstractRunner.java:147)
13-04-2018 16:54:13 PDT test-pig INFO - 	... 14 more

The cause is that the job process is not able to create a file under the same source script folder, because of the change (#1325).

In this PR, I used the most straightforward solution to create the bak file under the root working directory. Test passed in Reportal staging server.


