### PR TITLE
allow project admin to pause/resume flow trigger schedule

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -110,9 +110,9 @@ public class NodeBeanLoader {
     final String cronExpression = scheduleMap.get(FlowTriggerProps.SCHEDULE_VALUE).trim();
     final String[] cronParts = cronExpression.split("\\s+");
 
-//    Preconditions
-//        .checkArgument(cronParts[0].equals("0"), "interval of flow trigger schedule has to"
-//            + " be larger than 1 min");
+    Preconditions
+        .checkArgument(cronParts[0].equals("0"), "interval of flow trigger schedule has to"
+            + " be larger than 1 min");
 
     Preconditions.checkArgument(scheduleMap.size() == 2, "flow trigger schedule must "
         + "contain type and value only");

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -110,9 +110,9 @@ public class NodeBeanLoader {
     final String cronExpression = scheduleMap.get(FlowTriggerProps.SCHEDULE_VALUE).trim();
     final String[] cronParts = cronExpression.split("\\s+");
 
-    Preconditions
-        .checkArgument(cronParts[0].equals("0"), "interval of flow trigger schedule has to"
-            + " be larger than 1 min");
+//    Preconditions
+//        .checkArgument(cronParts[0].equals("0"), "interval of flow trigger schedule has to"
+//            + " be larger than 1 min");
 
     Preconditions.checkArgument(scheduleMap.size() == 2, "flow trigger schedule must "
         + "contain type and value only");

--- a/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
@@ -267,22 +267,22 @@ public class NodeBeanLoaderTest {
     assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean.getTrigger()))
         .isInstanceOf(IllegalArgumentException.class);
 
-    loader.load(ExecutionsTestUtil.getFlowFile(
+    final NodeBean nodeBean1 = loader.load(ExecutionsTestUtil.getFlowFile(
         TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_second_level_cron_expression1.flow"));
 
-    assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean.getTrigger()))
-        .isInstanceOf(IllegalArgumentException.class);
-
-    loader.load(ExecutionsTestUtil.getFlowFile(
-        TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_second_level_cron_expression2.flow"));
-
-    assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean.getTrigger()))
+    assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean1.getTrigger()))
         .isInstanceOf(IllegalArgumentException.class);
 
     final NodeBean nodeBean2 = loader.load(ExecutionsTestUtil.getFlowFile(
-        TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_no_schedule.flow"));
+        TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_second_level_cron_expression2.flow"));
 
     assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean2.getTrigger()))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    final NodeBean nodeBean3 = loader.load(ExecutionsTestUtil.getFlowFile(
+        TRIGGER_FLOW_YML_TEST_DIR, "flow_trigger_no_schedule.flow"));
+
+    assertThatThrownBy(() -> loader.toFlowTrigger(nodeBean3.getTrigger()))
         .isInstanceOf(NullPointerException.class);
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -119,7 +119,7 @@ public class QuartzScheduler {
    */
   public synchronized void pauseJob(final String groupName) throws SchedulerException {
     if (!ifJobExist(groupName)) {
-      logger.warn("can not find job with " + groupName + " in quartz.");
+      throw new SchedulerException("can not find job with group name: " + groupName + " in quartz.");
     } else {
       this.scheduler.pauseJob(new JobKey(DEFAULT_JOB_NAME, groupName));
     }
@@ -144,7 +144,7 @@ public class QuartzScheduler {
    */
   public synchronized void resumeJob(final String groupName) throws SchedulerException {
     if (!ifJobExist(groupName)) {
-      logger.warn("can not find job with " + groupName + " in quartz.");
+      throw new SchedulerException("can not find job with group name: " + groupName + " in quartz.");
     } else {
       this.scheduler.resumeJob(new JobKey(DEFAULT_JOB_NAME, groupName));
     }
@@ -156,7 +156,7 @@ public class QuartzScheduler {
    */
   public synchronized void unregisterJob(final String groupName) throws SchedulerException {
     if (!ifJobExist(groupName)) {
-      logger.warn("can not find job with " + groupName + " in quartz.");
+      throw new SchedulerException("can not find job with group name: " + groupName + " in quartz.");
     } else {
       this.scheduler.deleteJob(new JobKey(DEFAULT_JOB_NAME, groupName));
     }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerInstanceServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerInstanceServlet.java
@@ -118,13 +118,11 @@ public class FlowTriggerInstanceServlet extends LoginAbstractAzkabanServlet {
         final Project project = this.projectManager.getProject(projectName);
         if (project == null) {
           ret.put("error", "please specify a valid project name");
-          return;
         }
-        if (!hasPermission(project, session.getUser(), Type.READ)) {
+        else if (!hasPermission(project, session.getUser(), Type.READ)) {
           ret.put("error", "Permission denied. Need READ access.");
-          return;
         }
-        ajaxFetchTriggerInstances(project.getId(), flowId, ret, req);
+        else ajaxFetchTriggerInstances(project.getId(), flowId, ret, req);
       } else {
         ret.put("error", "please specify project id and flow id");
       }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
@@ -112,14 +112,12 @@ public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
           try {
             if(ajaxName.equals("pauseTrigger")) {
               this.scheduler.pauseFlowTrigger(projectId, flowId);
-            }
-            else {
+            } else {
               this.scheduler.resumeFlowTrigger(projectId, flowId);
             }
             ret.put("status", "success");
           } catch (SchedulerException ex) {
-            ret.put("status", "error");
-            ret.put("message", ex);
+            ret.put("error", ex.getMessage());
           }
         }
       }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -165,6 +165,7 @@
 
               <td>${trigger.isPaused()}</td>
 
+              ##todo chengren311: add pause/resume button in flow page.
               <td>
                 #if (${trigger.isPaused()} == "false")
                   <button type="button" id="pausebtn" class="btn btn-danger btn-sm"

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -21,6 +21,7 @@
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
   <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
@@ -33,6 +34,36 @@
       var jobTable = $("#scheduleFlowTriggers");
       jobTable.tablesorter();
     });
+  </script>
+
+  <script type="text/javascript">
+    function pauseTrigger(projectId, flowId) {
+      var requestURL = document.location.href;
+      var requestData = {"projectId": projectId, "flowId" : flowId, "ajax": "pauseTrigger"};
+      var successHandler = function (data) {
+        if (data.error) {
+          showDialog("Error", data.error);
+        }
+        else {
+          window.location = requestURL;
+        }
+      };
+      ajaxCall(requestURL, requestData, successHandler);
+    }
+
+    function resumeTrigger(projectId, flowId) {
+      var requestURL = document.location.href;
+      var requestData = {"projectId": projectId, "flowId" : flowId, "ajax": "resumeTrigger"};
+      var successHandler = function (data) {
+        if (data.error) {
+          showDialog("Error", data.error);
+        }
+        else {
+          window.location = requestURL;
+        }
+      };
+      ajaxCall(requestURL, requestData, successHandler);
+    }
   </script>
 </head>
 <body>
@@ -73,6 +104,8 @@
           <th>Schedule</th>
           <th>Max Wait Mins</th>
           <th>Dependencies</th>
+          <th>Is Paused</th>
+          <th>Pause/Resume</th>
         </tr>
         </thead>
         <tbody>
@@ -129,6 +162,20 @@
                   </div>
                 </div>
               </div>
+
+              <td>${trigger.isPaused()}</td>
+
+              <td>
+                #if (${trigger.isPaused()} == "false")
+                  <button type="button" id="pausebtn" class="btn btn-danger btn-sm"
+                          onclick="pauseTrigger('${trigger.getProjectId()}', '${trigger.getFlowId()}')">Pause
+                  </button>
+                #else
+                  <button type="button" id="resumebtn" class="btn btn-info btn-sm"
+                          onclick="resumeTrigger('${trigger.getProjectId()}', '${trigger.getFlowId()}')">Resume
+                  </button>
+                #end
+              </td>
 
             </tr>
             #end


### PR DESCRIPTION
The thinking behind that is scheduled flow trigger needs to be paused if something goes south, e.x: the triggered flow is consuming too much azkaban resource. One way to stop the schedule is reupload a new project with new flow config with flow trigger turned off, but allowing the project admin to pause/resume schedule is apparently much more convenient option. 

Tested manually. Unit test will follow up. 