### PR TITLE
Fix flaky test ExecutorServiceUtilsTest

### DIFF
--- a/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
@@ -57,8 +57,9 @@ public class ExecutorServiceUtilsTest {
     assertThat(service.isShutdown()).isTrue();
     final long shutdownDuration = endShutdownTime - beginShutdownTime;
     // Give some buffer for overhead to reduce false positives.
-    // 100 is still much smaller than 1000 if the task were not forcefully terminated.
-    assertThat(shutdownDuration).isLessThan(100);
+    // 5 seconds is still much smaller than 30 seconds sleep time if the task were not forcefully
+    // terminated.
+    assertThat(shutdownDuration).isLessThan(5000);
   }
 
   @Test
@@ -80,7 +81,7 @@ public class ExecutorServiceUtilsTest {
 
   private void sleep() {
     try {
-      Thread.sleep(1000);
+      Thread.sleep(30_000);
     } catch (final InterruptedException ex) {
     }
   }

--- a/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/ExecutorServiceUtilsTest.java
@@ -57,7 +57,8 @@ public class ExecutorServiceUtilsTest {
     assertThat(service.isShutdown()).isTrue();
     final long shutdownDuration = endShutdownTime - beginShutdownTime;
     // Give some buffer for overhead to reduce false positives.
-    assertThat(shutdownDuration).isLessThan(10);
+    // 100 is still much smaller than 1000 if the task were not forcefully terminated.
+    assertThat(shutdownDuration).isLessThan(100);
   }
 
   @Test


### PR DESCRIPTION
Failure on Travis:

azkaban.utils.ExecutorServiceUtilsTest > force_shutdown_after_timeout FAILED
    java.lang.AssertionError:
    Expecting:
     <11L>
    to be less than:
     <10L>
        at azkaban.utils.ExecutorServiceUtilsTest.force_shutdown_after_timeout(ExecutorServiceUtilsTest.java:60)
azkaban.utils.ExecutorServiceUtilsTest

Cause:

When the test host is busy, the execution time may be greater.

Fix:
Add more buffer and a comment to explain the test.