### PR TITLE
Improve dispatch request handling of a previously submitted execution

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -424,6 +424,10 @@ public class FlowRunnerManager implements EventListener,
     // Finally, queue the sucker.
     this.runningFlows.put(execId, runner);
 
+    submitFlowRunner(runner);
+  }
+
+  private void submitFlowRunner(FlowRunner runner) throws ExecutorManagerException {
     try {
       // The executorService already has a queue.
       // The submit method below actually returns an instance of FutureTask,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -354,28 +354,35 @@ public class FlowRunnerManager implements EventListener,
   }
 
   public void submitFlow(final int execId) throws ExecutorManagerException {
-    // Load file and submit
-    if (this.runningFlows.containsKey(execId)) {
-      throw new ExecutorManagerException("Execution " + execId
-          + " is already running.");
+    if (isAlreadyRunning(execId)) {
+      return;
     }
-
     final FlowRunner runner = createFlowRunner(execId);
-
     // Check again.
-    if (this.runningFlows.containsKey(execId)) {
-      throw new ExecutorManagerException("Execution " + execId
-          + " is already running.");
+    if (isAlreadyRunning(execId)) {
+      return;
     }
-
-    // Finally, queue the sucker.
-    this.runningFlows.put(execId, runner);
-
     submitFlowRunner(runner);
   }
 
-  private FlowRunner createFlowRunner(int execId) throws ExecutorManagerException {
-    ExecutableFlow flow;
+  private boolean isAlreadyRunning(int execId) throws ExecutorManagerException {
+    if (this.runningFlows.containsKey(execId)) {
+      logger.info("Execution " + execId + " is already in running.");
+      if (!this.submittedFlows.containsValue(execId)) {
+        // Execution had been added to running flows but not submitted - something's wrong.
+        // Return a response with error: this is a cue for the dispatcher to retry or finalize the
+        // execution as failed.
+        throw new ExecutorManagerException("Execution " + execId +
+            " is in runningFlows but not in submittedFlows. Most likely submission had failed.");
+      }
+      // Already running, everything seems fine. Report as a successful submission.
+      return true;
+    }
+    return false;
+  }
+
+  private FlowRunner createFlowRunner(final int execId) throws ExecutorManagerException {
+    final ExecutableFlow flow;
     flow = this.executorLoader.fetchExecutableFlow(execId);
     if (flow == null) {
       throw new ExecutorManagerException("Error loading flow with exec "
@@ -432,7 +439,8 @@ public class FlowRunnerManager implements EventListener,
     return runner;
   }
 
-  private void submitFlowRunner(FlowRunner runner) throws ExecutorManagerException {
+  private void submitFlowRunner(final FlowRunner runner) throws ExecutorManagerException {
+    this.runningFlows.put(runner.getExecutionId(), runner);
     try {
       // The executorService already has a queue.
       // The submit method below actually returns an instance of FutureTask,
@@ -444,6 +452,7 @@ public class FlowRunnerManager implements EventListener,
       // update the last submitted time.
       this.lastFlowSubmittedDate = System.currentTimeMillis();
     } catch (final RejectedExecutionException re) {
+      this.runningFlows.remove(runner.getExecutionId());
       final StringBuffer errorMsg = new StringBuffer(
           "Azkaban executor can't execute any more flows. ");
       if (this.executorService.isShutdown()) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -360,7 +360,22 @@ public class FlowRunnerManager implements EventListener,
           + " is already running.");
     }
 
-    ExecutableFlow flow = null;
+    final FlowRunner runner = createFlowRunner(execId);
+
+    // Check again.
+    if (this.runningFlows.containsKey(execId)) {
+      throw new ExecutorManagerException("Execution " + execId
+          + " is already running.");
+    }
+
+    // Finally, queue the sucker.
+    this.runningFlows.put(execId, runner);
+
+    submitFlowRunner(runner);
+  }
+
+  private FlowRunner createFlowRunner(int execId) throws ExecutorManagerException {
+    ExecutableFlow flow;
     flow = this.executorLoader.fetchExecutableFlow(execId);
     if (flow == null) {
       throw new ExecutorManagerException("Error loading flow with exec "
@@ -414,17 +429,7 @@ public class FlowRunnerManager implements EventListener,
         .setNumJobThreads(numJobThreads).addListener(this);
 
     configureFlowLevelMetrics(runner);
-
-    // Check again.
-    if (this.runningFlows.containsKey(execId)) {
-      throw new ExecutorManagerException("Execution " + execId
-          + " is already running.");
-    }
-
-    // Finally, queue the sucker.
-    this.runningFlows.put(execId, runner);
-
-    submitFlowRunner(runner);
+    return runner;
   }
 
   private void submitFlowRunner(FlowRunner runner) throws ExecutorManagerException {


### PR DESCRIPTION
Improve dispatch request handling of a previously submitted execution
- If the execution is indeed running, return OK so that dispatcher knows that it was successfully dispatched
- If the execution was left in some intermediate state, return an error so that dispatcher knows to retry or finalize the execution as failed