### PR TITLE
Revert "Add presto jdbc dependency for reportal module (#1959)"

### DIFF
--- a/az-reportal/build.gradle
+++ b/az-reportal/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     compileOnly project(":azkaban-common")
     compileOnly project(":azkaban-hadoop-security-plugin")
     compile project(':az-crypto')
-    compile deps.prestoJdbc
 
     compileOnly deps.bcprov
     compileOnly deps.hadoopCommon
@@ -39,6 +38,16 @@ dependencies {
     }
     compileOnly(deps.pig) {
         transitive = false
+    }
+}
+
+distributions {
+    main {
+        contents {
+            from(jar) {
+                into 'lib'
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,7 @@ ext.deps = [
         jacksonAnnotation   : 'com.fasterxml.jackson.core:jackson-annotations:2.7.4',
         jacksonDatabind     : 'com.fasterxml.jackson.core:jackson-databind:2.7.4',
         jasypt              : 'org.jasypt:jasypt:1.9.2',
-        jacksonCore         : 'com.fasterxml.jackson.core:jackson-core:2.9.2',
-        prestoJdbc          : 'com.facebook.presto:presto-jdbc:0.157.1'
+        jacksonCore         : 'com.fasterxml.jackson.core:jackson-core:2.9.2'
 ]
 
 subprojects {


### PR DESCRIPTION
This reverts commit b70ee970be437eed69db45353b3362efbbd15bf5.

Reportal has to work with internal version of presto JDBC instead of OSS version.