### PR TITLE
adding text to indicate that columns are sortable

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -62,6 +62,7 @@
 
   <div class="row" id="currently-running-view">
     <div class="col-xs-12">
+      <i>* Click column headers to sort.</i>
       <table id="executingJobs"
              class="table table-striped table-bordered table-hover table-condensed executions-table">
         <thead>
@@ -132,6 +133,7 @@
 
   <div class="row" id="recently-finished-view">
     <div class="col-xs-12">
+      <i>* Click column headers to sort.</i>
       <table id="recentlyFinished"
              class="table table-striped table-bordered table-hover table-condensed executions-table">
         <thead>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -81,6 +81,7 @@
 
     <div class="row">
       <div class="col-xs-12">
+        <i>* Click column headers to sort.</i>
         <table id="executingJobs"
                class="table table-striped table-bordered table-hover table-condensed executions-table">
           <thead>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
@@ -68,6 +68,7 @@
 
     <div class="row">
       <div class="col-xs-12">
+        <i>* Click column headers to sort.</i>
         <table id="scheduledFlowsTbl"
                class="table table-striped table-condensed table-bordered table-hover">
           <thead>


### PR DESCRIPTION
As mentioned in issue #1778, having a tooltip on the table would let the user know that it can be sorted when the header is clicked. This pull request will add the tooltip on scheduling page and history page which are being mostly used.

Sample screenshot:
![image](https://user-images.githubusercontent.com/1619937/40787974-e4e77ea4-64bc-11e8-8df0-e1e1540f5873.png)

This is a duplicate PR (https://github.com/azkaban/azkaban/pull/1780) but from a different branch, I moved these changes from master->sort-text in my repo.