### PR TITLE
Download permission fix

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -465,6 +465,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
+    if (!hasPermission(project, user, Type.READ)) {
+      this.setErrorMessageInCookie(resp, "No permission to download project " + projectName
+          + ".");
+      resp.sendRedirect(req.getContextPath());
+      return;
+    }
+
     int version = -1;
     if (hasParam(req, "version")) {
       version = getIntParam(req, "version");


### PR DESCRIPTION
Bug fix to #1618 

Any logged user could download a zip from project by a request to `host/manager?project=projectName&download=true`, so this PR creates a check for READ permission to download.

### Before: 

Accessing `host/manager?project=projectName&download=true`, any logged user could download the project with no permission

### After:

`guest` has no permission to `READ` project `blabla`.

`host/manager?project=blabla&download=true`

![screen shot 2018-04-17 at 11 21 08 am](https://user-images.githubusercontent.com/16767329/38877623-767631a8-4235-11e8-863e-36f2ec97f8ec.png)
