### PR TITLE
Demo: Fix email alerts resolve props

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -26,6 +26,7 @@ import azkaban.project.FlowLoaderUtils.DirFilter;
 import azkaban.project.FlowLoaderUtils.SuffixFilter;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.Props;
+import azkaban.utils.PropsUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -323,7 +324,7 @@ public class DirectoryFlowLoader implements FlowLoader {
         final Flow flow = new Flow(base.getId());
         final Props jobProp = this.jobPropsMap.get(base.getId());
 
-        FlowLoaderUtils.addEmailPropsToFlow(flow, jobProp);
+        FlowLoaderUtils.addEmailPropsToFlow(flow, PropsUtils.resolveProps(jobProp));
 
         flow.addAllFlowProperties(this.flowPropsList);
         final Set<String> visitedNodesOnPath = new HashSet<>();

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
@@ -87,7 +87,7 @@ public class DirectoryFlowLoaderTest {
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir("embedded"));
     Assert.assertEquals(0, loader.getErrors().size());
     Assert.assertEquals(2, loader.getFlowMap().size());
-    Assert.assertEquals(0, loader.getPropsList().size());
+    Assert.assertEquals(1, loader.getPropsList().size());
     Assert.assertEquals(9, loader.getJobPropsMap().size());
   }
 

--- a/azkaban-common/src/test/java/azkaban/utils/EmailerTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/EmailerTest.java
@@ -113,7 +113,8 @@ public class EmailerTest {
     final Emailer emailer = new Emailer(this.props, commonMetrics, this.messageCreator,
         this.executorLoader);
     emailer.alertOnError(exFlow);
-    verify(this.message).addAllToAddress(this.receiveAddrList);
+    verify(this.message)
+        .addAllToAddress(Arrays.asList("receive2@domain.com", "receive@domain.com"));
     verify(this.message).setSubject("Flow 'jobe' has failed on azkaban");
     assertThat(TestUtils.readResource("errorEmail2.html", this))
         .isEqualToIgnoringWhitespace(this.message.getBody());
@@ -122,7 +123,6 @@ public class EmailerTest {
   @Test
   public void alertOnFailedUpdate() throws Exception {
     final Flow flow = this.project.getFlow("jobe");
-    flow.addFailureEmails(this.receiveAddrList);
     Assert.assertNotNull(flow);
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
     final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
@@ -132,7 +132,7 @@ public class EmailerTest {
     final List<ExecutableFlow> executions = Arrays.asList(exFlow, exFlow);
     final ExecutorManagerException exception = DefaultMailCreatorTest.createTestStracktrace();
     emailer.alertOnFailedUpdate(executor, executions, exception);
-    verify(this.message).addAllToAddress(this.receiveAddrList);
+    verify(this.message).addAllToAddress(Arrays.asList("receive2@domain.com"));
     verify(this.message)
         .setSubject("Flow status could not be updated from executor1-host on azkaban");
     assertThat(TestUtils.readResource("failedUpdateMessage2.html", this))

--- a/test/execution-test-data/embedded/embedded.properties
+++ b/test/execution-test-data/embedded/embedded.properties
@@ -1,1 +1,2 @@
-failure.emails=receive2@domain.com
+failure_emails=receive2@domain.com
+failure.emails=${failure_emails}

--- a/test/execution-test-data/embedded/embedded.properties
+++ b/test/execution-test-data/embedded/embedded.properties
@@ -1,0 +1,1 @@
+failure.emails=receive2@domain.com


### PR DESCRIPTION
I found a problem in the way how failure.emails etc. are handled. Unfortunately variable placeholders are not resolved.

I had conf like this (simplified):

```properties
failure_emails=receive2@domain.com
failure.emails=${failure_emails}
```

This caused flow-level email alerts to fail, because they were tried to be sent to `${failure_emails}` instead of `receive2@domain.com`. Turns out this is because props are not resolved at all in this case, even though properties are inherited from parent nodes etc.

----

To demonstrate the problem in an easy to reproduce form I did this:

1. Test flow level email options
2. Demonstrate email fix with props resolving

NOTE: this fix alone can't be applied in practice, because job type plugin props & common props added by JobRunner are missing, and which can make the job properties resolving fail in many cases . The full set of props should be resolved in the same way on both sides (web:DirectoryFlowLoader & executor:JobRunner & co.).