### PR TITLE
New 'expand/collapse all flows' menu options on flow views

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -81,18 +81,34 @@ var nodeClickCallback = function (event, model, node) {
     var flowRequestURL = contextURL + "/manager?project=" + projectName
         + "&flow=" + node.flowId;
     if (node.expanded) {
-      menu = [{
-        title: "Collapse Flow...", callback: function () {
-          model.trigger("collapseFlow", node);
+      menu = [
+        {
+          title: "Collapse Flow...", callback: function () {
+            model.trigger("collapseFlow", node);
+          }
+        },
+        {
+          title: "Collapse all Flows...", callback: function () {
+            model.trigger("collapseAllFlows", node);
+            model.trigger("resetPanZoom");
+          }
         }
-      }];
+      ];
     }
     else {
-      menu = [{
-        title: "Expand Flow...", callback: function () {
-          model.trigger("expandFlow", node);
+      menu = [
+        {
+          title: "Expand Flow...", callback: function () {
+            model.trigger("expandFlow", node);
+          }
+        },
+        {
+          title: "Expand all Flows...", callback: function () {
+            model.trigger("expandAllFlows", node);
+            model.trigger("resetPanZoom");
+          }
         }
-      }];
+      ];
     }
 
     $.merge(menu, [
@@ -100,30 +116,30 @@ var nodeClickCallback = function (event, model, node) {
       {break: 1},
       {
         title: "Open Flow...", callback: function () {
-        window.location.href = flowRequestURL;
-      }
+          window.location.href = flowRequestURL;
+        }
       },
       {
         title: "Open Flow in New Window...", callback: function () {
-        window.open(flowRequestURL);
-      }
+          window.open(flowRequestURL);
+        }
       },
       {break: 1},
       {
         title: "Open Properties...", callback: function () {
-        window.location.href = requestURL;
-      }
+          window.location.href = requestURL;
+        }
       },
       {
         title: "Open Properties in New Window...", callback: function () {
-        window.open(requestURL);
-      }
+          window.open(requestURL);
+        }
       },
       {break: 1},
       {
         title: "Center Flow", callback: function () {
-        model.trigger("centerNode", node);
-      }
+          model.trigger("centerNode", node);
+        }
       }
     ]);
   }
@@ -133,19 +149,19 @@ var nodeClickCallback = function (event, model, node) {
       //  {break: 1},
       {
         title: "Open Job...", callback: function () {
-        window.location.href = requestURL;
-      }
+          window.location.href = requestURL;
+        }
       },
       {
         title: "Open Job in New Window...", callback: function () {
-        window.open(requestURL);
-      }
+          window.open(requestURL);
+        }
       },
       {break: 1},
       {
         title: "Center Job", callback: function () {
-        model.trigger("centerNode", node)
-      }
+          model.trigger("centerNode", node)
+        }
       }
     ];
   }
@@ -171,30 +187,30 @@ var jobClickCallback = function (event, model, node) {
       //  {break: 1},
       {
         title: "Open Flow...", callback: function () {
-        window.location.href = flowRequestURL;
-      }
+          window.location.href = flowRequestURL;
+        }
       },
       {
         title: "Open Flow in New Window...", callback: function () {
-        window.open(flowRequestURL);
-      }
+          window.open(flowRequestURL);
+        }
       },
       {break: 1},
       {
         title: "Open Properties...", callback: function () {
-        window.location.href = requestURL;
-      }
+          window.location.href = requestURL;
+        }
       },
       {
         title: "Open Properties in New Window...", callback: function () {
-        window.open(requestURL);
-      }
+          window.open(requestURL);
+        }
       },
       {break: 1},
       {
         title: "Center Flow", callback: function () {
-        model.trigger("centerNode", node)
-      }
+          model.trigger("centerNode", node)
+        }
       }
     ];
   }
@@ -204,19 +220,19 @@ var jobClickCallback = function (event, model, node) {
       //  {break: 1},
       {
         title: "Open Job...", callback: function () {
-        window.location.href = requestURL;
-      }
+          window.location.href = requestURL;
+        }
       },
       {
         title: "Open Job in New Window...", callback: function () {
-        window.open(requestURL);
-      }
+          window.open(requestURL);
+        }
       },
       {break: 1},
       {
         title: "Center Job", callback: function () {
-        graphModel.trigger("centerNode", node)
-      }
+          graphModel.trigger("centerNode", node)
+        }
       }
     ];
   }
