### PR TITLE
Fix flaky test runFlowOnJobStatusConditionNull_2

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -147,7 +147,9 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     setUp(CONDITIONAL_FLOW_3, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     flow.getExecutableNode("jobC").setConditionOnJobStatus(null);
+    InteractiveTestJob.getTestJob("jobA").succeedJob();
     assertStatus(flow, "jobA", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("jobB").succeedJob();
     assertStatus(flow, "jobB", Status.SUCCEEDED);
     assertStatus(flow, "jobC", Status.SUCCEEDED);
     assertFlowStatus(flow, Status.SUCCEEDED);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -147,11 +147,10 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     setUp(CONDITIONAL_FLOW_3, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
     flow.getExecutableNode("jobC").setConditionOnJobStatus(null);
-    InteractiveTestJob.getTestJob("jobA").failJob();
-    assertStatus(flow, "jobA", Status.FAILED);
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
     assertStatus(flow, "jobB", Status.SUCCEEDED);
-    assertStatus(flow, "jobC", Status.CANCELLED);
-    assertFlowStatus(flow, Status.FAILED);
+    assertStatus(flow, "jobC", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
   }
 
   /**

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -16,12 +16,6 @@ nodes:
 
   - name: jobA
     type: test
-    config:
-      fail: false
-      seconds: 0
 
   - name: jobB
     type: test
-    config:
-      fail: false
-      seconds: 0

--- a/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
+++ b/test/execution-test-data/conditionalflowyamltest/conditional_flow3.flow
@@ -16,6 +16,9 @@ nodes:
 
   - name: jobA
     type: test
+    config:
+      fail: false
+      seconds: 0
 
   - name: jobB
     type: test


### PR DESCRIPTION
The previous fix in #1940 did not cover the case where all the jobs have finished early before the null condition takes effect. 
This fix will make sure the condition of jobC is set to null first and then evaluated.