### PR TITLE
Azkaban configuration validator

### DIFF
--- a/az-core/src/main/java/azkaban/ConfigValidator.java
+++ b/az-core/src/main/java/azkaban/ConfigValidator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban;
+
+import static java.util.Objects.requireNonNull;
+
+import azkaban.utils.Props;
+
+/**
+ * Validator of Azkaban configuration.
+ * Inheriting class will need to implement its own validation logic.
+ * E.g: azkaban executor will need to validate executor config.
+ */
+public abstract class ConfigValidator {
+
+  protected final Props props;
+
+  public ConfigValidator(final Props azProps) {
+    this.props = requireNonNull(azProps, "azProps cannot be null");
+  }
+
+  /**
+   * This method is adapted from
+   * {@link com.google.common.base.Preconditions#checkArgument(boolean, Object)}
+   *
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage the exception message to use if the check fails;
+   * @throws InvalidAzkabanConfigException if {@code expression} is false
+   */
+  protected final void check(final boolean expression, final String errorMessage) {
+    if (!expression) {
+      throw new InvalidAzkabanConfigException(errorMessage);
+    }
+  }
+
+  /**
+   * Returns int representation of the value.
+   *
+   * @param configKey the config key
+   * @param defaultValue default value to return if value is null;
+   * @return the value of the {@param configKey}
+   * @throws InvalidAzkabanConfigException if value is non-int.
+   */
+  protected final int getInt(final String configKey, final int defaultValue) {
+    try {
+      final int val = this.props.getInt(configKey, defaultValue);
+      return val;
+    } catch (final NumberFormatException e) {
+      throw new InvalidAzkabanConfigException(String.format("Invalid azkaban config value for key"
+          + " : %s", configKey));
+    }
+  }
+
+  /**
+   * Returns long representation of the value.
+   *
+   * @param configKey the config key
+   * @param defaultValue default value to return if value is null;
+   * @return the value of the {@param configKey}
+   * @throws InvalidAzkabanConfigException if value is non-int.
+   */
+  protected final long getLong(final String configKey, final long defaultValue) {
+    try {
+      final long val = this.props.getLong(configKey, defaultValue);
+      return val;
+    } catch (final NumberFormatException e) {
+      throw new InvalidAzkabanConfigException(String.format("Invalid azkaban config value for key"
+          + " : %s", configKey));
+    }
+  }
+
+  /**
+   * Validate azkaban executor's configuration
+   *
+   * @throws InvalidAzkabanConfigException if configuration is invalid
+   */
+  abstract public void validate();
+}

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -311,4 +311,13 @@ public class Constants {
     public static final String START_TIME = "startTime";
     public static final String TRIGGER_INSTANCE_ID = "triggerInstanceId";
   }
+
+
+  public static class DefaultValue {
+
+    public static final int PROJECT_DIR_CLEANUP_START_THRESHOLD = 90;
+    public static final int PROJECT_DIR_CLEANUP_STOP_THRESHOLD = 60;
+    //128G
+    public static final long PROJECT_DIR_MAX_SIZE = 12800;
+  }
 }