@@ -236,20 +252,33 @@ var graphClickCallback = function (event, model) {
 
   var menu = [
     {
+      title: "Expand all Flows...", callback: function () {
+        model.trigger("expandAllFlows");
+        model.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Collapse all Flows...", callback: function () {
+        model.trigger("collapseAllFlows");
+        model.trigger("resetPanZoom");
+      }
+    },
+    {break: 1},
+    {
       title: "Open Flow...", callback: function () {
-      window.location.href = requestURL;
-    }
+        window.location.href = requestURL;
+      }
     },
     {
       title: "Open Flow in New Window...", callback: function () {
-      window.open(requestURL);
-    }
+        window.open(requestURL);
+      }
     },
     {break: 1},
     {
       title: "Center Graph", callback: function () {
-      model.trigger("resetPanZoom");
-    }
+        model.trigger("resetPanZoom");
+      }
     }
   ];
 

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -252,13 +252,13 @@ var graphClickCallback = function (event, model) {
 
   var menu = [
     {
-      title: "Expand all Flows...", callback: function () {
+      title: "Expand All Flows...", callback: function () {
         model.trigger("expandAllFlows");
         model.trigger("resetPanZoom");
       }
     },
     {
-      title: "Collapse all Flows...", callback: function () {
+      title: "Collapse All Flows...", callback: function () {
         model.trigger("collapseAllFlows");
         model.trigger("resetPanZoom");
       }

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -88,7 +88,7 @@ var nodeClickCallback = function (event, model, node) {
           }
         },
         {
-          title: "Collapse all Flows...", callback: function () {
+          title: "Collapse All Flows...", callback: function () {
             model.trigger("collapseAllFlows", node);
             model.trigger("resetPanZoom");
           }
@@ -103,7 +103,7 @@ var nodeClickCallback = function (event, model, node) {
           }
         },
         {
-          title: "Expand all Flows...", callback: function () {
+          title: "Expand All Flows...", callback: function () {
             model.trigger("expandAllFlows", node);
             model.trigger("resetPanZoom");
           }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -374,8 +374,9 @@ azkaban.EditTableView = Backbone.View.extend({
   },
 
   handleEditColumn: function (evt) {
-    if (evt.target.tagName == "INPUT")
+    if (evt.target.tagName == "INPUT") {
       return;
+    }
     var curTarget = evt.currentTarget;
 
     var text = $(curTarget).children(".spanValue").text();
@@ -636,13 +637,19 @@ var expanelNodeClickCallback = function (event, model, node) {
       menu = [
         {
           title: "Collapse Flow...", callback: function () {
-          model.trigger("collapseFlow", node);
-        }
+            model.trigger("collapseFlow", node);
+          }
+        },
+        {
+          title: "Collapse all Flows...", callback: function () {
+            model.trigger("collapseAllFlows", node);
+            model.trigger("resetPanZoom");
+          }
         },
         {
           title: "Open Flow in New Window...", callback: function () {
-          window.open(flowRequestURL);
-        }
+            window.open(flowRequestURL);
+          }
         }
       ];
 
@@ -651,13 +658,19 @@ var expanelNodeClickCallback = function (event, model, node) {
       menu = [
         {
           title: "Expand Flow...", callback: function () {
-          model.trigger("expandFlow", node);
-        }
+            model.trigger("expandFlow", node);
+          }
+        },
+        {
+          title: "Expand all Flows...", callback: function () {
+            model.trigger("expandAllFlows", node);
+            model.trigger("resetPanZoom");
+          }
         },
         {
           title: "Open Flow in New Window...", callback: function () {
-          window.open(flowRequestURL);
-        }
+            window.open(flowRequestURL);
+          }
         }
       ];
     }
@@ -668,8 +681,8 @@ var expanelNodeClickCallback = function (event, model, node) {
     menu = [
       {
         title: "Open Job in New Window...", callback: function () {
-        window.open(requestURL);
-      }
+          window.open(requestURL);
+        }
       },
     ];
   }
@@ -678,70 +691,70 @@ var expanelNodeClickCallback = function (event, model, node) {
     {break: 1},
     {
       title: "Enable", callback: function () {
-      touchNode(node, false);
-    }, submenu: [
-      {
-        title: "Parents", callback: function () {
-        touchParents(node, false);
-      }
-      },
-      {
-        title: "Ancestors", callback: function () {
-        touchAncestors(node, false);
-      }
-      },
-      {
-        title: "Children", callback: function () {
-        touchChildren(node, false);
-      }
-      },
-      {
-        title: "Descendents", callback: function () {
-        touchDescendents(node, false);
-      }
-      },
-      {
-        title: "Enable All", callback: function () {
-        enableAll();
-      }
-      }
-    ]
+        touchNode(node, false);
+      }, submenu: [
+        {
+          title: "Parents", callback: function () {
+            touchParents(node, false);
+          }
+        },
+        {
+          title: "Ancestors", callback: function () {
+            touchAncestors(node, false);
+          }
+        },
+        {
+          title: "Children", callback: function () {
+            touchChildren(node, false);
+          }
+        },
+        {
+          title: "Descendents", callback: function () {
+            touchDescendents(node, false);
+          }
+        },
+        {
+          title: "Enable All", callback: function () {
+            enableAll();
+          }
+        }
+      ]
     },
     {
       title: "Disable", callback: function () {
-      touchNode(node, true)
-    }, submenu: [
-      {
-        title: "Parents", callback: function () {
-        touchParents(node, true);
-      }
-      },
-      {
-        title: "Ancestors", callback: function () {
-        touchAncestors(node, true);
-      }
-      },
-      {
-        title: "Children", callback: function () {
-        touchChildren(node, true);
-      }
-      },
-      {
-        title: "Descendents", callback: function () {
-        touchDescendents(node, true);
-      }
-      },
-      {
-        title: "Disable All", callback: function () {
-        disableAll();
-      }
-      }
-    ]
+        touchNode(node, true)
+      }, submenu: [
+        {
+          title: "Parents", callback: function () {
+            touchParents(node, true);
+          }
+        },
+        {
+          title: "Ancestors", callback: function () {
+            touchAncestors(node, true);
+          }
+        },
+        {
+          title: "Children", callback: function () {
+            touchChildren(node, true);
+          }
+        },
+        {
+          title: "Descendents", callback: function () {
+            touchDescendents(node, true);
+          }
+        },
+        {
+          title: "Disable All", callback: function () {
+            disableAll();
+          }
+        }
+      ]
     },
     {
       title: "Center Job", callback: function () {
-      model.trigger("centerNode", node);
-    }
+        model.trigger("centerNode", node);
+      }
     }
   ]);
 
@@ -760,26 +773,38 @@ var expanelGraphClickCallback = function (event) {
 
   var menu = [
     {
+      title: "Expand all Flows...", callback: function () {
+        executableGraphModel.trigger("expandAllFlows");
+        executableGraphModel.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Collapse all Flows...", callback: function () {
+        executableGraphModel.trigger("collapseAllFlows");
+        executableGraphModel.trigger("resetPanZoom");
+      }
+    },
+    {
       title: "Open Flow in New Window...", callback: function () {
-      window.open(requestURL);
-    }
+        window.open(requestURL);
+      }
     },
     {break: 1},
     {
       title: "Enable All", callback: function () {
-      enableAll();
-    }
+        enableAll();
+      }
     },
     {
       title: "Disable All", callback: function () {
-      disableAll();
-    }
+        disableAll();
+      }
     },
     {break: 1},
     {
       title: "Center Graph", callback: function () {
-      executableGraphModel.trigger("resetPanZoom");
-    }
+        executableGraphModel.trigger("resetPanZoom");
+      }
     }
   ];
 

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -773,13 +773,13 @@ var expanelGraphClickCallback = function (event) {
 
   var menu = [
     {
-      title: "Expand all Flows...", callback: function () {
+      title: "Expand All Flows...", callback: function () {
         executableGraphModel.trigger("expandAllFlows");
         executableGraphModel.trigger("resetPanZoom");
       }
     },
     {
-      title: "Collapse all Flows...", callback: function () {
+      title: "Collapse All Flows...", callback: function () {
         executableGraphModel.trigger("collapseAllFlows");
         executableGraphModel.trigger("resetPanZoom");
       }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -641,7 +641,7 @@ var expanelNodeClickCallback = function (event, model, node) {
           }
         },
         {
-          title: "Collapse all Flows...", callback: function () {
+          title: "Collapse All Flows...", callback: function () {
             model.trigger("collapseAllFlows", node);
             model.trigger("resetPanZoom");
           }
@@ -662,7 +662,7 @@ var expanelNodeClickCallback = function (event, model, node) {
           }
         },
         {
-          title: "Expand all Flows...", callback: function () {
+          title: "Expand All Flows...", callback: function () {
             model.trigger("expandAllFlows", node);
             model.trigger("resetPanZoom");
           }

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -83,7 +83,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
   },
 
   render: function () {
-    console.log("graph render");
     $(this.mainG).empty();
 
     this.graphBounds = this.renderGraph(this.model.get("data"), this.mainG);
@@ -469,9 +468,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
       // collapse already rendered nodes of type flow
       if (node.type == 'flow' && node.gNode) {
         this.collapseFlow(node);
-      }
 
-      if (node.nodes && node.nodes.length > 0) {
         for (var i = 0; i < node.nodes.length; ++i) {
           this.collapseAllFlows(node.nodes[i]);
         }

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -33,6 +33,8 @@ azkaban.SvgGraphView = Backbone.View.extend({
     this.model.bind('change:updateAll', this.handleUpdateAllStatus, this);
     this.model.bind('expandFlow', this.expandFlow, this);
     this.model.bind('collapseFlow', this.collapseFlow, this);
+    this.model.bind('expandAllFlows', this.expandAllFlows, this);
+    this.model.bind('collapseAllFlows', this.collapseAllFlows, this);
 
     this.graphMargin = settings.graphMargin ? settings.graphMargin : 25;
     this.svgns = "http://www.w3.org/2000/svg";
@@ -437,6 +439,50 @@ azkaban.SvgGraphView = Backbone.View.extend({
     bounds.maxX = bounds.maxX ? bounds.maxX + margin : margin;
     bounds.maxY = bounds.maxY ? bounds.maxY + margin : margin;
     this.graphBounds = bounds;
+  },
+
+  expandAllFlows: function (node) {
+    if (node) {
+      // expands all embedded flows inside given node
+      if (node.type == 'flow') {
+        this.expandFlow(node);
+      }
+
+      if (node.nodes && node.nodes.length > 0) {
+        for (var i = 0; i < node.nodes.length; ++i) {
+          this.expandAllFlows(node.nodes[i]);
+        }
+      }
+    } else {
+      // expands all embedded flows in the graph
+      var nodes = this.model.get("data").nodes;
+      for (var i = 0; i < nodes.length; ++i) {
+        this.expandAllFlows(nodes[i]);
+      }
+    }
+  },
+
+  collapseAllFlows: function (node) {
+    if (node) {
+      // collapse all embedded flows inside given node
+
+      // collapse already rendered nodes of type flow
+      if (node.type == 'flow' && node.gNode) {
+        this.collapseFlow(node);
+      }
+
+      if (node.nodes && node.nodes.length > 0) {
+        for (var i = 0; i < node.nodes.length; ++i) {
+          this.collapseAllFlows(node.nodes[i]);
+        }
+      }
+    } else {
+      // collapse all embedded flows in the graph
+      var nodes = this.model.get("data").nodes;
+      for (var i = 0; i < nodes.length; ++i) {
+        this.collapseAllFlows(nodes[i]);
+      }
+    }
   },
 
   relayoutFlow: function (node) {

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -445,9 +445,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
       // expands all embedded flows inside given node
       if (node.type == 'flow') {
         this.expandFlow(node);
-      }
 
-      if (node.nodes && node.nodes.length > 0) {
         for (var i = 0; i < node.nodes.length; ++i) {
           this.expandAllFlows(node.nodes[i]);
         }


### PR DESCRIPTION
Improvement:
-The new menu options on Flow, Flow Execution and Schedule/Execute pages prevent users from having to unfold deeply nested flows by clicking one by one.
-Users will be able to browse flows and enable or disable job executions more easily.
-Options are shown and work on projects using both flow 1.0 and flow 2.0

<img width="1336" alt="screen shot 2018-11-09 at 5 42 21 pm" src="https://user-images.githubusercontent.com/44478711/48296124-e88a7880-e447-11e8-8db3-e369011365e3.png">
<img width="1520" alt="screen shot 2018-11-09 at 5 41 11 pm" src="https://user-images.githubusercontent.com/44478711/48296143-022bc000-e448-11e8-88b4-7e984fe8d223.png">
<img width="831" alt="screen shot 2018-11-09 at 5 44 58 pm" src="https://user-images.githubusercontent.com/44478711/48296150-0eb01880-e448-11e8-87ce-a73547f5ad46.png">