### PR TITLE
add "size" parameter during initializing a new page.

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -295,6 +295,8 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("utils", utils);
     page.add("timezone", TimeZone.getDefault().getID());
     page.add("currentTime", (new DateTime()).getMillis());
+    page.add("size", getDisplayExecutionPageSize());
+    
     if (session != null && session.getUser() != null) {
       page.add("user_id", session.getUser().getUserId());
     }
@@ -344,6 +346,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("timezone", TimeZone.getDefault().getID());
     page.add("currentTime", (new DateTime()).getMillis());
     page.add("context", req.getContextPath());
+    page.add("size", getDisplayExecutionPageSize());
 
     // @TODO, allow more than one type of viewer. For time sake, I only install
     // the first one

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -114,7 +114,8 @@ azkaban.ExecutionsView = Backbone.View.extend({
   initialize: function (settings) {
     this.model.bind('change:view', this.handleChangeView, this);
     this.model.bind('render', this.render, this);
-    this.model.set({page: 1, pageSize: this.model.get("pageSize")});
+    console.log("during initialization, pageSize: " + pageSize);
+    this.model.set({page: 1, pageSize: pageSize});
     this.model.bind('change:page', this.handlePageChange, this);
   },
 


### PR DESCRIPTION
#1797 introduced a bug that executions history cannot be displayed in `executions` tab give every project, like:

![image](https://user-images.githubusercontent.com/2895882/45010108-90a34180-afc0-11e8-8866-4b82f0890fae.png)

The issue is that javascript cannot find ${size}. The resolution is simple that we should add "size" to the context so that javascript is able to locate it.

After the change:

![image](https://user-images.githubusercontent.com/2895882/45010184-ff809a80-afc0-11e8-88a6-29e266ed3cd3.png)

Tested in the staging server.