### PR TITLE
#1947 wrong 'Host' header in http callbacks deleted.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -260,7 +260,6 @@ public class JobCallbackManager implements EventListener {
     for (final HttpRequestBase httpRequest : httpRequests) {
       httpRequest.addHeader(new BasicHeader("Date", this.gmtDateFormatter
           .format(new Date())));
-      httpRequest.addHeader(new BasicHeader("Host", this.azkabanHostName));
     }
 
   }


### PR DESCRIPTION
Could you please accept this fix of issue #1947?