### PR TITLE
Conditional workflow - modify conditionOnJobStatus macros.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/ConditionOnJobStatus.java
+++ b/azkaban-common/src/main/java/azkaban/flow/ConditionOnJobStatus.java
@@ -20,9 +20,7 @@ public enum ConditionOnJobStatus {
   ALL_FAILED("all_failed"),
   ALL_DONE("all_done"),
   ONE_FAILED("one_failed"),
-  ONE_SUCCESS("one_success"),
-  ONE_FAILED_ALL_DONE("one_failed_all_done"),
-  ONE_SUCCESS_ALL_DONE("one_success_all_done");
+  ONE_SUCCESS("one_success");
 
   private final String condition;
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ConditionalWorkflowUtils.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ConditionalWorkflowUtils.java
@@ -18,9 +18,7 @@ package azkaban.execapp;
 import static azkaban.flow.ConditionOnJobStatus.ALL_FAILED;
 import static azkaban.flow.ConditionOnJobStatus.ALL_SUCCESS;
 import static azkaban.flow.ConditionOnJobStatus.ONE_FAILED;
-import static azkaban.flow.ConditionOnJobStatus.ONE_FAILED_ALL_DONE;
 import static azkaban.flow.ConditionOnJobStatus.ONE_SUCCESS;
-import static azkaban.flow.ConditionOnJobStatus.ONE_SUCCESS_ALL_DONE;
 
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.Status;
@@ -42,9 +40,6 @@ public class ConditionalWorkflowUtils {
       case ONE_FAILED:
       case ONE_SUCCESS:
         return checkOneStatus(node, conditionOnJobStatus);
-      case ONE_FAILED_ALL_DONE:
-      case ONE_SUCCESS_ALL_DONE:
-        return checkOneStatusAllDone(node, conditionOnJobStatus);
       default:
         return checkAllStatus(node, ALL_SUCCESS);
     }
@@ -68,30 +63,14 @@ public class ConditionalWorkflowUtils {
 
   private static String checkOneStatus(final ExecutableNode node, final ConditionOnJobStatus
       condition) {
-    boolean finished = true;
-    for (final String dependency : node.getInNodes()) {
-      final ExecutableNode dependencyNode = node.getParentFlow().getExecutableNode(dependency);
-      final Status depStatus = dependencyNode.getStatus();
-      if ((condition.equals(ONE_SUCCESS) && Status.isStatusSucceeded(depStatus)) ||
-          (condition.equals(ONE_FAILED) && Status.isStatusFailed(depStatus))) {
-        return SATISFIED;
-      } else if (!Status.isStatusFinished(depStatus)) {
-        finished = false;
-      }
-    }
-    return finished ? FAILED : PENDING;
-  }
-
-  private static String checkOneStatusAllDone(final ExecutableNode node, final ConditionOnJobStatus
-      condition) {
     String result = FAILED;
     for (final String dependency : node.getInNodes()) {
       final ExecutableNode dependencyNode = node.getParentFlow().getExecutableNode(dependency);
       final Status depStatus = dependencyNode.getStatus();
       if (!Status.isStatusFinished(depStatus)) {
         return PENDING;
-      } else if ((condition.equals(ONE_SUCCESS_ALL_DONE) && Status.isStatusSucceeded(depStatus)) ||
-          (condition.equals(ONE_FAILED_ALL_DONE) && Status.isStatusFailed(depStatus))) {
+      } else if ((condition.equals(ONE_SUCCESS) && Status.isStatusSucceeded(depStatus)) ||
+          (condition.equals(ONE_FAILED) && Status.isStatusFailed(depStatus))) {
         result = SATISFIED;
       }
     }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -95,18 +95,6 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void runFlowOnJobStatusOneFailed() throws Exception {
-    final HashMap<String, String> flowProps = new HashMap<>();
-    setUp(CONDITIONAL_FLOW_3, flowProps);
-    final ExecutableFlow flow = this.runner.getExecutableFlow();
-    InteractiveTestJob.getTestJob("jobA").failJob();
-    assertStatus(flow, "jobA", Status.FAILED);
-    assertStatus(flow, "jobB", Status.RUNNING);
-    assertStatus(flow, "jobC", Status.SUCCEEDED);
-    assertFlowStatus(flow, Status.SUCCEEDED);
-  }
-
-  @Test
   public void runFlowOnJobStatusAllFailed() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     setUp(CONDITIONAL_FLOW_4, flowProps);
@@ -122,7 +110,7 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void runFlowOnJobStatusOneSuccessAllDone() throws Exception {
+  public void runFlowOnJobStatusOneSuccess() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     setUp(CONDITIONAL_FLOW_5, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow2.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow2.flow
@@ -16,8 +16,6 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      seconds: 0
 
   - name: jobB
     type: test

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -17,10 +17,10 @@ nodes:
   - name: jobA
     type: test
     config:
-      seconds: 2
+      seconds: 0
 
   - name: jobB
     type: test
     config:
       fail: false
-      seconds: 2
+      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -16,8 +16,6 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      seconds: 0
 
   - name: jobB
     type: test

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
@@ -17,9 +17,9 @@ nodes:
   - name: jobA
     type: test
     config:
-      seconds: 2
+      seconds: 0
 
   - name: jobB
     type: test
     config:
-      seconds: 2
+      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow4.flow
@@ -16,10 +16,6 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      seconds: 0
 
   - name: jobB
     type: test
-    config:
-      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
@@ -16,10 +16,6 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      seconds: 0
 
   - name: jobB
     type: test
-    config:
-      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow5.flow
@@ -8,7 +8,7 @@ nodes:
     config:
       fail: false
       seconds: 0
-    condition: one_success_all_done
+    condition: one_success
 
     dependsOn:
       - jobA
@@ -17,9 +17,9 @@ nodes:
   - name: jobA
     type: test
     config:
-      seconds: 2
+      seconds: 0
 
   - name: jobB
     type: test
     config:
-      seconds: 2
+      seconds: 0


### PR DESCRIPTION
Based on some users' feedback, the definition of `one_success` needs to be modified to: 
At least one parent job has succeeded and all the parent jobs have finished. 
They don't want their jobs to be canceled when the flow finally finishes. So we modify the definition to satisfy most common use cases. If needed in the future, we can add the support back for `one_success_cancel_rest `or name it differently.

Conditional workflow design: https://github.com/azkaban/azkaban/issues/1826