### PR TITLE
Don't log an ERROR for skipped scheduled executions

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import azkaban.event.EventHandler;
 import azkaban.executor.ExecutorManager;
+import azkaban.executor.ExecutorManagerException;
 import azkaban.utils.Props;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -361,10 +362,16 @@ public class TriggerManager extends EventHandler implements
         try {
           logger.info("Doing trigger actions " + action.getDescription() + " for " + t);
           action.doAction();
-        } catch (final Exception e) {
-          logger.error("Failed to do action " + action.getDescription() + " for " + t, e);
+        } catch (final ExecutorManagerException e) {
+          if (e.getReason() == ExecutorManagerException.Reason.SkippedExecution) {
+            logger.info("Skipped action [" + action.getDescription() + "] for [" + t +
+                "] because: " + e.getMessage());
+          } else {
+            logger.error("Failed to do action [" + action.getDescription() + "] for [" + t + "]",
+                e);
+          }
         } catch (final Throwable th) {
-          logger.error("Failed to do action " + action.getDescription() + " for " + t, th);
+          logger.error("Failed to do action [" + action.getDescription() + "] for [" + t + "]", th);
         }
       }
 

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -19,7 +19,6 @@ package azkaban.trigger.builtin;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorManagerAdapter;
-import azkaban.executor.ExecutorManagerException;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowUtils;
 import azkaban.project.Project;
@@ -224,13 +223,9 @@ public class ExecuteFlowAction implements TriggerAction {
       exflow.setSlaOptions(this.slaOptions);
     }
 
-    try {
-      logger.info("Invoking flow " + project.getName() + "." + this.flowName);
-      executorManager.submitExecutableFlow(exflow, this.submitUser);
-      logger.info("Invoked flow " + project.getName() + "." + this.flowName);
-    } catch (final ExecutorManagerException e) {
-      throw new RuntimeException(e);
-    }
+    logger.info("Invoking flow " + project.getName() + "." + this.flowName);
+    executorManager.submitExecutableFlow(exflow, this.submitUser);
+    logger.info("Invoked flow " + project.getName() + "." + this.flowName);
   }
 
   @Override


### PR DESCRIPTION
If a flow is scheduled with `concurrentOption=skip`, it's perfectly normal that triggering of a schedule is skipped. This PR changes such ERROR lines in the server log to INFO level.

On a general level, in my opinion ERROR level should be only used for platform errors, ie. when Azkaban fails to do something that it promises to be able to do. If this rule holds, it will be easier to monitor that Azkaban is working correctly by checking that server logs don't contain errors.

Before:

```
2018/10/23 13:41:14.337 +0300 INFO [ExecuteFlowAction] Invoking flow test-project.test-flow
2018/10/23 13:41:14.338 +0300 ERROR [TriggerManager] Failed to do action Execute flow test-flow from project test-project for Trigger Id: 0, Description: Trigger from triggerLoader with trigger condition of ThresholdChecker.eval() and expire condition of EndTimeCheck_1.eval(), Execute flow test-flow from project test-project
java.lang.RuntimeException: azkaban.executor.ExecutorManagerException: Flow is already running. Skipping execution.
	at azkaban.trigger.builtin.ExecuteFlowAction.doAction(ExecuteFlowAction.java:232)
	at azkaban.trigger.TriggerManager$TriggerScannerThread.onTriggerTrigger(TriggerManager.java:363)
	at azkaban.trigger.TriggerManager$TriggerScannerThread.checkAllTriggers(TriggerManager.java:343)
	at azkaban.trigger.TriggerManager$TriggerScannerThread.run(TriggerManager.java:297)
Caused by: azkaban.executor.ExecutorManagerException: Flow is already running. Skipping execution.
	at azkaban.trigger.builtin.ExecuteFlowAction.doAction(ExecuteFlowAction.java:229)
	... 3 more
```

After:

```
2018/10/23 13:41:51.778 +0300 INFO [ExecuteFlowAction] Invoking flow test-project.test-flow
2018/10/23 13:41:51.779 +0300 INFO [TriggerManager] Skipped action [Execute flow test-flow from project test-project] for [Trigger Id: 0, Description: Trigger from triggerLoader with trigger condition of ThresholdChecker.eval() and expire condition of EndTimeCheck_1.eval(), Execute flow test-flow from project test-project] because: Flow is already running. Skipping execution.
```
