### PR TITLE
Always use multi-executor mode

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -58,8 +58,7 @@ public class Constants {
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
   public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";
   public static final String DEFAULT_CONF_PATH = "conf";
-  public static final String AZKABAN_EXECUTOR_PORT_FILENAME = "executor.port";
-  public static final String AZKABAN_EXECUTOR_PORT_FILE = "executor.portfile";
+  public static final String DEFAULT_EXECUTOR_PORT_FILE = "executor.port";
 
   public static final String AZKABAN_SERVLET_CONTEXT_KEY = "azkaban_app";
 
@@ -156,7 +155,8 @@ public class Constants {
 
     // Legacy configs section, new configs should follow the naming convention of azkaban.server.<rest of the name> for server configs.
 
-    // The property is used for the web server to get the port of the executor when running in SOLO mode.
+    public static final String EXECUTOR_PORT_FILE = "executor.portfile";
+    // To set a fixed port for executor-server. Otherwise some available port is used.
     public static final String EXECUTOR_PORT = "executor.port";
 
     // Max flow running time in mins, server will kill flows running longer than this setting.

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -156,9 +156,6 @@ public class Constants {
 
     // Legacy configs section, new configs should follow the naming convention of azkaban.server.<rest of the name> for server configs.
 
-    // The property is used for the web server to get the host name of the executor when running in SOLO mode.
-    public static final String EXECUTOR_HOST = "executor.host";
-
     // The property is used for the web server to get the port of the executor when running in SOLO mode.
     public static final String EXECUTOR_PORT = "executor.port";
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -108,8 +108,9 @@ public class ExecutorManager extends EventHandler implements
   private List<String> filterList;
   private Map<String, Integer> comparatorWeightsMap;
   private long lastSuccessfulExecutorInfoRefresh;
-  private ExecutorService executorInforRefresherService;
+  private final ExecutorService executorInfoRefresherService;
   private Duration sleepAfterDispatchFailure = Duration.ofSeconds(1L);
+  private boolean initialized = false;
 
   @Inject
   public ExecutorManager(final Props azkProps, final ExecutorLoader executorLoader,
@@ -129,30 +130,33 @@ public class ExecutorManager extends EventHandler implements
     this.updaterStage = updaterStage;
     this.executionFinalizer = executionFinalizer;
     this.updaterThread = updaterThread;
-    this.setupExecutors();
-    this.loadRunningExecutions();
-
-    this.queuedFlows = new QueuedExecutions(
-        azkProps.getLong(Constants.ConfigurationKeys.WEBSERVER_QUEUE_SIZE, 100000));
-
-    // The default threshold is set to 30 for now, in case some users are affected. We may
-    // decrease this number in future, to better prevent DDos attacks.
     this.maxConcurrentRunsOneFlow = azkProps
-        .getInt(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW,
+        .getInt(ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW,
             DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
-    this.loadQueuedFlows();
-
-    this.cacheDir = new File(azkProps.getString("cache.directory", "cache"));
-
-    if (isMultiExecutorMode()) {
-      setupMultiExecutorMode();
-    }
-
     final long executionLogsRetentionMs =
         azkProps.getLong("execution.logs.retention.ms",
             DEFAULT_EXECUTION_LOGS_RETENTION_MS);
-
     this.cleanerThread = new CleanerThread(executionLogsRetentionMs);
+    this.executorInfoRefresherService = createExecutorInfoRefresherService();
+  }
+
+  void initialize() throws ExecutorManagerException {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    this.setupExecutors();
+    this.loadRunningExecutions();
+    this.queuedFlows = new QueuedExecutions(
+        this.azkProps.getLong(ConfigurationKeys.WEBSERVER_QUEUE_SIZE, 100000));
+    // The default threshold is set to 30 for now, in case some users are affected. We may
+    // decrease this number in future, to better prevent DDos attacks.
+    this.loadQueuedFlows();
+    this.cacheDir = new File(this.azkProps.getString("cache.directory", "cache"));
+    // TODO extract QueueProcessor as a separate class, move all of this into it
+    setupExecutotrComparatorWeightsMap();
+    setupExecutorFilterList();
+    this.queueProcessor = setupQueueProcessor();
   }
 
   // TODO move to some common place
@@ -167,17 +171,11 @@ public class ExecutorManager extends EventHandler implements
     }
   }
 
-  // TODO switch to always use "multi executor mode" - even for single server
-  public static boolean isMultiExecutorMode(final Props props) {
-    return props.getBoolean(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, false);
-  }
-
-  public void start() {
+  public void start() throws ExecutorManagerException {
+    initialize();
     this.updaterThread.start();
     this.cleanerThread.start();
-    if (isMultiExecutorMode()) {
-      this.queueProcessor.start();
-    }
+    this.queueProcessor.start();
   }
 
   private String findApplicationIdFromLog(final String logData) {
@@ -190,39 +188,42 @@ public class ExecutorManager extends EventHandler implements
     return appId;
   }
 
-  private void setupMultiExecutorMode() {
-    // initialize hard filters for executor selector from azkaban.properties
-    final String filters = this.azkProps
-        .getString(Constants.ConfigurationKeys.EXECUTOR_SELECTOR_FILTERS, "");
-    if (filters != null) {
-      this.filterList = Arrays.asList(StringUtils.split(filters, ","));
-    }
+  private QueueProcessorThread setupQueueProcessor() {
+    return new QueueProcessorThread(
+        this.azkProps.getBoolean(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, true),
+        this.azkProps.getLong(Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_MS, 50000),
+        this.azkProps.getInt(
+            Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW, 5),
+        this.azkProps.getInt(
+            Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED,
+            this.activeExecutors.getAll().size()),
+        this.sleepAfterDispatchFailure);
+  }
 
+  private void setupExecutotrComparatorWeightsMap() {
     // initialize comparator feature weights for executor selector from azkaban.properties
     final Map<String, String> compListStrings = this.azkProps
-        .getMapByPrefix(Constants.ConfigurationKeys.EXECUTOR_SELECTOR_COMPARATOR_PREFIX);
+        .getMapByPrefix(ConfigurationKeys.EXECUTOR_SELECTOR_COMPARATOR_PREFIX);
     if (compListStrings != null) {
       this.comparatorWeightsMap = new TreeMap<>();
       for (final Map.Entry<String, String> entry : compListStrings.entrySet()) {
         this.comparatorWeightsMap.put(entry.getKey(), Integer.valueOf(entry.getValue()));
       }
     }
+  }
 
-    this.executorInforRefresherService =
-        Executors.newFixedThreadPool(this.azkProps.getInt(
-            Constants.ConfigurationKeys.EXECUTORINFO_REFRESH_MAX_THREADS, 5));
+  private void setupExecutorFilterList() {
+    // initialize hard filters for executor selector from azkaban.properties
+    final String filters = this.azkProps
+        .getString(ConfigurationKeys.EXECUTOR_SELECTOR_FILTERS, "");
+    if (filters != null) {
+      this.filterList = Arrays.asList(StringUtils.split(filters, ","));
+    }
+  }
 
-    // configure queue processor
-    this.queueProcessor =
-        new QueueProcessorThread(
-            this.azkProps.getBoolean(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, true),
-            this.azkProps.getLong(Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_MS, 50000),
-            this.azkProps.getInt(
-                Constants.ConfigurationKeys.ACTIVE_EXECUTOR_REFRESH_IN_NUM_FLOW, 5),
-            this.azkProps.getInt(
-                Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED,
-                this.activeExecutors.getAll().size()),
-            this.sleepAfterDispatchFailure);
+  private ExecutorService createExecutorInfoRefresherService() {
+    return Executors.newFixedThreadPool(this.azkProps.getInt(
+        ConfigurationKeys.EXECUTORINFO_REFRESH_MAX_THREADS, 5));
   }
 
   /**
@@ -232,11 +233,16 @@ public class ExecutorManager extends EventHandler implements
    */
   @Override
   public void setupExecutors() throws ExecutorManagerException {
+    checkMultiExecutorMode();
     this.activeExecutors.setupExecutors();
   }
 
-  private boolean isMultiExecutorMode() {
-    return isMultiExecutorMode(this.azkProps);
+  private void checkMultiExecutorMode() {
+    if (!this.azkProps.getBoolean(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, false)) {
+      throw new IllegalArgumentException(
+          Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS +
+              " must be true. Single executor mode is not supported any more.");
+    }
   }
 
   /**
@@ -249,7 +255,7 @@ public class ExecutorManager extends EventHandler implements
     for (final Executor executor : this.activeExecutors.getAll()) {
       // execute each executorInfo refresh task to fetch
       final Future<ExecutorInfo> fetchExecutionInfo =
-          this.executorInforRefresherService.submit(
+          this.executorInfoRefresherService.submit(
               () -> this.apiGateway.callForJsonType(executor.getHost(),
                   executor.getPort(), "/serverStatistics", null, ExecutorInfo.class));
       futures.add(new Pair<>(executor,
@@ -286,41 +292,23 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /**
-   * Throws exception if running in local mode {@inheritDoc}
-   *
    * @see azkaban.executor.ExecutorManagerAdapter#disableQueueProcessorThread()
    */
   @Override
-  public void disableQueueProcessorThread() throws ExecutorManagerException {
-    if (isMultiExecutorMode()) {
-      this.queueProcessor.setActive(false);
-    } else {
-      throw new ExecutorManagerException(
-          "Cannot disable QueueProcessor in local mode");
-    }
+  public void disableQueueProcessorThread() {
+    this.queueProcessor.setActive(false);
   }
 
   /**
-   * Throws exception if running in local mode {@inheritDoc}
-   *
    * @see azkaban.executor.ExecutorManagerAdapter#enableQueueProcessorThread()
    */
   @Override
-  public void enableQueueProcessorThread() throws ExecutorManagerException {
-    if (isMultiExecutorMode()) {
-      this.queueProcessor.setActive(true);
-    } else {
-      throw new ExecutorManagerException(
-          "Cannot enable QueueProcessor in local mode");
-    }
+  public void enableQueueProcessorThread() {
+    this.queueProcessor.setActive(true);
   }
 
   public State getQueueProcessorThreadState() {
-    if (isMultiExecutorMode()) {
-      return this.queueProcessor.getState();
-    } else {
-      return State.NEW; // not started in local mode
-    }
+    return this.queueProcessor.getState();
   }
 
   /**
@@ -328,11 +316,7 @@ public class ExecutorManager extends EventHandler implements
    * dispatched as expected
    */
   public boolean isQueueProcessorThreadActive() {
-    if (isMultiExecutorMode()) {
-      return this.queueProcessor.isActive();
-    } else {
-      return false;
-    }
+    return this.queueProcessor.isActive();
   }
 
   /**
@@ -1113,30 +1097,9 @@ public class ExecutorManager extends EventHandler implements
         final ExecutionReference reference =
             new ExecutionReference(exflow.getExecutionId());
 
-        if (isMultiExecutorMode()) {
-          //Take MultiExecutor route
-          this.executorLoader.addActiveExecutableReference(reference);
-          this.queuedFlows.enqueue(exflow, reference);
-        } else {
-          // assign only local executor we have
-          final Executor choosenExecutor = this.activeExecutors.getAll().iterator().next();
-          this.executorLoader.addActiveExecutableReference(reference);
-          try {
-            dispatch(reference, exflow, choosenExecutor);
-            this.commonMetrics.markDispatchSuccess();
-          } catch (final ExecutorManagerException e) {
-            // When flow dispatch fails, should update the flow status
-            // to FAILED in execution_flows DB table as well. Currently
-            // this logic is only implemented in multiExecutorMode but
-            // missed in single executor case.
-            this.commonMetrics.markDispatchFail();
-            this.executionFinalizer.finalizeFlow(exflow, "Dispatching failed", e);
-            throw e;
-          }
-        }
-        message +=
-            "Execution submitted successfully with exec id "
-                + exflow.getExecutionId();
+        this.executorLoader.addActiveExecutableReference(reference);
+        this.queuedFlows.enqueue(exflow, reference);
+        message += "Execution queued successfully with exec id " + exflow.getExecutionId();
       }
       return message;
     }
@@ -1199,9 +1162,7 @@ public class ExecutorManager extends EventHandler implements
 
   @Override
   public void shutdown() {
-    if (isMultiExecutorMode()) {
-      this.queueProcessor.shutdown();
-    }
+    this.queueProcessor.shutdown();
     this.updaterThread.shutdown();
   }
 
@@ -1478,7 +1439,7 @@ public class ExecutorManager extends EventHandler implements
             + "reached " + ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED
             + " (tried " + reference.getNumErrors() + " executors)";
         ExecutorManager.logger.error(message);
-        executionFinalizer.finalizeFlow(exflow, message, lastError);
+        ExecutorManager.this.executionFinalizer.finalizeFlow(exflow, message, lastError);
       }
     }
 
@@ -1486,7 +1447,7 @@ public class ExecutorManager extends EventHandler implements
         final Executor selectedExecutor) {
       remainingExecutors.remove(selectedExecutor);
       if (remainingExecutors.isEmpty()) {
-        remainingExecutors.addAll(activeExecutors.getAll());
+        remainingExecutors.addAll(ExecutorManager.this.activeExecutors.getAll());
         sleepAfterDispatchFailure();
       }
     }
@@ -1579,7 +1540,7 @@ public class ExecutorManager extends EventHandler implements
   }
 
   @VisibleForTesting
-  void setSleepAfterDispatchFailure(Duration sleepAfterDispatchFailure) {
+  void setSleepAfterDispatchFailure(final Duration sleepAfterDispatchFailure) {
     this.sleepAfterDispatchFailure = sleepAfterDispatchFailure;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -243,6 +243,11 @@ public class ExecutorManager extends EventHandler implements
     this.activeExecutors.setupExecutors();
   }
 
+  // TODO Enforced for now to ensure that users migrate to multi-executor mode acknowledgingly.
+  // TODO Remove this once confident enough that all active users have already updated to some
+  // version new enough to have this change - for example after 1 year has passed.
+  // TODO Then also delete ConfigurationKeys.USE_MULTIPLE_EXECUTORS.
+  @Deprecated
   private void checkMultiExecutorMode() {
     if (!this.azkProps.getBoolean(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, false)) {
       throw new IllegalArgumentException(

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.alert.Alerter;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
@@ -119,7 +120,7 @@ public class ExecutorManagerTest {
    */
   @Test
   public void testLocalExecutorScenario() {
-    this.props.put("executor.port", 12345);
+    this.props.put(ConfigurationKeys.EXECUTOR_PORT, 12345);
     final Throwable thrown = catchThrowable(() -> createExecutorManager());
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
     assertThat(thrown.getMessage()).isEqualTo(

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -18,6 +18,7 @@ package azkaban.trigger;
 
 import static org.mockito.Mockito.mock;
 
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.executor.ActiveExecutors;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutionFinalizer;
@@ -61,7 +62,7 @@ public class TriggerManagerDeadlockTest {
     this.loader = new MockTriggerLoader();
     final Props props = new Props();
     props.put("trigger.scan.interval", 1000);
-    props.put("executor.port", 12321);
+    props.put(ConfigurationKeys.EXECUTOR_PORT, 12321);
     this.execLoader = new MockExecutorLoader();
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.runningExecutions = new RunningExecutions();

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -75,7 +75,7 @@ public class TriggerManagerDeadlockTest {
   }
 
   private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {
-    final ActiveExecutors activeExecutors = new ActiveExecutors(props, this.execLoader);
+    final ActiveExecutors activeExecutors = new ActiveExecutors(this.execLoader);
     final RunningExecutionsUpdaterThread updaterThread = getRunningExecutionsUpdaterThread();
     return new ExecutorManager(props, this.execLoader, this.commonMetrics, this.apiGateway,
         this.runningExecutions, activeExecutors, this.updaterStage, this.executionFinalizer,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -16,7 +16,7 @@
 
 package azkaban.execapp;
 
-import static azkaban.Constants.AZKABAN_EXECUTOR_PORT_FILENAME;
+import static azkaban.Constants.DEFAULT_EXECUTOR_PORT_FILE;
 import static azkaban.Constants.ConfigurationKeys;
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 import static azkaban.execapp.ExecJettyServerModule.EXEC_JETTY_SERVER;
@@ -289,7 +289,7 @@ public class AzkabanExecutorServer {
   private void dumpPortToFile() throws IOException {
     // By default this should write to the working directory
     final String portFileName = this.props
-        .getString(Constants.AZKABAN_EXECUTOR_PORT_FILE, AZKABAN_EXECUTOR_PORT_FILENAME);
+        .getString(ConfigurationKeys.EXECUTOR_PORT_FILE, DEFAULT_EXECUTOR_PORT_FILE);
     FileIOUtils.dumpNumberToFile(Paths.get(portFileName), getPort());
   }
 
@@ -468,7 +468,7 @@ public class AzkabanExecutorServer {
    * @return hostname
    */
   public String getHost() {
-    if (this.props.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_HOST_NAME)) {
+    if (this.props.containsKey(ConfigurationKeys.AZKABAN_SERVER_HOST_NAME)) {
       final String hostName = this.props
           .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_HOST_NAME);
       if (!StringUtils.isEmpty(hostName)) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecJettyServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecJettyServerModule.java
@@ -1,5 +1,6 @@
 package azkaban.execapp;
 
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -38,7 +39,7 @@ public class ExecJettyServerModule extends AbstractModule {
      * The Jetty server automatically finds an unused port when the port number is set to zero
      * TODO: This is using a highly outdated version of jetty [year 2010]. needs to be updated.
      */
-    final Server server = new Server(props.getInt("executor.port", 0));
+    final Server server = new Server(props.getInt(ConfigurationKeys.EXECUTOR_PORT, 0));
     final QueuedThreadPool httpThreadPool = new QueuedThreadPool(maxThreads);
     server.setThreadPool(httpThreadPool);
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/AzkabanExecutorServerTest.java
@@ -75,7 +75,7 @@ public class AzkabanExecutorServerTest {
   public static void tearDown() throws Exception {
     deleteQuietly(new File("h2.mv.db"));
     deleteQuietly(new File("h2.trace.db"));
-    deleteQuietly(new File("executor.port"));
+    deleteQuietly(new File(Constants.DEFAULT_EXECUTOR_PORT_FILE));
     deleteQuietly(new File("executions"));
     deleteQuietly(new File("projects"));
   }

--- a/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
+++ b/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import azkaban.AzkabanCommonModule;
 import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.database.AzkabanDatabaseUpdater;
 import azkaban.execapp.AzkabanExecServerModule;
@@ -65,7 +66,7 @@ public class AzkabanSingleServerTest {
   public static void tearDown() {
     deleteQuietly(new File("h2.mv.db"));
     deleteQuietly(new File("h2.trace.db"));
-    deleteQuietly(new File("executor.port"));
+    deleteQuietly(new File(Constants.DEFAULT_EXECUTOR_PORT_FILE));
     deleteQuietly(new File("executions"));
     deleteQuietly(new File("projects"));
   }
@@ -85,7 +86,7 @@ public class AzkabanSingleServerTest {
     props.put("server.useSSL", "true");
     props.put("jetty.use.ssl", "false");
     props.put("user.manager.xml.file", new File(confPath, "azkaban-users.xml").getPath());
-    props.put("executor.port", "12321");
+    props.put(ConfigurationKeys.EXECUTOR_PORT, "12321");
 
     // Quartz settings
     props.put("org.quartz.threadPool.class", "org.quartz.simpl.SimpleThreadPool");

--- a/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
+++ b/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
@@ -62,7 +62,7 @@ public class AzkabanSingleServerTest {
   }
 
   @AfterClass
-  public static void tearDown() throws Exception {
+  public static void tearDown() {
     deleteQuietly(new File("h2.mv.db"));
     deleteQuietly(new File("h2.trace.db"));
     deleteQuietly(new File("executor.port"));
@@ -79,7 +79,7 @@ public class AzkabanSingleServerTest {
     props.put("database.type", "h2");
     props.put("h2.path", "./h2");
 
-    props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "false");
+    props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     props.put("server.port", "0");
     props.put("jetty.port", "0");
     props.put("server.useSSL", "true");
@@ -98,13 +98,13 @@ public class AzkabanSingleServerTest {
   }
 
   @Test
-  public void testInjection() throws Exception {
+  public void testInjection() {
     SERVICE_PROVIDER.unsetInjector();
     /* Initialize Guice Injector */
     final Injector injector = Guice.createInjector(
         new AzkabanCommonModule(props),
-        new AzkabanWebServerModule(),
-        new AzkabanExecServerModule()
+        new AzkabanExecServerModule(),
+        new AzkabanWebServerModule()
     );
     SERVICE_PROVIDER.setInjector(injector);
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -111,7 +111,7 @@ public class AzkabanWebServerTest {
 
     deleteQuietly(new File("h2.mv.db"));
     deleteQuietly(new File("h2.trace.db"));
-    deleteQuietly(new File("executor.port"));
+    deleteQuietly(new File(Constants.DEFAULT_EXECUTOR_PORT_FILE));
     deleteQuietly(new File("executions"));
     deleteQuietly(new File("projects"));
   }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -281,7 +281,7 @@ Executor Server Properties
 +-----------------------+-----------------------+-----------------------+
 | Parameter             | Description           | Default               |
 +=======================+=======================+=======================+
-|   executor.port       | The port for azkaban  | 12321                 |
+|   executor.port       | The port for azkaban  | 0 (any free port)     |
 |                       | executor server       |                       |
 +-----------------------+-----------------------+-----------------------+
 |   executor.global.pro | A path to the         |   none                |

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -216,13 +216,6 @@ Executor Manager Properties
 +-----------------------+-----------------------+-----------------------+
 | Parameter             | Description           | Default               |
 +=======================+=======================+=======================+
-| executor.port         | The port for the      | 12321                 |
-|                       | azkaban executor      |                       |
-|                       | server                |                       |
-+-----------------------+-----------------------+-----------------------+
-| executor.host         | The host for azkaban  | localhost             |
-|                       | executor server       |                       |
-+-----------------------+-----------------------+-----------------------+
 | execution.logs.retent | Time in milliseconds  | 7257600000L (12       |
 | ion.ms                | that execution logs   | weeks)                |
 |                       | are retained          |                       |


### PR DESCRIPTION
This to simplify the code.

This requires users to migrate to `azkaban.use.multiple.executors=true` if not already using it.
After this change Azkaban will refuse to start if the property is missing or if it's set to false.

----

Note: a related pattern on executor side is the RemoteFlowWatcher vs. LocalFlowWatcher, which is used to track pipelined jobs & flows. It would be better to have just a single implementation (remote). However, that doesn't have anything to do with the multi-executor mode per se. Executor picks the FlowWatcher type based on whether the tracked execution is running on the same executor or a different one.