### PR TITLE
project LRU cache part 1

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -89,6 +89,8 @@ public class Constants {
   // The flow exec id for a flow trigger instance unable to trigger a flow yet
   public static final int FAILED_EXEC_ID = -2;
 
+  // Name of the file which keeps project directory size
+  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_project_dir_size_";
 
   public static class ConfigurationKeys {
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -90,7 +90,7 @@ public class Constants {
   public static final int FAILED_EXEC_ID = -2;
 
   // Name of the file which keeps project directory size
-  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_azkaban_project_dir_size_in_bytes_";
+  public static final String PROJECT_DIR_SIZE_FILE_NAME = "___azkaban_project_dir_size_in_bytes___";
 
   public static class ConfigurationKeys {
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -90,7 +90,7 @@ public class Constants {
   public static final int FAILED_EXEC_ID = -2;
 
   // Name of the file which keeps project directory size
-  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_azkaban_project_dir_size_";
+  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_azkaban_project_dir_size_in_bytes_";
 
   public static class ConfigurationKeys {
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -89,9 +89,6 @@ public class Constants {
   // The flow exec id for a flow trigger instance unable to trigger a flow yet
   public static final int FAILED_EXEC_ID = -2;
 
-  // Name of the file which keeps project directory size
-  public static final String PROJECT_DIR_SIZE_FILE_NAME = "___azkaban_project_dir_size_in_bytes___";
-
   public static class ConfigurationKeys {
 
     // Configures Azkaban Flow Version in project YAML file

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -90,7 +90,7 @@ public class Constants {
   public static final int FAILED_EXEC_ID = -2;
 
   // Name of the file which keeps project directory size
-  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_project_dir_size_";
+  public static final String PROJECT_DIR_SIZE_FILE_NAME = "_azkaban_project_dir_size_";
 
   public static class ConfigurationKeys {
 

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -96,14 +97,11 @@ public class FileIOUtils {
    */
   public static long readNumberFromFile(final Path filePath)
       throws IOException, NumberFormatException {
-    try (BufferedReader reader = Files
-        .newBufferedReader(filePath, StandardCharsets.UTF_8)) {
-      final long num = Long.parseLong(reader.readLine());
-      return num;
-    } catch (final IOException | NumberFormatException e) {
-      logger.error(String.format("Failed to read the number from the file %s", filePath),
-          e);
-      throw e;
+    final List<String> allLines = Files.readAllLines(filePath);
+    if (!allLines.isEmpty()) {
+      return Long.parseLong(allLines.get(0));
+    } else {
+      throw new NumberFormatException("unable to parse empty file " + filePath.toString());
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -90,8 +89,7 @@ public class FileIOUtils {
    */
   public static void dumpNumberToFile(final String filePath, final long num) throws IOException {
     try (BufferedWriter writer = Files
-        .newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8,
-            StandardOpenOption.TRUNCATE_EXISTING)) {
+        .newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8)) {
       writer.write(String.valueOf(num));
       writer.write("\n");
     } catch (final IOException e) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -28,6 +28,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,11 +79,10 @@ public class FileIOUtils {
    * @param num the number to dump
    * @throws IOException if file already exists
    */
-  public static void dumpNumberToFile(final String filePath, final long num) throws IOException {
+  public static void dumpNumberToFile(final Path filePath, final long num) throws IOException {
     try (BufferedWriter writer = Files
-        .newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8)) {
+        .newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
       writer.write(String.valueOf(num));
-      writer.write("\n");
     } catch (final IOException e) {
       logger.error(String.format("Failed to write the number %s to the file %s", num, filePath), e);
       throw e;
@@ -94,10 +94,10 @@ public class FileIOUtils {
    *
    * @param filePath the target file
    */
-  public static long readNumberFromFile(final String filePath)
+  public static long readNumberFromFile(final Path filePath)
       throws IOException, NumberFormatException {
     try (BufferedReader reader = Files
-        .newBufferedReader(Paths.get(filePath), StandardCharsets.UTF_8)) {
+        .newBufferedReader(filePath, StandardCharsets.UTF_8)) {
       final long num = Long.parseLong(reader.readLine());
       return num;
     } catch (final IOException | NumberFormatException e) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -16,6 +16,7 @@
 
 package azkaban.utils;
 
+import com.google.common.base.Preconditions;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -29,6 +30,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -72,25 +74,24 @@ public class FileIOUtils {
 
 
   /**
-   * Return creation time of file.
+   * Returns last modified time of file.
    */
-  public static long getCreationTime(final File file) throws IOException {
+  public static long getLastModifiedTime(final File file) throws IOException {
     Preconditions.checkArgument(file.exists(), file + " doesn't exist");
-    final BasicFileAttributes attrs = Files
-        .readAttributes(file.toPath(), BasicFileAttributes.class);
-    final FileTime time = attrs.creationTime();
-    return time.toMillis();
+    return file.lastModified();
   }
 
   /**
-   * Dumps a number into a file. Overwrites the file if it exists.
+   * Dumps a number into a new file.
    *
    * @param filePath the target file
    * @param num the number to dump
+   * @throws IOException if file already exists
    */
   public static void dumpNumberToFile(final String filePath, final long num) throws IOException {
     try (BufferedWriter writer = Files
-        .newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8)) {
+        .newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8,
+            StandardOpenOption.TRUNCATE_EXISTING)) {
       writer.write(String.valueOf(num));
       writer.write("\n");
     } catch (final IOException e) {
@@ -115,21 +116,6 @@ public class FileIOUtils {
           e);
       throw e;
     }
-  }
-
-  /**
-   * Return the size of dir in KB.
-   */
-  public static long sizeInKB(final File dir) throws IOException {
-    Preconditions.checkArgument(dir.isDirectory(), dir + " is not a directory");
-    Preconditions.checkArgument(dir.exists(), dir + " doesn't exist");
-
-    final java.util.Scanner s = new java.util.Scanner(
-        Runtime.getRuntime().exec("du -sh -k " + dir.getAbsolutePath()).getInputStream(),
-        Charset.defaultCharset().name()).useDelimiter("\\A");
-    final String str = s.hasNext() ? s.next() : "";
-    final String[] res = str.split("\\s+");
-    return Long.valueOf(res[0]);
   }
 
   public static String getSourcePathFromClass(final Class<?> containedClass) {

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -16,7 +16,6 @@
 
 package azkaban.utils;
 
-import com.google.common.base.Preconditions;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -71,14 +70,6 @@ public class FileIOUtils {
     return true;
   }
 
-
-  /**
-   * Returns last modified time of file.
-   */
-  public static long getLastModifiedTime(final File file) throws IOException {
-    Preconditions.checkArgument(file.exists(), file + " doesn't exist");
-    return file.lastModified();
-  }
 
   /**
    * Dumps a number into a new file.

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -112,7 +112,7 @@ public class FileIOUtilsTest {
 
   private File dumpNumberToTempFile(final String fileName, final long num) throws IOException {
     final File fileToDump = this.temp.newFile(fileName);
-    FileIOUtils.dumpNumberToFile(fileToDump.getAbsolutePath(), num);
+    FileIOUtils.dumpNumberToFile(fileToDump.toPath(), num);
     return fileToDump;
   }
 
@@ -121,7 +121,7 @@ public class FileIOUtilsTest {
     final String fileName = "number";
     final long num = 94127;
     final File fileToDump = dumpNumberToTempFile(fileName, num);
-    assertThat(FileIOUtils.readNumberFromFile(fileToDump.getAbsolutePath())).isEqualTo(num);
+    assertThat(FileIOUtils.readNumberFromFile(fileToDump.toPath())).isEqualTo(num);
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/FileIOUtilsTest.java
@@ -109,6 +109,31 @@ public class FileIOUtilsTest {
     FileUtils.deleteDirectory(this.destDir);
   }
 
+
+  private File dumpNumberToTempFile(final String fileName, final long num) throws IOException {
+    final File fileToDump = this.temp.newFile(fileName);
+    FileIOUtils.dumpNumberToFile(fileToDump.getAbsolutePath(), num);
+    return fileToDump;
+  }
+
+  @Test
+  public void testDumpNumberToFileAndReadFromFile() throws IOException {
+    final String fileName = "number";
+    final long num = 94127;
+    final File fileToDump = dumpNumberToTempFile(fileName, num);
+    assertThat(FileIOUtils.readNumberFromFile(fileToDump.getAbsolutePath())).isEqualTo(num);
+  }
+
+  @Test
+  public void testDumpNumberToExistingFile() throws IOException {
+    final String fileName = "number";
+    final long firstNum = 94127;
+    final long secondNum = 94128;
+    dumpNumberToTempFile(fileName, firstNum);
+    assertThatThrownBy(() -> dumpNumberToTempFile(fileName, secondNum))
+        .isInstanceOf(IOException.class).hasMessageContaining("already exists");
+  }
+
   @Test
   public void testHardlinkCopy() throws IOException {
     FileIOUtils.createDeepHardlink(this.sourceDir, this.destDir);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -58,6 +58,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
@@ -273,9 +274,9 @@ public class AzkabanExecutorServer {
 
   private void dumpPortToFile() throws IOException {
     // By default this should write to the working directory
-    final String portFile = this.props
+    final String portFileName = this.props
         .getString(Constants.AZKABAN_EXECUTOR_PORT_FILE, AZKABAN_EXECUTOR_PORT_FILENAME);
-    FileIOUtils.dumpNumberToFile(portFile, getPort());
+    FileIOUtils.dumpNumberToFile(Paths.get(portFileName), getPort());
   }
 
   private void configureJobCallback(final Props props) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -44,12 +44,12 @@ import azkaban.metric.MetricReportManager;
 import azkaban.metric.inmemoryemitter.InMemoryMetricEmitter;
 import azkaban.metrics.MetricsManager;
 import azkaban.server.AzkabanServer;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StdOutErrRedirect;
 import azkaban.utils.Utils;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,8 +58,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
@@ -277,14 +275,7 @@ public class AzkabanExecutorServer {
     // By default this should write to the working directory
     final String portFile = this.props
         .getString(Constants.AZKABAN_EXECUTOR_PORT_FILE, AZKABAN_EXECUTOR_PORT_FILENAME);
-    try (BufferedWriter writer = Files
-        .newBufferedWriter(Paths.get(portFile), StandardCharsets.UTF_8)) {
-      writer.write(String.valueOf(getPort()));
-      writer.write("\n");
-    } catch (final IOException e) {
-      logger.error("Failed to write the port number to a file", e);
-      throw e;
-    }
+    FileIOUtils.dumpNumberToFile(portFile, getPort());
   }
 
   private void configureJobCallback(final Props props) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -144,7 +144,7 @@ public class FlowPreparer {
       final File zipFile = requireNonNull(projectFileHandler.getLocalFile());
       final ZipFile zip = new ZipFile(zipFile);
       Utils.unzip(zip, tempDir);
-      persistDirSize(tempDir);
+      updateDirSize(tempDir, pv);
       Files.move(tempDir.toPath(), pv.getInstalledDir().toPath(), StandardCopyOption.ATOMIC_MOVE);
       log.warn(String.format("Project preparation completes. [%s]", pv));
     } finally {
@@ -157,12 +157,15 @@ public class FlowPreparer {
   }
 
   /**
-   * Creates a file which keeps the size of {@param dir} in bytes inside the {@param dir}.
+   * Creates a file which keeps the size of {@param dir} in bytes inside the {@param dir} and sets
+   * the dirSize for {@param pv}.
    *
    * @param dir the directory whose size needs to be kept in the file to be created.
+   * @param pv the projectVersion whose size needs to updated.
    */
-  private void persistDirSize(final File dir) {
+  private void updateDirSize(final File dir, final ProjectVersion pv) {
     final long size = FileUtils.sizeOfDirectory(dir);
+    pv.setDirSize(size);
     try {
       FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)
           .toString(), size);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -20,7 +20,6 @@ package azkaban.execapp;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
-import azkaban.Constants;
 import azkaban.executor.ExecutableFlow;
 import azkaban.project.ProjectFileHandler;
 import azkaban.project.ProjectManagerException;
@@ -44,6 +43,8 @@ import org.apache.log4j.Logger;
 
 public class FlowPreparer {
 
+  // Name of the file which keeps project directory size
+  static final String PROJECT_DIR_SIZE_FILE_NAME = "___azkaban_project_dir_size_in_bytes___";
   private static final Logger log = Logger.getLogger(FlowPreparer.class);
   // TODO spyne: move to config class
   private final File executionsDir;
@@ -124,7 +125,7 @@ public class FlowPreparer {
     if (pv.getInstalledDir().exists()) {
       log.info("Project already cached. Skipping download. " + pv);
       touchIfExists(
-          Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
+          Paths.get(pv.getInstalledDir().getPath(), PROJECT_DIR_SIZE_FILE_NAME));
       return;
     }
 
@@ -168,7 +169,7 @@ public class FlowPreparer {
     final long sizeInByte = FileUtils.sizeOfDirectory(dir);
     pv.setDirSize(sizeInByte);
     try {
-      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME),
+      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), PROJECT_DIR_SIZE_FILE_NAME),
           sizeInByte);
     } catch (final IOException e) {
       log.error(e);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -96,7 +96,8 @@ public class FlowPreparer {
    *
    * @param path path to the target file
    */
-  private void touchIfExists(final Path path) {
+  @VisibleForTesting
+  void touchIfExists(final Path path) {
     try {
       Files.setLastModifiedTime(path, FileTime.fromMillis(System.currentTimeMillis()));
     } catch (final IOException ex) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -45,12 +45,10 @@ import org.apache.log4j.Logger;
 public class FlowPreparer {
 
   private static final Logger log = Logger.getLogger(FlowPreparer.class);
-
   // TODO spyne: move to config class
   private final File executionsDir;
   // TODO spyne: move to config class
   private final File projectsDir;
-
   private final Map<Pair<Integer, Integer>, ProjectVersion> installedProjects;
   private final StorageManager storageManager;
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -32,8 +32,10 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
@@ -93,11 +95,13 @@ public class FlowPreparer {
   /**
    * Touch the file if it exists.
    *
-   * @param file the target file
+   * @param path path to the target file
    */
-  private void touchIfExists(final File file) {
-    if (file.exists()) {
-      file.setLastModified(System.currentTimeMillis());
+  private void touchIfExists(final Path path) {
+    try {
+      Files.setLastModifiedTime(path, FileTime.fromMillis(System.currentTimeMillis()));
+    } catch (final IOException ex) {
+      log.error(ex);
     }
   }
 
@@ -122,8 +126,7 @@ public class FlowPreparer {
     if (pv.getInstalledDir().exists()) {
       log.info("Project already cached. Skipping download. " + pv);
       touchIfExists(
-          new File(Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)
-              .toString()));
+          Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
       return;
     }
 
@@ -167,8 +170,8 @@ public class FlowPreparer {
     final long sizeInByte = FileUtils.sizeOfDirectory(dir);
     pv.setDirSize(sizeInByte);
     try {
-      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)
-          .toString(), sizeInByte);
+      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME),
+          sizeInByte);
     } catch (final IOException e) {
       log.error(e);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -164,11 +164,11 @@ public class FlowPreparer {
    * @param pv the projectVersion whose size needs to updated.
    */
   private void updateDirSize(final File dir, final ProjectVersion pv) {
-    final long size = FileUtils.sizeOfDirectory(dir);
-    pv.setDirSize(size);
+    final long sizeInByte = FileUtils.sizeOfDirectory(dir);
+    pv.setDirSize(sizeInByte);
     try {
       FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)
-          .toString(), size);
+          .toString(), sizeInByte);
     } catch (final IOException e) {
       log.error(e);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
@@ -18,10 +18,7 @@ package azkaban.execapp;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import azkaban.Constants;
-import azkaban.utils.FileIOUtils;
 import java.io.File;
-import java.nio.file.Paths;
 
 
 public class ProjectVersion implements Comparable<ProjectVersion> {
@@ -43,21 +40,14 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
   public ProjectVersion(final int projectId, final int version, final File installedDir) {
     this(projectId, version);
     this.installedDir = installedDir;
-    this.dirSize = readFileSize();
-  }
-
-  private Long readFileSize() {
-    Long fileSize = null;
-    try {
-      fileSize = FileIOUtils.readNumberFromFile(
-          Paths.get(this.installedDir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME).toString());
-    } catch (final Exception ex) {
-    }
-    return fileSize;
   }
 
   public Long getDirSize() {
     return this.dirSize;
+  }
+
+  public void setDirSize(final Long dirSize) {
+    this.dirSize = dirSize;
   }
 
   public int getProjectId() {
@@ -74,7 +64,6 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
 
   public void setInstalledDir(final File installedDir) {
     this.installedDir = installedDir;
-    this.dirSize = readFileSize();
   }
 
   @Override

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectVersion.java
@@ -18,7 +18,10 @@ package azkaban.execapp;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import azkaban.Constants;
+import azkaban.utils.FileIOUtils;
 import java.io.File;
+import java.nio.file.Paths;
 
 
 public class ProjectVersion implements Comparable<ProjectVersion> {
@@ -27,6 +30,7 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
   private final int version;
 
   private File installedDir;
+  private Long dirSize;
 
   public ProjectVersion(final int projectId, final int version) {
     checkArgument(projectId > 0);
@@ -39,6 +43,21 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
   public ProjectVersion(final int projectId, final int version, final File installedDir) {
     this(projectId, version);
     this.installedDir = installedDir;
+    this.dirSize = readFileSize();
+  }
+
+  private Long readFileSize() {
+    Long fileSize = null;
+    try {
+      fileSize = FileIOUtils.readNumberFromFile(
+          Paths.get(this.installedDir.getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME).toString());
+    } catch (final Exception ex) {
+    }
+    return fileSize;
+  }
+
+  public Long getDirSize() {
+    return this.dirSize;
   }
 
   public int getProjectId() {
@@ -55,6 +74,7 @@ public class ProjectVersion implements Comparable<ProjectVersion> {
 
   public void setInstalledDir(final File installedDir) {
     this.installedDir = installedDir;
+    this.dirSize = readFileSize();
   }
 
   @Override

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -29,7 +29,9 @@ import azkaban.storage.StorageManager;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Pair;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -82,11 +84,11 @@ public class FlowPreparerTest {
     this.instance.setupProject(pv);
 
     final long actualDirSize = 259;
-    final String sizeFile = Paths
-        .get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME).toString();
 
     assertThat(pv.getDirSize()).isEqualTo(actualDirSize);
-    assertThat(FileIOUtils.readNumberFromFile(sizeFile)).isEqualTo(actualDirSize);
+    assertThat(FileIOUtils.readNumberFromFile(
+        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)))
+        .isEqualTo(actualDirSize);
     assertTrue(pv.getInstalledDir().exists());
     assertTrue(new File(pv.getInstalledDir(), "sample_flow_01").exists());
   }
@@ -97,12 +99,15 @@ public class FlowPreparerTest {
     final ProjectVersion pv = new ProjectVersion(12, 34,
         new File(this.projectsDir, "sample_project_01"));
     this.instance.setupProject(pv);
-    final long lastModifiedTime1 = new File(Paths.get(pv.getInstalledDir().getPath(), Constants
-        .PROJECT_DIR_SIZE_FILE_NAME).toString()).lastModified();
+
+    final FileTime lastModifiedTime1 = Files.getLastModifiedTime(
+        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
+
     Thread.sleep(1000);
     this.instance.setupProject(pv);
-    final long lastModifiedTime2 = new File(Paths.get(pv.getInstalledDir().getPath(), Constants
-        .PROJECT_DIR_SIZE_FILE_NAME).toString()).lastModified();
+
+    final FileTime lastModifiedTime2 = Files.getLastModifiedTime(
+        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
 
     assertThat(lastModifiedTime2).isGreaterThan(lastModifiedTime1);
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import azkaban.Constants;
 import azkaban.executor.ExecutableFlow;
 import azkaban.project.ProjectFileHandler;
 import azkaban.storage.StorageManager;
@@ -87,7 +86,7 @@ public class FlowPreparerTest {
 
     assertThat(pv.getDirSize()).isEqualTo(actualDirSize);
     assertThat(FileIOUtils.readNumberFromFile(
-        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME)))
+        Paths.get(pv.getInstalledDir().getPath(), FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME)))
         .isEqualTo(actualDirSize);
     assertTrue(pv.getInstalledDir().exists());
     assertTrue(new File(pv.getInstalledDir(), "sample_flow_01").exists());
@@ -101,13 +100,13 @@ public class FlowPreparerTest {
     this.instance.setupProject(pv);
 
     final FileTime lastModifiedTime1 = Files.getLastModifiedTime(
-        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
+        Paths.get(pv.getInstalledDir().getPath(), FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME));
 
     Thread.sleep(1000);
     this.instance.setupProject(pv);
 
     final FileTime lastModifiedTime2 = Files.getLastModifiedTime(
-        Paths.get(pv.getInstalledDir().getPath(), Constants.PROJECT_DIR_SIZE_FILE_NAME));
+        Paths.get(pv.getInstalledDir().getPath(), FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME));
 
     assertThat(lastModifiedTime2).isGreaterThan(lastModifiedTime1);
   }


### PR DESCRIPTION
The problem this PR targets to solve is detailed in https://github.com/azkaban/azkaban/pull/1803 

Drawback of previous design is detailed in https://github.com/azkaban/azkaban/pull/1841

New design:
1. Create a file in each project directory and write the size of the project to the file when the project is created. The project files are not supposed to change after creation. Touch this file each time the project is used. This way, we can have a more efficient LRU algorithm based on last access time, not creation time.
2. Maintain the total size of the project cache in memory to avoid the overhead of re-calculating it. The size shouldn't change too often. This way we can afford to run the check more frequently.


This PR implements part 1.
