### PR TITLE
Fix NPE in ExecutableNode.fillMapFromExecutable()

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -294,7 +294,9 @@ public class ExecutableNode {
     objMap.put(UPDATETIME_PARAM, this.updateTime);
     objMap.put(TYPE_PARAM, this.type);
     objMap.put(CONDITION_PARAM, this.condition);
-    objMap.put(CONDITION_ON_JOB_STATUS_PARAM, this.conditionOnJobStatus.toString());
+    if (this.conditionOnJobStatus != null) {
+      objMap.put(CONDITION_ON_JOB_STATUS_PARAM, this.conditionOnJobStatus.toString());
+    }
     objMap.put(ATTEMPT_PARAM, this.attempt);
 
     if (this.inNodes != null && !this.inNodes.isEmpty()) {


### PR DESCRIPTION
When loading some old executions (at least in order to finalize them), it's possible that the serialized flow_data doesn't include the conditionOnJobStatus at all.

Based on this stack trace, which points to the that I'm guarding with a null-check now:

```
2018/07/25 12:56:52.853 -0700 ERROR [ExecutorManager] [Azkaban] Unexpected exception in updating executions
java.lang.NullPointerException
	at azkaban.executor.ExecutableNode.fillMapFromExecutable(ExecutableNode.java:297)
	at azkaban.executor.ExecutableFlowBase.fillMapFromExecutable(ExecutableFlowBase.java:219)
	at azkaban.executor.ExecutableFlow.toObject(ExecutableFlow.java:226)
	at azkaban.executor.ExecutionFlowDao.updateExecutableFlow(ExecutionFlowDao.java:230)
	at azkaban.executor.ExecutionFlowDao.updateExecutableFlow(ExecutionFlowDao.java:220)
	at azkaban.executor.JdbcExecutorLoader.updateExecutableFlow(JdbcExecutorLoader.java:73)
	at azkaban.executor.ExecutorManager.finalizeFlows(ExecutorManager.java:1245)
	at azkaban.executor.ExecutorManager.access$900(ExecutorManager.java:78)
	at azkaban.executor.ExecutorManager$ExecutingManagerUpdaterThread.run(ExecutorManager.java:1660)
2018/07/25 12:56:52.856 -0700 WARN [ExecutorManager] [Azkaban] Finalizing execution 2624. Executor id of this execution doesn't exist
2018/07/25 12:56:52.856 -0700 WARN [ExecutorManager] [Azkaban] Finalizing execution 1724. Executor id of this execution doesn't exist
2018/07/25 12:56:52.856 -0700 WARN [ExecutorManager] [Azkaban] Finalizing execution 2047. Executor id of this execution doesn't exist
```
