### PR TITLE
job name should be customized for different types of quartz jobs

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
@@ -34,6 +34,8 @@ public class FlowTriggerQuartzJob extends AbstractQuartzJob {
   public static final String FLOW_ID = "FLOW_ID";
   public static final String FLOW_VERSION = "FLOW_VERSION";
 
+  public static final String JOB_NAME = "FLOW_TRIGGER";
+
   private final FlowTriggerService triggerService;
   private final ProjectManager projectManager;
 

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -102,7 +102,8 @@ public class FlowTriggerScheduler {
                         generateGroupName(flow), contextMap));
           }
         } catch (final Exception ex) {
-          logger.error("error in registering flow", ex);
+          logger.error(String.format("error in registering flow [project: %s, flow: %s]", project
+              .getName(), flow.getId()), ex);
         } finally {
           FlowLoaderUtils.cleanUpDir(tempDir);
         }

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzJobDescription.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzJobDescription.java
@@ -26,11 +26,11 @@ import java.util.Map;
 public class QuartzJobDescription<T extends AbstractQuartzJob> {
 
   private final String groupName;
+  private final String jobName;
   private final Class<T> jobClass;
   private final Map<String, ? extends Serializable> contextMap;
-
   public QuartzJobDescription(final Class<T> jobClass,
-      final String groupName,
+      final String jobName, final String groupName,
       final Map<String, ? extends Serializable> contextMap) {
 
     /**
@@ -41,23 +41,18 @@ public class QuartzJobDescription<T extends AbstractQuartzJob> {
       throw new ClassCastException("jobClass must extend AbstractQuartzJob class");
     }
     this.jobClass = jobClass;
+    this.jobName = jobName;
     this.groupName = groupName;
     this.contextMap = contextMap;
   }
 
   public QuartzJobDescription(final Class<T> jobClass,
-      final String groupName) {
+      final String jobName, final String groupName) {
+    this(jobClass, jobName, groupName, new HashMap<String, String>());
+  }
 
-    /**
-     * This check is necessary for raw type. Please see test
-     * {@link QuartzJobDescriptionTest#testCreateQuartzJobDescription2}
-     */
-    if (jobClass.getSuperclass() != AbstractQuartzJob.class) {
-      throw new ClassCastException("jobClass must extend AbstractQuartzJob class");
-    }
-    this.jobClass = jobClass;
-    this.groupName = groupName;
-    this.contextMap = new HashMap<String, String>();
+  public String getJobName() {
+    return jobName;
   }
 
   public Class<? extends AbstractQuartzJob> getJobClass() {

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -39,7 +39,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manages Quartz schedules. Azkaban regards QuartzJob and QuartzTrigger as an one-to-one mapping.
+ * Manages Quartz schedules. Azkaban regards QuartzJob and QuartzTrigger as an one-to-one
+ * mapping.
+ * Quartz job key naming standard:
+ * Job key is composed of job name and group name. Job type denotes job name. Project id+flow
+ * name denotes group name.
+ * E.x FLOW_TRIGGER as job name, 1.flow1 as group name
  */
 @Singleton
 public class QuartzScheduler {

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -114,18 +114,22 @@ public class QuartzScheduler {
     }
   }
 
+  private void checkJobExistence(final String jobName, final String groupName)
+      throws SchedulerException {
+    if (!ifJobExist(jobName, groupName)) {
+      throw new SchedulerException(String.format("can not find job with job name: %s and group "
+          + "name %s: in quartz.", jobName, groupName));
+    }
+  }
+
   /**
    * pause a job given the groupname. since pausing request might be issued concurrently,
    * so synchronized is added to ensure thread safety.
    */
   public synchronized void pauseJob(final String jobName, final String groupName)
       throws SchedulerException {
-    if (!ifJobExist(jobName, groupName)) {
-      throw new SchedulerException(
-          "can not find job with group name: " + groupName + " in quartz.");
-    } else {
-      this.scheduler.pauseJob(new JobKey(jobName, groupName));
-    }
+    checkJobExistence(jobName, groupName);
+    this.scheduler.pauseJob(new JobKey(jobName, groupName));
   }
 
   public synchronized boolean isJobPaused(final String jobName, final String groupName)
@@ -148,12 +152,8 @@ public class QuartzScheduler {
    */
   public synchronized void resumeJob(final String jobName, final String groupName)
       throws SchedulerException {
-    if (!ifJobExist(jobName, groupName)) {
-      throw new SchedulerException(
-          "can not find job with group name: " + groupName + " in quartz.");
-    } else {
-      this.scheduler.resumeJob(new JobKey(jobName, groupName));
-    }
+    checkJobExistence(jobName, groupName);
+    this.scheduler.resumeJob(new JobKey(jobName, groupName));
   }
 
   /**
@@ -162,12 +162,8 @@ public class QuartzScheduler {
    */
   public synchronized void unregisterJob(final String jobName, final String groupName) throws
       SchedulerException {
-    if (!ifJobExist(jobName, groupName)) {
-      throw new SchedulerException(
-          "can not find job with group name: " + groupName + " in quartz.");
-    } else {
-      this.scheduler.deleteJob(new JobKey(jobName, groupName));
-    }
+    checkJobExistence(jobName, groupName);
+    this.scheduler.deleteJob(new JobKey(jobName, groupName));
   }
 
   /**
@@ -190,10 +186,7 @@ public class QuartzScheduler {
     requireNonNull(jobDescription, "jobDescription is null");
 
     // Not allowed to register duplicate job name.
-    if (ifJobExist(jobDescription.getJobName(), jobDescription.getGroupName())) {
-      throw new SchedulerException(
-          "can not register existing job " + jobDescription.getGroupName());
-    }
+    checkJobExistence(jobDescription.getJobName(), jobDescription.getGroupName());
 
     if (!CronExpression.isValidExpression(cronExpression)) {
       throw new SchedulerException(

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -122,6 +122,7 @@ public class QuartzScheduler {
     }
   }
 
+
   /**
    * pause a job given the groupname. since pausing request might be issued concurrently,
    * so synchronized is added to ensure thread safety.
@@ -185,8 +186,10 @@ public class QuartzScheduler {
 
     requireNonNull(jobDescription, "jobDescription is null");
 
-    // Not allowed to register duplicate job name.
-    checkJobExistence(jobDescription.getJobName(), jobDescription.getGroupName());
+    if (ifJobExist(jobDescription.getJobName(), jobDescription.getGroupName())) {
+      throw new SchedulerException(String.format("can not register existing job with job name: "
+          + "%s and group name: %s", jobDescription.getJobName(), jobDescription.getGroupName()));
+    }
 
     if (!CronExpression.isValidExpression(cronExpression)) {
       throw new SchedulerException(

--- a/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzJobDescriptionTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzJobDescriptionTest.java
@@ -26,19 +26,18 @@ import org.junit.Test;
 public class QuartzJobDescriptionTest {
 
   @Test
-  public void testCreateQuartzJobDescription() throws Exception{
+  public void testCreateQuartzJobDescription() throws Exception {
     final Map<String, SampleService> contextMap = new HashMap<>();
     assertThatCode(() -> {
-          new QuartzJobDescription<>(SampleQuartzJob.class,
-          "SampleService",
-          contextMap);
+      new QuartzJobDescription<>(SampleQuartzJob.class, "SampleJob",
+          "SampleService", contextMap);
     }).doesNotThrowAnyException();
   }
 
   @Test
   public void testCreateQuartzJobDescriptionRawType2() throws Exception {
     assertThatThrownBy(
-        () -> new QuartzJobDescription(SampleService.class, "SampleService"))
+        () -> new QuartzJobDescription(SampleService.class, "SampleJob", "SampleService"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("jobClass must extend AbstractQuartzJob class");
   }

--- a/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
@@ -94,7 +94,7 @@ public class QuartzSchedulerTest {
   @Test
   public void testCreateScheduleAndRun() throws Exception {
     scheduler.registerJob("* * * * * ?", createJobDescription());
-    assertThat(scheduler.ifJobExist("SampleService")).isEqualTo(true);
+    assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
     TestUtils.await().untilAsserted(() -> assertThat(SampleQuartzJob.COUNT_EXECUTION)
         .isNotNull().isGreaterThan(1));
   }
@@ -119,9 +119,27 @@ public class QuartzSchedulerTest {
   @Test
   public void testUnregisterSchedule() throws Exception {
     scheduler.registerJob("* * * * * ?", createJobDescription());
-    assertThat(scheduler.ifJobExist("SampleService")).isEqualTo(true);
-    scheduler.unregisterJob("SampleService");
-    assertThat(scheduler.ifJobExist("SampleService")).isEqualTo(false);
+    assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
+    scheduler.unregisterJob("SampleJob", "SampleService");
+    assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(false);
+  }
+
+  @Test
+  public void testPauseSchedule() throws Exception {
+    scheduler.registerJob("* * * * * ?", createJobDescription());
+    scheduler.pauseJob("SampleJob", "SampleService");
+    assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
+    scheduler.resumeJob("SampleJob", "SampleService");
+    assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(false);
+
+    // test pausing a paused job
+    scheduler.pauseJob("SampleJob", "SampleService");
+    scheduler.pauseJob("SampleJob", "SampleService");
+    assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
+    // test resuming a non-paused job
+    scheduler.resumeJob("SampleJob", "SampleService");
+    scheduler.resumeJob("SampleJob", "SampleService");
+    assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(false);
   }
 
   @Ignore("Flaky test, slow too. Don't use Thread.sleep in unit tests.")
@@ -138,6 +156,6 @@ public class QuartzSchedulerTest {
   }
 
   private QuartzJobDescription createJobDescription() {
-    return new QuartzJobDescription<>(SampleQuartzJob.class, "SampleService");
+    return new QuartzJobDescription<>(SampleQuartzJob.class, "SampleJob", "SampleService");
   }
 }


### PR DESCRIPTION
A quartz job is identified by job name and group name. Group name is the combination of project id and flow id. But job name was a constant string. This PR replaces it with dynamic job name variable. 
For flow trigger, the job name is FLOW_TRIGGER. This is to provide flexibility in case where same flow could have multiple scheduled quartz jobs in the future. 