### PR TITLE
Disable noisy logger "property x.jor is empty"

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -905,7 +905,7 @@ public class JdbcProjectImpl implements ProjectLoader {
                   propsName);
 
       if (properties == null || properties.isEmpty()) {
-        logger.warn("Project " + projectId + " version " + projectVer + " property " + propsName
+        logger.debug("Project " + projectId + " version " + projectVer + " property " + propsName
             + " is empty.");
         return null;
       }


### PR DESCRIPTION
It's totally normal that `.jor` doesn't exist in the DB if there's no override, not worth logging on WARN level.

https://github.com/azkaban/azkaban/blob/cefb48346c21c3163e4fed0ebd8e5070c3f2c227/az-core/src/main/java/azkaban/Constants.java#L54-L55