### PR TITLE
Shut down single server if startup fails

### DIFF
--- a/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
+++ b/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
@@ -53,7 +53,16 @@ public class AzkabanSingleServer {
     this.executor = executor;
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
+    try {
+      start(args);
+    } catch (Exception e) {
+      log.error("Failed to start single server. Shutting down.", e);
+      System.exit(1);
+    }
+  }
+
+  public static void start(String[] args) throws Exception {
     log.info("Starting Azkaban Server");
 
     if (System.getSecurityManager() == null) {


### PR DESCRIPTION
The single server first starts executor server, then web server.

If web server startup failed, the single server process was left running, making it harder to realize that there was an issue in startup.

This PR makes it easier to spot a startup error by stopping JVM in case of a startup error.