### PR TITLE
Create Md5HasherTest

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/Md5Hasher.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Md5Hasher.java
@@ -31,7 +31,7 @@ public class Md5Hasher {
 
   private static final int BYTE_BUFFER_SIZE = 1024;
 
-  public static MessageDigest getMd5Digest() {
+  private static MessageDigest getMd5Digest() {
     MessageDigest digest = null;
     try {
       digest = MessageDigest.getInstance("MD5");

--- a/azkaban-common/src/test/java/azkaban/utils/Md5HasherTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/Md5HasherTest.java
@@ -1,0 +1,19 @@
+package azkaban.utils;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import org.junit.Test;
+
+public class Md5HasherTest {
+
+  private static final File ZIP_FILE = new File("src/test/resources/sample_flow_01.zip");
+
+  @Test
+  public void md5Hash() throws Exception {
+    assertThat(Md5Hasher.md5Hash(ZIP_FILE), is(new byte[]{
+        -59, -26, 22, -50, -80, -101, -57, -121, -27, 46, -71, -101, -85, -115, 42, -116}));
+  }
+
+}


### PR DESCRIPTION
Just adding a unit test.

----

Reason why I was looking at Md5Hasher is that we're often getting this ERROR right after azkaban-executor startup (it doesn't always happen):

```
2018/10/08 17:33:44.102 +0000 ERROR [ExecutorServlet] [Azkaban] azkaban.project.ProjectManagerException: Md5 Hash failed on retrieval of file
java.lang.RuntimeException: azkaban.project.ProjectManagerException: Md5 Hash failed on retrieval of file
        at azkaban.execapp.FlowPreparer.setup(FlowPreparer.java:117)
        at azkaban.execapp.FlowRunnerManager.submitFlow(FlowRunnerManager.java:369)
        at azkaban.execapp.ExecutorServlet.handleAjaxExecute(ExecutorServlet.java:289)
        at azkaban.execapp.ExecutorServlet.handleRequest(ExecutorServlet.java:136)
        at azkaban.execapp.ExecutorServlet.doPost(ExecutorServlet.java:93)
```

Has anyone else had this problem?

It's probably something wrong in our internal setup though.