### PR TITLE
Download permission fix and NullPointerException

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -388,6 +388,11 @@ public abstract class LoginAbstractAzkabanServlet extends
 
     for (final String roleName : user.getRoles()) {
       final Role role = userManager.getRole(roleName);
+
+      if (role == null) {
+          continue;
+      }
+
       if (role.getPermission().isPermissionSet(type)
           || role.getPermission().isPermissionSet(Permission.Type.ADMIN)) {
         return true;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -465,6 +465,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
+    if (!hasPermission(project, user, Type.READ)) {
+      this.setErrorMessageInCookie(resp, "No permission to download project " + projectName
+          + ".");
+      resp.sendRedirect(req.getContextPath());
+      return;
+    }
+
     int version = -1;
     if (hasParam(req, "version")) {
       version = getIntParam(req, "version");


### PR DESCRIPTION
Bug fix to #1618 

Any logged user could download a zip from project by a request to `host/manager?project=projectName&download=true`, so this PR creates a check for READ permission to download.

Additionally, create a fix to a NullPointerException in `hasPermission` method of `LoginAbstractAzkabanServlet` class: role could be null and that creates a HTTP500 response.

### Before: 

#### NullPointerException
Having `azkaban-users.xml` like this one 
```
<azkaban-users>

    <role name="admin" permissions="ADMIN" />
    <role name="metrics" permissions="METRICS"/>

	<group name="administrators" roles="admin" />
	<group name="guests" roles="metrics" />

    <user username="adm" password="adm" groups="administrators" />
    <user username="guest" password="guest" roles="fakeRole"/>

</azkaban-users>
```

`guest` user has a role that is not defined. This cause `final Role role = userManager.getRole(roleName);` to be null, and accessing a project that does exist but `guest` does not have permission creates a NullPointerException.

`host/manager?project=projectName`

![screen shot 2018-04-17 at 11 36 37 am](https://user-images.githubusercontent.com/16767329/38876842-a88cadae-4233-11e8-8d41-ec6876aebd11.png)

#### Downloading a project

Accessing `host/manager?project=projectName&download=true`, any logged user could download the project with no permission

### After:

#### NullPointerException

With the same `azkaban-users.xml`, the result of accessing a project that `guest` does not have permission:

`host/manager?project=projectName`

![screen shot 2018-04-17 at 11 20 45 am](https://user-images.githubusercontent.com/16767329/38877449-183378da-4235-11e8-8d48-0b6b25ce20e7.png)

#### Downloading a project

`guest` has no permission to `READ` project `blabla`.

`host/manager?project=blabla&download=true`

![screen shot 2018-04-17 at 11 21 08 am](https://user-images.githubusercontent.com/16767329/38877623-767631a8-4235-11e8-863e-36f2ec97f8ec.png)
