### PR TITLE
Clean shared project directory when disk usage is too high

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -235,7 +235,7 @@ public class Constants {
         + ".start_cleanup_threshold";
 
     // the disk usage threshold to stop project dir cleanup.
-    // E.g, if set to 0.6, cleanup will stop when project dir size <= 0.6 of
+    // E.g, if set to 0.6, cleanup will stop when project dir size < 0.6 of
     // {@value#PROJECT_DIR_MAX_SIZE}.
     public static final String PROJECT_DIR_CLEANUP_STOP_THRESHOLD = "azkaban.project"
         + ".stop_cleanup_threshold";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -224,6 +224,21 @@ public class Constants {
     public static final String QUEUEPROCESSING_ENABLED = "azkaban.queueprocessing.enabled";
 
     public static final String SESSION_TIME_TO_LIVE = "session.time.to.live";
+
+    // allowed max size of project dir in mb
+    public static final String PROJECT_DIR_MAX_SIZE = "azkaban.project.dir_max_size";
+
+    // the disk usage threshold to trigger project dir cleanup.
+    // E.g, if set to 0.8, cleanup will trigger when project dir size >= 0.8 of
+    // {@value#PROJECT_DIR_MAX_SIZE}.
+    public static final String PROJECT_DIR_CLEANUP_START_THRESHOLD = "azkaban.project"
+        + ".start_cleanup_threshold";
+
+    // the disk usage threshold to stop project dir cleanup.
+    // E.g, if set to 0.6, cleanup will stop when project dir size <= 0.6 of
+    // {@value#PROJECT_DIR_MAX_SIZE}.
+    public static final String PROJECT_DIR_CLEANUP_STOP_THRESHOLD = "azkaban.project"
+        + ".stop_cleanup_threshold";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -16,6 +16,7 @@
 
 package azkaban.utils;
 
+import com.google.common.base.Preconditions;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -28,6 +29,8 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -67,6 +70,32 @@ public class FileIOUtils {
       }
     }
     return true;
+  }
+
+
+  /**
+   * Return creation time of file.
+   */
+  public static long creationTime(final File file) throws IOException {
+    final BasicFileAttributes attrs = Files
+        .readAttributes(file.toPath(), BasicFileAttributes.class);
+    final FileTime time = attrs.creationTime();
+    return time.toMillis();
+  }
+
+  /**
+   * Return the size of dir in KB.
+   */
+  public static long sizeInKB(final File dir) throws IOException {
+    Preconditions.checkArgument(dir.isDirectory(), dir + " is not a directory");
+    Preconditions.checkArgument(dir.exists(), dir + " doesn't exist");
+
+    final java.util.Scanner s = new java.util.Scanner(
+        Runtime.getRuntime().exec("du -sh -k " + dir.getAbsolutePath()).getInputStream())
+        .useDelimiter("\\A");
+    final String str = s.hasNext() ? s.next() : "";
+    final String[] res = str.split("\\s+");
+    return Long.valueOf(res[0]);
   }
 
   public static String getSourcePathFromClass(final Class<?> containedClass) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -78,6 +78,7 @@ public class FileIOUtils {
    * Return creation time of file.
    */
   public static long getCreationTime(final File file) throws IOException {
+    Preconditions.checkArgument(file.exists(), file + " doesn't exist");
     final BasicFileAttributes attrs = Files
         .readAttributes(file.toPath(), BasicFileAttributes.class);
     final FileTime time = attrs.creationTime();

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -77,7 +77,7 @@ public class FileIOUtils {
   /**
    * Return creation time of file.
    */
-  public static long creationTime(final File file) throws IOException {
+  public static long getCreationTime(final File file) throws IOException {
     final BasicFileAttributes attrs = Files
         .readAttributes(file.toPath(), BasicFileAttributes.class);
     final FileTime time = attrs.creationTime();

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -91,8 +92,8 @@ public class FileIOUtils {
     Preconditions.checkArgument(dir.exists(), dir + " doesn't exist");
 
     final java.util.Scanner s = new java.util.Scanner(
-        Runtime.getRuntime().exec("du -sh -k " + dir.getAbsolutePath()).getInputStream())
-        .useDelimiter("\\A");
+        Runtime.getRuntime().exec("du -sh -k " + dir.getAbsolutePath()).getInputStream(),
+        Charset.defaultCharset().name()).useDelimiter("\\A");
     final String str = s.hasNext() ? s.next() : "";
     final String[] res = str.split("\\s+");
     return Long.valueOf(res[0]);

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -23,11 +23,13 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Date;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.comparator.NameFileComparator;
 import org.junit.After;
@@ -107,6 +109,30 @@ public class FileIOUtilsTest {
     FileUtils.deleteDirectory(this.baseDir);
     FileUtils.deleteDirectory(this.sourceDir);
     FileUtils.deleteDirectory(this.destDir);
+  }
+
+  @Test
+  public void testSizeOfDirectory() throws IOException {
+    final File testDir = new File(this.baseDir.getAbsolutePath() + "/dirsizetest");
+    testDir.mkdir();
+
+    for (int i = 1; i <= 5; i++) {
+      final Path tmpDirPath = Paths.get(testDir.getAbsolutePath(), "dir" + i);
+      Files.createDirectory(tmpDirPath);
+      for (int j = 1; j <= 5; j++) {
+        final Path tmp = Paths.get(tmpDirPath.toAbsolutePath().toString(), String.valueOf(j));
+        final RandomAccessFile f = new RandomAccessFile(tmp.toFile(), "rw");
+        try {
+          f.setLength(1000000);
+        } finally {
+          f.close();
+        }
+      }
+    }
+
+//    final BigInteger size = FileIOUtils.sizeOf(testDir);
+//    assertThat(BigInteger.valueOf(1024 * 1024 * 1024 * 25)).isEqualTo(size);
+    System.out.println("size:" + new Date(FileIOUtils.creationTime(new File("/Users/chren"))));
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -23,13 +23,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Date;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.comparator.NameFileComparator;
 import org.junit.After;
@@ -109,30 +107,6 @@ public class FileIOUtilsTest {
     FileUtils.deleteDirectory(this.baseDir);
     FileUtils.deleteDirectory(this.sourceDir);
     FileUtils.deleteDirectory(this.destDir);
-  }
-
-  @Test
-  public void testSizeOfDirectory() throws IOException {
-    final File testDir = new File(this.baseDir.getAbsolutePath() + "/dirsizetest");
-    testDir.mkdir();
-
-    for (int i = 1; i <= 5; i++) {
-      final Path tmpDirPath = Paths.get(testDir.getAbsolutePath(), "dir" + i);
-      Files.createDirectory(tmpDirPath);
-      for (int j = 1; j <= 5; j++) {
-        final Path tmp = Paths.get(tmpDirPath.toAbsolutePath().toString(), String.valueOf(j));
-        final RandomAccessFile f = new RandomAccessFile(tmp.toFile(), "rw");
-        try {
-          f.setLength(1000000);
-        } finally {
-          f.close();
-        }
-      }
-    }
-
-//    final BigInteger size = FileIOUtils.sizeOf(testDir);
-//    assertThat(BigInteger.valueOf(1024 * 1024 * 1024 * 25)).isEqualTo(size);
-    System.out.println("size:" + new Date(FileIOUtils.creationTime(new File("/Users/chren"))));
   }
 
   @Test

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -70,14 +70,16 @@ public class FlowPreparer {
       // First get the ProjectVersion
       final ProjectVersion projectVersion = getProjectVersion(flow);
 
-      // Setup the project
-      setupProject(projectVersion);
+      synchronized (projectVersion) {
+        // Setup the project
+        setupProject(projectVersion);
 
-      // Create the execution directory
-      execDir = createExecDir(flow);
+        // Create the execution directory
+        execDir = createExecDir(flow);
 
-      // Create the symlinks from the project
-      copyCreateHardlinkDirectory(projectVersion.getInstalledDir(), execDir);
+        // Create the symlinks from the project
+        copyCreateHardlinkDirectory(projectVersion.getInstalledDir(), execDir);
+      }
 
       log.info(String.format("Flow Preparation complete. [execid: %d, path: %s]",
           flow.getExecutionId(), execDir.getPath()));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -70,15 +70,21 @@ public class FlowPreparer {
       // First get the ProjectVersion
       final ProjectVersion projectVersion = getProjectVersion(flow);
 
+      // Synchronized on {@code projectVersion} to prevent
+      // cleaning thread in {@link azkaban.execapp.FlowRunnerManager}
+      // cleaning up the same project version when creating hardlink
       synchronized (projectVersion) {
+        log.info("start to setup project" + projectVersion);
+        Thread.sleep(5000);
         // Setup the project
         setupProject(projectVersion);
 
         // Create the execution directory
         execDir = createExecDir(flow);
 
-        // Create the symlinks from the project
+        // Create the links from the project
         copyCreateHardlinkDirectory(projectVersion.getInstalledDir(), execDir);
+        log.info("completes setuping project " + projectVersion);
       }
 
       log.info(String.format("Flow Preparation complete. [execid: %d, path: %s]",

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -74,8 +74,6 @@ public class FlowPreparer {
       // cleaning thread in {@link azkaban.execapp.FlowRunnerManager}
       // cleaning up the same project version when creating hardlink
       synchronized (projectVersion) {
-        log.info("start to setup project" + projectVersion);
-        Thread.sleep(5000);
         // Setup the project
         setupProject(projectVersion);
 
@@ -84,11 +82,10 @@ public class FlowPreparer {
 
         // Create the links from the project
         copyCreateHardlinkDirectory(projectVersion.getInstalledDir(), execDir);
-        log.info("completes setuping project " + projectVersion);
+        log.info(String.format("Flow Preparation complete. [execid: %d, path: %s]",
+            flow.getExecutionId(), execDir.getPath()));
       }
 
-      log.info(String.format("Flow Preparation complete. [execid: %d, path: %s]",
-          flow.getExecutionId(), execDir.getPath()));
     } catch (final Exception e) {
       log.error("Error in setting up project directory: " + this.projectsDir + ", Exception: " + e);
       cleanup(execDir);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -861,7 +861,8 @@ public class FlowRunnerManager implements EventListener,
               this.lastExecutionDirCleanTime = currentTime;
             }
 
-            if (currentTime - LRU_PROJECT_DIR_INTERVAL_MS > this.lastLRUProjectCleanTime) {
+            if (currentTime - LRU_PROJECT_DIR_INTERVAL_MS > this.lastLRUProjectCleanTime
+                && FlowRunnerManager.this.isExecutorActive) {
               logger.info("Cleaning LRU project dirs");
               cleanLRUProjects();
               this.lastLRUProjectCleanTime = currentTime;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -1080,7 +1080,7 @@ public class FlowRunnerManager implements EventListener,
      * It first acquires object lock of {@code version} waiting for other threads creating
      * execution dir to finish to avoid race condition. An example of race condition scenario:
      * delete the dir of a project while an execution of a flow in the same project is being setup
-     * and the flow's execution dir is being created({@link FlowPreparer#setup).
+     * and the flow's execution dir is being created({@link FlowPreparer#setup}).
      */
     private void delete(final ProjectVersion version) {
       synchronized (version) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -142,7 +142,7 @@ public class FlowRunnerManager implements EventListener,
   private Props globalProps;
 
   private long lastCleanerThreadCheckTime = -1;
-  private long executionDirRetention = 1 * 24 * 60 * 60 * 1000; // 1 day
+  private long executionDirRetention = 1 * 2 * 60 * 60 * 1000; // 2 hours
 
   // We want to limit the log sizes to about 20 megs
   private String jobLogChunkSize = "5MB";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -142,7 +142,7 @@ public class FlowRunnerManager implements EventListener,
   private Props globalProps;
 
   private long lastCleanerThreadCheckTime = -1;
-  private long executionDirRetention = 1 * 2 * 60 * 60 * 1000; // 2 hours
+  private long executionDirRetention = 1 * 24 * 60 * 60 * 1000; // 1 day
 
   // We want to limit the log sizes to about 20 megs
   private String jobLogChunkSize = "5MB";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -830,7 +830,7 @@ public class FlowRunnerManager implements EventListener,
             if (currentTime - OLD_PROJECT_DIR_INTERVAL_MS > this.lastOldProjectCleanTime
                 && FlowRunnerManager.this.isExecutorActive) {
               logger.info("Cleaning old projects");
-              cleanOlderProjects();
+              cleanProjectsOfOldVersions();
               this.lastOldProjectCleanTime = currentTime;
             }
 
@@ -919,7 +919,7 @@ public class FlowRunnerManager implements EventListener,
       }
     }
 
-    private void cleanOlderProjects() {
+    private void cleanProjectsOfOldVersions() {
       final Map<Integer, ArrayList<ProjectVersion>> projectVersions =
           new HashMap<>();
       for (final ProjectVersion version : FlowRunnerManager.this.installedProjects.values()) {
@@ -932,13 +932,7 @@ public class FlowRunnerManager implements EventListener,
         versionList.add(version);
       }
 
-      final HashSet<Pair<Integer, Integer>> activeProjectVersions =
-          new HashSet<>();
-      for (final FlowRunner runner : FlowRunnerManager.this.runningFlows.values()) {
-        final ExecutableFlow flow = runner.getExecutableFlow();
-        activeProjectVersions.add(new Pair<>(flow
-            .getProjectId(), flow.getVersion()));
-      }
+      final HashSet<Pair<Integer, Integer>> activeProjectVersions = getActiveProjectVersions();
 
       for (final Map.Entry<Integer, ArrayList<ProjectVersion>> entry : projectVersions
           .entrySet()) {
@@ -967,6 +961,42 @@ public class FlowRunnerManager implements EventListener,
               logger.error(e);
             }
           }
+        }
+      }
+    }
+
+    private HashSet<Pair<Integer, Integer>> getActiveProjectVersions() {
+      final HashSet<Pair<Integer, Integer>> activeProjectVersions =
+          new HashSet<>();
+      for (final FlowRunner runner : FlowRunnerManager.this.runningFlows.values()) {
+        final ExecutableFlow flow = runner.getExecutableFlow();
+        activeProjectVersions.add(new Pair<>(flow
+            .getProjectId(), flow.getVersion()));
+      }
+      return activeProjectVersions;
+    }
+
+    private boolean shouldPurge() {
+
+    }
+
+    private List<ProjectVersion> getLeastRecentlyUsedProjectVersions() {
+
+    }
+
+    /**
+     * delete least recently used projects
+     */
+    private void cleanLRUProjects() {
+      if (shouldPurge()) {
+        for (final ProjectVersion version : FlowRunnerManager.this.installedProjects.values()) {
+          ArrayList<ProjectVersion> versionList =
+              projectVersions.get(version.getProjectId());
+          if (versionList == null) {
+            versionList = new ArrayList<>();
+            projectVersions.put(version.getProjectId(), versionList);
+          }
+          versionList.add(version);
         }
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -16,7 +16,7 @@
 
 package azkaban.execapp;
 
-import static azkaban.utils.FileIOUtils.creationTime;
+import static azkaban.utils.FileIOUtils.getCreationTime;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
@@ -1004,6 +1004,9 @@ public class FlowRunnerManager implements EventListener,
       return activeProjectVersions;
     }
 
+    /**
+     * Checks if the project version contains any running flow
+     */
     private boolean isActiveProject(final ProjectVersion version) {
       final Pair<Integer, Integer> versionKey = new Pair<>(version.getProjectId(),
           version.getVersion());
@@ -1048,8 +1051,8 @@ public class FlowRunnerManager implements EventListener,
         // sort project version by last creation time in ascending order
         projectVersionList.sort((o1, o2) -> {
           try {
-            final long creationTime1 = creationTime(o1.getInstalledDir());
-            final long creationTime2 = creationTime(o2.getInstalledDir());
+            final long creationTime1 = getCreationTime(o1.getInstalledDir());
+            final long creationTime2 = getCreationTime(o2.getInstalledDir());
             if (creationTime1 < creationTime2) {
               return -1;
             } else if (creationTime1 > creationTime2) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -142,7 +142,7 @@ public class FlowRunnerManager implements EventListener,
   private Props globalProps;
 
   private long lastCleanerThreadCheckTime = -1;
-  private long executionDirRetention = 1 * 24 * 60 * 60 * 1000; // 1 Day
+  private long executionDirRetention = 1 * 6 * 60 * 60 * 1000; // 6 hours
 
   // We want to limit the log sizes to about 20 megs
   private String jobLogChunkSize = "5MB";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -142,7 +142,7 @@ public class FlowRunnerManager implements EventListener,
   private Props globalProps;
 
   private long lastCleanerThreadCheckTime = -1;
-  private long executionDirRetention = 1 * 6 * 60 * 60 * 1000; // 6 hours
+  private long executionDirRetention = 1 * 2 * 60 * 60 * 1000; // 2 hours
 
   // We want to limit the log sizes to about 20 megs
   private String jobLogChunkSize = "5MB";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -16,7 +16,10 @@
 
 package azkaban.execapp;
 
+import static azkaban.utils.FileIOUtils.creationTime;
+
 import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.event.Event;
 import azkaban.event.EventListener;
 import azkaban.execapp.event.FlowWatcher;
@@ -46,6 +49,7 @@ import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.ThreadPoolExecutingListener;
 import azkaban.utils.TrackingThreadPool;
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -125,6 +129,10 @@ public class FlowRunnerManager implements EventListener,
   private final File executionDirectory;
   private final File projectDirectory;
 
+  private final long projectDirMaxSizeInMB;
+  private final double projectDirStartDeletionThreshold;
+  private final double projectDirStopDeletionThreshold;
+
   private final Object executionDirDeletionSync = new Object();
 
   private int numThreads = DEFAULT_NUM_EXECUTING_FLOWS;
@@ -172,6 +180,16 @@ public class FlowRunnerManager implements EventListener,
     if (!this.projectDirectory.exists()) {
       this.projectDirectory.mkdirs();
     }
+
+    this.projectDirMaxSizeInMB = props.getLong(ConfigurationKeys.PROJECT_DIR_MAX_SIZE,
+        2000000); // default value as 2TB
+    this.projectDirStartDeletionThreshold = props
+        .getDouble(ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD, 0.9);
+    this.projectDirStopDeletionThreshold = props
+        .getDouble(ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD, 0.8);
+    Preconditions.checkArgument(this.projectDirStartDeletionThreshold >= 0 && this
+        .projectDirStartDeletionThreshold <= 1 && this.projectDirStopDeletionThreshold >= 0 &&
+        this.projectDirStopDeletionThreshold <= 1);
 
     this.installedProjects = loadExistingProjects();
 
@@ -781,11 +799,14 @@ public class FlowRunnerManager implements EventListener,
     private static final long OLD_PROJECT_DIR_INTERVAL_MS = 5 * 60 * 1000;
     // Every 2 mins clean the recently finished list
     private static final long RECENTLY_FINISHED_INTERVAL_MS = 2 * 60 * 1000;
+    // Every 30 mins clean least recently used project dir
+    private static final long LRU_PROJECT_DIR_INTERVAL_MS = 30 * 60 * 1000;
 
     // Every 5 mins kill flows running longer than allowed max running time
     private static final long LONG_RUNNING_FLOW_KILLING_INTERVAL_MS = 5 * 60 * 1000;
     private final long flowMaxRunningTimeInMins = FlowRunnerManager.this.azkabanProps.getInt(
         Constants.ConfigurationKeys.AZKABAN_MAX_FLOW_RUNNING_MINS, -1);
+    private long lastLRUProjectCleanTime = -1;
     private boolean shutdown = false;
     private long lastExecutionDirCleanTime = -1;
     private long lastOldProjectCleanTime = -1;
@@ -838,6 +859,12 @@ public class FlowRunnerManager implements EventListener,
               logger.info("Cleaning old execution dirs");
               cleanOlderExecutionDirs();
               this.lastExecutionDirCleanTime = currentTime;
+            }
+
+            if (currentTime - LRU_PROJECT_DIR_INTERVAL_MS > this.lastLRUProjectCleanTime) {
+              logger.info("Cleaning LRU project dirs");
+              cleanLRUProjects();
+              this.lastLRUProjectCleanTime = currentTime;
             }
 
             if (this.flowMaxRunningTimeInMins > 0
@@ -976,27 +1003,87 @@ public class FlowRunnerManager implements EventListener,
       return activeProjectVersions;
     }
 
-    private boolean shouldPurge() {
-
+    private boolean isActiveProject(final ProjectVersion version) {
+      final Pair<Integer, Integer> versionKey = new Pair<>(version.getProjectId(),
+          version.getVersion());
+      return getActiveProjectVersions().contains(versionKey);
     }
 
-    private List<ProjectVersion> getLeastRecentlyUsedProjectVersions() {
-
+    private boolean shouldCleanup(final File projectDir) {
+      final long dirSize;
+      try {
+        dirSize = FileIOUtils.sizeInKB(projectDir);
+        final long upperLimitInKB = (long) (FlowRunnerManager.this.projectDirMaxSizeInMB *
+            FlowRunnerManager.this.projectDirStartDeletionThreshold * 1024);
+        return dirSize >= upperLimitInKB;
+      } catch (final IOException e) {
+        logger.error(e);
+        return false;
+      }
     }
+
+    private boolean shouldKeepCleanup(final File projectDir) {
+      final long dirSize;
+      try {
+        dirSize = FileIOUtils.sizeInKB(projectDir);
+        final long lowerLimitInKB = (long) (FlowRunnerManager.this.projectDirMaxSizeInMB *
+            FlowRunnerManager.this.projectDirStopDeletionThreshold * 1024);
+        return dirSize >= lowerLimitInKB;
+      } catch (final IOException e) {
+        logger.error(e);
+        return false;
+      }
+    }
+
 
     /**
      * delete least recently used projects
      */
-    private void cleanLRUProjects() {
-      if (shouldPurge()) {
-        for (final ProjectVersion version : FlowRunnerManager.this.installedProjects.values()) {
-          ArrayList<ProjectVersion> versionList =
-              projectVersions.get(version.getProjectId());
-          if (versionList == null) {
-            versionList = new ArrayList<>();
-            projectVersions.put(version.getProjectId(), versionList);
+    private void cleanLRUProjects() throws IOException {
+      if (shouldCleanup(FlowRunnerManager.this.projectDirectory)) {
+        final List<ProjectVersion> projectVersionList = new ArrayList<>(
+            FlowRunnerManager.this.installedProjects.values());
+
+        // sort project version by last creation time in ascending order
+        projectVersionList.sort((o1, o2) -> {
+          try {
+            final long creationTime1 = creationTime(o1.getInstalledDir());
+            final long creationTime2 = creationTime(o2.getInstalledDir());
+            if (creationTime1 < creationTime2) {
+              return -1;
+            } else if (creationTime1 > creationTime2) {
+              return 1;
+            } else {
+              return 0;
+            }
+          } catch (final IOException ex) {
+            logger.error("error reading project dir", ex);
+            return 0;
           }
-          versionList.add(version);
+        });
+
+        for (final ProjectVersion version : projectVersionList) {
+          if (!isActiveProject(version) && shouldKeepCleanup(FlowRunnerManager.this
+              .projectDirectory)) {
+            delete(version);
+          }
+        }
+      }
+    }
+
+    /**
+     * Delete the project dir associated with {@code version}.
+     * It first acquires object lock of {@code version} waiting for other threads creating
+     * execution dir to finish to avoid race condition. An example of race condition scenario:
+     * delete the dir of a project while an execution of a flow in the same project is being setup
+     * and the flow's execution dir is being created({@link FlowPreparer#setup).
+     */
+    private void delete(final ProjectVersion version) {
+      synchronized (version) {
+        try {
+          deleteDirectory(version);
+        } catch (final IOException ex) {
+          logger.error(ex);
         }
       }
     }


### PR DESCRIPTION
 This PR implements LRU project purging to prevent project files eating up disk space on executor.

We will encapsulate following logic inside the background cleanup thread:
if(disk space consumed by projects >= predefined threshold) 
   List all project files and sort them by creation time in ascending order
   Iterate over the project file list, delete the file if the project is not running until disk size of projects drops down below a predefined lower threshold or no more projects to delete.

Why using creation time not last access time:
Directory last access time is not maintained by most file systems so we cannot rely on file system API to get last access time. An alternative considered is to modify the project dir every time the code reads it, then last modification time would be equivalent of last access time. The associate cons are code complexity and overhead of disk IO. We will use last creation time as the indicator of oldness of the project. Although creation time might not be as indicative as last access time to determine the hotness of a project, we are still ok with using it based on the assumption that the older the project is, more likely it’s not being used.

This PR also changes execution dir retention from 1 day to 2 hours. Since execution dir is hard linked to project dir, so disk space will be released only when no reference to project dir exists. That's why we want to shorten the execution dir retention time so that disk pressure can be alleviated sooner.

Project cleanup is executed by active executor only to prevent ensure only one thread will be performing deletion. Currently it relies on FlowRunnerManager#isExecutorActive to determine whether itself is active. But isExecutorActive is reliable only when azkaban admin uses activate API to active the executor. If admin manually updates the executors table in database and call reloadExecutors API, then the flag won't be set which inactive executor to perform deletion. So improvement need to be done here to make sure isExecutorActive is authentic. 
