### PR TITLE
WIP give up dispatching on a non-retriable error

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -59,6 +59,26 @@ public interface ConnectorParams {
 
   public static final String RESPONSE_NOTFOUND = "notfound";
   public static final String RESPONSE_ERROR = "error";
+  public static final String RESPONSE_ERROR_TYPE = "errortype";
+
+  public static enum ResponseErrorType {
+    /**
+     * Bad request means that such request will never succeed. Client should give up.
+     */
+    BAD_REQUEST,
+    /**
+     * Unknown means that the request might succeed on a retry, but it could also be a problem in
+     * the request itself. Client should give it some retries, but not too many.
+     */
+    UNKNOWN,
+    /**
+     * Service unavailable means that this executor is not accepting new requests right now. The
+     * request itself is supposedly fine. Client should retry as long as it makes sense from
+     * client's own perspective.
+     */
+    SERVICE_UNAVAILABLE
+  }
+
   public static final String RESPONSE_SUCCESS = "success";
   public static final String RESPONSE_ALIVE = "alive";
   public static final String RESPONSE_UPDATETIME = "lasttime";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorResponseErrorException.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorResponseErrorException.java
@@ -1,0 +1,23 @@
+package azkaban.executor;
+
+import azkaban.executor.ConnectorParams.ResponseErrorType;
+
+public class ExecutorResponseErrorException extends ExecutorManagerException {
+
+  private final ResponseErrorType errorType;
+
+  public ExecutorResponseErrorException(String msg, ResponseErrorType errorType) {
+    super(msg);
+    this.errorType = errorType;
+  }
+
+  public ExecutorResponseErrorException(String msg, Throwable t, ResponseErrorType errorType) {
+    super(msg, t);
+    this.errorType = errorType;
+  }
+
+  public ResponseErrorType getErrorType() {
+    return errorType;
+  }
+
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -24,6 +24,7 @@ import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
+import azkaban.executor.ExecutorResponseErrorException;
 import azkaban.utils.FileIOUtils.JobMetaData;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.JSONUtils;
@@ -133,7 +134,7 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
           } else if (action.equals(ATTACHMENTS_ACTION)) {
             handleFetchAttachmentsEvent(execid, req, resp, respMap);
           } else if (action.equals(EXECUTE_ACTION)) {
-            handleAjaxExecute(req, respMap, execid);
+            handleAjaxExecute(respMap, execid);
           } else if (action.equals(STATUS_ACTION)) {
             handleAjaxFlowStatus(respMap, execid);
           } else if (action.equals(CANCEL_ACTION)) {
@@ -282,13 +283,21 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
     respMap.put(RESPONSE_UPDATED_FLOWS, updateList);
   }
 
-  private void handleAjaxExecute(final HttpServletRequest req,
-      final Map<String, Object> respMap, final int execId) {
+  private void handleAjaxExecute(final Map<String, Object> respMap, final int execId) {
     try {
       this.flowRunnerManager.submitFlow(execId);
     } catch (final ExecutorManagerException e) {
       logger.error(e.getMessage(), e);
       respMap.put(RESPONSE_ERROR, e.getMessage());
+      respMap.put(RESPONSE_ERROR_TYPE, getErrorType(e).toString());
+    }
+  }
+
+  private ResponseErrorType getErrorType(ExecutorManagerException e) {
+    if (e instanceof ExecutorResponseErrorException) {
+      return ((ExecutorResponseErrorException) e).getErrorType();
+    } else {
+      return ResponseErrorType.UNKNOWN;
     }
   }
 


### PR DESCRIPTION
Before going further I'd like to get some early feedback on this.

Here's an initial implementation for the executor API to support detecting non-retriable errors.

As you can see, the new `enum ResponseErrorType` defines 3 different scenarios:
1. BAD_REQUEST
   - dispatch shouldn't be attempted at all
   - so far I don't know of other use cases for this than the case of "execution already running"
1. UNKNOWN
   - dispatch should be attempted maybe on another executor, or even this one, but it won't be too likely to succeed despite the retry. It's better to stop dispatching after a couple of retries and give room to the next executions in the queue, because most likely there's something bad in the execution itself
1. SERVICE_UNAVAILABLE
   - should keep retrying as much as `azkaban.maxDispatchingErrors` says

In addition to these, if the HTTP request status != 2xx, assume SERVICE_UNAVAILABLE on the client side.