### PR TITLE
Handle the case where ConditionOnJobStatus is null

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -478,7 +478,8 @@ public class ExecutableNode {
   }
 
   public ConditionOnJobStatus getConditionOnJobStatus() {
-    return this.conditionOnJobStatus;
+    return this.conditionOnJobStatus == null ? ConditionOnJobStatus.ALL_SUCCESS
+        : this.conditionOnJobStatus;
   }
 
   public void setConditionOnJobStatus(final ConditionOnJobStatus conditionOnJobStatus) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -134,6 +134,19 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     assertFlowStatus(flow, Status.SUCCEEDED);
   }
 
+  @Test
+  public void runFlowOnJobStatusConditionNull() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_3, flowProps);
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    flow.getExecutableNode("jobC").setConditionOnJobStatus(null);
+    InteractiveTestJob.getTestJob("jobA").failJob();
+    assertStatus(flow, "jobA", Status.FAILED);
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertFlowStatus(flow, Status.FAILED);
+  }
+
   private void setUp(final String flowName, final HashMap<String, String> flowProps)
       throws Exception {
     final String flowYamlFile = flowName + ".flow";

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -22,4 +22,5 @@ nodes:
   - name: jobB
     type: test
     config:
+      fail: false
       seconds: 2


### PR DESCRIPTION
By default, conditionOnJobStatus is set to ALL_SUCCESS. But it could cause potential issues for some old execution flows that don't have conditionOnJobStatus defined in the flow object when finalizing the flows. 
See https://github.com/azkaban/azkaban/pull/1868. This fix adds additional safety guard to the original fix.