### PR TITLE
Exclude condition in json response when condition is null.

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -867,7 +867,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     nodeObj.put("endTime", node.getEndTime());
     nodeObj.put("updateTime", node.getUpdateTime());
     nodeObj.put("type", node.getType());
-    nodeObj.put("condition", node.getCondition());
+    if (node.getCondition() != null) {
+      nodeObj.put("condition", node.getCondition());
+    }
     nodeObj.put("nestedId", node.getNestedId());
 
     nodeObj.put("attempt", node.getAttempt());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -801,7 +801,9 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       final HashMap<String, Object> nodeObj = new HashMap<>();
       nodeObj.put("id", node.getId());
       nodeObj.put("type", node.getType());
-      nodeObj.put("condition", node.getCondition());
+      if (node.getCondition() != null) {
+        nodeObj.put("condition", node.getCondition());
+      }
       if (node.getEmbeddedFlowId() != null) {
         nodeObj.put("flowId", node.getEmbeddedFlowId());
         fillFlowInfo(project, node.getEmbeddedFlowId(), nodeObj);


### PR DESCRIPTION
Some users are relying on the json response from `fetchexecflow` API call to generate some report. They would like the condition to be excluded in the json response if it is null.  

```
jasun-mn1:~ jasun$ curl -k --data "session.id=<SESSION_ID>&ajax=fetchexecflow&execid=25990" http://localhost:8081/executor
{
  "project" : "az_acceptance_test",
  "updateTime" : 1541794379559,
  "type" : null,
  "attempt" : 0,
  "execid" : 25990,
  "submitTime" : 1541794369342,
  "nodes" : [ {
    "nestedId" : "IntegrationTest",
    "in" : [ "IntegrationTest_jobCommand" ],
    "startTime" : 1541794379498,
    "updateTime" : 1541794379543,
    "id" : "IntegrationTest",
    "endTime" : 1541794379536,
    "type" : "noop",
    "attempt" : 0,
    "status" : "SUCCEEDED"
  }, {
    "nestedId" : "IntegrationTest_jobCommand",
    "startTime" : 1541794369455,
    "updateTime" : 1541794379490,
    "id" : "IntegrationTest_jobCommand",
    "endTime" : 1541794379486,
    "type" : "command",
    "attempt" : 0,
    "status" : "SUCCEEDED"
  } ],
  "nestedId" : "IntegrationTest",
  "submitUser" : "azkaban",
  "startTime" : 1541794369452,
  "id" : "IntegrationTest",
  "endTime" : 1541794379557,
  "projectId" : 135,
  "flowId" : "IntegrationTest",
  "flow" : "IntegrationTest",
  "status" : "SUCCEEDED"

```