### PR TITLE
Allow more dispatch retries

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -109,7 +109,7 @@ public class ExecutorManager extends EventHandler implements
   private Map<String, Integer> comparatorWeightsMap;
   private long lastSuccessfulExecutorInfoRefresh;
   private ExecutorService executorInforRefresherService;
-  private long sleepAfterDispatchFailureMillis = 1000L;
+  private Duration sleepAfterDispatchFailure = Duration.ofSeconds(1L);
 
   @Inject
   public ExecutorManager(final Props azkProps, final ExecutorLoader executorLoader,
@@ -222,7 +222,7 @@ public class ExecutorManager extends EventHandler implements
             this.azkProps.getInt(
                 Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED,
                 this.activeExecutors.getAll().size()),
-            this.sleepAfterDispatchFailureMillis);
+            this.sleepAfterDispatchFailure);
   }
 
   /**
@@ -1327,7 +1327,7 @@ public class ExecutorManager extends EventHandler implements
     private final int maxDispatchingErrors;
     private final long activeExecutorRefreshWindowInMillisec;
     private final int activeExecutorRefreshWindowInFlows;
-    private final long sleepAfterDispatchFailureMillis;
+    private final Duration sleepAfterDispatchFailure;
 
     private volatile boolean shutdown = false;
     private volatile boolean isActive = true;
@@ -1336,14 +1336,14 @@ public class ExecutorManager extends EventHandler implements
         final long activeExecutorRefreshWindowInTime,
         final int activeExecutorRefreshWindowInFlows,
         final int maxDispatchingErrors,
-        final long sleepAfterDispatchFailureMillis) {
+        final Duration sleepAfterDispatchFailure) {
       setActive(isActive);
       this.maxDispatchingErrors = maxDispatchingErrors;
       this.activeExecutorRefreshWindowInFlows =
           activeExecutorRefreshWindowInFlows;
       this.activeExecutorRefreshWindowInMillisec =
           activeExecutorRefreshWindowInTime;
-      this.sleepAfterDispatchFailureMillis = sleepAfterDispatchFailureMillis;
+      this.sleepAfterDispatchFailure = sleepAfterDispatchFailure;
       this.setName("AzkabanWebServer-QueueProcessor-Thread");
     }
 
@@ -1493,7 +1493,7 @@ public class ExecutorManager extends EventHandler implements
 
     private void sleepAfterDispatchFailure() {
       try {
-        Thread.sleep(this.sleepAfterDispatchFailureMillis);
+        Thread.sleep(this.sleepAfterDispatchFailure.toMillis());
       } catch (final InterruptedException e1) {
         ExecutorManager.logger.warn("Sleep after dispatch failure was interrupted - ignoring");
       }
@@ -1579,7 +1579,7 @@ public class ExecutorManager extends EventHandler implements
   }
 
   @VisibleForTesting
-  void setSleepAfterDispatchFailureMillis(long sleepAfterDispatchFailureMillis) {
-    this.sleepAfterDispatchFailureMillis = sleepAfterDispatchFailureMillis;
+  void setSleepAfterDispatchFailure(Duration sleepAfterDispatchFailure) {
+    this.sleepAfterDispatchFailure = sleepAfterDispatchFailure;
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -36,6 +36,7 @@ import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -161,7 +162,7 @@ public class ExecutorManagerTest {
     final ExecutorManager executorManager = new ExecutorManager(this.props, this.loader,
         this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
         this.updaterStage, executionFinalizer, updaterThread);
-    executorManager.setSleepAfterDispatchFailureMillis(0L);
+    executorManager.setSleepAfterDispatchFailure(Duration.ZERO);
     return executorManager;
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
@@ -154,12 +155,14 @@ public class ExecutorManagerTest {
     final RunningExecutionsUpdaterThread updaterThread = new RunningExecutionsUpdaterThread(
         new RunningExecutionsUpdater(
             this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-            this.runningExecutions, executionFinalizer), runningExecutions);
+            this.runningExecutions, executionFinalizer), this.runningExecutions);
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
-    return new ExecutorManager(this.props, this.loader, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, activeExecutors, this.updaterStage, executionFinalizer,
-        updaterThread);
+    final ExecutorManager executorManager = new ExecutorManager(this.props, this.loader,
+        this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
+        this.updaterStage, executionFinalizer, updaterThread);
+    executorManager.setSleepAfterDispatchFailureMillis(0L);
+    return executorManager;
   }
 
   /*
@@ -311,7 +314,7 @@ public class ExecutorManagerTest {
     testSetUpForRunningFlows();
     this.manager.start();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
+    doReturn(flow1).when(this.loader).fetchExecutableFlow(-1);
     mockFlowDoesNotExist();
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
         .thenThrow(new ExecutorManagerException("Mocked dispatch exception"))
@@ -346,7 +349,9 @@ public class ExecutorManagerTest {
         .callWithExecutable(flow1, this.manager.fetchExecutor(2), ConnectorParams.EXECUTE_ACTION);
     verify(this.loader, Mockito.times(2)).unassignExecutor(-1);
     verify(this.mailAlerter).alertOnError(eq(flow1),
-        eq("Failed to dispatch because reached azkaban.maxDispatchingErrors (tried 2 executors)"));
+        eq("Failed to dispatch queued execution derived-member-data because reached "
+            + "azkaban.maxDispatchingErrors (tried 2 executors)"),
+        contains("Mocked dispatch exception"));
   }
 
   private void mockFlowDoesNotExist() throws Exception {
@@ -445,6 +450,43 @@ public class ExecutorManagerTest {
         activeExecutorServerHosts.contains(executor1.getHost() + ":" + executor1.getPort()));
     Assert.assertTrue(
         activeExecutorServerHosts.contains(executor2.getHost() + ":" + executor2.getPort()));
+  }
+
+  /**
+   * ExecutorManager should try to dispatch to all executors until it succeeds.
+   */
+  @Test
+  public void testDispatchMultipleRetries() throws Exception {
+    this.props.put(Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED, 4);
+    testSetUpForRunningFlows();
+    this.manager.start();
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    flow1.getExecutionOptions().setFailureEmails(Arrays.asList("test@example.com"));
+    when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
+
+    // fail 2 first dispatch attempts, then succeed
+    when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
+        .thenThrow(new ExecutorManagerException("Mocked dispatch exception 1"))
+        .thenThrow(new ExecutorManagerException("Mocked dispatch exception 2"))
+        .thenReturn(null);
+
+    // this is just to clean up the execution as FAILED after it has been submitted
+    mockFlowDoesNotExist();
+
+    this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    waitFlowFinished(flow1);
+
+    // it's random which executor is chosen each time, but both should have been tried at least once
+    verify(this.apiGateway, Mockito.atLeast(1))
+        .callWithExecutable(flow1, this.manager.fetchExecutor(1), ConnectorParams.EXECUTE_ACTION);
+    verify(this.apiGateway, Mockito.atLeast(1))
+        .callWithExecutable(flow1, this.manager.fetchExecutor(2), ConnectorParams.EXECUTE_ACTION);
+
+    // verify that there was a 3rd (successful) dispatch call
+    verify(this.apiGateway, Mockito.times(3))
+        .callWithExecutable(eq(flow1), any(), eq(ConnectorParams.EXECUTE_ACTION));
+
+    verify(this.loader, Mockito.times(2)).unassignExecutor(-1);
   }
 
   /*


### PR DESCRIPTION
Allow more dispatch attempts than number of active executors.

The configuration key `azkaban.maxDispatchingErrors` is thus respected without an upper cap.

Normally azkaban-web shouldn't ever fail dispatching executions to executors as long as there are active executors available. This change allows configuring a limit that is in practice high enough to keep retrying forever, until at least one responsive executor appears.

----

NOTE: The handling of dispatch errors should be improved to distinguish between retriable & non-retriable errors.

The dispatch call itself is simple: it contains the execution id and username. I can't imagine a case where the request would be syntactically invalid/incompatible with the executor.

However, If executor returns a response with "error" in it, the dispatch on ExecutorManager currently fails the dispatch, and keeps retrying until the give up condition is met. It shouldn't be like this in all cases.

For example:
- if the error is about "already running" (on that executor), ExecutorManager should treat that as a successful dispatch (even though it may be that this can't ever happen in practice).
   - Actually for this case I think executor shouldn't even return an error response.
- If the error reason is that the execution is not found in the DB when executor tries to load it (how could that happen though..?), ExecutorManager should just give up dispatching.
- And so on.

Any way, cleaning up Azkaban DB manually from problematic executions like mentioned above can be left for the responsibility of the admin, if the admin chooses to configure a non-default value for maxDispatchingErrors. This PR doesn't have to deal with handling different dispatch error cases. It can be handled later.

But this is how I'd plan to do it:
- If response is connection error -> keep retrying
- If response is received but status is not HTTP 200 OK -> keep retrying
- If response is "already running on this executor" -> treat as a success (implement this so that executor doesn't return an error in the first place)
- If response is received with any other error -> give up after receiving this kind of error from all active executors

----

Additional note on retrying after dispatch failure with "is already running":

I'm afraid that this can happen with the current azkaban code (remains to be verified though):
- azkaban-web tries to dispatch execution 123 to executor 1
- azkaban-web crashes / is killed
- executor 1 has started the execution 123 and it's running
- azkaban-web starts again
- azkaban-web fetches the queued executions from the DB
- azkaban-web tries to dispatch execution 123 to the assigned executor 1
- executor 1 returns an error
- azkaban-web rolls back executor assignment of execution 123
- azkaban-web dispaches execution 123 to executor 2
- execution 123 is running on both executors 1 & 2 at the same time

Also fix is simple: don't return an error if execution is already running on the executor.

However even that fix is not bullet-proof. Azkaban-web could also fail to receive the response of a  dispatch call because of a connection error for example. It would also then automatically try the next executor.. One option would be to have some cooldown period after a failed dispatch attempt and checking from DB if the execution is running before trying to dispatch on another executor? Seems hard to get this right without adding some proper locking though. Whew, I'm happy to realize that in our setup we typically have only 1 active executor at a time.