### PR TITLE
Fix flaky test - testKillBasicFlowWithoutEndNode.

### DIFF
--- a/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
+++ b/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
@@ -18,5 +18,5 @@ nodes:
   - name: jobC
     type: test
     config:
-      seconds: 1
+      seconds: 2
       fail: false


### PR DESCRIPTION
Flaky test failure:
azkaban.execapp.FlowRunnerTestYaml > testKillBasicFlowWithoutEndNode STANDARD_ERROR
    testJob: jobB SUCCEEDED
    testJob: jobA SUCCEEDED
    testJob: jobC SUCCEEDED
    ExecutableFlow: basic_flow KILLED
    ExecutableNode: jobB SUCCEEDED
    ExecutableNode: jobA SUCCEEDED
    ExecutableNode: jobC SUCCEEDED

azkaban.execapp.FlowRunnerTestYaml > testKillBasicFlowWithoutEndNode FAILED
    java.lang.AssertionError: Wrong status for [jobC] expected:<KILLED> but was:<SUCCEEDED>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at azkaban.execapp.FlowRunnerTestBase.assertStatus(FlowRunnerTestBase.java:133)
        at azkaban.execapp.FlowRunnerTestBase.assertStatus(FlowRunnerTestBase.java:138)
        at azkaban.execapp.FlowRunnerTestYaml.testKillBasicFlowWithoutEndNode(FlowRunnerTestYaml.java:69)

This could happen when jobC has already finished before the flow is killed. After changing the duration of jobC, this timing issue could be relieved.