### PR TITLE
Fix single server startup (by activating the executor)

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/Executor.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Executor.java
@@ -97,9 +97,9 @@ public class Executor implements Comparable<Executor> {
 
   @Override
   public String toString() {
-    return String.format("%s:%s (id: %s)",
+    return String.format("%s:%s (id: %s), active=%s",
         null == this.host || this.host.length() == 0 ? "(empty)" : this.host,
-        this.port, this.id);
+        this.port, this.id, this.isActive);
   }
 
   public String getHost() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -277,7 +277,10 @@ public class AzkabanExecutorServer {
       checkState(port != -1);
       final Executor executor = this.executionLoader.fetchExecutor(host, port);
       if (executor == null) {
+        logger.info("This executor wasn't found in the DB. Adding self.");
         this.executionLoader.addExecutor(host, port);
+      } else {
+        logger.info("This executor is already in the DB. Found: " + executor);
       }
       // If executor already exists, ignore it
     } catch (final ExecutorManagerException e) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecutorServlet.java
@@ -27,7 +27,6 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.utils.FileIOUtils.JobMetaData;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.JSONUtils;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -372,18 +371,8 @@ public class ExecutorServlet extends HttpServlet implements ConnectorParams {
 
   private void setActiveInternal(final boolean value)
       throws ExecutorManagerException {
-    final ExecutorLoader executorLoader = this.application.getExecutorLoader();
-    final Executor executor = executorLoader.fetchExecutor(this.application.getHost(),
-        this.application.getPort());
-    Preconditions.checkState(executor != null, "Unable to obtain self entry in DB");
-    if (executor.isActive() != value) {
-      executor.setActive(value);
-      executorLoader.updateExecutor(executor);
-      this.flowRunnerManager.setExecutorActive(value);
-    } else {
-      logger.warn(
-          "Set active action ignored. Executor is already " + (value ? "active" : "inactive"));
-    }
+    this.flowRunnerManager.setExecutorActive(value,
+        this.application.getHost(), this.application.getPort());
   }
 
   /**

--- a/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
+++ b/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
@@ -115,6 +115,10 @@ public class AzkabanSingleServer {
     AzkabanExecutorServer.launch(this.executor);
     log.info("Azkaban Exec Server started...");
 
+    this.executor.getFlowRunnerManager()
+        .setExecutorActive(true, this.executor.getHost(), this.executor.getPort());
+    log.info("Azkaban Exec Server activated...");
+
     AzkabanWebServer.launch(this.webServer);
     log.info("Azkaban Web Server started...");
   }

--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -43,3 +43,4 @@ executor.connector.stats=true
 azkaban.jobtype.plugin.dir=plugins/jobtypes
 # Number of executions to be displayed
 azkaban.display.execution_page_size=16
+azkaban.use.multiple.executors=true


### PR DESCRIPTION
In single server startup, set the executor active before starting web.

This fixes the following error:

```
2018/10/23 16:15:53.933 -0700 INFO [AzkabanWebServer] [Azkaban] Azkaban Exec Server started...
2018/10/23 16:15:53.933 -0700 INFO [ExecutorManager] [Azkaban] Initializing executors from database.
2018/10/23 16:15:53.934 -0700 ERROR [ExecutorManager] [Azkaban] No active executors found
Exception in thread "main" azkaban.executor.ExecutorManagerException: No active executors found
        at azkaban.executor.ActiveExecutors.setupExecutors(ActiveExecutors.java:52)
        at azkaban.executor.ExecutorManager.setupExecutors(ExecutorManager.java:243)
        at azkaban.executor.ExecutorManager.initialize(ExecutorManager.java:156)
        at azkaban.executor.ExecutorManager.start(ExecutorManager.java:181)
        at azkaban.webapp.AzkabanWebServer.launch(AzkabanWebServer.java:231)
        at azkaban.soloserver.AzkabanSingleServer.launch(AzkabanSingleServer.java:118)
        at azkaban.soloserver.AzkabanSingleServer.main(AzkabanSingleServer.java:96)
```
(as reported originally by @jamiesjc in https://github.com/azkaban/azkaban/pull/2001)

Also setting `azkaban.use.multiple.executors=true` in the single server default properties to fix this error:
```
2018/10/23 16:10:14.853 -0700 INFO [AzkabanWebServer] [Azkaban] Azkaban Exec Server started...
Exception in thread "main" java.lang.IllegalArgumentException: azkaban.use.multiple.executors must be true. Single executor mode is not supported any more.
        at azkaban.executor.ExecutorManager.checkMultiExecutorMode(ExecutorManager.java:253)
        at azkaban.executor.ExecutorManager.setupExecutors(ExecutorManager.java:242)
        at azkaban.executor.ExecutorManager.initialize(ExecutorManager.java:156)
        at azkaban.executor.ExecutorManager.start(ExecutorManager.java:181)
        at azkaban.webapp.AzkabanWebServer.launch(AzkabanWebServer.java:231)
        at azkaban.soloserver.AzkabanSingleServer.launch(AzkabanSingleServer.java:118)
        at azkaban.soloserver.AzkabanSingleServer.main(AzkabanSingleServer.java:96)
```