### PR TITLE
Evict executions on unresponsive executors (by default)

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -151,7 +151,7 @@ public class ExecutorManagerTest {
     final RunningExecutionsUpdaterThread updaterThread = new RunningExecutionsUpdaterThread(
         new RunningExecutionsUpdater(
             this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-            this.runningExecutions, executionFinalizer), this.runningExecutions);
+            this.runningExecutions, executionFinalizer, this.props), this.runningExecutions);
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
     final ExecutorManager executorManager = new ExecutorManager(this.props, this.loader,

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -56,13 +56,14 @@ public class TriggerManagerDeadlockTest {
   private AlerterHolder alertHolder;
   private ExecutionFinalizer executionFinalizer;
   private CommonMetrics commonMetrics;
+  private Props props;
 
   @Before
   public void setup() throws ExecutorManagerException, TriggerManagerException {
     this.loader = new MockTriggerLoader();
-    final Props props = new Props();
-    props.put("trigger.scan.interval", 1000);
-    props.put(ConfigurationKeys.EXECUTOR_PORT, 12321);
+    this.props = new Props();
+    this.props.put("trigger.scan.interval", 1000);
+    this.props.put(ConfigurationKeys.EXECUTOR_PORT, 12321);
     this.execLoader = new MockExecutorLoader();
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.runningExecutions = new RunningExecutions();
@@ -71,14 +72,14 @@ public class TriggerManagerDeadlockTest {
     this.executionFinalizer = new ExecutionFinalizer(this.execLoader,
         this.updaterStage, this.alertHolder, this.runningExecutions);
     this.commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
-    final ExecutorManager executorManager = getExecutorManager(props);
-    this.triggerManager = new TriggerManager(props, this.loader, executorManager);
+    final ExecutorManager executorManager = getExecutorManager();
+    this.triggerManager = new TriggerManager(this.props, this.loader, executorManager);
   }
 
-  private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {
+  private ExecutorManager getExecutorManager() throws ExecutorManagerException {
     final ActiveExecutors activeExecutors = new ActiveExecutors(this.execLoader);
     final RunningExecutionsUpdaterThread updaterThread = getRunningExecutionsUpdaterThread();
-    return new ExecutorManager(props, this.execLoader, this.commonMetrics, this.apiGateway,
+    return new ExecutorManager(this.props, this.execLoader, this.commonMetrics, this.apiGateway,
         this.runningExecutions, activeExecutors, this.updaterStage, this.executionFinalizer,
         updaterThread);
   }
@@ -86,7 +87,7 @@ public class TriggerManagerDeadlockTest {
   private RunningExecutionsUpdaterThread getRunningExecutionsUpdaterThread() {
     return new RunningExecutionsUpdaterThread(new RunningExecutionsUpdater(
         this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, this.executionFinalizer), runningExecutions);
+        this.runningExecutions, this.executionFinalizer, this.props), this.runningExecutions);
   }
 
   @After


### PR DESCRIPTION
See discussion in https://github.com/azkaban/azkaban/pull/1661#issuecomment-431197754.

However, I don't think the problem is in the application design. If an executor instance is removed, the deployment strategy should make sure that the corresponding executor entry is deleted from the DB. Or then there's some actual bug that I haven't seen before.

Any way, enabling evicting again for now. Users (like me) can set `azkaban.evictUnresponsiveExecutions=false` to keep the previous behaviour.

There is actually one nice-to-have improvement to be done before stopping evictions by default again: automatic refreshing of removed executors from the DB. It was blocked by some preliminary work before, but now this is available to be built upon:
https://github.com/azkaban/azkaban/pull/1975#discussion_r225306559.