### PR TITLE
Add presto jdbc dependency for reportal module

### DIFF
--- a/az-reportal/build.gradle
+++ b/az-reportal/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compileOnly project(":azkaban-common")
     compileOnly project(":azkaban-hadoop-security-plugin")
     compile project(':az-crypto')
+    compile deps.prestoJdbc
 
     compileOnly deps.bcprov
     compileOnly deps.hadoopCommon

--- a/az-reportal/build.gradle
+++ b/az-reportal/build.gradle
@@ -45,16 +45,6 @@ dependencies {
 distributions {
     main {
         contents {
-            from(jar) {
-                into 'lib'
-            }
-        }
-    }
-}
-
-distributions {
-    main {
-        contents {
             from(configurations.runtime) {
                 into 'lib'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,8 @@ ext.deps = [
         jacksonAnnotation   : 'com.fasterxml.jackson.core:jackson-annotations:2.7.4',
         jacksonDatabind     : 'com.fasterxml.jackson.core:jackson-databind:2.7.4',
         jasypt              : 'org.jasypt:jasypt:1.9.2',
-        jacksonCore         : 'com.fasterxml.jackson.core:jackson-core:2.9.2'
+        jacksonCore         : 'com.fasterxml.jackson.core:jackson-core:2.9.2',
+        prestoJdbc          : 'com.facebook.presto:presto-jdbc:0.157.1'
 ]
 
 subprojects {


### PR DESCRIPTION
Presto jdbc is required by presto reportal jobtype.