### PR TITLE
Adding the ability to read global.properties in HTTP job callbacks 

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -260,7 +260,6 @@ public class JobCallbackManager implements EventListener {
     for (final HttpRequestBase httpRequest : httpRequests) {
       httpRequest.addHeader(new BasicHeader("Date", this.gmtDateFormatter
           .format(new Date())));
-      httpRequest.addHeader(new BasicHeader("Host", this.azkabanHostName));
     }
 
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -53,8 +53,10 @@ public class JobCallbackManager implements EventListener {
   private final JmxJobCallbackMBean callbackMbean;
   private final String azkabanHostName;
   private final SimpleDateFormat gmtDateFormatter;
+  private final Props azkabanProps;
 
   private JobCallbackManager(final Props props) {
+    azkabanProps = props;
     maxNumCallBack = props.getInt("jobcallback.max_count", maxNumCallBack);
 
     // initialize the request maker
@@ -210,7 +212,9 @@ public class JobCallbackManager implements EventListener {
 
       // don't want to waste time resolving properties if there are
       // callback properties to parse
-      final Props props = PropsUtils.resolveProps(jobRunner.getProps());
+      Props current = new Props(azkabanProps);
+      current.putAll(jobRunner.getProps());
+      final Props props = PropsUtils.resolveProps(current);
 
       final Map<String, String> contextInfo =
           JobCallbackUtil.buildJobContextInfoMap(event, this.azkabanHostName);


### PR DESCRIPTION
It's the fix of the issue #1950

Technically I just save azkabanProps passed in JobCallbackManager and use these properties during HTTP job callbacks params resolving. 
 