### PR TITLE
Make ActiveExecutors a singleton

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ActiveExecutors.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ActiveExecutors.java
@@ -21,11 +21,13 @@ import azkaban.utils.Props;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.log4j.Logger;
 
 /**
  * Loads & provides executors.
  */
+@Singleton
 public class ActiveExecutors {
 
   private static final Logger logger = Logger.getLogger(ExecutorManager.class);


### PR DESCRIPTION
It was only used by one class that's singleton itself, so no harm done for now. But this is how it should be, in case it will be injected to more than one instances later.