### PR TITLE
remove goHomeDir action

### DIFF
--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -56,13 +56,10 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       "hadoop.security.manager.class";
 
   private static final int DEFAULT_FILE_MAX_LINES = 1000;
-
+  private static Logger logger = Logger.getLogger(HdfsBrowserServlet.class);
   private int fileMaxLines;
   private int defaultStartLine;
   private int defaultEndLine;
-
-  private static Logger logger = Logger.getLogger(HdfsBrowserServlet.class);
-
   private ArrayList<HdfsFileViewer> viewers = new ArrayList<HdfsFileViewer>();
 
   private HdfsFileViewer defaultViewer;
@@ -174,9 +171,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
       throws ServletException {
     User user = session.getUser();
     String username = user.getUserId();
-    if (hasParam(req, "action") && getParam(req, "action").equals("goHomeDir")) {
-      username = getParam(req, "proxyname");
-    } else if (allowGroupProxy) {
+    if (allowGroupProxy) {
       String proxyName =
           (String) session.getSessionData(PROXY_USER_SESSION_KEY);
       if (proxyName != null) {


### PR DESCRIPTION
The HdfsBrowserServlet allows a user to view HDFS as their own authenticated user or as any other proxy user. Looking at the validation logic, 3 branches exist for obtaining the username of the current user which the plugin proxies as:

Current user from session
Proxy user via session attribute which validates the user has permissions
A "proxyname" parameter when "action" is set to "goHomeDir"
The final option is implemented as follows:
plugins/hdfsviewer/src/azkaban/viewer/hdfs/HdfsBrowserServlet.java
if(hasParam(req, "action") && getParam(req, "action").equals("goHomeDir")) {
username = getParam(req, "proxyname");
}

This means a user can "proxy" as any other valid user by simple appending "?action=goHomeDir&proxyname=$username" to the URL.

This PR removes goHomeDir action.