### PR TITLE
add past executions for failed flow in failure email

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -16,8 +16,8 @@
 
 package azkaban.executor;
 
-import azkaban.db.EncodingType;
 import azkaban.db.DatabaseOperator;
+import azkaban.db.EncodingType;
 import azkaban.db.SQLTransaction;
 import azkaban.utils.GZIPUtils;
 import azkaban.utils.JSONUtils;
@@ -108,9 +108,24 @@ public class ExecutionFlowDao {
     }
   }
 
+  /**
+   * fetch flow execution history with specified {@code projectId}, {@code flowId} and flow start
+   * time >= {@code startTime}
+   *
+   * @return the list of flows meeting the specified criteria
+   */
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId, final
+  long startTime) throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_BY_START_TIME,
+          new FetchExecutableFlows(), projectId, flowId, startTime);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching historic flows", e);
+    }
+  }
+
   List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
-      final int skip, final int num,
-      final Status status)
+      final int skip, final int num, final Status status)
       throws ExecutorManagerException {
     try {
       return this.dbOperator.query(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_BY_STATUS,
@@ -267,6 +282,9 @@ public class ExecutionFlowDao {
   public static class FetchExecutableFlows implements
       ResultSetHandler<List<ExecutableFlow>> {
 
+    static String FETCH_EXECUTABLE_FLOW_BY_START_TIME =
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef WHERE project_id=? "
+            + "AND flow_id=? AND start_time >= ? ORDER BY start_time DESC";
     static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
         "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef";
     static String FETCH_EXECUTABLE_FLOW =

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -52,6 +52,9 @@ public interface ExecutorLoader {
       String flowContains, String userNameContains, int status, long startData,
       long endData, int skip, int num) throws ExecutorManagerException;
 
+  List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+      final long startTime) throws ExecutorManagerException;
+
   /**
    * <pre>
    * Fetch all executors from executors table

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -20,12 +20,12 @@ import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class JdbcExecutorLoader implements ExecutorLoader {
@@ -122,6 +122,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
       final int skip, final int num) throws ExecutorManagerException {
     return this.executionFlowDao.fetchFlowHistory(projectId, flowId, skip, num);
+  }
+
+  @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+      final long startTime) throws ExecutorManagerException {
+    return this.executionFlowDao.fetchFlowHistory(projectId, flowId, startTime);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/DefaultMailCreator.java
@@ -137,9 +137,9 @@ public class DefaultMailCreator implements MailCreator {
   }
 
   @Override
-  public boolean createErrorEmail(final ExecutableFlow flow, final EmailMessage message,
-      final String azkabanName, final String scheme, final String clientHostname,
-      final String clientPortNumber, final String... vars) {
+  public boolean createErrorEmail(final ExecutableFlow flow, final List<ExecutableFlow>
+      pastExecutions, final EmailMessage message, final String azkabanName, final String scheme,
+      final String clientHostname, final String clientPortNumber, final String... vars) {
 
     final ExecutionOptions option = flow.getExecutionOptions();
 
@@ -185,6 +185,30 @@ public class DefaultMailCreator implements MailCreator {
       }
 
       message.println("</ul>");
+
+      message.println("");
+
+      int failedCount = 0;
+      for (final ExecutableFlow executableFlow : pastExecutions) {
+        if (executableFlow.getStatus().equals(Status.FAILED)) {
+          failedCount++;
+        }
+      }
+
+      message.println(String.format("<h3>Executions from past 72 hours (%s out %s) failed</h3>",
+          failedCount, pastExecutions.size()));
+      for (final ExecutableFlow executableFlow : pastExecutions) {
+        message.println("<table>");
+        message.println(
+            "<tr><td>Execution Id</td><td>" + (executableFlow.getExecutionId()) + "</td></tr>");
+        message.println("<tr><td>Start Time</td><td>"
+            + convertMSToString(executableFlow.getStartTime()) + "</td></tr>");
+        message.println("<tr><td>End Time</td><td>"
+            + convertMSToString(executableFlow.getEndTime()) + "</td></tr>");
+        message.println("<tr><td>Status</td><td>" + flow.getStatus() + "</td></tr>");
+        message.println("</table>");
+      }
+
       return true;
     }
     return false;

--- a/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
@@ -18,6 +18,7 @@ package azkaban.executor.mail;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.utils.EmailMessage;
+import java.util.List;
 
 public interface MailCreator {
 
@@ -25,8 +26,8 @@ public interface MailCreator {
       EmailMessage message, String azkabanName, String scheme,
       String clientHostname, String clientPortNumber, String... vars);
 
-  public boolean createErrorEmail(ExecutableFlow flow, EmailMessage message,
-      String azkabanName, String scheme, String clientHostname,
+  public boolean createErrorEmail(ExecutableFlow flow, List<ExecutableFlow> pastExecutions,
+      EmailMessage message, String azkabanName, String scheme, String clientHostname,
       String clientPortNumber, String... vars);
 
   public boolean createSuccessEmail(ExecutableFlow flow, EmailMessage message,

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -206,7 +206,7 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
       final long startTime) throws ExecutorManagerException {
-    return null;
+    return new ArrayList<>();
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -204,6 +204,12 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
+      final long startTime) throws ExecutorManagerException {
+    return null;
+  }
+
+  @Override
   public List<ExecutableJobInfo> fetchJobHistory(final int projectId, final String jobId,
       final int skip, final int size) throws ExecutorManagerException {
     // TODO Auto-generated method stub

--- a/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
@@ -15,6 +15,8 @@ import azkaban.utils.EmailMessage;
 import azkaban.utils.EmailMessageCreator;
 import azkaban.utils.TestUtils;
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TimeZone;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
@@ -93,9 +95,10 @@ public class DefaultMailCreatorTest {
     setJobStatus(Status.FAILED);
     this.executableFlow.setEndTime(END_TIME_MILLIS);
     this.executableFlow.setStatus(Status.FAILED);
+    final List<ExecutableFlow> executableFlows = new ArrayList<>();
     assertTrue(this.mailCreator.createErrorEmail(
-        this.executableFlow, this.message, this.azkabanName, this.scheme, this.clientHostname,
-        this.clientPortNumber));
+        this.executableFlow, executableFlows, this.message, this.azkabanName, this.scheme, this
+            .clientHostname, this.clientPortNumber));
     assertEquals("Flow 'mail-creator-test' has failed on unit-tests", this.message.getSubject());
     assertThat(TestUtils.readResource("errorEmail.html", this))
         .isEqualToIgnoringWhitespace(this.message.getBody());

--- a/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
@@ -96,6 +96,21 @@ public class DefaultMailCreatorTest {
     this.executableFlow.setEndTime(END_TIME_MILLIS);
     this.executableFlow.setStatus(Status.FAILED);
     final List<ExecutableFlow> executableFlows = new ArrayList<>();
+
+    final ExecutableFlow executableFlow1 = new ExecutableFlow(this.project, this.flow);
+    executableFlow1.setExecutionId(1);
+    executableFlow1.setStartTime(START_TIME_MILLIS);
+    executableFlow1.setEndTime(END_TIME_MILLIS);
+    executableFlow1.setStatus(Status.FAILED);
+    executableFlows.add(executableFlow1);
+
+    final ExecutableFlow executableFlow2 = new ExecutableFlow(this.project, this.flow);
+    executableFlow2.setExecutionId(2);
+    executableFlow2.setStartTime(START_TIME_MILLIS);
+    executableFlow2.setEndTime(END_TIME_MILLIS);
+    executableFlow2.setStatus(Status.SUCCEEDED);
+    executableFlows.add(executableFlow2);
+
     assertTrue(this.mailCreator.createErrorEmail(
         this.executableFlow, executableFlows, this.message, this.azkabanName, this.scheme, this
             .clientHostname, this.clientPortNumber));

--- a/azkaban-common/src/test/resources/azkaban/executor/mail/errorEmail.html
+++ b/azkaban-common/src/test/resources/azkaban/executor/mail/errorEmail.html
@@ -22,4 +22,40 @@
 <ul>
   <li><a href="http://localhost:8081/executor?execid=-1&job=test-job">Failed job 'test-job' Link</a>
   </li>
-</ul>
+</ul><h3>Executions from past 72 hours (1 out 2) failed</h3>
+<table>
+  <tr>
+    <td>Execution Id</td>
+    <td>1</td>
+  </tr>
+  <tr>
+    <td>Start Time</td>
+    <td>2016/07/17 11:54:11 EEST</td>
+  </tr>
+  <tr>
+    <td>End Time</td>
+    <td>2016/07/17 11:54:16 EEST</td>
+  </tr>
+  <tr>
+    <td>Status</td>
+    <td>FAILED</td>
+  </tr>
+</table>
+<table>
+  <tr>
+    <td>Execution Id</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>Start Time</td>
+    <td>2016/07/17 11:54:11 EEST</td>
+  </tr>
+  <tr>
+    <td>End Time</td>
+    <td>2016/07/17 11:54:16 EEST</td>
+  </tr>
+  <tr>
+    <td>Status</td>
+    <td>FAILED</td>
+  </tr>
+</table>

--- a/azkaban-common/src/test/resources/azkaban/utils/errorEmail2.html
+++ b/azkaban-common/src/test/resources/azkaban/utils/errorEmail2.html
@@ -18,4 +18,4 @@
     <td>READY</td>
   </tr>
 </table><a href="http://localhost:8786/executor?execid=-1">jobe Execution Link</a><h3>Reason</h3>
-<ul></ul>
+<ul></ul><h3>Executions from past 72 hours (0 out 0) failed</h3>

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -23,7 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManager;
+import azkaban.executor.MockExecutorLoader;
 import azkaban.flow.Flow;
 import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
 import azkaban.metrics.CommonMetrics;
@@ -66,6 +68,7 @@ public class TriggerInstanceProcessorTest {
   private CountDownLatch sendEmailLatch;
   private CountDownLatch submitFlowLatch;
   private CountDownLatch updateExecIDLatch;
+  private ExecutorLoader executorLoader;
 
   private static TriggerInstance createTriggerInstance() throws ParseException {
     final FlowTrigger flowTrigger = new FlowTrigger(
@@ -103,10 +106,11 @@ public class TriggerInstanceProcessorTest {
     this.messageCreator = EmailerTest.mockMessageCreator(this.message);
     this.triggerInstLoader = mock(FlowTriggerInstanceLoader.class);
     this.executorManager = mock(ExecutorManager.class);
+    this.executorLoader = new MockExecutorLoader();
     when(this.executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");
     final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
     this.emailer = Mockito.spy(new Emailer(EmailerTest.createMailProperties(), commonMetrics,
-        this.messageCreator));
+        this.messageCreator, this.executorLoader));
 
     this.sendEmailLatch = new CountDownLatch(1);
     doAnswer(invocation -> {


### PR DESCRIPTION
This PR adds following information to the failure email template:
overall failed execution among last 72 hours' execution(e.x 3/25 failed)
past 72 hours execution tables(status, start/end time).

The motivation is to capture people's attention if the flow has been failing too many times recently.

Eg:
![image](https://user-images.githubusercontent.com/1428327/43347499-614d6318-91aa-11e8-863f-6926de886fab.png)


