### PR TITLE
Conditional workflow - Apply security restriction on arbitrary code in the condition

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -59,6 +59,9 @@ import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
@@ -130,6 +133,17 @@ public class AzkabanExecutorServer {
     StdOutErrRedirect.redirectOutAndErrToLog();
 
     logger.info("Starting Jetty Azkaban Executor...");
+
+    if (System.getSecurityManager() == null) {
+      Policy.setPolicy(new Policy() {
+        @Override
+        public boolean implies(final ProtectionDomain domain, final Permission permission) {
+          return true; // allow all
+        }
+      });
+      System.setSecurityManager(new SecurityManager());
+    }
+
     final Props props = AzkabanServer.loadProps(args);
 
     if (props == null) {

--- a/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
+++ b/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
@@ -31,6 +31,9 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import java.io.File;
 import java.io.IOException;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.ProtectionDomain;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -52,6 +55,16 @@ public class AzkabanSingleServer {
 
   public static void main(String[] args) throws Exception {
     log.info("Starting Azkaban Server");
+
+    if (System.getSecurityManager() == null) {
+      Policy.setPolicy(new Policy() {
+        @Override
+        public boolean implies(final ProtectionDomain domain, final Permission permission) {
+          return true; // allow all
+        }
+      });
+      System.setSecurityManager(new SecurityManager());
+    }
 
     if (args.length == 0) {
       args = prepareDefaultConf();

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow7.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow7.flow
@@ -1,0 +1,17 @@
+nodes:
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+
+    condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var f = new File('new'); f.createNewFile(); }
+
+    dependsOn:
+      - jobA
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0


### PR DESCRIPTION
In conditional workflow design, we use scriptEngine to evaluate the condition provided by users. To prevent users from injecting malicious code inside the condition, we need to restrict the permissions like creating a new file or overwriting an existing one, or calling any system method.  
`AccessController.doPrivileged` can be used to reduce the permissions. Also `SecurityManager` needs to be enabled so that the access control will take effect.
Apart from this PR, we will also work on another PR to whitelist the syntax allowed for a valid condition.

Reference: https://wiki.sei.cmu.edu/confluence/display/java/IDS52-J.+Prevent+code+injection