### PR TITLE
Load global.properties even if common.properties doesn't exist

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -123,8 +123,8 @@ public class JobTypeManager {
       }
     } else {
       logger.info("Common plugin job props file " + commonJobPropsFile
-          + " not found. Using empty props.");
-      commonPluginJobProps = new Props();
+          + " not found. Using only globals props");
+      commonPluginJobProps = new Props(this.globalProperties);
     }
 
     // Loads the common properties used by all plugins when loading


### PR DESCRIPTION
Use **global.properties** even if **common.properties** doesn't exist