### PR TITLE
Avoid sending email alerts caused by invalid address from users.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -29,6 +29,7 @@ import azkaban.sla.SlaOption;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.mail.internet.AddressException;
 import org.apache.log4j.Logger;
 
 @Singleton
@@ -147,7 +148,9 @@ public class Emailer extends AbstractMailer implements Alerter {
         this.commonMetrics.markSendEmailSuccess();
       } catch (final Exception e) {
         logger.error("Failed to send " + operation, e);
-        this.commonMetrics.markSendEmailFail();
+        if (!(e instanceof AddressException)) {
+          this.commonMetrics.markSendEmailFail();
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, we collect all email sending failures and raise alerts whenever the failure rate is above the threshold. There are some failures caused by invalid email recipient address entered by users. In this case, we do not want to raise the alert to Azkaban admins since it is supposed to be resolved by users themselves. The alerts should be used to only indicate the reliability of our system.