### PR TITLE
Fix kill by sla bug

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -838,19 +838,15 @@ public class JobRunner extends EventHandler implements Runnable {
   }
 
   public void killBySLA() {
-    kill();
-
-    // demonstrate kill bug
-    try {
-      Thread.sleep(1000L);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-
-    this.getNode().setKilledBySLA(true);
-
     synchronized (this.syncObject) {
-      // TODO wrapping those calls with this should help
+      kill();
+      // demonstrate that kill bug has been fixed - this doesn't cause a failure any more
+      try {
+        Thread.sleep(1000L);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      this.getNode().setKilledBySLA(true);
     }
 
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -840,15 +840,8 @@ public class JobRunner extends EventHandler implements Runnable {
   public void killBySLA() {
     synchronized (this.syncObject) {
       kill();
-      // demonstrate that kill bug has been fixed - this doesn't cause a failure any more
-      try {
-        Thread.sleep(1000L);
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
       this.getNode().setKilledBySLA(true);
     }
-
   }
 
   public void kill() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -839,7 +839,20 @@ public class JobRunner extends EventHandler implements Runnable {
 
   public void killBySLA() {
     kill();
+
+    // demonstrate kill bug
+    try {
+      Thread.sleep(1000L);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
     this.getNode().setKilledBySLA(true);
+
+    synchronized (this.syncObject) {
+      // TODO wrapping those calls with this should help
+    }
+
   }
 
   public void kill() {


### PR DESCRIPTION
Not only another flaky test fix – this is an actual bugfix.

Split to commits like this:

1. Demonstrate kill by sla bug  …
   - This makes FlowRunnerTest2.testFlowKilledByJobLevelSLA fail every time
1. Fix kill by sla bug with a wrapping sync block
   - This makes FlowRunnerTest2.testFlowKilledByJobLevelSLA pass every time (but it's 1s slower, obviously)
1. Remove extra sleep that was used to reproduce kill by sla bug
   - Keep the fix but remove extra sleep

I expect commits to be squashed when merging this PR :)

## Explanation of the concurrency bug

First of all, `FlowRunner#killBySLA` is the method under test:

https://github.com/azkaban/azkaban/blob/abdf69127d11cb7d0977ec1c246c90653fae9abc/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java#L843-L846

The relevant actions this does is set:
- inside a synchronized block: `this.changeStatus(Status.KILLING);` and `this.killed = true;` 
- without synchronization: `this.killedBySLA = true;`

Then the DAG is processed further.. until the time comes where this should fail the job & its flow:

https://github.com/azkaban/azkaban/blob/abdf69127d11cb7d0977ec1c246c90653fae9abc/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java#L476-L488

However, if this happens too early, before `this.killedBySLA = true;` has propagated, `node.isKilledBySLA()` returns `false` and the flow gets stuck. As you can see from the failed test output below, `joba` is left with `KILLED` status, but its parent flow doesn't get cancelled (`setFlowFailed(node);` is responsible for propagating the failure to the parent flow(s)).

The fix is simple: wrap the actions of `FlowRunner#killBySLA` with a sync block.

## Test runs with this PR's commits

1st commit, demonstrate the bug:
```
git checkout ae8bce3c1af162821ab905e9c4aef09d7848091f
HEAD is now at ae8bce3c Demonstrate kill by sla bug

Run FlowRunnerTest2#testFlowKilledByJobLevelSLA

testJob: joba1 RUNNING
testJob: joba KILLED
ExecutableFlow: jobf RUNNING
ExecutableNode: joba1 RUNNING
ExecutableFlow: jobb CANCELLED
ExecutableNode: jobb:innerFlow READY
ExecutableNode: jobb:innerJobB READY
ExecutableNode: jobb:innerJobA READY
ExecutableNode: jobb:innerJobC READY
ExecutableNode: joba KILLED
ExecutableFlow: jobd CANCELLED
ExecutableNode: jobd:innerJobA READY
ExecutableNode: jobd:innerFlow2 READY
ExecutableNode: jobc CANCELLED
ExecutableNode: jobf READY
ExecutableNode: jobe CANCELLED

java.lang.AssertionError: 
Expected :KILLED
Actual   :RUNNING

at azkaban.execapp.FlowRunnerTestBase.assertFlowStatus(FlowRunnerTestBase.java:125)
	at azkaban.execapp.FlowRunnerTestBase.waitForAndAssertFlowStatus(FlowRunnerTestBase.java:119)
	at azkaban.execapp.FlowRunnerTest2.testFlowKilledByJobLevelSLA(FlowRunnerTest2.java:994)

^ waitForAndAssertFlowStatus(Status.KILLED);

Tests failed: 1 of 1 test - 14 s 470 ms
```

2nd commit - the fix:
```
git checkout 4714f57dbc59555abefd0e809fece83f5ab41896
HEAD is now at 4714f57d Fix kill by sla bug with a wrapping sync block

Run FlowRunnerTest2#testFlowKilledByJobLevelSLA

Tests passed: 1 of 1 test - 2 s 907 ms
```

## Full test logs

1st commit, demonstrate the bug:

```
git checkout ae8bce3c1af162821ab905e9c4aef09d7848091f
HEAD is now at ae8bce3c Demonstrate kill by sla bug

Run FlowRunnerTest2#testFlowKilledByJobLevelSLA

2019/01/11 20:19:57.314 +0200 INFO [main] [DirectoryFlowLoader] Adding test1.properties
2019/01/11 20:19:57.315 +0200 INFO [main] [DirectoryFlowLoader] Adding test2.properties
2019/01/11 20:19:59.077 +0200 INFO [main] [JmxJobMBeanManager] Initializing azkaban.execapp.jmx.JmxJobMBeanManager
2019/01/11 20:19:59.082 +0200 INFO [main] [JobTypeManager] Loading plugin default job types
2019/01/11 20:19:59.181 +0200 INFO [Thread-1] [jobf] Running execid:101 flow:jobf project:1 version:-1
2019/01/11 20:19:59.200 +0200 INFO [FlowRunner-exec-101] [jobf] Updating initial flow directory.
2019/01/11 20:19:59.200 +0200 INFO [FlowRunner-exec-101] [jobf] Fetching job and shared properties.
2019/01/11 20:19:59.202 +0200 INFO [FlowRunner-exec-101] [jobf] Starting flows
2019/01/11 20:19:59.204 +0200 INFO [FlowRunner-exec-101] [jobf] Running flow 'jobf'.
2019/01/11 20:19:59.221 +0200 INFO [FlowRunner-exec-101] [jobf] Configuring Azkaban metrics tracking for jobrunner object
2019/01/11 20:19:59.222 +0200 INFO [FlowRunner-exec-101] [jobf] Submitting job 'joba1' to run.
2019/01/11 20:19:59.224 +0200 INFO [FlowRunner-exec-101] [jobf] Configuring Azkaban metrics tracking for jobrunner object
2019/01/11 20:19:59.224 +0200 INFO [FlowRunner-exec-101] [jobf] Submitting job 'joba' to run.
2019/01/11 20:19:59.225 +0200 INFO [JobRunner-joba1-101] [jobf] Created file appender for job joba1
2019/01/11 20:19:59.225 +0200 INFO [JobRunner-joba1-101] [jobf] Attached file appender for job joba1
2019/01/11 20:19:59.226 +0200 INFO [JobRunner-joba-101] [jobf] Created file appender for job joba
2019/01/11 20:19:59.226 +0200 INFO [JobRunner-joba-101] [jobf] Attached file appender for job joba
2019/01/11 20:19:59.226 +0200 INFO [JobRunner-joba1-101] [jobf] Job Started: joba1
2019/01/11 20:19:59.336 +0200 INFO [JobRunner-joba-101] [jobf] Job Started: joba
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'user.to.proxy'. Replacing with empty string.
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'user.to.proxy'. Replacing with empty string.
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'azkaban.flow.projectlastchangedby'. Replacing with empty string.
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'azkaban.flow.projectlastchangedby'. Replacing with empty string.
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'azkaban.flow.submituser'. Replacing with empty string.
2019/01/11 20:19:59.340 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'azkaban.flow.submituser'. Replacing with empty string.
2019/01/11 20:19:59.417 +0200 INFO [JobRunner-joba-101] [jobf] No attachment file for job joba written.
2019/01/11 20:19:59.418 +0200 INFO [JobRunner-joba-101] [jobf] Job joba finished with status KILLED in 0 seconds
2019/01/11 20:19:59.419 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobb
2019/01/11 20:19:59.419 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobb' due to prior errors.
2019/01/11 20:19:59.420 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobd
2019/01/11 20:19:59.420 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobd' due to prior errors.
2019/01/11 20:19:59.420 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobc
2019/01/11 20:19:59.420 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobc' due to prior errors.
2019/01/11 20:19:59.420 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobe
2019/01/11 20:19:59.421 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobe' due to prior errors.
testJob: joba1 RUNNING
testJob: joba KILLED
ExecutableFlow: jobf RUNNING
ExecutableNode: joba1 RUNNING
ExecutableFlow: jobb CANCELLED
ExecutableNode: jobb:innerFlow READY
ExecutableNode: jobb:innerJobB READY
ExecutableNode: jobb:innerJobA READY
ExecutableNode: jobb:innerJobC READY
ExecutableNode: joba KILLED
ExecutableFlow: jobd CANCELLED
ExecutableNode: jobd:innerJobA READY
ExecutableNode: jobd:innerFlow2 READY
ExecutableNode: jobc CANCELLED
ExecutableNode: jobf READY
ExecutableNode: jobe CANCELLED

java.lang.AssertionError: 
Expected :KILLED
Actual   :RUNNING
 <Click to see difference>


	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at azkaban.execapp.FlowRunnerTestBase.assertFlowStatus(FlowRunnerTestBase.java:125)
	at azkaban.execapp.FlowRunnerTestBase.waitForAndAssertFlowStatus(FlowRunnerTestBase.java:119)
	at azkaban.execapp.FlowRunnerTest2.testFlowKilledByJobLevelSLA(FlowRunnerTest2.java:994)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)


Process finished with exit code 255
```

2nd commit - the fix:
```
git checkout 4714f57dbc59555abefd0e809fece83f5ab41896
HEAD is now at 4714f57d Fix kill by sla bug with a wrapping sync block

Run FlowRunnerTest2#testFlowKilledByJobLevelSLA



2019/01/11 20:23:27.497 +0200 INFO [main] [DirectoryFlowLoader] Adding test1.properties
2019/01/11 20:23:27.498 +0200 INFO [main] [DirectoryFlowLoader] Adding test2.properties
2019/01/11 20:23:28.954 +0200 INFO [main] [JmxJobMBeanManager] Initializing azkaban.execapp.jmx.JmxJobMBeanManager
2019/01/11 20:23:28.960 +0200 INFO [main] [JobTypeManager] Loading plugin default job types
2019/01/11 20:23:29.049 +0200 INFO [Thread-1] [jobf] Running execid:101 flow:jobf project:1 version:-1
2019/01/11 20:23:29.049 +0200 INFO [FlowRunner-exec-101] [jobf] Updating initial flow directory.
2019/01/11 20:23:29.050 +0200 INFO [FlowRunner-exec-101] [jobf] Fetching job and shared properties.
2019/01/11 20:23:29.051 +0200 INFO [FlowRunner-exec-101] [jobf] Starting flows
2019/01/11 20:23:29.053 +0200 INFO [FlowRunner-exec-101] [jobf] Running flow 'jobf'.
2019/01/11 20:23:29.069 +0200 INFO [FlowRunner-exec-101] [jobf] Configuring Azkaban metrics tracking for jobrunner object
2019/01/11 20:23:29.071 +0200 INFO [FlowRunner-exec-101] [jobf] Submitting job 'joba1' to run.
2019/01/11 20:23:29.072 +0200 INFO [FlowRunner-exec-101] [jobf] Configuring Azkaban metrics tracking for jobrunner object
2019/01/11 20:23:29.072 +0200 INFO [FlowRunner-exec-101] [jobf] Submitting job 'joba' to run.
2019/01/11 20:23:29.073 +0200 INFO [JobRunner-joba1-101] [jobf] Created file appender for job joba1
2019/01/11 20:23:29.073 +0200 INFO [JobRunner-joba1-101] [jobf] Attached file appender for job joba1
2019/01/11 20:23:29.073 +0200 INFO [JobRunner-joba-101] [jobf] Created file appender for job joba
2019/01/11 20:23:29.073 +0200 INFO [JobRunner-joba-101] [jobf] Attached file appender for job joba
2019/01/11 20:23:29.074 +0200 INFO [JobRunner-joba1-101] [jobf] Job Started: joba1
2019/01/11 20:23:29.167 +0200 INFO [JobRunner-joba-101] [jobf] Job Started: joba
2019/01/11 20:23:29.173 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'user.to.proxy'. Replacing with empty string.
2019/01/11 20:23:29.173 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'user.to.proxy'. Replacing with empty string.
2019/01/11 20:23:29.173 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'azkaban.flow.projectlastchangedby'. Replacing with empty string.
2019/01/11 20:23:29.173 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'azkaban.flow.projectlastchangedby'. Replacing with empty string.
2019/01/11 20:23:29.174 +0200 WARN [JobRunner-joba1-101] [PropsUtils] Null value in props for key 'azkaban.flow.submituser'. Replacing with empty string.
2019/01/11 20:23:29.174 +0200 WARN [JobRunner-joba-101] [PropsUtils] Null value in props for key 'azkaban.flow.submituser'. Replacing with empty string.
2019/01/11 20:23:30.245 +0200 INFO [JobRunner-joba-101] [jobf] No attachment file for job joba written.
2019/01/11 20:23:30.245 +0200 INFO [JobRunner-joba-101] [jobf] Job joba finished with status KILLED in 1 seconds
2019/01/11 20:23:30.246 +0200 INFO [FlowRunner-exec-101] [jobf] Setting jobf to KILLED
2019/01/11 20:23:30.246 +0200 INFO [FlowRunner-exec-101] [jobf] Kill has been called on flow 101
2019/01/11 20:23:30.246 +0200 INFO [FlowRunner-exec-101] [jobf] Killing 1 jobs.
2019/01/11 20:23:30.246 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobd
2019/01/11 20:23:30.246 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobd' due to prior errors.
2019/01/11 20:23:30.247 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobc
2019/01/11 20:23:30.247 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobc' due to prior errors.
2019/01/11 20:23:30.247 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobb
2019/01/11 20:23:30.247 +0200 INFO [JobRunner-joba1-101] [jobf] No attachment file for job joba1 written.
2019/01/11 20:23:30.247 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobb' due to prior errors.
2019/01/11 20:23:30.247 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobe
2019/01/11 20:23:30.248 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobe' due to prior errors.
2019/01/11 20:23:30.248 +0200 INFO [FlowRunner-exec-101] [jobf] Condition on job status: all_success is evaluated to false for jobf
2019/01/11 20:23:30.248 +0200 INFO [FlowRunner-exec-101] [jobf] Cancelling 'jobf' due to prior errors.
2019/01/11 20:23:30.249 +0200 INFO [FlowRunner-exec-101] [jobf] Setting flow '' status to KILLED in 1 seconds
2019/01/11 20:23:30.249 +0200 INFO [FlowRunner-exec-101] [jobf] Finishing up flow. Awaiting Termination
2019/01/11 20:23:30.249 +0200 INFO [JobRunner-joba1-101] [jobf] Job joba1 finished with status KILLED in 1 seconds
2019/01/11 20:23:30.249 +0200 INFO [FlowRunner-exec-101] [jobf] Finished Flow
2019/01/11 20:23:30.249 +0200 INFO [FlowRunner-exec-101] [jobf] Setting end time for flow 101 to 1547231010249

Process finished with exit code 0
```