### PR TITLE
add serialVersionUID for serializable flow trigger classes

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
+++ b/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  */
 public class CronSchedule implements Serializable {
 
+  private static final long serialVersionUID = -1330280892166841227L;
   private final String cronExpression;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/project/FlowTrigger.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowTrigger.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang.StringUtils;
  */
 public class FlowTrigger implements Serializable {
 
+  private static final long serialVersionUID = 5613379236523054097L;
   private final Map<String, FlowTriggerDependency> dependencies;
   private final CronSchedule schedule;
   private final Duration maxWaitDuration;

--- a/azkaban-common/src/main/java/azkaban/project/FlowTriggerDependency.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowTriggerDependency.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
  */
 public class FlowTriggerDependency implements Serializable {
 
+  private static final long serialVersionUID = 5875910030716100311L;
   private final Map<String, String> props;
   private final String name;
   private final String type;


### PR DESCRIPTION
Flow trigger classes will be serialized and persisted in quartz tables and deserialized back. 
If serialVersionUID is not defined specifically, JVM would generate a default id in runtime which is dependent on compiler implementation, and and can thus result in unexpected  nvalidClassExceptions during deserialization if new deployment has different serialVersionUID from old deployment which has been persisted in db. 

Why choose those numbers(-1330280892166841227L ...)?
To be backward compatible since those are the serialVersionUID of first deployment of flow trigger classes and already have been persisted in database.

