### PR TITLE
Conditional workflow UI - add condition in job info and flow summary

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -50,6 +50,7 @@ public class Flow {
   private boolean isLayedOut = false;
   private boolean isEmbeddedFlow = false;
   private double azkabanFlowVersion = Constants.DEFAULT_AZKABAN_FLOW_VERSION;
+  private String condition = null;
 
   public Flow(final String id) {
     this.id = id;
@@ -62,6 +63,8 @@ public class Flow {
     final Boolean layedout = (Boolean) flowObject.get("layedout");
     final Boolean isEmbeddedFlow = (Boolean) flowObject.get("embeddedFlow");
     final Double azkabanFlowVersion = (Double) flowObject.get("azkabanFlowVersion");
+    final String condition = (String) flowObject.get("condition");
+
     final Flow flow = new Flow(id);
     if (layedout != null) {
       flow.setLayedOut(layedout);
@@ -73,6 +76,10 @@ public class Flow {
 
     if (azkabanFlowVersion != null) {
       flow.setAzkabanFlowVersion(azkabanFlowVersion);
+    }
+
+    if (condition != null) {
+      flow.setCondition(condition);
     }
 
     final int projId = (Integer) flowObject.get("project.id");
@@ -171,28 +178,28 @@ public class Flow {
         }
       }
 
-      setLevelsAndEdgeNodes(new HashSet<>(startNodes), 0);
+      setLevelsAndEdgeNodes(new HashSet<>(this.startNodes), 0);
     }
   }
 
-  private void setLevelsAndEdgeNodes(final Set<Node> levelNodes, int level) {
+  private void setLevelsAndEdgeNodes(final Set<Node> levelNodes, final int level) {
     final Set<Node> nextLevelNodes = new HashSet<>();
 
-    for (Node node : levelNodes) {
+    for (final Node node : levelNodes) {
       node.setLevel(level);
 
-      final Set<Edge> edges = outEdges.get(node.getId());
+      final Set<Edge> edges = this.outEdges.get(node.getId());
       if (edges != null) {
         edges.forEach(edge -> {
           edge.setSource(node);
-          edge.setTarget(nodes.get(edge.getTargetId()));
+          edge.setTarget(this.nodes.get(edge.getTargetId()));
 
           nextLevelNodes.add(edge.getTarget());
         });
       }
     }
 
-    numLevels = level;
+    this.numLevels = level;
 
     if (!nextLevelNodes.isEmpty()) {
       setLevelsAndEdgeNodes(nextLevelNodes, level + 1);
@@ -339,6 +346,8 @@ public class Flow {
     flowObj.put("layedout", this.isLayedOut);
     flowObj.put("embeddedFlow", this.isEmbeddedFlow);
     flowObj.put("azkabanFlowVersion", this.azkabanFlowVersion);
+    flowObj.put("condition", this.condition);
+
     if (this.errors != null) {
       flowObj.put("errors", this.errors);
     }
@@ -402,6 +411,14 @@ public class Flow {
 
   public void setAzkabanFlowVersion(final double azkabanFlowVersion) {
     this.azkabanFlowVersion = azkabanFlowVersion;
+  }
+
+  public String getCondition() {
+    return this.condition;
+  }
+
+  public void setCondition(final String condition) {
+    this.condition = condition;
   }
 
   public Map<String, Object> getMetadata() {

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -44,6 +44,7 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String DEPENDENCY_UNDEFINED_YAML_DIR = "dependencyundefinedyamltest";
   private static final String INVALID_JOBPROPS_YAML_DIR = "invalidjobpropsyamltest";
   private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
+  private static final String CONDITION_YAML_DIR = "conditionalflowyamltest";
   private static final String INVALID_CONDITION_YAML_DIR = "invalidconditionalflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
@@ -59,6 +60,7 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String EMBEDDED_FLOW_B2 =
       "embedded_flow_b" + Constants.PATH_DELIMITER + "embedded_flow1" + Constants.PATH_DELIMITER
           + "embedded_flow2";
+  private static final String CONDITIONAL_FLOW = "conditional_flow6";
   private static final String DUPLICATE_NODENAME_FLOW_FILE = "duplicate_nodename.flow";
   private static final String DEPENDENCY_UNDEFINED_FLOW_FILE = "dependency_undefined.flow";
   private static final String CYCLE_FOUND_FLOW = "cycle_found";
@@ -168,6 +170,21 @@ public class DirectoryYamlFlowLoaderTest {
     final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(NO_FLOW_YAML_DIR));
     checkFlowLoaderProperties(loader, 0, 0, 0);
+  }
+
+  @Test
+  public void testFlowYamlFileWithValidCondition() {
+    final DirectoryYamlFlowLoader loader = new DirectoryYamlFlowLoader(new Props());
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir(CONDITION_YAML_DIR));
+    assertThat(loader.getFlowMap().containsKey(CONDITIONAL_FLOW)).isTrue();
+    checkFlowProperties(loader, CONDITIONAL_FLOW, 0, 4, 1, 4, null);
+    assertThat(loader.getFlowMap().get(CONDITIONAL_FLOW).getNode("jobA").getCondition()).isNull();
+    assertThat(loader.getFlowMap().get(CONDITIONAL_FLOW).getNode("jobB").getCondition())
+        .isEqualTo("${jobA:props} == 'foo'");
+    assertThat(loader.getFlowMap().get(CONDITIONAL_FLOW).getNode("jobC").getCondition())
+        .isEqualTo("${jobA:props} == 'bar'");
+    assertThat(loader.getFlowMap().get(CONDITIONAL_FLOW).getNode("jobD").getCondition())
+        .isEqualTo("one_success && ${jobA:props} == 'foo'");
   }
 
   @Test

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -923,17 +923,19 @@ public class FlowRunner extends EventHandler implements Runnable {
     String replaced = condition;
     // Replace the condition on job status macro with "true" to skip the evaluation by Script
     // Engine since it has already been evaluated.
-    Matcher matcher = CONDITION_ON_JOB_STATUS_PATTERN.matcher(condition);
-    if (matcher.find()) {
-      replaced = condition.replace(matcher.group(1), "true");
+    final Matcher jobStatusMatcher = CONDITION_ON_JOB_STATUS_PATTERN.matcher
+        (condition);
+    if (jobStatusMatcher.find()) {
+      replaced = condition.replace(jobStatusMatcher.group(1), "true");
     }
 
-    matcher = CONDITION_VARIABLE_REPLACEMENT_PATTERN.matcher(replaced);
+    final Matcher variableMatcher = CONDITION_VARIABLE_REPLACEMENT_PATTERN.matcher(replaced);
 
-    while (matcher.find()) {
-      final String value = findValueForJobVariable(node, matcher.group(1), matcher.group(2));
+    while (variableMatcher.find()) {
+      final String value = findValueForJobVariable(node, variableMatcher.group(1),
+          variableMatcher.group(2));
       if (value != null) {
-        replaced = replaced.replace(matcher.group(), "'" + value + "'");
+        replaced = replaced.replace(variableMatcher.group(), "'" + value + "'");
       }
       this.logger.info("Resolved condition of " + node.getId() + " is " + replaced);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -20,6 +20,7 @@ import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_HOST_NAME;
 import static azkaban.execapp.ConditionalWorkflowUtils.FAILED;
 import static azkaban.execapp.ConditionalWorkflowUtils.PENDING;
 import static azkaban.execapp.ConditionalWorkflowUtils.checkConditionOnJobStatus;
+import static azkaban.project.DirectoryYamlFlowLoader.CONDITION_ON_JOB_STATUS_PATTERN;
 import static azkaban.project.DirectoryYamlFlowLoader.CONDITION_VARIABLE_REPLACEMENT_PATTERN;
 
 import azkaban.Constants;
@@ -878,6 +879,8 @@ public class FlowRunner extends EventHandler implements Runnable {
     // Check if condition on job status is satisfied
     switch (checkConditionOnJobStatus(node)) {
       case FAILED:
+        this.logger.info("Condition on job status: " + node.getConditionOnJobStatus() + " is "
+            + "evaluated to false for " + node.getId());
         status = Status.CANCELLED;
         break;
       // Condition not satisfied yet, need to wait
@@ -887,7 +890,7 @@ public class FlowRunner extends EventHandler implements Runnable {
         break;
     }
 
-    if (!isConditionOnRuntimeVariableMet(node)) {
+    if (status != Status.CANCELLED && !isConditionOnRuntimeVariableMet(node)) {
       status = Status.CANCELLED;
     }
 
@@ -917,15 +920,22 @@ public class FlowRunner extends EventHandler implements Runnable {
       return true;
     }
 
-    final Matcher matcher = CONDITION_VARIABLE_REPLACEMENT_PATTERN.matcher(condition);
     String replaced = condition;
+    // Replace the condition on job status macro with "true" to skip the evaluation by Script
+    // Engine since it has already been evaluated.
+    Matcher matcher = CONDITION_ON_JOB_STATUS_PATTERN.matcher(condition);
+    if (matcher.find()) {
+      replaced = condition.replace(matcher.group(1), "true");
+    }
+
+    matcher = CONDITION_VARIABLE_REPLACEMENT_PATTERN.matcher(replaced);
 
     while (matcher.find()) {
       final String value = findValueForJobVariable(node, matcher.group(1), matcher.group(2));
       if (value != null) {
         replaced = replaced.replace(matcher.group(), "'" + value + "'");
       }
-      this.logger.info("Condition is " + replaced);
+      this.logger.info("Resolved condition of " + node.getId() + " is " + replaced);
     }
 
     // Evaluate string expression using script engine
@@ -971,10 +981,10 @@ public class FlowRunner extends EventHandler implements Runnable {
         result = (boolean) object;
       }
     } catch (final Exception e) {
-      this.logger.error("Failed to evaluate the expression.", e);
+      this.logger.error("Failed to evaluate the condition.", e);
     }
 
-    this.logger.info("Evaluate expression result: " + result);
+    this.logger.info("Condition is evaluated to " + result);
     return result;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -365,15 +365,17 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       throws ServletException {
     final String flowName = getParam(req, "flow");
 
-    Flow flow = null;
     try {
-      flow = project.getFlow(flowName);
+      final Flow flow = project.getFlow(flowName);
       if (flow == null) {
         ret.put("error", "Flow " + flowName + " not found.");
         return;
       }
 
       ret.put("jobTypes", getFlowJobTypes(flow));
+      if (flow.getCondition() != null) {
+        ret.put("condition", flow.getCondition());
+      }
     } catch (final AccessControlException e) {
       ret.put("error", e.getMessage());
     }
@@ -1355,6 +1357,9 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
       page.add("jobid", node.getId());
       page.add("jobtype", node.getType());
+      if (node.getCondition() != null) {
+        page.add("condition", node.getCondition());
+      }
 
       final ArrayList<String> dependencies = new ArrayList<>();
       final Set<Edge> inEdges = flow.getInEdges(node.getId());

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -121,6 +121,19 @@
           <p><strong>Job Type</strong> $jobtype</p>
         </div>
 
+      ## Condition
+
+        <div class="panel panel-default">
+          <div class="panel-heading">Condition</div>
+          <ul class="list-group">
+            #if ($condition)
+              <li class="list-group-item">$condition</li>
+            #else
+              <li class="list-group-item">No Condition</li>
+            #end
+          </ul>
+        </div><!-- /panel -->
+
       ## Dependencies
 
         <div class="panel panel-default">

--- a/azkaban-web-server/src/main/tl/flowsummary.tl
+++ b/azkaban-web-server/src/main/tl/flowsummary.tl
@@ -10,6 +10,14 @@
         <td class="property-key">Job Types Used</td>
         <td>{#jobTypes}{.} {/jobTypes}</td>
       </tr>
+      <tr>
+        <td class="property-key">Condition</td>
+        {?condition}
+          <td>{condition}</td>
+        {:else}
+          <td>none</td>
+        {/condition}
+      </tr>
       </tbody>
     </table>
   </div>

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -363,7 +363,8 @@ azkaban.SummaryView = Backbone.View.extend({
     var successHandler = function (data) {
       console.log(data);
       model.set({
-        'jobTypes': data.jobTypes
+        'jobTypes': data.jobTypes,
+        'condition': data.condition
       });
       model.trigger('render');
     };
@@ -454,6 +455,7 @@ azkaban.SummaryView = Backbone.View.extend({
       projectName: projectName,
       flowName: flowId,
       jobTypes: this.model.get('jobTypes'),
+      condition: this.model.get('condition'),
       schedule: this.model.get('schedule'),
       flowtrigger: this.model.get('flowtrigger'),
     };


### PR DESCRIPTION
Added the UI support for conditional workflow:
1. Added condition in job info page.
2. Added condition in flow summary page.
Previously, the condition was resolved and updated during the validation step. However, in order to show the original condition on UI page, the condition should remain unchanged until the execution time. Also for the condition of an embedded flow to show up on UI, I explicitly added the condition for flow object.
I also improved some logging messages during the evaluation of the condition.

Example-1 Condition defined on job info page: 
![screen shot 2018-09-18 at 3 53 57 pm](https://user-images.githubusercontent.com/23324945/45773778-18638f80-bc00-11e8-9e3c-825e7aaf1f0b.png)

Example-2 No condition defined on job info page: 
![screen shot 2018-09-18 at 3 45 35 pm](https://user-images.githubusercontent.com/23324945/45773780-18638f80-bc00-11e8-9a7c-e809c9db44fb.png)

Example-3 Condition defined on flow summary page: 
![screen shot 2018-09-18 at 3 43 48 pm](https://user-images.githubusercontent.com/23324945/45773782-18638f80-bc00-11e8-9e22-7f6dcf15e4b8.png)

Example-4 No condition defined on flow summary page: 
![screen shot 2018-09-18 at 3 45 51 pm](https://user-images.githubusercontent.com/23324945/45773779-18638f80-bc00-11e8-92f1-87c1aa820cab.png)

Users might need to clear the browser cache to see the new UI change.
Conditional workflow design #1826 