### PR TITLE
Include error stacktrace in updater thread logging

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1674,7 +1674,7 @@ public class ExecutorManager extends EventHandler implements
             }
           }
         } catch (final Exception e) {
-          logger.error(e);
+          logger.error("Unexpected exception in updating executions", e);
         }
       }
     }


### PR DESCRIPTION
It was calling `log.error(Object message)`, so we didn't get a stack trace at all. For example this was logged, which is not too helpful: `ERROR [ExecutorManager] [Azkaban] java.lang.NullPointerException` (the value of `e.toString()`, as you can see).