### PR TITLE
fix hadoop jobtype flaky test

### DIFF
--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-// This test class needs more refactors.
+// TODO kunkun-tang: This test class needs more refactors.
 public class TestHadoopJobUtilsExecutionJar {
   private Logger logger = Logger.getRootLogger();
 
@@ -28,7 +28,6 @@ public class TestHadoopJobUtilsExecutionJar {
   public static void setupFolder() {
     workingDirString = currentDirString + "/../temp/TestHadoopSpark";
     workingDirFile = new File(workingDirString);
-    libFolderFile = new File(workingDirFile, "lib");
     libFolderFile = new File(workingDirFile, "lib");
     executionJarFile = new File(libFolderFile,
         "hadoop-spark-job-test-execution-x.y.z-a.b.c"
@@ -50,7 +49,7 @@ public class TestHadoopJobUtilsExecutionJar {
   @Test
   public void testNoLibFolder() throws IOException {
     FileUtils.deleteDirectory(libFolderFile);
-    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*", logger);
+    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "lib/*", logger);
     Assert.assertEquals(retval, "");
   }
 
@@ -59,7 +58,7 @@ public class TestHadoopJobUtilsExecutionJar {
   public void testLibFolderHasNothingInIt() throws IOException {
     FileUtils.deleteDirectory(libFolderFile);
     libFolderFile.mkdirs();
-    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*", logger);
+    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "lib/*", logger);
 
     Assert.assertEquals(retval, "");
   }
@@ -67,12 +66,12 @@ public class TestHadoopJobUtilsExecutionJar {
 
   @Test
   public void testOneLibFolderExpansion() throws IOException {
-    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*", logger);
+    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "lib/*", logger);
     Set<String> retvalSet = new HashSet<String>(Arrays.asList(retval.split(",")));
 
     Set<String> expected = new HashSet<String>();
-    expected.add(workingDirFile + "/./lib/library.jar");
-    expected.add(workingDirFile + "/./lib/hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
+    expected.add(workingDirFile + "/lib/library.jar");
+    expected.add(workingDirFile + "/lib/hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
 
     Assert.assertTrue("Expected size is different from retrieval size. Expected: " + expected + " , Actual: " + retvalSet,
                       expected.size() == retvalSet.size());
@@ -89,14 +88,14 @@ public class TestHadoopJobUtilsExecutionJar {
     lib2test1Jar.createNewFile();
     File lib2test2Jar = new File(lib2FolderFile, "test2.jar");
     lib2test2Jar.createNewFile();
-    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*,./lib2/*",
+    String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "lib/*,lib2/*",
             logger);
 
-    Assert.assertTrue(retval.contains(workingDirFile + "/./lib/library.jar"));
-    Assert.assertTrue(retval.contains(workingDirFile + "/./lib/hadoop-spark-job-test-execution-x.y"
+    Assert.assertTrue(retval.contains(workingDirFile + "/lib/library.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/lib/hadoop-spark-job-test-execution-x.y"
         + ".z-a.b.c.jar"));
-    Assert.assertTrue(retval.contains(workingDirFile + "/./lib2/test1.jar"));
-    Assert.assertTrue(retval.contains(workingDirFile + "/./lib2/test2.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/lib2/test1.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/lib2/test2.jar"));
   }
 
     @Test
@@ -109,11 +108,11 @@ public class TestHadoopJobUtilsExecutionJar {
       File lib2test1Jar = new File(lib2FolderFile, "test1.jar");
       lib2test1Jar.createNewFile();
 
-      String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*,./lib2/*",
+      String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "lib/*,lib2/*",
               logger);
 
       Assert.assertEquals(
               retval,
-          workingDirFile + "/./lib/library.jar," + workingDirFile + "/./lib2/test1.jar");
+          workingDirFile + "/lib/library.jar," + workingDirFile + "/lib2/test1.jar");
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
@@ -10,28 +10,31 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import azkaban.utils.Props;
-
+// This test class needs more refactors.
 public class TestHadoopJobUtilsExecutionJar {
-  Props jobProps = null;
+  private Logger logger = Logger.getRootLogger();
 
-  Logger logger = Logger.getRootLogger();
+  private static String currentDirString = System.getProperty("user.dir");
+  private static String workingDirString = null;
+  private static File workingDirFile = null;
+  private static File libFolderFile = null;
+  private static File executionJarFile = null;
+  private static File libraryJarFile = null;
 
-  String workingDirString = "/tmp/TestHadoopSpark";
-
-  File workingDirFile = new File(workingDirString);
-
-  File libFolderFile = new File(workingDirFile, "lib");
-
-  String executionJarName = "hadoop-spark-job-test-execution-x.y.z-a.b.c.jar";
-
-  File executionJarFile = new File(libFolderFile, "hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
-
-  File libraryJarFile = new File(libFolderFile, "library.jar");
-
-  String delim = SparkJobArg.delimiter;
+  @BeforeClass
+  public static void setupFolder() {
+    workingDirString = currentDirString + "/../temp/TestHadoopSpark";
+    workingDirFile = new File(workingDirString);
+    libFolderFile = new File(workingDirFile, "lib");
+    libFolderFile = new File(workingDirFile, "lib");
+    executionJarFile = new File(libFolderFile,
+        "hadoop-spark-job-test-execution-x.y.z-a.b.c"
+            + ".jar");
+    libraryJarFile = new File(libFolderFile, "library.jar");
+  }
 
   @Before
   public void beforeMethod() throws IOException {
@@ -41,7 +44,6 @@ public class TestHadoopJobUtilsExecutionJar {
     libFolderFile.mkdirs();
     executionJarFile.createNewFile();
     libraryJarFile.createNewFile();
-
   }
 
   // nothing should happen
@@ -49,7 +51,6 @@ public class TestHadoopJobUtilsExecutionJar {
   public void testNoLibFolder() throws IOException {
     FileUtils.deleteDirectory(libFolderFile);
     String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*", logger);
-
     Assert.assertEquals(retval, "");
   }
 
@@ -70,8 +71,8 @@ public class TestHadoopJobUtilsExecutionJar {
     Set<String> retvalSet = new HashSet<String>(Arrays.asList(retval.split(",")));
 
     Set<String> expected = new HashSet<String>();
-    expected.add("/tmp/TestHadoopSpark/./lib/library.jar");
-    expected.add("/tmp/TestHadoopSpark/./lib/hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
+    expected.add(workingDirFile + "/./lib/library.jar");
+    expected.add(workingDirFile + "/./lib/hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
 
     Assert.assertTrue("Expected size is different from retrieval size. Expected: " + expected + " , Actual: " + retvalSet,
                       expected.size() == retvalSet.size());
@@ -91,10 +92,11 @@ public class TestHadoopJobUtilsExecutionJar {
     String retval = HadoopJobUtils.resolveWildCardForJarSpec(workingDirString, "./lib/*,./lib2/*",
             logger);
 
-    Assert.assertTrue(retval.contains("/tmp/TestHadoopSpark/./lib/library.jar"));
-    Assert.assertTrue(retval.contains("/tmp/TestHadoopSpark/./lib/hadoop-spark-job-test-execution-x.y.z-a.b.c.jar"));
-    Assert.assertTrue(retval.contains("/tmp/TestHadoopSpark/./lib2/test1.jar"));
-    Assert.assertTrue(retval.contains("/tmp/TestHadoopSpark/./lib2/test2.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/./lib/library.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/./lib/hadoop-spark-job-test-execution-x.y"
+        + ".z-a.b.c.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/./lib2/test1.jar"));
+    Assert.assertTrue(retval.contains(workingDirFile + "/./lib2/test2.jar"));
   }
 
     @Test
@@ -112,6 +114,6 @@ public class TestHadoopJobUtilsExecutionJar {
 
       Assert.assertEquals(
               retval,
-              "/tmp/TestHadoopSpark/./lib/library.jar,/tmp/TestHadoopSpark/./lib2/test1.jar");
+          workingDirFile + "/./lib/library.jar," + workingDirFile + "/./lib2/test1.jar");
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import azkaban.utils.Props;
 
+// TODO kunkun-tang: This test class needs more refactors.
 public class TestHadoopJobUtilsResolveJarSpec {
   private Logger logger = Logger.getRootLogger();
 
@@ -25,7 +26,6 @@ public class TestHadoopJobUtilsResolveJarSpec {
   public static void setupFolder() {
     workingDirString = currentDirString + "/../temp/TestHadoopSpark";
     workingDirFile = new File(workingDirString);
-    libFolderFile = new File(workingDirFile, "lib");
     libFolderFile = new File(workingDirFile, "lib");
     executionJarFile = new File(libFolderFile,
         "hadoop-spark-job-test-execution-x.y.z-a.b.c"

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
@@ -5,30 +5,33 @@ import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import azkaban.utils.Props;
 
 public class TestHadoopJobUtilsResolveJarSpec {
-  Props jobProps = null;
+  private Logger logger = Logger.getRootLogger();
 
-  Logger logger = Logger.getRootLogger();
+  private static String currentDirString = System.getProperty("user.dir");
+  private static String workingDirString = null;
+  private static File workingDirFile = null;
+  private static File libFolderFile = null;
+  private static File executionJarFile = null;
+  private static File libraryJarFile = null;
 
-  String workingDirString = "/tmp/TestHadoopSpark";
-
-  File workingDirFile = new File(workingDirString);
-
-  File libFolderFile = new File(workingDirFile, "lib");
-
-  String executionJarName = "hadoop-spark-job-test-execution-x.y.z-a.b.c.jar";
-
-  File executionJarFile = new File(libFolderFile, "hadoop-spark-job-test-execution-x.y.z-a.b.c.jar");
-
-  File libraryJarFile = new File(libFolderFile, "library.jar");
-
-  String delim = SparkJobArg.delimiter;
+  @BeforeClass
+  public static void setupFolder() {
+    workingDirString = currentDirString + "/../temp/TestHadoopSpark";
+    workingDirFile = new File(workingDirString);
+    libFolderFile = new File(workingDirFile, "lib");
+    libFolderFile = new File(workingDirFile, "lib");
+    executionJarFile = new File(libFolderFile,
+        "hadoop-spark-job-test-execution-x.y.z-a.b.c"
+            + ".jar");
+    libraryJarFile = new File(libFolderFile, "library.jar");
+  }
 
   @Before
   public void beforeMethod() throws IOException {
@@ -44,12 +47,12 @@ public class TestHadoopJobUtilsResolveJarSpec {
   // nothing should happen
   @Test(expected = IllegalStateException.class)
   public void testJarDoesNotExist() throws IOException {
-    HadoopJobUtils.resolveExecutionJarName(workingDirString, "./lib/abc.jar", logger);
+    HadoopJobUtils.resolveExecutionJarName(workingDirString, "/lib/abc.jar", logger);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testNoLibFolder() throws IOException {
     FileUtils.deleteDirectory(libFolderFile);
-    HadoopJobUtils.resolveExecutionJarName(workingDirString, "./lib/abc.jar", logger);
+    HadoopJobUtils.resolveExecutionJarName(workingDirString, "/lib/abc.jar", logger);
   }
 }


### PR DESCRIPTION
The two below classes test related Jar functions and were messing /temp/HadoopTest folder. It caused out test fail. 
>Gradle test > azkaban.jobtype.TestHadoopJobUtilsExecutionJar.testLibFolderHasNothingInIt > captured output:
    log4j:WARN No appenders could be found for logger (root).
    log4j:WARN Please initialize the log4j system properly.
    log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
azkaban.jobtype.TestHadoopJobUtilsExecutionJar > testLibFolderHasNothingInIt FAILED
    java.lang.IllegalStateException: the File[] matchingFiles variable is null.  This means an IOException occured while doing listFiles.  Please check disk availability and retry again
        at azkaban.jobtype.HadoopJobUtils.getFilesInFolderByRegex(HadoopJobUtils.java:371)
        at azkaban.jobtype.HadoopJobUtils.resolveWildCardForJarSpec(HadoopJobUtils.java:244)
        at azkaban.jobtype.TestHadoopJobUtilsExecutionJar.testLibFolderHasNothingInIt(TestHadoopJobUtilsExecutionJar.java:61)
:azkaban-web-server:uploadDefault
:az-hadoop-jobtype-plugin -- There are test failures!

In this PR, I changed the temp folder to the $buildDir/temp folder. $buildDir/temp is already ignored in .gitignore file.

