### PR TITLE
check if project is removed while uploading

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1671,6 +1671,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final User user = session.getUser();
     final String projectName = (String) multipart.get("project");
     final Project project = this.projectManager.getProject(projectName);
+    if (project.isActive() == false) {
+      registerError(ret, "Installation Failed. Project '" + project.getName()
+          + "' was alreaady removed.", resp, 410);
+      return;
+    }
     logger.info(
         "Upload: reference of project " + projectName + " is " + System.identityHashCode(project));
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1673,7 +1673,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final Project project = this.projectManager.getProject(projectName);
     if (project.isActive() == false) {
       registerError(ret, "Installation Failed. Project '" + project.getName()
-          + "' was alreaady removed.", resp, 410);
+          + "' was already removed.", resp, 410);
       return;
     }
     logger.info(

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1671,7 +1671,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final User user = session.getUser();
     final String projectName = (String) multipart.get("project");
     final Project project = this.projectManager.getProject(projectName);
-    if (project.isActive() == false) {
+    if (!project.isActive()) {
       registerError(ret, "Installation Failed. Project '" + project.getName()
           + "' was already removed.", resp, 410);
       return;

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -77,6 +77,12 @@ public class ProjectManagerResource extends ResourceContextHolder {
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, errorMsg);
     }
 
+    if (!project.isActive()) {
+      final String errorMsg =
+          "Installation Failed. Project '" + projectName + "' was already removed.";
+      throw new RestLiServiceException(HttpStatus.S_410_GONE, errorMsg);
+    }
+
     if (!ResourceUtils.hasPermission(project, user, Permission.Type.WRITE)) {
       final String errorMsg =
           "User " + user.getUserId()


### PR DESCRIPTION
We found that upload API doesn't return an error when a deleted project zip is uploaded. 

When a project is deleted, Azkaban just marks it to be inactive today. In this PR, we fix this issue by adding the check. 410 Gone client error response code indicates that access to the target resource is no longer available at the origin server and that this condition is likely to be permanent.