### PR TITLE
Improve error message for a cleaned project version

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -230,6 +230,9 @@ public class Constants {
     // allowed max size of shared project dir in MB
     public static final String PROJECT_DIR_MAX_SIZE_IN_MB = "azkaban.project_cache_max_size_in_mb";
 
+    // how many older versions of project files are kept in DB before deleting them
+    public static final String PROJECT_VERSION_RETENTION = "project.version.retention";
+
     // number of rows to be displayed on the executions page.
     public static final String DISPLAY_EXECUTION_PAGE_SIZE = "azkaban.display.execution_page_size";
   }

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -75,7 +75,7 @@ class AzkabanProjectLoader {
     } else {
       log.info("Using temp dir: " + this.tempDir.getAbsolutePath());
     }
-    this.projectVersionRetention = props.getInt("project.version.retention", 3);
+    this.projectVersionRetention = props.getInt(ConfigurationKeys.PROJECT_VERSION_RETENTION, 3);
     log.info("Project version retention is set to " + this.projectVersionRetention);
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -524,7 +524,10 @@ public class JdbcProjectImpl implements ProjectLoader {
     if (Arrays.equals(projHandler.getMd5Hash(), md5)) {
       logger.info("Md5 Hash is valid");
     } else {
-      throw new ProjectManagerException("Md5 Hash failed on retrieval of file");
+      throw new ProjectManagerException(
+          "Md5 Hash failed on project " + projHandler.getProjectId() + " version " + projHandler
+              .getVersion() + " retrieval of file " + file.getAbsolutePath() + ". Expected hash: " +
+              Arrays.toString(projHandler.getMd5Hash()) + " , got hash: " + Arrays.toString(md5));
     }
 
     projHandler.setLocalFile(file);

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -24,6 +24,7 @@ import static azkaban.project.JdbcProjectHandlerSet.ProjectPropertiesResultsHand
 import static azkaban.project.JdbcProjectHandlerSet.ProjectResultHandler;
 import static azkaban.project.JdbcProjectHandlerSet.ProjectVersionResultHandler;
 
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.db.DatabaseOperator;
 import azkaban.db.DatabaseTransOperator;
 import azkaban.db.EncodingType;
@@ -469,6 +470,13 @@ public class JdbcProjectImpl implements ProjectLoader {
       return null;
     }
     final int numChunks = projHandler.getNumChunks();
+    if (numChunks <= 0) {
+      throw new ProjectManagerException(String.format("Got numChunks=%s for version %s of project "
+              + "%s - seems like this version has been cleaned up already, because enough newer "
+              + "versions have been uploaded. To increase the retention of project versions, set "
+              + "%s", numChunks, version, projectId,
+          ConfigurationKeys.PROJECT_VERSION_RETENTION));
+    }
     BufferedOutputStream bStream = null;
     File file;
     try {

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -522,7 +522,7 @@ public class JdbcProjectImpl implements ProjectLoader {
     }
 
     // Check md5.
-    byte[] md5 = null;
+    byte[] md5;
     try {
       md5 = Md5Hasher.md5Hash(file);
     } catch (final IOException e) {
@@ -533,9 +533,10 @@ public class JdbcProjectImpl implements ProjectLoader {
       logger.info("Md5 Hash is valid");
     } else {
       throw new ProjectManagerException(
-          "Md5 Hash failed on project " + projHandler.getProjectId() + " version " + projHandler
-              .getVersion() + " retrieval of file " + file.getAbsolutePath() + ". Expected hash: " +
-              Arrays.toString(projHandler.getMd5Hash()) + " , got hash: " + Arrays.toString(md5));
+          String.format("Md5 Hash failed on project %s version %s retrieval of file %s. "
+                  + "Expected hash: %s , got hash: %s",
+              projHandler.getProjectId(), projHandler.getVersion(), file.getAbsolutePath(),
+              Arrays.toString(projHandler.getMd5Hash()), Arrays.toString(md5)));
     }
 
     projHandler.setLocalFile(file);

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -368,7 +368,7 @@ public class JdbcProjectImplTest {
     this.loader.cleanOlderProjectVersion(project.getId(), newVersion + 1);
 
     assertNumChunks(project, newVersion, 0);
-    assertGetUploadedFileOfCleanedVersion(project, newVersion);
+    assertGetUploadedFileOfCleanedVersion(project.getId(), newVersion);
   }
 
   private void assertNumChunks(final Project project, final int version, final int expectedChunks) {
@@ -377,14 +377,11 @@ public class JdbcProjectImplTest {
     Assert.assertEquals(expectedChunks, fileHandler.getNumChunks());
   }
 
-  private void assertGetUploadedFileOfCleanedVersion(final Project project, final int version) {
-    final Throwable thrown = catchThrowable(
-        () -> this.loader.getUploadedFile(project.getId(), version));
-    // TODO this is a really misleading error
-    // in reality the project has been cleaned and that's why it can't retrieve any real Md5 hash
+  private void assertGetUploadedFileOfCleanedVersion(final int project, final int version) {
+    final Throwable thrown = catchThrowable(() -> this.loader.getUploadedFile(project, version));
     assertThat(thrown).isInstanceOf(ProjectManagerException.class);
-    assertThat(thrown).hasMessageStartingWith(String.format(
-        "Md5 Hash failed on project %s version %s retrieval of file", project.getId(), version));
+    assertThat(thrown).hasMessageStartingWith(String.format("Got numChunks=0 for version %s of "
+        + "project %s - seems like this version has been cleaned up", version, project));
   }
 
   @Test


### PR DESCRIPTION
1st commit shows the problem:
When trying to execute a cleaned project version, an exception is thrown that says that hash code comparison failed.

2nd commit improves the error message in case of trying to read a cleaned (deleted) version. It also fails _faster_ (don't try to generate a hashcode from 0 chunks).

\+ Move `project.version.retention` to `Constants.java`.