### PR TITLE
Condition on job status - Step 1

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.flow.ConditionOnJobStatus;
 import azkaban.flow.Node;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
@@ -44,6 +45,7 @@ public class ExecutableNode {
   public static final String OUTNODES_PARAM = "outNodes";
   public static final String TYPE_PARAM = "type";
   public static final String CONDITION_PARAM = "condition";
+  public static final String CONDITION_ON_JOB_STATUS_PARAM = "conditionOnJobStatus";
   public static final String PROPS_SOURCE_PARAM = "propSource";
   public static final String JOB_SOURCE_PARAM = "jobSource";
   public static final String OUTPUT_PROPS_PARAM = "outputProps";
@@ -68,6 +70,7 @@ public class ExecutableNode {
   private long delayExecution = 0;
   private ArrayList<ExecutionAttempt> pastAttempts = null;
   private String condition;
+  private ConditionOnJobStatus conditionOnJobStatus = ConditionOnJobStatus.ALL_SUCCESS;
 
   // Transient. These values aren't saved, but rediscovered.
   private ExecutableFlowBase parentFlow;
@@ -79,18 +82,20 @@ public class ExecutableNode {
   }
 
   public ExecutableNode(final Node node, final ExecutableFlowBase parent) {
-    this(node.getId(), node.getType(), node.getCondition(), node.getJobSource(), node
+    this(node.getId(), node.getType(), node.getCondition(), node.getConditionOnJobStatus(), node
+        .getJobSource(), node
         .getPropsSource(), parent);
   }
 
-  public ExecutableNode(final String id, final String type, final String condition, final String
-      jobSource,
+  public ExecutableNode(final String id, final String type, final String condition,
+      final ConditionOnJobStatus conditionOnJobStatus, final String jobSource,
       final String propsSource, final ExecutableFlowBase parent) {
     this.id = id;
     this.jobSource = jobSource;
     this.propsSource = propsSource;
     this.type = type;
     this.condition = condition;
+    this.conditionOnJobStatus = conditionOnJobStatus;
     setParentFlow(parent);
   }
 
@@ -289,6 +294,7 @@ public class ExecutableNode {
     objMap.put(UPDATETIME_PARAM, this.updateTime);
     objMap.put(TYPE_PARAM, this.type);
     objMap.put(CONDITION_PARAM, this.condition);
+    objMap.put(CONDITION_ON_JOB_STATUS_PARAM, this.conditionOnJobStatus.toString());
     objMap.put(ATTEMPT_PARAM, this.attempt);
 
     if (this.inNodes != null && !this.inNodes.isEmpty()) {
@@ -324,6 +330,8 @@ public class ExecutableNode {
     this.id = wrappedMap.getString(ID_PARAM);
     this.type = wrappedMap.getString(TYPE_PARAM);
     this.condition = wrappedMap.getString(CONDITION_PARAM);
+    this.conditionOnJobStatus = ConditionOnJobStatus.fromString(wrappedMap.getString
+        (CONDITION_ON_JOB_STATUS_PARAM));
     this.status = Status.valueOf(wrappedMap.getString(STATUS_PARAM));
     this.startTime = wrappedMap.getLong(STARTTIME_PARAM);
     this.endTime = wrappedMap.getLong(ENDTIME_PARAM);
@@ -467,5 +475,13 @@ public class ExecutableNode {
 
   public void setCondition(final String condition) {
     this.condition = condition;
+  }
+
+  public ConditionOnJobStatus getConditionOnJobStatus() {
+    return this.conditionOnJobStatus;
+  }
+
+  public void setConditionOnJobStatus(final ConditionOnJobStatus conditionOnJobStatus) {
+    this.conditionOnJobStatus = conditionOnJobStatus;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -74,6 +74,28 @@ public enum Status {
     }
   }
 
+  public static boolean isStatusFailed(final Status status) {
+    switch (status) {
+      case FAILED:
+      case KILLED:
+      case CANCELLED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static boolean isStatusSucceeded(final Status status) {
+    switch (status) {
+      case SUCCEEDED:
+      case FAILED_SUCCEEDED:
+      case SKIPPED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public int getNumVal() {
     return this.numVal;
   }

--- a/azkaban-common/src/main/java/azkaban/flow/ConditionOnJobStatus.java
+++ b/azkaban-common/src/main/java/azkaban/flow/ConditionOnJobStatus.java
@@ -1,0 +1,47 @@
+/*
+* Copyright 2018 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the “License”); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package azkaban.flow;
+
+public enum ConditionOnJobStatus {
+  ALL_SUCCESS("all_success"),
+  ALL_FAILED("all_failed"),
+  ALL_DONE("all_done"),
+  ONE_FAILED("one_failed"),
+  ONE_SUCCESS("one_success"),
+  ONE_FAILED_ALL_DONE("one_failed_all_done"),
+  ONE_SUCCESS_ALL_DONE("one_success_all_done");
+
+  private final String condition;
+
+  ConditionOnJobStatus(final String condition) {
+    this.condition = condition;
+  }
+
+  public static ConditionOnJobStatus fromString(final String condition) {
+    for (final ConditionOnJobStatus conditionOnJobStatus : ConditionOnJobStatus.values()) {
+      if (conditionOnJobStatus.condition.equalsIgnoreCase(condition)) {
+        return conditionOnJobStatus;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return this.condition;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/flow/Node.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Node.java
@@ -36,6 +36,8 @@ public class Node {
 
   private String condition = null;
 
+  private ConditionOnJobStatus conditionOnJobStatus = ConditionOnJobStatus.ALL_SUCCESS;
+
   public Node(final String id) {
     this.id = id;
   }
@@ -190,5 +192,13 @@ public class Node {
 
   public void setCondition(final String condition) {
     this.condition = condition;
+  }
+
+  public ConditionOnJobStatus getConditionOnJobStatus() {
+    return this.conditionOnJobStatus;
+  }
+
+  public void setConditionOnJobStatus(final ConditionOnJobStatus conditionOnJobStatus) {
+    this.conditionOnJobStatus = conditionOnJobStatus;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -17,6 +17,7 @@
 package azkaban.project;
 
 import azkaban.Constants;
+import azkaban.flow.ConditionOnJobStatus;
 import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowProps;
@@ -33,6 +34,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,6 +168,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     final Node node = new Node(azkabanNode.getName());
     node.setType(azkabanNode.getType());
     node.setCondition(azkabanNode.getCondition());
+    setConditionOnJobStatus(node);
     node.setPropsSource(flowFile.getName());
     node.setJobSource(flowFile.getName());
 
@@ -217,4 +222,22 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     }
   }
 
+  private void setConditionOnJobStatus(final Node node) {
+    String condition = node.getCondition();
+    if (condition != null) {
+      final String patternString =
+          "\\b(" + StringUtils.join(ConditionOnJobStatus.values(), "|") + ")\\b";
+      final Pattern pattern = Pattern.compile(patternString);
+      final Matcher matcher = pattern.matcher(condition);
+
+      // Todo jamiesjc: need to add validation for condition
+      while (matcher.find()) {
+        logger.info("Found conditionOnJobStatus: " + matcher.group(1));
+        node.setConditionOnJobStatus(ConditionOnJobStatus.fromString(matcher.group(1)));
+        condition = condition.replace(matcher.group(1), "true");
+        logger.info("condition is " + condition);
+        node.setCondition(condition);
+      }
+    }
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -225,8 +225,11 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   private void setConditionOnJobStatus(final Node node) {
     String condition = node.getCondition();
     if (condition != null) {
+      // Only values in the ConditionOnJobStatus enum can be matched by this pattern. Some examples:
+      // Valid: all_done, one_success && ${jobA: param1} == 1, ALL_FAILED
+      // Invalid: two_success, one_faileddd, {one_failed}
       final String patternString =
-          "\\b(" + StringUtils.join(ConditionOnJobStatus.values(), "|") + ")\\b";
+          "(?i)\\b(" + StringUtils.join(ConditionOnJobStatus.values(), "|") + ")\\b";
       final Pattern pattern = Pattern.compile(patternString);
       final Matcher matcher = pattern.matcher(condition);
 

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -42,13 +42,10 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String DUPLICATE_NODENAME_YAML_DIR = "duplicatenodenamesyamltest";
   private static final String DEPENDENCY_UNDEFINED_YAML_DIR = "dependencyundefinedyamltest";
   private static final String INVALID_JOBPROPS_YAML_DIR = "invalidjobpropsyamltest";
-  private static final String CONDITIONAL_FLOW_YAML_DIR = "conditionalflowyamltest";
   private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
   private static final String EMBEDDED_FLOW = "embedded_flow";
-  private static final String CONDITIONAL_FLOW_1 = "conditional_flow1";
-  private static final String CONDITIONAL_FLOW_2 = "conditional_flow2";
   private static final String EMBEDDED_FLOW_1 = "embedded_flow" + Constants.PATH_DELIMITER +
       "embedded_flow1";
   private static final String EMBEDDED_FLOW_2 =
@@ -169,16 +166,6 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(NO_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 0, 0);
-  }
-
-  @Test
-  public void testLoadConditionalWorkflowYamlFile() {
-    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
-    loader.loadProjectFlow(this.project,
-        ExecutionsTestUtil.getFlowDir(CONDITIONAL_FLOW_YAML_DIR));
-    checkFlowLoaderProperties(loader, 0, 2, 2);
-    checkFlowProperties(loader, CONDITIONAL_FLOW_1, 0, 4, 1, 4, null);
-    checkFlowProperties(loader, CONDITIONAL_FLOW_2, 0, 4, 1, 4, null);
   }
 
   private void checkFlowLoaderProperties(final DirectoryYamlFlowLoader loader, final int numError,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ConditionalWorkflowUtils.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ConditionalWorkflowUtils.java
@@ -1,0 +1,101 @@
+/*
+* Copyright 2018 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the “License”); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package azkaban.execapp;
+
+import static azkaban.flow.ConditionOnJobStatus.ALL_FAILED;
+import static azkaban.flow.ConditionOnJobStatus.ALL_SUCCESS;
+import static azkaban.flow.ConditionOnJobStatus.ONE_FAILED;
+import static azkaban.flow.ConditionOnJobStatus.ONE_FAILED_ALL_DONE;
+import static azkaban.flow.ConditionOnJobStatus.ONE_SUCCESS;
+import static azkaban.flow.ConditionOnJobStatus.ONE_SUCCESS_ALL_DONE;
+
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.Status;
+import azkaban.flow.ConditionOnJobStatus;
+
+public class ConditionalWorkflowUtils {
+
+  public static final String SATISFIED = "satisfied";
+  public static final String PENDING = "pending";
+  public static final String FAILED = "failed";
+
+  public static String checkConditionOnJobStatus(final ExecutableNode node) {
+    final ConditionOnJobStatus conditionOnJobStatus = node.getConditionOnJobStatus();
+    switch (conditionOnJobStatus) {
+      case ALL_SUCCESS:
+      case ALL_FAILED:
+      case ALL_DONE:
+        return checkAllStatus(node, conditionOnJobStatus);
+      case ONE_FAILED:
+      case ONE_SUCCESS:
+        return checkOneStatus(node, conditionOnJobStatus);
+      case ONE_FAILED_ALL_DONE:
+      case ONE_SUCCESS_ALL_DONE:
+        return checkOneStatusAllDone(node, conditionOnJobStatus);
+      default:
+        return checkAllStatus(node, ALL_SUCCESS);
+    }
+  }
+
+  private static String checkAllStatus(final ExecutableNode node, final ConditionOnJobStatus
+      condition) {
+    String result = SATISFIED;
+    for (final String dependency : node.getInNodes()) {
+      final ExecutableNode dependencyNode = node.getParentFlow().getExecutableNode(dependency);
+      final Status depStatus = dependencyNode.getStatus();
+      if (!Status.isStatusFinished(depStatus)) {
+        return PENDING;
+      } else if ((condition.equals(ALL_SUCCESS) && Status.isStatusFailed(depStatus)) ||
+          (condition.equals(ALL_FAILED) && Status.isStatusSucceeded(depStatus))) {
+        result = FAILED;
+      }
+    }
+    return result;
+  }
+
+  private static String checkOneStatus(final ExecutableNode node, final ConditionOnJobStatus
+      condition) {
+    boolean finished = true;
+    for (final String dependency : node.getInNodes()) {
+      final ExecutableNode dependencyNode = node.getParentFlow().getExecutableNode(dependency);
+      final Status depStatus = dependencyNode.getStatus();
+      if ((condition.equals(ONE_SUCCESS) && Status.isStatusSucceeded(depStatus)) ||
+          (condition.equals(ONE_FAILED) && Status.isStatusFailed(depStatus))) {
+        return SATISFIED;
+      } else if (!Status.isStatusFinished(depStatus)) {
+        finished = false;
+      }
+    }
+    return finished ? FAILED : PENDING;
+  }
+
+  private static String checkOneStatusAllDone(final ExecutableNode node, final ConditionOnJobStatus
+      condition) {
+    String result = FAILED;
+    for (final String dependency : node.getInNodes()) {
+      final ExecutableNode dependencyNode = node.getParentFlow().getExecutableNode(dependency);
+      final Status depStatus = dependencyNode.getStatus();
+      if (!Status.isStatusFinished(depStatus)) {
+        return PENDING;
+      } else if ((condition.equals(ONE_SUCCESS_ALL_DONE) && Status.isStatusSucceeded(depStatus)) ||
+          (condition.equals(ONE_FAILED_ALL_DONE) && Status.isStatusFailed(depStatus))) {
+        result = SATISFIED;
+      }
+    }
+    return result;
+  }
+
+}

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -1,0 +1,25 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobC
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: one_failed
+
+    dependsOn:
+      - jobA
+      - jobB
+
+  - name: jobA
+    type: test
+    config:
+      seconds: 2
+
+  - name: jobB
+    type: test
+    config:
+      seconds: 2

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
@@ -1,0 +1,25 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobC
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: all_failed
+
+    dependsOn:
+      - jobA
+      - jobB
+
+  - name: jobA
+    type: test
+    config:
+      seconds: 2
+
+  - name: jobB
+    type: test
+    config:
+      seconds: 2

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
@@ -1,0 +1,25 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobC
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: one_success_all_done
+
+    dependsOn:
+      - jobA
+      - jobB
+
+  - name: jobA
+    type: test
+    config:
+      seconds: 2
+
+  - name: jobB
+    type: test
+    config:
+      seconds: 2

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow6.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow6.flow
@@ -1,0 +1,41 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobD
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: one_success && ${jobA:azkaban.server.name} == 'foo'
+
+    dependsOn:
+      - jobB
+      - jobC
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0
+
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ${jobA:azkaban.server.name} == 'foo'
+
+    dependsOn:
+      - jobA
+
+  - name: jobC
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ${jobA:azkaban.server.name} == 'bar'
+
+    dependsOn:
+      - jobA


### PR DESCRIPTION
Users can use predefined macros to specify the condition on job status. For example, they can write `condition: one_success` for a job in the flow yaml file. And this job will run as soon as one of its parent jobs has succeeded. 
Below is the list of condition macros we will support:

- **all_success** (default)
- **all_failed**
- **all_done**
- **one_failed**: fire as soon as at least one parent has failed.
- **one_success**: fire as soon as at least one parent has succeeded.
- **one_failed_all_done**: fire when at least one parent has failed and all parents have finished.
- **one_success_all_done**: fire when at least one parent has succeeded and all parents have finished.

By default, the condition on job status is all_success.
The execution logic will change under different conditions. For example, the `flowFailed `flag might not always be set to true when a job fails for a conditional workflow. 
Users can define both condition on runtime parameters and job status. E.g., `condition: one_success && ${jobA: param1} == 1  `

Please see the design doc for more details: #1826 