### PR TITLE
when loading project dir metadata into memory, create the project size file if it doesn't exist

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -82,7 +82,7 @@ public class FlowPreparer {
       FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), PROJECT_DIR_SIZE_FILE_NAME),
           sizeInByte);
     } catch (final IOException e) {
-      log.error(e);
+      log.error("error when dumping number to file", e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -68,6 +68,23 @@ public class FlowPreparer {
 
   }
 
+  /**
+   * Creates a file which keeps the size of {@param dir} in bytes inside the {@param dir} and sets
+   * the dirSize for {@param pv}.
+   *
+   * @param dir the directory whose size needs to be kept in the file to be created.
+   * @param pv the projectVersion whose size needs to updated.
+   */
+  static void updateDirSize(final File dir, final ProjectVersion pv) {
+    final long sizeInByte = FileUtils.sizeOfDirectory(dir);
+    pv.setDirSizeInBytes(sizeInByte);
+    try {
+      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), PROJECT_DIR_SIZE_FILE_NAME),
+          sizeInByte);
+    } catch (final IOException e) {
+      log.error(e);
+    }
+  }
 
   /**
    * Prepare the flow directory for execution.
@@ -177,24 +194,6 @@ public class FlowPreparer {
       }
       // Clean up: Remove tempDir if exists
       FileUtils.deleteDirectory(tempDir);
-    }
-  }
-
-  /**
-   * Creates a file which keeps the size of {@param dir} in bytes inside the {@param dir} and sets
-   * the dirSize for {@param pv}.
-   *
-   * @param dir the directory whose size needs to be kept in the file to be created.
-   * @param pv the projectVersion whose size needs to updated.
-   */
-  private void updateDirSize(final File dir, final ProjectVersion pv) {
-    final long sizeInByte = FileUtils.sizeOfDirectory(dir);
-    pv.setDirSizeInBytes(sizeInByte);
-    try {
-      FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), PROJECT_DIR_SIZE_FILE_NAME),
-          sizeInByte);
-    } catch (final IOException e) {
-      log.error(e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -82,7 +82,7 @@ public class FlowPreparer {
       FileIOUtils.dumpNumberToFile(Paths.get(dir.getPath(), PROJECT_DIR_SIZE_FILE_NAME),
           sizeInByte);
     } catch (final IOException e) {
-      log.error("error when dumping number to file", e);
+      log.error("error when dumping dir size to file", e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -299,17 +299,17 @@ public class FlowRunnerManager implements EventListener,
           final String fileName = project.getFileName().toString();
           final int projectId = Integer.parseInt(fileName.split("\\.")[0]);
           final int versionNum = Integer.parseInt(fileName.split("\\.")[1]);
-          final ProjectVersion version =
+          final ProjectVersion projVersion =
               new ProjectVersion(projectId, versionNum, project.toFile());
           final Path projectDirSizeFile = Paths
-              .get(version.getInstalledDir().toString(), FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME);
-          if (Files.exists(projectDirSizeFile)) {
-            version.setDirSizeInBytes(FileIOUtils.readNumberFromFile(projectDirSizeFile));
-          } else {
-            FlowPreparer.updateDirSize(version.getInstalledDir(), version);
+              .get(projVersion.getInstalledDir().toString(),
+                  FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME);
+          if (!Files.exists(projectDirSizeFile)) {
+            FlowPreparer.updateDirSize(projVersion.getInstalledDir(), projVersion);
           }
 
-          allProjects.put(new Pair<>(projectId, versionNum), version);
+          projVersion.setDirSizeInBytes(FileIOUtils.readNumberFromFile(projectDirSizeFile));
+          allProjects.put(new Pair<>(projectId, versionNum), projVersion);
         } catch (final Exception e) {
           logger.error("error while loading project dir metadata", e);
         }


### PR DESCRIPTION
the method updateDirSize is already verified by FlowPreparerTest#testSetupProject, so unit test is not needed.  