### PR TITLE
Make testCancelAfterJobProcessCreation more reliable

### DIFF
--- a/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp.
+ * Copyright 2018 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -205,14 +205,13 @@ public class ProcessJobTest {
 
   @Test
   public void testCancelAfterJobProcessCreation() throws InterruptedException, ExecutionException {
-    this.props.put(ProcessJob.COMMAND, "sleep 1");
+    this.props.put(ProcessJob.COMMAND, "sleep 5");
 
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     final Future future = executorService.submit(() -> {
       try {
         this.job.run();
       } catch (final Exception e) {
-        e.printStackTrace();
       }
     });
 


### PR DESCRIPTION
Issue:

The test failed today on trunk

azkaban.jobExecutor.ProcessJobTest > testCancelAfterJobProcessCreation FAILED
    org.junit.ComparisonFailure: expected:<[fals]e> but was:<[tru]e>
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at azkaban.jobExecutor.ProcessJobTest.testCancelAfterJobProcessCreation(ProcessJobTest.java:228)

Cause:

I suspect it is because of the travis CI machine being too busy to cancel
the job before it finishes.

Solution:

Increase the running time of the job from 1 second to 5 seconds.
This will not increase the test running time when the test is successful
since the job will be canceled as soon as possible.
However it will increase the test running time if the cancel logic
doesn't interrupt the job as expected.

Also removed the printout of the stacktrace from the job. This information
doesn't deliver much value and only makes the log noisier.
