### PR TITLE
Refactor DagService shutdown method and add tests

### DIFF
--- a/az-core/src/main/java/azkaban/utils/ExecutorServiceUtils.java
+++ b/az-core/src/main/java/azkaban/utils/ExecutorServiceUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.utils;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executor service related utilities.
+ */
+public class ExecutorServiceUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ExecutorServiceUtils.class);
+  private static final TimeUnit MILLI_SECONDS_TIME_UNIT = TimeUnit.MILLISECONDS;
+
+  /**
+   * Gracefully shuts down the given executor service.
+   *
+   * <p>Adopted from
+   * <a href="https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html">
+   * the Oracle JAVA Documentation.
+   * </a>
+   *
+   * @param service the service to shutdown
+   * @param timeout max wait time for the tasks to shutdown. Note that the max wait time is 2
+   *     times this value due to the two stages shutdown strategy.
+   * @throws InterruptedException if the current thread is interrupted
+   */
+  public void gracefulShutdown(final ExecutorService service, final Duration timeout)
+      throws InterruptedException {
+    service.shutdown(); // Disable new tasks from being submitted
+    final long timeout_in_unit_of_miliseconds = timeout.toMillis();
+    // Wait a while for existing tasks to terminate
+    if (!service.awaitTermination(timeout_in_unit_of_miliseconds, MILLI_SECONDS_TIME_UNIT)) {
+      service.shutdownNow(); // Cancel currently executing tasks
+      // Wait a while for tasks to respond to being cancelled
+      if (!service.awaitTermination(timeout_in_unit_of_miliseconds, MILLI_SECONDS_TIME_UNIT)) {
+        logger.error("The executor service did not terminate.");
+      }
+    }
+  }
+}

--- a/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Test;
+
+public class ExecutorServiceUtilsTest {
+
+  private final ExecutorServiceUtils executorServiceUtils = new ExecutorServiceUtils();
+
+  @Test
+  public void gracefulShutdown() throws InterruptedException {
+    // given
+    final ExecutorService service = Executors.newSingleThreadExecutor();
+
+    // when
+    this.executorServiceUtils.gracefulShutdown(service, Duration.ofMillis(1));
+
+    // then
+    assertThat(service.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void force_shutdown_after_timeout() throws InterruptedException {
+    // given
+    final ExecutorService service = Executors.newSingleThreadExecutor();
+
+    // when
+    service.submit(this::sleep);
+    final long beginShutdownTime = System.currentTimeMillis();
+    this.executorServiceUtils.gracefulShutdown(service, Duration.ofMillis(1));
+    final long endShutdownTime = System.currentTimeMillis();
+
+    // then
+    assertThat(service.isShutdown()).isTrue();
+    final long shutdownDuration = endShutdownTime - beginShutdownTime;
+    // Give some buffer for overhead to reduce false positives.
+    assertThat(shutdownDuration).isLessThan(10);
+  }
+
+  @Test
+  public void can_not_submit_tasks_after_shutdown() throws
+      InterruptedException {
+    // given
+    final ExecutorService service = Executors.newSingleThreadExecutor();
+    service.submit(this::sleep);
+
+    // when
+    this.executorServiceUtils.gracefulShutdown(service, Duration.ofMillis(1));
+    final Throwable thrown = catchThrowable(() -> {
+      service.submit(this::sleep);
+    });
+
+    // then
+    assertThat(thrown).isInstanceOf(RejectedExecutionException.class);
+  }
+
+  private void sleep() {
+    try {
+      Thread.sleep(1000);
+    } catch (final InterruptedException ex) {
+    }
+  }
+}

--- a/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import org.junit.Test;
 
+@SuppressWarnings("FutureReturnValueIgnored")
 public class ExecutorServiceUtilsTest {
 
   private final ExecutorServiceUtils executorServiceUtils = new ExecutorServiceUtils();


### PR DESCRIPTION
Part of #1486

Create a new utility class to encapsulate the generic shutdown logic to
make it easier to test and allow better code reuse.

Also reduced the shutdown timeout from 60 seconds to 10 seconds.

With this change and #1763, the dag package will have 100% line
coverage.