### PR TITLE
fix PR 1797, a UI bug

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -114,7 +114,7 @@ azkaban.ExecutionsView = Backbone.View.extend({
   initialize: function (settings) {
     this.model.bind('change:view', this.handleChangeView, this);
     this.model.bind('render', this.render, this);
-    this.model.set({page: 1, pageSize: this.pageSize});
+    this.model.set({page: 1, pageSize: this.model.get("pageSize")});
     this.model.bind('change:page', this.handlePageChange, this);
   },
 
@@ -302,6 +302,7 @@ azkaban.ExecutionsView = Backbone.View.extend({
   handlePageChange: function (evt) {
     var page = this.model.get("page") - 1;
     var pageSize = this.model.get("pageSize");
+    console.log("pageSize = " + pageSize)
     var content = this.model.get("content");
     if (content == 'flow') {
       requestURL = contextURL + "/manager";


### PR DESCRIPTION
Found a UI bug in #1797  , when we deploy latest master to our staging cluster. The observation of this bug is all execution history table is missing, like:
￼
![image](https://user-images.githubusercontent.com/2895882/44872892-8d6c2680-ac4b-11e8-97cf-2989818ba6e6.png)

The cause looks like a javascript or backbone grammar issue.

The fix quite simple.