### PR TITLE
fix flaky test TriggerInstanceProcessorTest#testProcessSucceed 

### DIFF
--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -101,7 +101,6 @@ public class TriggerInstanceProcessorTest {
   public void setUp() throws Exception {
     this.message = EmailerTest.mockEmailMessage();
     this.messageCreator = EmailerTest.mockMessageCreator(this.message);
-
     this.triggerInstLoader = mock(FlowTriggerInstanceLoader.class);
     this.executorManager = mock(ExecutorManager.class);
     when(this.executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");


### PR DESCRIPTION
Since processSucceed is an asyn call, test needs to wait for updateAssociatedFlowExecId to be called before verification of its invocation. So when updateAssociatedFlowExecId is called, the associated countdownlatch is decremented to zero and unit test will wait on the countdown latch before verifying invocation of updateAssociatedFlowExecId.