### PR TITLE
fix the misleading error message when executor cannot take new flows

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -287,7 +287,6 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
     try {
       this.flowRunnerManager.submitFlow(execId);
     } catch (final ExecutorManagerException e) {
-      e.printStackTrace();
       logger.error(e.getMessage(), e);
       respMap.put(RESPONSE_ERROR, e.getMessage());
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -393,10 +393,12 @@ public class FlowRunnerManager implements EventListener,
       // update the last submitted time.
       this.lastFlowSubmittedDate = System.currentTimeMillis();
     } catch (final RejectedExecutionException re) {
-      throw new ExecutorManagerException(
-          "Azkaban server can't execute any more flows. "
-              + "The number of running flows has reached the system configured limit."
-              + "Please notify Azkaban administrators");
+      final StringBuffer errorMsg = new StringBuffer(
+          "Azkaban executor can't execute any more flows. ");
+      if (this.executorService.isShutdown()) {
+        errorMsg.append("The executor is being shut down.");
+      }
+      throw new ExecutorManagerException(errorMsg.toString(), re);
     }
   }
 


### PR DESCRIPTION
Original error message is misleading -
1. it doesn't clarify the error is from web server or executor.
2. executor service sometimes rejects new flow submission because it's being shut down after executor's shutdown api is called, but the message still indicates the reason as exceeding the thread pool limit.