--- a/az-core/src/main/java/azkaban/InvalidAzkabanConfigException.java
+++ b/az-core/src/main/java/azkaban/InvalidAzkabanConfigException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban;
+
+public class InvalidAzkabanConfigException extends RuntimeException {
+
+  public InvalidAzkabanConfigException(final String message) {
+    super(message);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorConfigValidator.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorConfigValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp;
+
+import azkaban.ConfigValidator;
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.Constants.DefaultValue;
+import azkaban.utils.Props;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Validator of Azkaban executor's configuration
+ */
+
+@Singleton
+public class ExecutorConfigValidator extends ConfigValidator {
+
+  @Inject
+  public ExecutorConfigValidator(final Props azProps) {
+    super(azProps);
+  }
+
+  /**
+   * Validate azkaban executor's configuration
+   *
+   * @throws azkaban.InvalidAzkabanConfigException if configuration is invalid
+   */
+  @Override
+  public void validate() {
+    final long projectDirMaxSize = getLong(ConfigurationKeys.PROJECT_DIR_MAX_SIZE,
+        DefaultValue.PROJECT_DIR_MAX_SIZE);
+
+    final int projectDirStartDeletionThreshold = getInt(
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD,
+        DefaultValue.PROJECT_DIR_CLEANUP_START_THRESHOLD);
+
+    final int projectDirStopDeletionThreshold = getInt(
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD,
+        DefaultValue.PROJECT_DIR_CLEANUP_STOP_THRESHOLD);
+
+    check(projectDirMaxSize > 0, ConfigurationKeys.PROJECT_DIR_MAX_SIZE + " must > 0");
+    check(projectDirStartDeletionThreshold >= 0 && projectDirStartDeletionThreshold <= 100,
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD + " must >= 0 and <= 100");
+    check(projectDirStopDeletionThreshold >= 0 && projectDirStopDeletionThreshold <= 100,
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD + " must >= 0 and <= 100");
+    check(projectDirStopDeletionThreshold < projectDirStartDeletionThreshold,
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD + " must < " + ConfigurationKeys
+            .PROJECT_DIR_CLEANUP_START_THRESHOLD);
+  }
+}

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/ExecutorConfigValidatorTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/ExecutorConfigValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp;
+
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import azkaban.ConfigValidator;
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.InvalidAzkabanConfigException;
+import azkaban.utils.Props;
+import org.junit.Test;
+
+public class ExecutorConfigValidatorTest {
+
+  @Test
+  public void projectDirMaxSizeAsZero() {
+    final Props props = new Props();
+    props.put(ConfigurationKeys.PROJECT_DIR_MAX_SIZE, 0);
+    final ConfigValidator configValidator = new ExecutorConfigValidator(props);
+    assertThatThrownBy(() -> {
+      configValidator.validate();
+    }).isInstanceOf(
+        InvalidAzkabanConfigException.class).hasMessage(ConfigurationKeys.PROJECT_DIR_MAX_SIZE +
+        " must > 0");
+  }
+
+  @Test
+  public void projectDirMaxSizeOverflow() {
+    final Props props = new Props();
+    props.put(ConfigurationKeys.PROJECT_DIR_MAX_SIZE, "99999999999999999999999999999999");
+    final ConfigValidator configValidator = new ExecutorConfigValidator(props);
+    assertThatThrownBy(() -> {
+      configValidator.validate();
+    }).isInstanceOf(
+        InvalidAzkabanConfigException.class).hasMessage("Invalid azkaban config value for key : "
+        + ConfigurationKeys.PROJECT_DIR_MAX_SIZE);
+  }
+
+  @Test
+  public void projectDirCleanupStartThresholdNegative() {
+    final Props props = new Props();
+    props.put(ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD, "-1");
+    final ConfigValidator configValidator = new ExecutorConfigValidator(props);
+    assertThatThrownBy(() -> {
+      configValidator.validate();
+    }).isInstanceOf(
+        InvalidAzkabanConfigException.class).hasMessage(
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD + " must >= 0 and <= 100");
+  }
+
+  @Test
+  public void projectDirCleanupStartThresholdGreaterThanStopThreshold() {
+    final Props props = new Props();
+    props.put(ConfigurationKeys.PROJECT_DIR_CLEANUP_START_THRESHOLD, "50");
+    props.put(ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD, "60");
+    final ConfigValidator configValidator = new ExecutorConfigValidator(props);
+    assertThatThrownBy(() -> {
+      configValidator.validate();
+    }).isInstanceOf(InvalidAzkabanConfigException.class).hasMessage(
+        ConfigurationKeys.PROJECT_DIR_CLEANUP_STOP_THRESHOLD + " must < " + ConfigurationKeys
+            .PROJECT_DIR_CLEANUP_START_THRESHOLD);
+  }
+
+}


### PR DESCRIPTION
Currently azkaban configuration validation logic is scattered and validation is performed when using the config. This PR adds a config validator serving as a central place to perform validation for executor and web server. This validator will be used when starting azkaban server, and startup will fail if validation fails. 