### PR TITLE
Fix compression vulnerability.

### DIFF
--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -27,6 +27,8 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
@@ -198,6 +200,14 @@ public class Utils {
     final Enumeration<?> entries = source.entries();
     while (entries.hasMoreElements()) {
       final ZipEntry entry = (ZipEntry) entries.nextElement();
+      final Path fileDestinationPath = Paths.get(dest.getAbsolutePath(),
+          entry.getName()).normalize();
+      if (!fileDestinationPath.startsWith(dest.getAbsolutePath())) {
+        throw new IOException(
+            "Extracting zip entry would have resulted in a file outside the specified destination"
+                + " directory.");
+      }
+
       final File newFile = new File(dest, entry.getName());
       if (entry.isDirectory()) {
         newFile.mkdirs();

--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -27,8 +27,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
@@ -200,15 +198,13 @@ public class Utils {
     final Enumeration<?> entries = source.entries();
     while (entries.hasMoreElements()) {
       final ZipEntry entry = (ZipEntry) entries.nextElement();
-      final Path fileDestinationPath = Paths.get(dest.getAbsolutePath(),
-          entry.getName()).normalize();
-      if (!fileDestinationPath.startsWith(dest.getAbsolutePath())) {
+      final File newFile = new File(dest, entry.getName());
+      if (!newFile.getCanonicalPath().startsWith(dest.getCanonicalPath())) {
         throw new IOException(
             "Extracting zip entry would have resulted in a file outside the specified destination"
                 + " directory.");
       }
 
-      final File newFile = new File(dest, entry.getName());
       if (entry.isDirectory()) {
         newFile.mkdirs();
       } else {

--- a/az-core/src/test/java/azkaban/utils/UtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/UtilsTest.java
@@ -36,7 +36,7 @@ public class UtilsTest {
     final ZipFile source = new ZipFile(zipFile);
     final File dest = Utils.createTempDir();
     assertThatThrownBy(() -> Utils.unzip(source, dest)).isInstanceOf(IOException.class)
-        .hasMessageContaining("Extracting Zip entry would have resulted in a file outside the "
+        .hasMessageContaining("Extracting zip entry would have resulted in a file outside the "
             + "specified destination directory.");
   }
 }

--- a/az-core/src/test/java/azkaban/utils/UtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/UtilsTest.java
@@ -1,0 +1,42 @@
+/*
+* Copyright 2018 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the “License”); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package azkaban.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.zip.ZipFile;
+import org.junit.Test;
+
+/**
+ * Test class for azkaban.utils.Utils
+ */
+public class UtilsTest {
+
+  private static final String INVALID_ZIP_FILE = "zip-slip.zip";
+
+  @Test
+  public void testUnzipInvalidFile() throws IOException {
+    final File zipFile = new File(
+        getClass().getClassLoader().getResource(INVALID_ZIP_FILE).getFile());
+    final ZipFile source = new ZipFile(zipFile);
+    final File dest = Utils.createTempDir();
+    assertThatThrownBy(() -> Utils.unzip(source, dest)).isInstanceOf(IOException.class)
+        .hasMessageContaining("Extracting Zip entry would have resulted in a file outside the "
+            + "specified destination directory.");
+  }
+}

--- a/az-core/src/test/java/azkaban/utils/UtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/UtilsTest.java
@@ -30,16 +30,20 @@ import org.junit.Test;
  */
 public class UtilsTest {
 
-  /* An insecure zip file may hold path traversal filenames. During unzipping, the filename gets
-  concatenated to the target directory. The final path may end up outside the target directory,
-  causing security issues. */
+  /**
+   * An insecure zip file may hold path traversal filenames. During unzipping, the filename gets
+   * concatenated to the target directory. The final path may end up outside the target directory,
+   * causing security issues.
+   *
+   * @throws IOException the io exception
+   */
   @Test
   public void testUnzipInsecureFile() throws IOException {
     final File zipFile = new File("myTest.zip");
-    final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile));
-    final ZipEntry entry = new ZipEntry("../../../../../evil.txt");
-    out.putNextEntry(entry);
-    out.close();
+    try (final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      final ZipEntry entry = new ZipEntry("../../../../../evil.txt");
+      out.putNextEntry(entry);
+    }
 
     final ZipFile source = new ZipFile(zipFile);
     final File dest = Utils.createTempDir();


### PR DESCRIPTION
This is to check whether the unzipped file will be outside of the target directory. If the file has a name which traverses its parent directory, e.g. `../../../`, it might end up overwriting other files outside the target directory, causing security issues.