### PR TITLE
Finalize execution if executor doesn't exist

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
@@ -81,7 +81,7 @@ public class RunningExecutionsUpdater {
       if (!executorOption.isPresent()) {
         for (final ExecutableFlow flow : entry.getValue()) {
           logger.warn("Finalizing execution " + flow.getExecutionId()
-              + ". Executor id of this execution doesn't exist");
+              + ". Executor is removed");
           finalizeFlows.add(flow);
         }
         continue;
@@ -139,7 +139,7 @@ public class RunningExecutionsUpdater {
       final ArrayList<ExecutableFlow> finalizeFlows) {
     logger.error("Failed to get update from executor " + executor.getHost(), e);
     boolean sendUnresponsiveEmail = false;
-    final boolean executorRemoved = executorRemoved(executor.getId());
+    final boolean executorRemoved = isExecutorRemoved(executor.getId());
     for (final ExecutableFlow flow : entry.getValue()) {
       final Pair<ExecutionReference, ExecutableFlow> pair =
           this.runningExecutions.get().get(flow.getExecutionId());
@@ -168,7 +168,7 @@ public class RunningExecutionsUpdater {
     }
   }
 
-  private boolean executorRemoved(final int id) {
+  private boolean isExecutorRemoved(final int id) {
     Executor fetchedExecutor;
     try {
       fetchedExecutor = this.executorLoader.fetchExecutor(id);

--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
@@ -81,7 +81,7 @@ public class RunningExecutionsUpdater {
       if (!executorOption.isPresent()) {
         for (final ExecutableFlow flow : entry.getValue()) {
           logger.warn("Finalizing execution " + flow.getExecutionId()
-              + ". Executor is removed");
+              + ". Executor id of this execution doesn't exist");
           finalizeFlows.add(flow);
         }
         continue;
@@ -149,7 +149,7 @@ public class RunningExecutionsUpdater {
 
       if (executorRemoved) {
         logger.warn("Finalizing execution " + flow.getExecutionId()
-            + ". Executor id of this execution doesn't exist");
+            + ". Executor is removed");
         finalizeFlows.add(flow);
       } else {
         final ExecutionReference ref = pair.getFirst();

--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
@@ -48,18 +48,20 @@ public class RunningExecutionsUpdater {
   private final ExecutorApiGateway apiGateway;
   private final RunningExecutions runningExecutions;
   private final ExecutionFinalizer executionFinalizer;
+  private final ExecutorLoader executorLoader;
 
   @Inject
   public RunningExecutionsUpdater(final ExecutorManagerUpdaterStage updaterStage,
       final AlerterHolder alerterHolder, final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final RunningExecutions runningExecutions,
-      final ExecutionFinalizer executionFinalizer) {
+      final ExecutionFinalizer executionFinalizer, final ExecutorLoader executorLoader) {
     this.updaterStage = updaterStage;
     this.alerterHolder = alerterHolder;
     this.commonMetrics = commonMetrics;
     this.apiGateway = apiGateway;
     this.runningExecutions = runningExecutions;
     this.executionFinalizer = executionFinalizer;
+    this.executorLoader = executorLoader;
   }
 
   /**
@@ -93,7 +95,7 @@ public class RunningExecutionsUpdater {
       try {
         results = this.apiGateway.updateExecutions(executor, entry.getValue());
       } catch (final ExecutorManagerException e) {
-        handleException(entry, executor, e);
+        handleException(entry, executor, e, finalizeFlows);
       }
 
       if (results != null) {
@@ -133,30 +135,49 @@ public class RunningExecutionsUpdater {
   }
 
   private void handleException(final Entry<Optional<Executor>, List<ExecutableFlow>> entry,
-      final Executor executor, final ExecutorManagerException e) {
+      final Executor executor, final ExecutorManagerException e,
+      final ArrayList<ExecutableFlow> finalizeFlows) {
     logger.error("Failed to get update from executor " + executor.getHost(), e);
     boolean sendUnresponsiveEmail = false;
+    final boolean executorRemoved = executorRemoved(executor.getId());
     for (final ExecutableFlow flow : entry.getValue()) {
       final Pair<ExecutionReference, ExecutableFlow> pair =
           this.runningExecutions.get().get(flow.getExecutionId());
-      // TODO can runningFlows.get ever return null, causing NPE below?
 
       this.updaterStage
           .set("Failed to get update for flow " + pair.getSecond().getExecutionId());
 
-      final ExecutionReference ref = pair.getFirst();
-      ref.setNextCheckTime(DateTime.now().getMillis() + this.errorThreshold);
-      ref.setNumErrors(ref.getNumErrors() + 1);
-      if (ref.getNumErrors() == this.numErrorsBeforeUnresponsiveEmail
-          || ref.getNumErrors() % this.numErrorsBetweenUnresponsiveEmail == 0) {
-        // if any of the executions has failed many enough updates, alert
-        sendUnresponsiveEmail = true;
+      if (executorRemoved) {
+        logger.warn("Finalizing execution " + flow.getExecutionId()
+            + ". Executor id of this execution doesn't exist");
+        finalizeFlows.add(flow);
+      } else {
+        final ExecutionReference ref = pair.getFirst();
+        ref.setNextCheckTime(DateTime.now().getMillis() + this.errorThreshold);
+        ref.setNumErrors(ref.getNumErrors() + 1);
+        if (ref.getNumErrors() == this.numErrorsBeforeUnresponsiveEmail
+            || ref.getNumErrors() % this.numErrorsBetweenUnresponsiveEmail == 0) {
+          // if any of the executions has failed many enough updates, alert
+          sendUnresponsiveEmail = true;
+        }
       }
     }
     if (sendUnresponsiveEmail) {
       final Alerter mailAlerter = this.alerterHolder.get("email");
       mailAlerter.alertOnFailedUpdate(executor, entry.getValue(), e);
     }
+  }
+
+  private boolean executorRemoved(final int id) {
+    Executor fetchedExecutor;
+    try {
+      fetchedExecutor = this.executorLoader.fetchExecutor(id);
+    } catch (final ExecutorManagerException e) {
+      logger.error("Couldn't check if executor exists", e);
+      // don't know if removed or not -> default to false
+      return false;
+    }
+    return fetchedExecutor == null;
   }
 
   /* Group Executable flow by Executors to reduce number of REST calls */

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -151,7 +151,7 @@ public class ExecutorManagerTest {
     final RunningExecutionsUpdaterThread updaterThread = new RunningExecutionsUpdaterThread(
         new RunningExecutionsUpdater(
             this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-            this.runningExecutions, executionFinalizer), this.runningExecutions);
+            this.runningExecutions, executionFinalizer, this.loader), this.runningExecutions);
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
     final ExecutorManager executorManager = new ExecutorManager(this.props, this.loader,

--- a/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
@@ -117,7 +117,7 @@ public class RunningExecutionsUpdaterTest {
   }
 
   /**
-   * Shuold finalize execution if executor doesn't exist in the DB.
+   * Should finalize execution if executor doesn't exist in the DB.
    */
   @Test
   public void updateExecutionsUpdateCallFailsExecutorDoesntExist() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -86,7 +86,7 @@ public class TriggerManagerDeadlockTest {
   private RunningExecutionsUpdaterThread getRunningExecutionsUpdaterThread() {
     return new RunningExecutionsUpdaterThread(new RunningExecutionsUpdater(
         this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, this.executionFinalizer), runningExecutions);
+        this.runningExecutions, this.executionFinalizer, this.execLoader), this.runningExecutions);
   }
 
   @After


### PR DESCRIPTION
Problem scenario:
1. An executor is stopped [1]
2. Executor is removed from DB table: `executors` [2]
3. Updater thread tries to get an update of an execution that was running on the removed executor
  - Request fails as executor is not running any more
  - Updater sends alert emails about unresponsive executor

Fix (this PR):
- **If update call fails against an executor, check from the DB directly if the executor still exists or not. If not, finalize the execution.** 
- If executor still exists (or couldn't be checked), do as before, ie. periodically alert about unresponsive executor.

----

[1] This can be a graceful shutdown or a sudden crash, doesn't matter

[2] Executor can be removed from the DB in the following ways
- Graceful shutdown: executor removes itself
- Unexpected shutdown – admin removes executor from DB manually, or external monitoring software does it after seeing that the instance has been stopped 