### PR TITLE
Check circular dependency

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/dag/DagBuilder.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/DagBuilder.java
@@ -107,7 +107,6 @@ public class DagBuilder {
        * @throws DagException if true
        */
       private void check() {
-        // The algorithm is described in
         while (!this.toVisit.isEmpty()) {
           final NodeBuilder node = removeOneNodeFromToVisitSet();
           if (checkNode(node)) {

--- a/azkaban-exec-server/src/test/java/azkaban/dag/DagBuilderTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/DagBuilderTest.java
@@ -94,9 +94,9 @@ public class DagBuilderTest {
       this.dagBuilder.build();
     });
 
-    System.out.println("Expect exception: " + thrown);
-
     // then
+    // Expect the exception message to show the loop: nb1 -> nb2 -> nb3 -> nb1.
+    System.out.println("Expect exception: " + thrown);
     assertThat(thrown).isInstanceOf(DagException.class);
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/dag/DagBuilderTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/DagBuilderTest.java
@@ -80,6 +80,27 @@ public class DagBuilderTest {
   }
 
   @Test
+  public void build_should_throw_exception_when_circular_dependency_is_detected() {
+    // given
+    final NodeBuilder nodeBuilder1 = createNodeBuilder("nb1");
+    final NodeBuilder nodeBuilder2 = createNodeBuilder("nb2");
+    final NodeBuilder nodeBuilder3 = createNodeBuilder("nb3");
+    nodeBuilder2.addParents(nodeBuilder1);
+    nodeBuilder3.addParents(nodeBuilder2);
+    nodeBuilder1.addParents(nodeBuilder3);
+
+    // when
+    final Throwable thrown = catchThrowable(() -> {
+      this.dagBuilder.build();
+    });
+
+    System.out.println("Expect exception: " + thrown);
+
+    // then
+    assertThat(thrown).isInstanceOf(DagException.class);
+  }
+
+  @Test
   public void add_dependency_should_not_affect_dag_already_built() {
     // given
     final Dag dag = this.dagBuilder.build();


### PR DESCRIPTION
Throws an exception when circular dependency is detected when building a
dag.