### PR TITLE
Fix flow log CSS

### DIFF
--- a/azkaban-web-server/src/main/less/base.less
+++ b/azkaban-web-server/src/main/less/base.less
@@ -30,6 +30,12 @@ div#graphView.container-fill {
   height: 750px;
 }
 
+div#flowLogView.container-fill {
+  position: relative;
+  top: 0px;
+  height: 750px;
+}
+
 .alert-default {
   color: #a0a0a0;
   background-color: #f5f5f5;


### PR DESCRIPTION
The Flow Log positioning was broken, as you can see here:

<img width="1013" alt="nayttokuva 2018-8-4 kello 10 20 51" src="https://user-images.githubusercontent.com/4446608/43673735-8478f128-97d0-11e8-8405-cb8aa1878953.png">

This happens if the bar above (the one that has `Submit User`, `Duration` etc.) spans to multiple rows. Even one of them is enough to cause overflowing positioning, but the screenshot above demonstrates an extreme case where the tab is barely visible any more.

As a quick fix, I copied the same rules that are set for `div#graphView.container-fill` (you can find it right above the changed lines).

Screenshot after fix:

<img width="1012" alt="nayttokuva 2018-8-4 kello 10 23 11" src="https://user-images.githubusercontent.com/4446608/43673759-efead908-97d0-11e8-837b-fabf1bfa2873.png">

As you can see, the fix sets a fixed height to the log textbox, and as the screenshot shows it gets cut off if the window size is not as high. There must be a way to make the position relative properly.. If that is found, why not apply that better rule also for `div#graphView.container-fill`?