### PR TITLE
Finalize running flows without matching executor

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionReference.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionReference.java
@@ -16,6 +16,9 @@
 
 package azkaban.executor;
 
+import java.util.Optional;
+import javax.annotation.Nullable;
+
 public class ExecutionReference {
 
   private final int execId;
@@ -30,11 +33,7 @@ public class ExecutionReference {
     this.execId = execId;
   }
 
-  public ExecutionReference(final int execId, final Executor executor) {
-    if (executor == null) {
-      throw new IllegalArgumentException(String.format(
-          "Executor cannot be null for exec id: %d ExecutionReference", execId));
-    }
+  public ExecutionReference(final int execId, @Nullable final Executor executor) {
     this.execId = execId;
     this.executor = executor;
   }
@@ -59,14 +58,6 @@ public class ExecutionReference {
     return this.execId;
   }
 
-  public String getHost() {
-    return this.executor.getHost();
-  }
-
-  public int getPort() {
-    return this.executor.getPort();
-  }
-
   public int getNumErrors() {
     return this.numErrors;
   }
@@ -75,11 +66,11 @@ public class ExecutionReference {
     this.numErrors = numErrors;
   }
 
-  public Executor getExecutor() {
-    return this.executor;
+  public Optional<Executor> getExecutor() {
+    return Optional.ofNullable(this.executor);
   }
 
-  public void setExecutor(final Executor executor) {
+  public void setExecutor(final @Nullable Executor executor) {
     this.executor = executor;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
@@ -46,14 +46,16 @@ public class ExecutorApiGateway {
 
   Map<String, Object> callWithReference(final ExecutionReference ref, final String action,
       final Pair<String, String>... params) throws ExecutorManagerException {
-    return callWithExecutionId(ref.getHost(), ref.getPort(), action, ref.getExecId(),
+    final Executor executor = ref.getExecutor().get();
+    return callWithExecutionId(executor.getHost(), executor.getPort(), action, ref.getExecId(),
         null, params);
   }
 
   Map<String, Object> callWithReferenceByUser(final ExecutionReference ref,
       final String action, final String user, final Pair<String, String>... params)
       throws ExecutorManagerException {
-    return callWithExecutionId(ref.getHost(), ref.getPort(), action,
+    final Executor executor = ref.getExecutor().get();
+    return callWithExecutionId(executor.getHost(), executor.getPort(), action,
         ref.getExecId(), user, params);
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1564,7 +1564,7 @@ public class ExecutorManager extends EventHandler implements
               final Optional<Executor> executorOption = entry.getKey();
               if (!executorOption.isPresent()) {
                 for (final ExecutableFlow flow : entry.getValue()) {
-                  logger.error("Finalizing execution " + flow.getExecutionId()
+                  logger.warn("Finalizing execution " + flow.getExecutionId()
                       + ". Executor id of this execution doesn't exist");
                   finalizeFlows.add(flow);
                 }
@@ -1613,7 +1613,7 @@ public class ExecutorManager extends EventHandler implements
                           + this.errorThreshold);
                       ref.setNumErrors(++numErrors);
                     } else {
-                      logger.error("Evicting flow " + flow.getExecutionId()
+                      logger.warn("Evicting execution " + flow.getExecutionId()
                           + ". The executor is unresponsive.");
                       // TODO should send out an unresponsive email here.
                       finalizeFlows.add(pair.getSecond());
@@ -1641,7 +1641,7 @@ public class ExecutorManager extends EventHandler implements
                     logger.error(e);
 
                     if (flow != null) {
-                      logger.error("Finalizing flow " + flow.getExecutionId());
+                      logger.warn("Finalizing execution " + flow.getExecutionId());
                       finalizeFlows.add(flow);
                     }
                   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -25,6 +25,7 @@ import java.lang.Thread.State;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ExecutorManagerAdapter {
@@ -44,7 +45,7 @@ public interface ExecutorManagerAdapter {
    * Note, returns empty list if there isn't any running or queued flows
    * </pre>
    */
-  public List<Pair<ExecutableFlow, Executor>> getActiveFlowsWithExecutor()
+  public List<Pair<ExecutableFlow, Optional<Executor>>> getActiveFlowsWithExecutor()
       throws IOException;
 
   public List<ExecutableFlow> getRecentlyFinishedFlows();

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -280,7 +280,11 @@ public class ExecutionFlowDaoTest {
         this.fetchActiveFlowDao.fetchActiveFlows();
 
     assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isTrue();
-    assertThat(activeFlows1.containsKey(flow2.getExecutionId())).isFalse();
+    assertThat(activeFlows1.get(flow1.getExecutionId()).getFirst().getExecutor().isPresent())
+        .isTrue();
+    assertThat(activeFlows1.containsKey(flow2.getExecutionId())).isTrue();
+    assertThat(activeFlows1.get(flow2.getExecutionId()).getFirst().getExecutor().isPresent())
+        .isFalse();
     final ExecutableFlow flow1Result =
         activeFlows1.get(flow1.getExecutionId()).getSecond();
     assertTwoFlowSame(flow1Result, flow1);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.After;
@@ -356,12 +357,12 @@ public class ExecutorManagerTest {
   @Test
   public void testFetchActiveFlowWithExecutor() throws Exception {
     testSetUpForRunningFlows();
-    final List<Pair<ExecutableFlow, Executor>> activeFlowsWithExecutor =
+    final List<Pair<ExecutableFlow, Optional<Executor>>> activeFlowsWithExecutor =
         this.manager.getActiveFlowsWithExecutor();
     Assert.assertTrue(activeFlowsWithExecutor.contains(new Pair<>(this.flow1,
-        this.manager.fetchExecutor(this.flow1.getExecutionId()))));
+        Optional.ofNullable(this.manager.fetchExecutor(this.flow1.getExecutionId())))));
     Assert.assertTrue(activeFlowsWithExecutor.contains(new Pair<>(this.flow2,
-        this.manager.fetchExecutor(this.flow2.getExecutionId()))));
+        Optional.ofNullable(this.manager.fetchExecutor(this.flow2.getExecutionId())))));
   }
 
   @Test

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -357,7 +358,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/executionspage.vm");
 
-    final List<Pair<ExecutableFlow, Executor>> runningFlows =
+    final List<Pair<ExecutableFlow, Optional<Executor>>> runningFlows =
         this.executorManager.getActiveFlowsWithExecutor();
     page.add("runningFlows", runningFlows.isEmpty() ? null : runningFlows);
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -93,8 +93,8 @@
                 <a href="${context}/executor?execid=${flow.getFirst().executionId}">${flow.getFirst().executionId}</a>
               </td>
               <td>
-                #if (${flow.getSecond()})
-                  ${flow.getSecond().getId()}
+                #if (${flow.getSecond().isPresent()})
+                  ${flow.getSecond().get().getId()}
                 #else
                   -
                 #end


### PR DESCRIPTION
A more complete cleanup: don't leave executions whose executor doesn't exist any more in some interim state like RUNNING - finalize them as FAILED.

----

To explain the problem scenario, it goes like this:
- if an executor is stopped gracefully (so that it has time to finish at least some shutdown hooks), it removes itself from the `executors` table 
- however, it's still possible that not all executions on that executor were properly finalized ie. status of each interrupted execution is set to one of FAILED/KILLED/SUCCESS
- when an executor is started, it adds itself into the `executors` table with an executor id that is the _next running number_

As a result, there can be executions with status RUNNING (for example) that would never be marked as FAILED, because the executor id of those executions is not found in `executors` table any more. This PR fixes that: the status of such executions are finalized.

This is only a concern in multi-executor mode. To be noted, it would be good to support _only multi-exec mode_ in the future. See also description of https://github.com/azkaban/azkaban/pull/1831.

----

Somewhat related: https://github.com/azkaban/azkaban/pull/1832 (merge order doesn't matter).