### PR TITLE
Exposing year on CRON expression and next 10 executions logic improvements

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -371,6 +371,8 @@ public class TriggerManager extends EventHandler implements
       if (t.isResetOnTrigger()) {
         t.resetTriggerConditions();
       } else {
+        logger.info("NextCheckTime did not change. Setting status to expired for trigger"
+            + t.getTriggerId());
         t.setStatus(TriggerStatus.EXPIRED);
       }
       try {

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -171,7 +171,13 @@ public class BasicTimeChecker implements ConditionChecker {
         break;
       } else if (this.cronExecutionTime != null) {
         final Date nextDate = this.cronExecutionTime.getNextValidTimeAfter(date.toDate());
-        date = new DateTime(nextDate);
+        // It's possible to have a cron expression
+        // that will schedule a finite number of executions.
+        if (nextDate != null) {
+          date = new DateTime(nextDate);
+        } else {
+          break;
+        }
       } else {
         date = date.plus(this.period);
       }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -171,8 +171,7 @@ public class BasicTimeChecker implements ConditionChecker {
         break;
       } else if (this.cronExecutionTime != null) {
         final Date nextDate = this.cronExecutionTime.getNextValidTimeAfter(date.toDate());
-        // It's possible to have a cron expression
-        // that will schedule a finite number of executions.
+        // Some Cron Expressions possibly do not have follow-up occurrences
         if (nextDate != null) {
           date = new DateTime(nextDate);
         } else {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -142,7 +142,7 @@
             <div class="col-xs-12" style="height:20px;"></div>
 
             <div class="col-sm-12" style="background-color:#f5f5f5; border:1px solid #e3e3e3">
-              <h4>
+              <h4 id="nextRecurLabel">
                 Next 10 scheduled executions:
               </h4>
               <ul id="nextRecurId">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -94,6 +94,12 @@
                   <input type="text" id="dow_input" value="*" class="form-control"
                          oninput="updateOutput()">
                 </div>
+                <br/> <br/> <br/>
+                <label class="col-sm-4 control-label" id="year_label">Year</label>
+                <div class="col-sm-8">
+                  <input type="text" id="year_input" value="" class="form-control"
+                         oninput="updateOutput()">
+                </div>
               </div>
 
               <div class="col-sm-5" style="background-color:#f5f5f5; border:1px solid #e3e3e3">

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
@@ -114,6 +114,7 @@ $(function () {
     $("#dom_input").val("?");
     $("#month_input").val("*");
     $("#dow_input").val("*");
+    $("#year_input").val("");
     $(cron_translate_id).text("")
     $(cron_translate_warning_id).text("")
     $('#nextRecurId').html("");
@@ -187,6 +188,18 @@ $(function () {
     $('#instructions tbody tr:last th').html("?");
     $('#instructions tbody tr:last td').html("Blank");
   });
+
+  $("#year_input").click(function () {
+    while ($("#instructions tbody tr:last").index() >= 4) {
+      $("#instructions tbody tr:last").remove();
+    }
+    resetLabelColor();
+    $("#year_label").css("color", "red");
+
+    $('#instructions tbody').append($("#instructions tbody tr:first").clone());
+    $('#instructions tbody tr:last th').html("");
+    $('#instructions tbody tr:last td').html("This field is optional");
+  });
 });
 
 function resetLabelColor() {
@@ -202,15 +215,15 @@ var cron_hours_id = "#hour_input";
 var cron_dom_id = "#dom_input";
 var cron_months_id = "#month_input";
 var cron_dow_id = "#dow_input";
+var cron_year_id = "#year_input";
 var cron_output_id = "#cron-output";
 var cron_translate_id = "#cronTranslate";
 var cron_translate_warning_id = "#translationWarning";
 
 function updateOutput() {
-  $(cron_output_id).val($(cron_minutes_id).val() + " " + $(cron_hours_id).val()
-      + " " +
-      $(cron_dom_id).val() + " " + $(cron_months_id).val() + " " + $(
-          cron_dow_id).val()
+  $(cron_output_id).val($(cron_minutes_id).val() + " " + $(cron_hours_id).val() + " " +
+      $(cron_dom_id).val() + " " + $(cron_months_id).val() + " " +
+      $(cron_dow_id).val() + " " + $(cron_year_id).val()
   );
   updateExpression();
 }

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
@@ -255,21 +255,31 @@ function updateExpression() {
   serverTimeInJsDateFormat.setUTCMonth(serverTime.get('month'),
       serverTime.get('date'));
 
-  // Calculate the following 10 occurences based on the current server time.
-  // The logic is a bit tricky here. since later.js only support UTC Date (javascript raw library).
-  // We transform from current browser-timezone-time to Server timezone.
-  // Then we let serverTimeInJsDateFormat is equal to the server time.
-  var occurrences = later.schedule(laterCron).next(10,
-      serverTimeInJsDateFormat);
+  //Calculate the following 10 occurrences based on the current server time.
+  for(var i = 9; i >= 0; i--) {
+    // The logic is a bit tricky here. since later.js only support UTC Date (javascript raw library).
+    // We transform from current browser-timezone-time to Server timezone.
+    // Then we let serverTimeInJsDateFormat is equal to the server time.
+    var occurrence = later.schedule(laterCron).next(1, serverTimeInJsDateFormat);
 
-  //The following component below displays a list of next 10 triggering timestamp.
-  for (var i = 9; i >= 0; i--) {
-    var strTime = JSON.stringify(occurrences[i]);
+    if (occurrence) {
+      var strTime = JSON.stringify(occurrence);
 
-    // Get the time. The original occurance time string is like: "2016-09-09T05:00:00.999",
-    // We trim the string to ignore milliseconds.
-    var nextTime = '<li style="color:DarkGreen">' + strTime.substring(
-        1, strTime.length - 6) + '</li>';
-    $('#nextRecurId').prepend(nextTime);
+      // Get the time. The original occurrence time string is like: "2016-09-09T05:00:00.999",
+      // We trim the string to ignore milliseconds.
+      var nextTime = '<li style="color:DarkGreen">' + strTime.substring(1, strTime.length-6) + '</li>';
+      $('#nextRecurId').append(nextTime);
+
+      serverTimeInJsDateFormat = occurrence;
+
+      // Add 10 seconds to exclude startDate from the next occurrences
+      serverTimeInJsDateFormat.setSeconds(serverTimeInJsDateFormat.getSeconds() + 10);
+    } else {
+      console.log("occurrence is null");
+      break;
+    }
   }
+
+  $('#nextRecurLabel').html("Next " + $('#nextRecurId li').length +
+		  " scheduled executions for this cron expression only:");
 }

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-panel.js
@@ -122,6 +122,8 @@ $(function () {
     while ($("#instructions tbody tr:last").index() >= 4) {
       $("#instructions tbody tr:last").remove();
     }
+
+    updateOutput();
   });
 
   $("#minute_input").click(function () {
@@ -208,6 +210,7 @@ function resetLabelColor() {
   $("#dom_label").css("color", "black");
   $("#mon_label").css("color", "black");
   $("#dow_label").css("color", "black");
+  $("#year_label").css("color", "black");
 }
 
 var cron_minutes_id = "#minute_input";


### PR DESCRIPTION
As described in #1822, CRON expression allows year to be specified. This pull request will expose year textbox in schedule panel, allow one time execution, and properly update the next 10 executions based on the CRON expression with a slightly improved descriptions. 

Sample screenshots:
One time execution
![image](https://user-images.githubusercontent.com/1619937/42235719-a03a169e-7ec6-11e8-8e78-fdc659597606.png)

0 occurrences
![image](https://user-images.githubusercontent.com/1619937/42235832-f244bf02-7ec6-11e8-825c-0f0e2344e8ef.png)

A typical CRON expression
![image](https://user-images.githubusercontent.com/1619937/42235873-0ddef340-7ec7-11e8-838e-887d2a8e7c7d.png)

