### PR TITLE
Handling recursive directories for Flow 2.0 projects.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -22,11 +22,11 @@ import azkaban.flow.Flow;
 import azkaban.flow.FlowProps;
 import azkaban.flow.Node;
 import azkaban.flow.SpecialJobTypes;
+import azkaban.project.FlowLoaderUtils.DirFilter;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.Props;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DirectoryFlowLoader implements FlowLoader {
 
-  private static final DirFilter DIR_FILTER = new DirFilter();
   private static final String PROPERTY_SUFFIX = ".properties";
   private static final String JOB_SUFFIX = ".job";
 
@@ -211,8 +210,7 @@ public class DirectoryFlowLoader implements FlowLoader {
       }
     }
 
-    final File[] subDirs = dir.listFiles(DIR_FILTER);
-    for (final File file : subDirs) {
+    for (final File file : dir.listFiles(new DirFilter())) {
       loadProjectFromDir(base, file, parent);
     }
   }
@@ -394,13 +392,4 @@ public class DirectoryFlowLoader implements FlowLoader {
   private String getRelativeFilePath(final String basePath, final String filePath) {
     return filePath.substring(basePath.length() + 1);
   }
-
-  private static class DirFilter implements FileFilter {
-
-    @Override
-    public boolean accept(final File pathname) {
-      return pathname.isDirectory();
-    }
-  }
-
 }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -21,6 +21,7 @@ import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowProps;
 import azkaban.flow.Node;
+import azkaban.project.FlowLoaderUtils.DirFilter;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.Props;
@@ -112,13 +113,21 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
               + ". Duplicate nodes found or dependency undefined.");
         } else {
           final AzkabanFlow azkabanFlow = (AzkabanFlow) loader.toAzkabanNode(nodeBean);
-          final Flow flow = convertAzkabanFlowToFlow(azkabanFlow, azkabanFlow.getName(), file);
-          this.flowMap.put(flow.getId(), flow);
+          if (this.flowMap.containsKey(azkabanFlow.getName())) {
+            this.errors.add("Duplicate flows found in the project with name " + azkabanFlow
+                .getName());
+          } else {
+            final Flow flow = convertAzkabanFlowToFlow(azkabanFlow, azkabanFlow.getName(), file);
+            this.flowMap.put(flow.getId(), flow);
+          }
         }
       } catch (final Exception e) {
         this.errors.add("Error loading flow yaml file " + file.getName() + ":"
             + e.getMessage());
       }
+    }
+    for (final File file : projectDir.listFiles(new DirFilter())) {
+      convertYamlFiles(file);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
@@ -332,4 +332,15 @@ public class FlowLoaderUtils {
           && name.length() > this.suffix.length() && name.endsWith(this.suffix);
     }
   }
+
+  /**
+   * Implements Directory filter.
+   */
+  public static class DirFilter implements FileFilter {
+
+    @Override
+    public boolean accept(final File pathname) {
+      return pathname.isDirectory();
+    }
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -35,6 +35,7 @@ public class DirectoryYamlFlowLoaderTest {
 
   private static final String BASIC_FLOW_YAML_DIR = "basicflowyamltest";
   private static final String MULTIPLE_FLOW_YAML_DIR = "multipleflowyamltest";
+  private static final String RECURSIVE_DIRECTORY_FLOW_YAML_DIR = "recursivedirectoryyamltest";
   private static final String EMBEDDED_FLOW_YAML_DIR = "embeddedflowyamltest";
   private static final String MULTIPLE_EMBEDDED_FLOW_YAML_DIR = "multipleembeddedflowyamltest";
   private static final String CYCLE_FOUND_YAML_DIR = "cyclefoundyamltest";
@@ -83,6 +84,16 @@ public class DirectoryYamlFlowLoaderTest {
     checkFlowLoaderProperties(loader, 0, 2, 2);
     checkFlowProperties(loader, BASIC_FLOW_1, 0, 4, 1, 3, null);
     checkFlowProperties(loader, BASIC_FLOW_2, 0, 3, 1, 2, null);
+  }
+
+  @Test
+  public void testLoadYamlFileRecursively() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(this.project,
+        ExecutionsTestUtil.getFlowDir(RECURSIVE_DIRECTORY_FLOW_YAML_DIR));
+    checkFlowLoaderProperties(loader, 0, 2, 2);
+    checkFlowProperties(loader, BASIC_FLOW_1, 0, 3, 1, 2, null);
+    checkFlowProperties(loader, BASIC_FLOW_2, 0, 4, 1, 3, null);
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowLoaderFactoryTest.java
@@ -28,6 +28,7 @@ public class FlowLoaderFactoryTest {
 
   private static final String FLOW_10_TEST_DIRECTORY = "exectest1";
   private static final String FLOW_20_TEST_DIRECTORY = "basicflowyamltest";
+  private static final String FLOW_20_TEST_RECURSIVE_DIRECTORY = "recursivedirectoryyamltest";
   private static final String DUPLICATE_PROJECT_DIRECTORY = "duplicateprojectyamltest";
   private static final String INVALID_FLOW_VERSION_DIRECTORY = "invalidflowversiontest";
   private static final String NO_FLOW_VERSION_DIRECTORY = "noflowversiontest";
@@ -44,6 +45,14 @@ public class FlowLoaderFactoryTest {
   public void testCreateDirectoryYamlFlowLoader() {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final File projectDir = ExecutionsTestUtil.getFlowDir(FLOW_20_TEST_DIRECTORY);
+    final FlowLoader loader = loaderFactory.createFlowLoader(projectDir);
+    assertThat(loader instanceof DirectoryYamlFlowLoader).isTrue();
+  }
+
+  @Test
+  public void testCreateDirectoryYamlFlowLoaderWithRecursiveDirectory() {
+    final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
+    final File projectDir = ExecutionsTestUtil.getFlowDir(FLOW_20_TEST_RECURSIVE_DIRECTORY);
     final FlowLoader loader = loaderFactory.createFlowLoader(projectDir);
     assertThat(loader instanceof DirectoryYamlFlowLoader).isTrue();
   }

--- a/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/basic_flow.flow
+++ b/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/basic_flow.flow
@@ -1,0 +1,20 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    type: command
+    config:
+      command: pwd

--- a/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/basic_flow.project
+++ b/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/basic_flow.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/basic_flow2.flow
+++ b/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/basic_flow2.flow
@@ -1,0 +1,26 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: shell_end
+    type: noop
+    dependsOn:
+      - shell_pwd
+      - shell_echo
+      - shell_bash
+
+  - name: shell_echo
+    type: command
+    config:
+      command: echo "This is an echoed text."
+
+  - name: shell_pwd
+    type: command
+    config:
+      command: pwd
+
+  - name: shell_bash
+    type: command
+    config:
+      command: bash ./subdirectory1/subdirectory2/sample_script.sh

--- a/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/sample_script.sh
+++ b/test/execution-test-data/recursivedirectoryyamltest/subdirectory1/subdirectory2/sample_script.sh
@@ -1,0 +1,1 @@
+echo "This is a bash script."


### PR DESCRIPTION
This PR is to enhance the current way of loading project flows in Flow 2.0 design.
When users create the project zip, sometimes they create a new directory first, put their project/flow yaml files inside and then zip the directory. This is different from zipping those files directly. Sometimes users want to create multiple subdirectories inside the project zip.
In order to handle different use cases, I extended the current logic of loading project/flow yaml files to subdirectories as well.