### PR TITLE
Conditional workflow - Validate conditions

### DIFF
--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -23,6 +23,7 @@ import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -43,6 +44,7 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String DEPENDENCY_UNDEFINED_YAML_DIR = "dependencyundefinedyamltest";
   private static final String INVALID_JOBPROPS_YAML_DIR = "invalidjobpropsyamltest";
   private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
+  private static final String INVALID_CONDITION_YAML_DIR = "invalidconditionalflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
   private static final String EMBEDDED_FLOW = "embedded_flow";
@@ -166,6 +168,23 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(NO_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 0, 0);
+  }
+
+  @Test
+  public void testFlowYamlFileWithInvalidConditions() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(INVALID_CONDITION_YAML_DIR));
+    checkFlowLoaderProperties(loader, 5, 5, 5);
+    Assert.assertTrue(
+        loader.getErrors().contains("Invalid condition for jobB: jobC doesn't exist in the flow."));
+    Assert.assertTrue(loader.getErrors().contains(
+        "Invalid condition for jobA: should not define condition on its descendant node jobD."));
+    Assert.assertTrue(
+        loader.getErrors().contains("Invalid condition for jobB: operand is an empty string."));
+    Assert.assertTrue(loader.getErrors().contains(
+        "Invalid condition for jobB: cannot resolve the condition. Please check the syntax for supported conditions."));
+    Assert.assertTrue(loader.getErrors().contains(
+        "Invalid condition for jobB: cannot combine more than one conditionOnJobStatus macros."));
   }
 
   private void checkFlowLoaderProperties(final DirectoryYamlFlowLoader loader, final int numError,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -20,6 +20,7 @@ import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_HOST_NAME;
 import static azkaban.execapp.ConditionalWorkflowUtils.FAILED;
 import static azkaban.execapp.ConditionalWorkflowUtils.PENDING;
 import static azkaban.execapp.ConditionalWorkflowUtils.checkConditionOnJobStatus;
+import static azkaban.project.DirectoryYamlFlowLoader.CONDITION_VARIABLE_REPLACEMENT_PATTERN;
 
 import azkaban.Constants;
 import azkaban.Constants.JobProperties;
@@ -78,7 +79,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -97,9 +97,6 @@ public class FlowRunner extends EventHandler implements Runnable {
 
   private static final Layout DEFAULT_LAYOUT = new PatternLayout(
       "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
-  // Pattern to match job variables in condition expressions: ${jobName:variable}
-  private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
-      .compile("\\$\\{([^:{}]+):([^:{}]+)\\}");
   // We check update every 5 minutes, just in case things get stuck. But for the
   // most part, we'll be idling.
   private static final long CHECK_WAIT_MS = 5 * 60 * 1000;
@@ -936,7 +933,7 @@ public class FlowRunner extends EventHandler implements Runnable {
       return true;
     }
 
-    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(condition);
+    final Matcher matcher = CONDITION_VARIABLE_REPLACEMENT_PATTERN.matcher(condition);
     String replaced = condition;
 
     while (matcher.find()) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -33,6 +33,7 @@ import java.security.ProtectionDomain;
 import java.util.HashMap;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
@@ -162,6 +163,16 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     assertFlowStatus(flow, Status.FAILED);
   }
 
+  /**
+   * JobB has defined "condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var
+   * f = new File('new'); f.createNewFile(); }"
+   * Null ProtectionDomain will restrict this arbitrary code from creating a new file.
+   * However it will not kick in when the change for condition whitelisting is implemented.
+   * As a result, this test case will be ignored.
+   *
+   * @throws Exception the exception
+   */
+  @Ignore
   @Test
   public void runFlowOnArbitraryCondition() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();

--- a/test/execution-test-data/invalidconditionalflowyamltest/condition_on_descendant.flow
+++ b/test/execution-test-data/invalidconditionalflowyamltest/condition_on_descendant.flow
@@ -1,0 +1,30 @@
+nodes:
+  - name: jobD
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    dependsOn:
+      - jobB
+      - jobC
+
+  - name: jobC
+    type: test
+    config:
+      fail: false
+      seconds: 0
+
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    dependsOn:
+      - jobA
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ${jobD:param} == 'foo'

--- a/test/execution-test-data/invalidconditionalflowyamltest/conditional_flow.project
+++ b/test/execution-test-data/invalidconditionalflowyamltest/conditional_flow.project
@@ -1,0 +1,1 @@
+azkaban-flow-version: 2.0

--- a/test/execution-test-data/invalidconditionalflowyamltest/empty_operand.flow
+++ b/test/execution-test-data/invalidconditionalflowyamltest/empty_operand.flow
@@ -4,8 +4,7 @@ nodes:
     config:
       fail: false
       seconds: 0
-
-    condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var f = new File('new'); f.createNewFile(); }
+    condition: ${jobA:param} != 'foo' || !() > 1
 
     dependsOn:
       - jobA

--- a/test/execution-test-data/invalidconditionalflowyamltest/invalid_variable_substitution.flow
+++ b/test/execution-test-data/invalidconditionalflowyamltest/invalid_variable_substitution.flow
@@ -1,0 +1,16 @@
+nodes:
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ($<jobA:param> == 'foo' || ${jobA:param.{param2}}) && !one_success && print("hello!")
+
+    dependsOn:
+      - jobA
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0

--- a/test/execution-test-data/invalidconditionalflowyamltest/job_not_exist.flow
+++ b/test/execution-test-data/invalidconditionalflowyamltest/job_not_exist.flow
@@ -1,0 +1,16 @@
+nodes:
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+    condition: ${jobC:param} == 'foo'
+
+    dependsOn:
+      - jobA
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0

--- a/test/execution-test-data/invalidconditionalflowyamltest/multiple_condition_on_job_status_macros.flow
+++ b/test/execution-test-data/invalidconditionalflowyamltest/multiple_condition_on_job_status_macros.flow
@@ -1,0 +1,17 @@
+nodes:
+  - name: jobB
+    type: test
+    config:
+      fail: false
+      seconds: 0
+
+    condition: one_success && all_success || all_failed
+
+    dependsOn:
+      - jobA
+
+  - name: jobA
+    type: test
+    config:
+      fail: false
+      seconds: 0


### PR DESCRIPTION
For security concerns, we want to whitelist only valid conditions for a project during uploading project zip step.
A valid condition expression should only contain the operators &&, ||, ==, !=, >, >=, <, <= and below operands:
1. conditionOnJobStatus macros. e.g., one_success, all_done
2. variable substitution. e.g., ${jobA:param}. The job name should be valid. A job is not allowed to define the condition on its descendant jobs.
3. number or a string.e.g., 1234, "hello", 'foo'