### PR TITLE
Expose hit ratio of project dir cache as metrics

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
@@ -43,5 +43,7 @@ public class ExecMetrics {
         .addGauge("EXEC-NumRunningFlows", flowRunnerManager::getNumRunningFlows);
     this.metricsManager
         .addGauge("EXEC-NumQueuedFlows", flowRunnerManager::getNumQueuedFlows);
+    this.metricsManager
+        .addGauge("EXEC-ProjectDirCacheHitRatio", flowRunnerManager::getProjectDirHitRatio);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
@@ -44,6 +44,6 @@ public class ExecMetrics {
     this.metricsManager
         .addGauge("EXEC-NumQueuedFlows", flowRunnerManager::getNumQueuedFlows);
     this.metricsManager
-        .addGauge("EXEC-ProjectDirCacheHitRatio", flowRunnerManager::getProjectDirHitRatio);
+        .addGauge("EXEC-ProjectDirCacheHitRatio", flowRunnerManager::getProjectDirCacheHitRatio);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -62,7 +62,7 @@ public class FlowPreparer {
   private final ProjectsDirCacheMetrics cacheMetrics;
 
   @VisibleForTesting
-  class ProjectsDirCacheMetrics {
+  static class ProjectsDirCacheMetrics {
 
     private long cacheHit;
     private long cacheMiss;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -202,6 +202,10 @@ public class FlowRunnerManager implements EventListener,
     this.cleanerThread.start();
   }
 
+  public double getProjectDirHitRatio() {
+    return this.flowPreparer.getProjectDirCacheHitRatio();
+  }
+
   /**
    * Setting the gid bit on the execution directory forces all files/directories created within the
    * directory to be a part of the group associated with the azkaban process. Then, when users

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -202,7 +202,7 @@ public class FlowRunnerManager implements EventListener,
     this.cleanerThread.start();
   }
 
-  public double getProjectDirHitRatio() {
+  public double getProjectDirCacheHitRatio() {
     return this.flowPreparer.getProjectDirCacheHitRatio();
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -183,4 +183,39 @@ public class FlowPreparerTest {
     assertThat(this.projectsDir.listFiles()).containsExactlyInAnyOrder(expectedRemainingFiles
         .toArray(new File[expectedRemainingFiles.size()]));
   }
+
+  @Test
+  public void testProjectsCacheMetricsZeroHit() {
+    //given
+    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics =
+        new FlowPreparer(null, null, null, null).new ProjectsDirCacheMetrics();
+
+    //when zero hit and zero miss then
+    assertThat(cacheMetrics.getHitRatio()).isEqualTo(0);
+
+    //when
+    cacheMetrics.incrementCacheMiss();
+    //then
+    assertThat(cacheMetrics.getHitRatio()).isEqualTo(0);
+
+  }
+
+  @Test
+  public void testProjectsCacheMetricsHit() {
+    //given
+    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics =
+        new FlowPreparer(null, null, null, null).new ProjectsDirCacheMetrics();
+
+    //when
+    cacheMetrics.incrementCacheHit();
+    //then
+    assertThat(cacheMetrics.getHitRatio()).isEqualTo(1);
+
+    //when
+    cacheMetrics.incrementCacheMiss();
+    //then
+    assertThat(cacheMetrics.getHitRatio()).isEqualTo(0.5);
+
+
+  }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -197,7 +197,6 @@ public class FlowPreparerTest {
     cacheMetrics.incrementCacheMiss();
     //then
     assertThat(cacheMetrics.getHitRatio()).isEqualTo(0);
-
   }
 
   @Test
@@ -205,16 +204,14 @@ public class FlowPreparerTest {
     //given
     final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics = new ProjectsDirCacheMetrics();
 
-    //when
+    //when one hit
     cacheMetrics.incrementCacheHit();
     //then
     assertThat(cacheMetrics.getHitRatio()).isEqualTo(1);
 
-    //when
+    //when one miss
     cacheMetrics.incrementCacheMiss();
     //then
     assertThat(cacheMetrics.getHitRatio()).isEqualTo(0.5);
-
-
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import azkaban.execapp.FlowPreparer.ProjectsDirCacheMetrics;
 import azkaban.executor.ExecutableFlow;
 import azkaban.project.ProjectFileHandler;
 import azkaban.storage.StorageManager;
@@ -187,8 +188,7 @@ public class FlowPreparerTest {
   @Test
   public void testProjectsCacheMetricsZeroHit() {
     //given
-    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics =
-        new FlowPreparer(null, null, null, null).new ProjectsDirCacheMetrics();
+    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics = new ProjectsDirCacheMetrics();
 
     //when zero hit and zero miss then
     assertThat(cacheMetrics.getHitRatio()).isEqualTo(0);
@@ -203,8 +203,7 @@ public class FlowPreparerTest {
   @Test
   public void testProjectsCacheMetricsHit() {
     //given
-    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics =
-        new FlowPreparer(null, null, null, null).new ProjectsDirCacheMetrics();
+    final FlowPreparer.ProjectsDirCacheMetrics cacheMetrics = new ProjectsDirCacheMetrics();
 
     //when
     cacheMetrics.incrementCacheHit();


### PR DESCRIPTION
This PR exposes hit ratio of a project dir cache(https://github.com/azkaban/azkaban/pull/1848) as metrics. Cache miss counts as a flow being setup without downloading its project zip, otherwise it counts as a cache hit. 