### PR TITLE
Add 'azkaban.use.multiple.executors=true' in solo server configuration

### DIFF
--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -27,7 +27,7 @@ mail.sender=
 mail.host=
 # User facing web server configurations used to construct the user facing server URLs. They are useful when there is a reverse proxy between Azkaban web servers and users.
 # enduser -> myazkabanhost:443 -> proxy -> localhost:8081
-# when this parameters set then these parameters are used to generate email links. 
+# when this parameters set then these parameters are used to generate email links.
 # if these parameters are not set then jetty.hostname, and jetty.port(if ssl configured jetty.ssl.port) are used.
 # azkaban.webserver.external_hostname=myazkabanhost.com
 # azkaban.webserver.external_ssl_port=443
@@ -43,3 +43,4 @@ executor.connector.stats=true
 azkaban.jobtype.plugin.dir=plugins/jobtypes
 # Number of executions to be displayed
 azkaban.display.execution_page_size=16
+azkaban.use.multiple.executors=true


### PR DESCRIPTION
Whenever there is a new GitHub PR merged, we run an internal job to start solo-server and run integration tests for verification. But the tests failed recently due to some connection issue to solo server. The solo server itself might not start properly due to the new change introduced in #1986. As we enforce the multiple executor mode, the configuration should also be updated for solo-server.

Error log:
```
2018/10/23 16:10:14.853 -0700 INFO [AzkabanWebServer] [Azkaban] Azkaban Exec Server started...
Exception in thread "main" java.lang.IllegalArgumentException: azkaban.use.multiple.executors must be true. Single executor mode is not supported any more.
        at azkaban.executor.ExecutorManager.checkMultiExecutorMode(ExecutorManager.java:253)
        at azkaban.executor.ExecutorManager.setupExecutors(ExecutorManager.java:242)
        at azkaban.executor.ExecutorManager.initialize(ExecutorManager.java:156)
        at azkaban.executor.ExecutorManager.start(ExecutorManager.java:181)
        at azkaban.webapp.AzkabanWebServer.launch(AzkabanWebServer.java:231)
        at azkaban.soloserver.AzkabanSingleServer.launch(AzkabanSingleServer.java:118)
        at azkaban.soloserver.AzkabanSingleServer.main(AzkabanSingleServer.java:96)
```
