### PR TITLE
Remove the find node by name method

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/dag/Dag.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/Dag.java
@@ -20,9 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A DAG (Directed acyclic graph) consists of {@link Node}s.
@@ -35,7 +33,6 @@ class Dag {
   private final String name;
   private final DagProcessor dagProcessor;
   private final List<Node> nodes = new ArrayList<>();
-  private final Map<String, Node> nameToNodeMap = new HashMap<>();
   private Status status = Status.READY;
 
   Dag(final String name, final DagProcessor dagProcessor) {
@@ -51,23 +48,16 @@ class Dag {
    * <p>It's important NOT to expose this method as public. The design relies on this to ensure
    * correctness. The DAG's structure shouldn't change after it is created.
    *
+   * <p>The DagBuilder will check that node names are unique within a dag. No check is necessary
+   * here since the method package private and where it is called is carefully controlled within
+   * a relatively small package.
+   * </p>
+   *
    * @param node a node to add
    */
   void addNode(final Node node) {
     assert (node.getDag() == this);
     this.nodes.add(node);
-    assert (!this.nameToNodeMap.containsKey(node.getName()));
-    this.nameToNodeMap.put(node.getName(), node);
-  }
-
-  /**
-   * Gets the node associated with the name.
-   *
-   * @param name node name
-   * @return node. null if the node with this name doesn't exist
-   */
-  Node getNodeByName(final String name) {
-    return this.nameToNodeMap.get(name);
   }
 
   void start() {

--- a/azkaban-exec-server/src/test/java/azkaban/dag/DagServiceTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/DagServiceTest.java
@@ -214,15 +214,13 @@ public class DagServiceTest {
     final Dag bDag = subDagBuilder.build();
 
     final TestSubDagNodeProcessor testSubDagNodeProcessor = new TestSubDagNodeProcessor
-        (this.dagService, this.statusChangeRecorder, bDag);
+        (this.dagService, this.statusChangeRecorder, bDag, testSubDagProcessor);
     final NodeBuilder subDagNodeBuilder = this.dagBuilder
         .createNode("sfb", testSubDagNodeProcessor);
 
     final NodeBuilder cBuilder = createNodeInTestDag("c");
     cBuilder.addParents(subDagNodeBuilder);
     final Dag dag = this.dagBuilder.build();
-
-    testSubDagProcessor.setNode(dag.getNodeByName(subDagNodeBuilder.getName()));
 
     addToExpectedSequence("fa", Status.RUNNING);
     addToExpectedSequence("sfb", Status.RUNNING);

--- a/azkaban-exec-server/src/test/java/azkaban/dag/TestSubDagNodeProcessor.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/TestSubDagNodeProcessor.java
@@ -24,15 +24,17 @@ public class TestSubDagNodeProcessor implements NodeProcessor {
   private final DagService dagService;
   private final StatusChangeRecorder statusChangeRecorder;
   private final Dag dag;
+  private final TestSubDagProcessor testSubDagProcessor;
 
 
   TestSubDagNodeProcessor(final DagService dagService,
       final StatusChangeRecorder statusChangeRecorder,
-      final Dag dag
-  ) {
+      final Dag dag,
+      final TestSubDagProcessor testSubDagProcessor) {
     this.dagService = dagService;
     this.statusChangeRecorder = statusChangeRecorder;
     this.dag = dag;
+    this.testSubDagProcessor = testSubDagProcessor;
   }
 
 
@@ -49,6 +51,9 @@ public class TestSubDagNodeProcessor implements NodeProcessor {
 
     switch (status) {
       case RUNNING:
+        //Discover the node in the parent Dag this subDag is associated with.
+        //This allows the subtag processor to inform the parent dag the status change.
+        this.testSubDagProcessor.setNode(node);
         this.dagService.startDag(this.dag);
         break;
       case KILLING:


### PR DESCRIPTION
Changed the test to discover the node corresponding to a subdag when
the subdag starts to run.

The find node by name method is no longer needed for now.