### PR TITLE
Only incorporate user pig additional jar setting or system's but not both

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -319,29 +319,30 @@ public class HadoopPigJob extends JavaProcessJob {
     return udfImports;
   }
 
-  protected List<String> getAdditionalJarsList() {
-    List<String> additionalJars = new ArrayList<String>();
-    mergeAdditionalJars(additionalJars, PIG_ADDITIONAL_JARS);
-    mergeAdditionalJars(additionalJars, DEFAULT_PIG_ADDITIONAL_JARS);
-    return additionalJars;
-  }
-
   /**
    * Merging all additional jars first from user specified/plugin.properties
    * then private.properties for additionalJarProperty property
+   * TODO kunkun-tang: A refactor is necessary here. Recommend using Java Optional to better handle
+   * parsing exceptions.
    */
-  private void mergeAdditionalJars(List<String> additionalJars,
-      String additionalJarProperty) {
+  protected List<String> getAdditionalJarsList() {
+    List<String> additionalJars = new ArrayList<>();
     List<String> jobJars =
-        getJobProps().getStringList(additionalJarProperty, null, ",");
+        getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
     List<String> typeJars =
-        getSysProps().getStringList(additionalJarProperty, null, ",");
+        getSysProps().getStringList(DEFAULT_PIG_ADDITIONAL_JARS, null, ",");
+
+    /*
+      if user defines the custom pig additional Jar, we only incorporate the user
+      settings; otherwise, if system configurations have it, we add the system
+      additional jar settings only.
+     */
     if (jobJars != null) {
       additionalJars.addAll(jobJars);
-    }
-    if (typeJars != null) {
+    } else if (typeJars != null) {
       additionalJars.addAll(typeJars);
     }
+    return additionalJars;
   }
 
   protected String getHadoopUGI() {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -320,8 +320,8 @@ public class HadoopPigJob extends JavaProcessJob {
   }
 
   /**
-   * Merging all additional jars first from user specified/plugin.properties
-   * then private.properties for additionalJarProperty property
+   * Merging all additional jars first from user specified property
+   * and private.properties (in the jobtype property) for additionalJarProperty
    * TODO kunkun-tang: A refactor is necessary here. Recommend using Java Optional to better handle
    * parsing exceptions.
    */

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -162,7 +162,7 @@ public class HadoopPigJob extends JavaProcessJob {
     }
 
     List<String> additionalJars = getAdditionalJarsList();
-    if (additionalJars.size() > 0) {
+    if (additionalJars != null && additionalJars.size() > 0) {
       args +=
           " -Dpig.additional.jars="
               + super.createArguments(additionalJars, ":");
@@ -326,7 +326,6 @@ public class HadoopPigJob extends JavaProcessJob {
    * parsing exceptions.
    */
   protected List<String> getAdditionalJarsList() {
-    List<String> additionalJars = new ArrayList<>();
     List<String> jobJars =
         getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
     List<String> typeJars =
@@ -334,15 +333,15 @@ public class HadoopPigJob extends JavaProcessJob {
 
     /*
       if user defines the custom pig additional Jar, we only incorporate the user
-      settings; otherwise, if system configurations have it, we add the system
-      additional jar settings only.
+      settings; otherwise, only when system configurations have it, we add the system
+      additional jar settings.
      */
     if (jobJars != null) {
-      additionalJars.addAll(jobJars);
+      return jobJars;
     } else if (typeJars != null) {
-      additionalJars.addAll(typeJars);
+      return typeJars;
     }
-    return additionalJars;
+    return null;
   }
 
   protected String getHadoopUGI() {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -162,7 +162,7 @@ public class HadoopPigJob extends JavaProcessJob {
     }
 
     List<String> additionalJars = getAdditionalJarsList();
-    if (additionalJars != null && additionalJars.size() > 0) {
+    if (additionalJars.size() > 0) {
       args +=
           " -Dpig.additional.jars="
               + super.createArguments(additionalJars, ":");
@@ -326,22 +326,32 @@ public class HadoopPigJob extends JavaProcessJob {
    * parsing exceptions.
    */
   protected List<String> getAdditionalJarsList() {
-    List<String> jobJars =
+
+    List<String> wholeAdditionalJarsList = new ArrayList<>();
+
+    List<String> jobAdditionalJars =
         getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
-    List<String> typeJars =
+
+    List<String> jobDefinedDefaultJars =
+        getJobProps().getStringList(DEFAULT_PIG_ADDITIONAL_JARS, null, ",");
+    List<String> systemDefinedDefaultJars =
         getSysProps().getStringList(DEFAULT_PIG_ADDITIONAL_JARS, null, ",");
 
     /*
-      if user defines the custom pig additional Jar, we only incorporate the user
+      if user defines the custom default pig Jar, we only incorporate the user
       settings; otherwise, only when system configurations have it, we add the system
       additional jar settings. We don't accept both at the same time.
      */
-    if (jobJars != null) {
-      return jobJars;
-    } else if (typeJars != null) {
-      return typeJars;
+    if (jobAdditionalJars != null) {
+      wholeAdditionalJarsList.addAll(jobAdditionalJars);
     }
-    return null;
+
+    if (jobDefinedDefaultJars != null) {
+      wholeAdditionalJarsList.addAll(jobDefinedDefaultJars);
+    } else if (systemDefinedDefaultJars != null) {
+      wholeAdditionalJarsList.addAll(systemDefinedDefaultJars);
+    }
+    return wholeAdditionalJarsList;
   }
 
   protected String getHadoopUGI() {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -334,7 +334,7 @@ public class HadoopPigJob extends JavaProcessJob {
     /*
       if user defines the custom pig additional Jar, we only incorporate the user
       settings; otherwise, only when system configurations have it, we add the system
-      additional jar settings.
+      additional jar settings. We don't accept both at the same time.
      */
     if (jobJars != null) {
       return jobJars;


### PR DESCRIPTION
We ran into a bug in the production environment. Users' jars cannot override default pig libraries. It was found that AZ always adds pig additional jar if pig job type defines it under plugin.properties. The fix is straightforward. If a user defines the property, we use it directly by not including system default settings.

To be tested in the staging environment.