### PR TITLE
Fix flaky test and remove sleep time in FlowRunnerYamlTest.

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerYamlTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerYamlTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.Status;
 import azkaban.project.Project;
 import azkaban.test.executions.ExecutionsTestUtil;
@@ -27,7 +28,7 @@ import java.io.File;
 import java.util.HashMap;
 import org.junit.Test;
 
-public class FlowRunnerTestYaml extends FlowRunnerTestBase {
+public class FlowRunnerYamlTest extends FlowRunnerTestBase {
 
   private static final String BASIC_FLOW_YAML_DIR = "basicflowwithoutendnode";
   private static final String FAIL_BASIC_FLOW_YAML_DIR = "failbasicflowwithoutendnode";
@@ -47,10 +48,9 @@ public class FlowRunnerTestYaml extends FlowRunnerTestBase {
     this.runner = this.testUtil.createFromFlowMap(BASIC_FLOW_NAME, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     FlowRunnerTestUtil.startThread(this.runner);
-    assertFlowStatus(flow, Status.RUNNING);
     assertStatus("jobA", Status.SUCCEEDED);
     assertStatus("jobB", Status.SUCCEEDED);
-    assertFlowStatus(flow, Status.RUNNING);
+    InteractiveTestJob.getTestJob("jobC").succeedJob();
     assertStatus("jobC", Status.SUCCEEDED);
     assertFlowStatus(flow, Status.SUCCEEDED);
   }
@@ -62,7 +62,6 @@ public class FlowRunnerTestYaml extends FlowRunnerTestBase {
     this.runner = this.testUtil.createFromFlowMap(BASIC_FLOW_NAME, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     FlowRunnerTestUtil.startThread(this.runner);
-    assertFlowStatus(flow, Status.RUNNING);
     assertStatus("jobA", Status.SUCCEEDED);
     assertStatus("jobB", Status.SUCCEEDED);
     this.runner.kill();
@@ -77,9 +76,11 @@ public class FlowRunnerTestYaml extends FlowRunnerTestBase {
     this.runner = this.testUtil.createFromFlowMap(FAIL_BASIC_FLOW_NAME, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     FlowRunnerTestUtil.startThread(this.runner);
-    assertFlowStatus(flow, Status.FAILED_FINISHING);
+    InteractiveTestJob.getTestJob("jobC").failJob();
     assertStatus("jobC", Status.FAILED);
+    InteractiveTestJob.getTestJob("jobB").succeedJob();
     assertStatus("jobB", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("jobA").succeedJob();
     assertStatus("jobA", Status.SUCCEEDED);
     assertStatus("jobD", Status.CANCELLED);
     assertFlowStatus(flow, Status.FAILED);
@@ -92,13 +93,10 @@ public class FlowRunnerTestYaml extends FlowRunnerTestBase {
     this.runner = this.testUtil.createFromFlowMap(EMBEDDED_FLOW_NAME, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     FlowRunnerTestUtil.startThread(this.runner);
-    assertFlowStatus(flow, Status.RUNNING);
     assertStatus("jobA", Status.SUCCEEDED);
     assertStatus("embedded_flow1:jobB", Status.SUCCEEDED);
-    assertFlowStatus(flow, Status.RUNNING);
     assertStatus("embedded_flow1:jobC", Status.SUCCEEDED);
     assertStatus("embedded_flow1", Status.SUCCEEDED);
-    assertFlowStatus(flow, Status.RUNNING);
     assertStatus("jobD", Status.SUCCEEDED);
     assertFlowStatus(flow, Status.SUCCEEDED);
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerYamlTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerYamlTest.java
@@ -50,6 +50,7 @@ public class FlowRunnerYamlTest extends FlowRunnerTestBase {
     FlowRunnerTestUtil.startThread(this.runner);
     assertStatus("jobA", Status.SUCCEEDED);
     assertStatus("jobB", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.RUNNING);
     InteractiveTestJob.getTestJob("jobC").succeedJob();
     assertStatus("jobC", Status.SUCCEEDED);
     assertFlowStatus(flow, Status.SUCCEEDED);

--- a/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
+++ b/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
@@ -17,5 +17,3 @@ nodes:
 
   - name: jobC
     type: test
-    config:
-      seconds: 0

--- a/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
+++ b/test/execution-test-data/basicflowwithoutendnode/basic_flow.flow
@@ -18,5 +18,4 @@ nodes:
   - name: jobC
     type: test
     config:
-      seconds: 2
-      fail: false
+      seconds: 0

--- a/test/execution-test-data/embeddedflowwithoutendnode/embedded_flow.flow
+++ b/test/execution-test-data/embeddedflowwithoutendnode/embedded_flow.flow
@@ -20,7 +20,7 @@ nodes:
       - name: jobC
         type: test
         config:
-          seconds: 1
+          seconds: 0
           fail: false
         dependsOn:
           - jobB
@@ -28,7 +28,7 @@ nodes:
   - name: jobD
     type: test
     config:
-      seconds: 1
+      seconds: 0
       fail: false
     dependsOn:
       - embedded_flow1

--- a/test/execution-test-data/failbasicflowwithoutendnode/fail_basic_flow.flow
+++ b/test/execution-test-data/failbasicflowwithoutendnode/fail_basic_flow.flow
@@ -14,17 +14,14 @@ nodes:
   - name: jobA
     type: test
     config:
-      seconds: 1
-      fail: false
+      seconds: 0
 
   - name: jobB
     type: test
     config:
-      seconds: 1
-      fail: false
+      seconds: 0
 
   - name: jobC
     type: test
     config:
-      seconds: 1
-      fail: true
+      seconds: 0

--- a/test/execution-test-data/failbasicflowwithoutendnode/fail_basic_flow.flow
+++ b/test/execution-test-data/failbasicflowwithoutendnode/fail_basic_flow.flow
@@ -13,15 +13,9 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      seconds: 0
 
   - name: jobB
     type: test
-    config:
-      seconds: 0
 
   - name: jobC
     type: test
-    config:
-      seconds: 0


### PR DESCRIPTION
1. Fix the flaky test #testKillBasicFlowWithoutEndNode.
2. Reduce the sleep time to 0 in the test cases.
3. Rename FlowRunnerTestYaml to FlowRunnerYamlTest.

See more discussions in https://github.com/azkaban/azkaban/issues/1921