### PR TITLE
Remove dead code in BasicTimeChecker

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -181,9 +181,6 @@ public class BasicTimeChecker implements ConditionChecker {
         date = date.plus(this.period);
       }
       count += 1;
-      if (!this.skipPastChecks) {
-        continue;
-      }
     }
     return date.getMillis();
   }


### PR DESCRIPTION
Having `continue` as the last statement of a loop doesn't change anything.

----

I just happened to notice this, as I was trying to understand the meaning of `skipPastChecks` in this class.