### PR TITLE
Enable project uploading from restli endpoint schedule flow trigger

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -66,7 +66,6 @@ public class FlowTriggerScheduler {
    */
   public void scheduleAll(final Project project, final String submitUser)
       throws SchedulerException, ProjectManagerException {
-    //todo chengren311: schedule on uploading via CRT
 
     for (final Flow flow : project.getFlows()) {
       //todo chengren311: we should validate embedded flow shouldn't have flow trigger defined.

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1730,6 +1730,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         //unscheduleall/scheduleall should only work with flow which has defined flow trigger
         //unschedule all flows within the old project
         if (this.enableQuartz) {
+          //todo chengren311: should maintain atomicity,
+          // e.g, if uploadProject fails, associated schedule shouldn't be added.
           this.scheduler.unscheduleAll(project);
         }
         final Map<String, ValidationReport> reports =

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -68,8 +68,7 @@ public class ProjectManagerResource extends ResourceContextHolder {
 
     final FlowTriggerScheduler scheduler = getAzkaban().getScheduler();
     final boolean enableQuartz = getAzkaban().getServerProps().getBoolean(ConfigurationKeys
-            .ENABLE_QUARTZ,
-        false);
+        .ENABLE_QUARTZ, false);
 
     logger.info("Deploy: reference of project " + projectName + " is " + System.identityHashCode
         (project));

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -15,6 +15,8 @@
  */
 package azkaban.restli;
 
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.flowtrigger.quartz.FlowTriggerScheduler;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.project.ProjectManagerException;
@@ -39,6 +41,7 @@ import java.util.Map;
 import javax.servlet.ServletException;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.quartz.SchedulerException;
 
 @RestLiActions(name = "project", namespace = "azkaban.restli")
 public class ProjectManagerResource extends ResourceContextHolder {
@@ -55,13 +58,19 @@ public class ProjectManagerResource extends ResourceContextHolder {
       @ActionParam("projectName") final String projectName,
       @ActionParam("packageUrl") final String packageUrl)
       throws ProjectManagerException, RestLiServiceException, UserManagerException,
-      ServletException, IOException {
+      ServletException, IOException, SchedulerException {
     logger.info("Deploy called. {projectName: " + projectName + ", packageUrl:" + packageUrl + "}");
 
     final String ip = ResourceUtils.getRealClientIpAddr(this.getContext());
     final User user = ResourceUtils.getUserFromSessionId(sessionId);
     final ProjectManager projectManager = getAzkaban().getProjectManager();
     final Project project = projectManager.getProject(projectName);
+
+    final FlowTriggerScheduler scheduler = getAzkaban().getScheduler();
+    final boolean enableQuartz = getAzkaban().getServerProps().getBoolean(ConfigurationKeys
+            .ENABLE_QUARTZ,
+        false);
+
     logger.info("Deploy: reference of project " + projectName + " is " + System.identityHashCode
         (project));
     if (project == null) {
@@ -111,16 +120,24 @@ public class ProjectManagerResource extends ResourceContextHolder {
     }
 
     try {
+      if (enableQuartz) {
+        scheduler.unscheduleAll(project);
+      }
       // Check if project upload runs into any errors, such as the file
       // having blacklisted jars
       final Props props = new Props();
       final Map<String, ValidationReport> reports = projectManager
           .uploadProject(project, archiveFile, "zip", user, props);
+
+      if (enableQuartz) {
+        scheduler.scheduleAll(project, user.getUserId());
+      }
+
       checkReports(reports);
       logger.info("Deploy: project " + projectName + " version is " + project.getVersion()
           + ", reference is " + System.identityHashCode(project));
       return Integer.toString(project.getVersion());
-    } catch (final ProjectManagerException e) {
+    } catch (final ProjectManagerException | SchedulerException e) {
       final String errorMsg = "Upload of project " + project + " from " + archiveFile + " failed";
       logger.error(errorMsg, e);
       throw e;

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -121,6 +121,8 @@ public class ProjectManagerResource extends ResourceContextHolder {
 
     try {
       if (enableQuartz) {
+        //todo chengren311: should maintain atomicity,
+        // e.g, if uploadProject fails, associated schedule shouldn't be added.
         scheduler.unscheduleAll(project);
       }
       // Check if project upload runs into any errors, such as the file


### PR DESCRIPTION
Upon project uploading, azkaban should be able to schedule the associated flow trigger. This is already achieved when project upload is done from ajax API call(#1631). This PR enables scheduling flow trigger when uploading project from restli endpoint.