### PR TITLE
Conditional workflow - condition on job props for embedded flows.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -48,6 +48,7 @@ public class ExecutableNode {
   public static final String CONDITION_ON_JOB_STATUS_PARAM = "conditionOnJobStatus";
   public static final String PROPS_SOURCE_PARAM = "propSource";
   public static final String JOB_SOURCE_PARAM = "jobSource";
+  public static final String JOB_PROPS_TEMP_FILE_PATH_PARAM = "jobPropsTempFilePath";
   public static final String OUTPUT_PROPS_PARAM = "outputProps";
   public static final String ATTEMPT_PARAM = "attempt";
   public static final String PASTATTEMPTS_PARAM = "pastAttempts";
@@ -63,6 +64,8 @@ public class ExecutableNode {
   private String jobSource;
   // Path to top level props file
   private String propsSource;
+  // Path to job props temp file
+  private String jobPropsTempFilePath;
   private Set<String> inNodes = new HashSet<>();
   private Set<String> outNodes = new HashSet<>();
   private Props inputProps;
@@ -198,12 +201,24 @@ public class ExecutableNode {
     return this.propsSource != null;
   }
 
+  public boolean hasJobPropsTempFilePath() {
+    return this.jobPropsTempFilePath != null;
+  }
+
   public String getJobSource() {
     return this.jobSource;
   }
 
   public String getPropsSource() {
     return this.propsSource;
+  }
+
+  public String getjobPropsTempFilePath() {
+    return this.jobPropsTempFilePath;
+  }
+
+  public void setjobPropsTempFilePath(final String jobPropsTempFilePath) {
+    this.jobPropsTempFilePath = jobPropsTempFilePath;
   }
 
   public Props getInputProps() {
@@ -313,6 +328,10 @@ public class ExecutableNode {
       objMap.put(JOB_SOURCE_PARAM, this.jobSource);
     }
 
+    if (hasJobPropsTempFilePath()) {
+      objMap.put(JOB_PROPS_TEMP_FILE_PATH_PARAM, this.jobPropsTempFilePath);
+    }
+
     if (this.outputProps != null && this.outputProps.size() > 0) {
       objMap.put(OUTPUT_PROPS_PARAM, PropsUtils.toStringMap(this.outputProps, true));
     }
@@ -350,6 +369,7 @@ public class ExecutableNode {
 
     this.propsSource = wrappedMap.getString(PROPS_SOURCE_PARAM);
     this.jobSource = wrappedMap.getString(JOB_SOURCE_PARAM);
+    this.jobPropsTempFilePath = wrappedMap.getString(JOB_PROPS_TEMP_FILE_PATH_PARAM);
 
     final Map<String, String> outputProps =
         wrappedMap.<String, String>getMap(OUTPUT_PROPS_PARAM);

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
@@ -80,6 +80,7 @@ public abstract class AbstractProcessJob extends AbstractJob {
     return tempFile;
   }
 
+  @Override
   public Props getJobProps() {
     return this.jobProps;
   }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/Job.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/Job.java
@@ -25,17 +25,20 @@ import azkaban.utils.Props;
  *
  * A job is required to have a constructor Job(String jobId, Props props)
  */
-
 public interface Job {
 
   /**
    * Returns a unique(should be checked in xml) string name/id for the Job.
+   *
+   * @return the id
    */
   public String getId();
 
   /**
    * Run the job. In general this method can only be run once. Must either succeed or throw an
    * exception.
+   *
+   * @throws Exception the exception
    */
   public void run() throws Exception;
 
@@ -49,17 +52,31 @@ public interface Job {
   /**
    * Returns a progress report between [0 - 1.0] to indicate the percentage complete
    *
+   * @return the progress
    * @throws Exception If getting progress fails
    */
   public double getProgress() throws Exception;
 
   /**
    * Get the generated properties from this job.
+   *
+   * @return the job generated properties
    */
   public Props getJobGeneratedProperties();
 
   /**
+   * Gets job props.
+   *
+   * @return the job props
+   */
+  public default Props getJobProps() {
+    return new Props();
+  }
+
+  /**
    * Determine if the job was cancelled.
+   *
+   * @return the boolean
    */
   public boolean isCanceled();
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -16,6 +16,9 @@
 
 package azkaban.execapp;
 
+import static azkaban.jobExecutor.AbstractProcessJob.ENV_PREFIX;
+import static azkaban.jobExecutor.AbstractProcessJob.JOB_PROP_ENV;
+
 import azkaban.Constants;
 import azkaban.Constants.JobProperties;
 import azkaban.event.Event;
@@ -108,7 +111,7 @@ public class JobRunner extends EventHandler implements Runnable {
     this.loader = loader;
     this.jobtypeManager = jobtypeManager;
     this.azkabanProps = azkabanProps;
-    final String jobLogLayout = props.getString(
+    final String jobLogLayout = this.props.getString(
         JobProperties.JOB_LOG_LAYOUT, DEFAULT_LAYOUT);
 
     this.loggerLayout = new EnhancedPatternLayout(jobLogLayout);
@@ -804,6 +807,7 @@ public class JobRunner extends EventHandler implements Runnable {
 
     if (this.job != null) {
       this.node.setOutputProps(this.job.getJobGeneratedProperties());
+      this.node.setjobPropsTempFilePath(this.job.getJobProps().get(ENV_PREFIX + JOB_PROP_ENV));
     }
 
     synchronized (this.syncObject) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -40,6 +40,8 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
   private static final String CONDITIONAL_FLOW_4 = "conditional_flow4";
   private static final String CONDITIONAL_FLOW_5 = "conditional_flow5";
   private static final String CONDITIONAL_FLOW_6 = "conditional_flow6";
+  private static final String CONDITIONAL_FLOW_EMBEDDED1 = "conditional_flow_embedded1";
+  private static final String CONDITIONAL_FLOW_EMBEDDED2 = "conditional_flow_embedded2";
   private FlowRunnerTestUtil testUtil;
   private Project project;
 
@@ -145,6 +147,36 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     assertStatus(flow, "jobB", Status.SUCCEEDED);
     assertStatus(flow, "jobC", Status.CANCELLED);
     assertFlowStatus(flow, Status.FAILED);
+  }
+
+  @Test
+  public void runEmbeddedFlowOnJobPropsCondition() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    flowProps.put("azkaban.server.name", "foo");
+    setUp(CONDITIONAL_FLOW_EMBEDDED1, flowProps);
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow:jobB", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow:jobC", Status.SUCCEEDED);
+    assertStatus(flow, "jobD", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
+  @Test
+  public void runEmbeddedFlowOnJobPropsCondition2() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_EMBEDDED2, flowProps);
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow:jobB", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow:jobC", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow2", Status.KILLED);
+    assertStatus(flow, "embedded_flow2:jobB", Status.SUCCEEDED);
+    assertStatus(flow, "embedded_flow2:jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.CANCELLED);
+    assertFlowStatus(flow, Status.KILLED);
   }
 
   private void setUp(final String flowName, final HashMap<String, String> flowProps)

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow_embedded1.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow_embedded1.flow
@@ -1,0 +1,39 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobD
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ${jobA:azkaban.server.name} == 'foo'
+    dependsOn:
+      - embedded_flow
+
+  - name: embedded_flow
+    type: flow
+    condition: ${jobA:azkaban.server.name} == 'foo'
+    dependsOn:
+      - jobA
+    nodes:
+      - name: jobB
+        type: test
+        config:
+          fail: false
+          seconds: 0
+
+      - name: jobC
+        type: test
+        config:
+          fail: false
+          seconds: 0
+        dependsOn:
+          - jobB
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow_embedded2.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow_embedded2.flow
@@ -1,0 +1,61 @@
+---
+config:
+  flow-level-parameter: value
+
+nodes:
+  - name: jobD
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    dependsOn:
+      - embedded_flow
+      - embedded_flow2
+
+  - name: embedded_flow
+    type: flow
+    dependsOn:
+      - jobA
+    nodes:
+      - name: jobB
+        type: test
+        config:
+          fail: false
+          seconds: 0
+          props1: value1
+
+      - name: jobC
+        type: test
+        config:
+          fail: false
+          seconds: 0
+        dependsOn:
+          - jobB
+        condition: ${jobB:props1} == 'value1'
+
+  - name: embedded_flow2
+    type: flow
+    dependsOn:
+      - jobA
+    nodes:
+      - name: jobB
+        type: test
+        config:
+          fail: false
+          seconds: 0
+          props1: value2
+
+      - name: jobC
+        type: test
+        config:
+          fail: false
+          seconds: 0
+        dependsOn:
+          - jobB
+        condition: ${jobB:props1} == 'value1'
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0


### PR DESCRIPTION
Jobs in an embedded flow can only define conditions on jobs within the same embedded flow. To distinguish the job props files with the same job name prefix between different embedded flows and the parent flows, I added a new field in the ExecutableNode to store that job props file path so that each ExecutableNode can be associated with a unique job props file. 
To achieve that, I also added a default method `getJopProps()` in the `Job` interface. Since it's default, it will not break other classes which implement this `Job` interface.
See conditional workflow design #1826 for more details.