### PR TITLE
Move python related gitignore configs to the root level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,13 @@ temp/
 out/
 
 currentpid
+
+# direnv files see https://github.com/direnv/direnv
+.envrc
+.direnv/
+
+# pytest
+.pytest_cache/
+
+#python
+__pycache__/

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,9 +1,0 @@
-# direnv files see https://github.com/direnv/direnv
-.envrc
-.direnv/
-
-# pytest
-.pytest_cache/
-
-#python
-__pycache__/


### PR DESCRIPTION
This is done to set up the python virtual environment at the root level
instead of the tools/ level.

This virtual environment will be shared by multiple submodules e.g.
tools and docs.