### PR TITLE
Upgrade error prone gradle plugin to v0.0.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.cinnober.gradle:semver-git:2.2.3'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
     }
 }
 


### PR DESCRIPTION
Fix #1783

"warning
Task :azkaban-solo-server:compileTestJava
The SimpleWorkResult type has been deprecated and is scheduled to be removed in Gradle 5.0. Please use WorkResults.didWork() instead.
"

Verified with
./gradlew clean build -Dorg.gradle.warning.mode=all