### PR TITLE
Configurable access error message

### DIFF
--- a/az-hdfs-viewer/src/conf/plugin.properties
+++ b/az-hdfs-viewer/src/conf/plugin.properties
@@ -1,0 +1,2 @@
+#viewer.access_denied_message=The folder you are trying to access is protected.
+#Need a filed of "viewer.access_denied_message" specifying the error message we want user to get when they don't have a permission

--- a/az-hdfs-viewer/src/conf/plugin.properties
+++ b/az-hdfs-viewer/src/conf/plugin.properties
@@ -1,2 +1,14 @@
-#viewer.access_denied_message=The folder you are trying to access is protected.
-#Need a filed of "viewer.access_denied_message" specifying the error message we want user to get when they don't have a permission
+viewer.name=HDFS
+viewer.path=hdfs
+viewer.order=1
+viewer.hidden=false
+viewer.external.classpaths=extlib/*
+viewer.servlet.class=azkaban.viewer.hdfs.HdfsBrowserServlet
+hadoop.security.manager.class=azkaban.security.HadoopSecurityManager_H_1_0
+azkaban.should.proxy=false
+proxy.user=azkaban
+proxy.keytab.location=
+allow.group.proxy=false
+file.max.lines=1000
+#Specifying the error message we want user to get when they don't have permissions
+viewer.access_denied_message=The folder you are trying to access is protected.

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -54,6 +54,8 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       "hdfs.browser.proxy.user";
   private static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM =
       "hadoop.security.manager.class";
+  private static final String HDFSVIEWER_ACCESS_DENIED_MESSAGE = 
+      "viewer.access_denied_message";
 
   private static final int DEFAULT_FILE_MAX_LINES = 1000;
 
@@ -337,7 +339,8 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       }
       page.add("dirsize", size);
     } catch (AccessControlException e) {
-      page.add("error_message", "Permission denied: " + e.getMessage());
+      String error_message = props.getString(HDFSVIEWER_ACCESS_DENIED_MESSAGE);
+      page.add("error_message", "Permission denied: " + error_message);
       page.add("no_fs", "true");
     } catch (IOException e) {
       page.add("error_message", "Error: " + e.getMessage());


### PR DESCRIPTION
What we had for error message was hard-coded static string. But now, we created a configurable error message.