### PR TITLE
Conditional workflow - Cancel remaining jobs before flow is finalized.

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -40,6 +40,7 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
   private static final String CONDITIONAL_FLOW_4 = "conditional_flow4";
   private static final String CONDITIONAL_FLOW_5 = "conditional_flow5";
   private static final String CONDITIONAL_FLOW_6 = "conditional_flow6";
+  private static final String CONDITIONAL_FLOW_7 = "conditional_flow7";
   private FlowRunnerTestUtil testUtil;
   private Project project;
 
@@ -145,6 +146,19 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     assertStatus(flow, "jobB", Status.SUCCEEDED);
     assertStatus(flow, "jobC", Status.CANCELLED);
     assertFlowStatus(flow, Status.FAILED);
+  }
+
+  @Test
+  public void runFlowOnJobStatusOneFailedCancelRemainingJobs() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_7, flowProps);
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    InteractiveTestJob.getTestJob("jobA").failJob();
+    assertStatus(flow, "jobA", Status.FAILED);
+    assertStatus(flow, "jobD", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.KILLED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
   }
 
   private void setUp(final String flowName, final HashMap<String, String> flowProps)

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow7.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow7.flow
@@ -1,0 +1,32 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobD
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: one_failed
+
+    dependsOn:
+      - jobA
+      - jobC
+
+  - name: jobA
+    type: test
+    config:
+      seconds: 2
+
+  - name: jobB
+    type: test
+    config:
+      seconds: 10
+
+  - name: jobC
+    type: test
+    config:
+      seconds: 10
+    dependsOn:
+      - jobB


### PR DESCRIPTION
For conditional workflows, if conditionOnJobStatus is ONE_SUCCESS or ONE_FAILED, some jobs might still be running or not started yet when the end nodes have finished. In this case, we need to cancel all the remaining jobs before finalizing the flow.  

