### PR TITLE
Feature to disable some http methods eg. TRACE

### DIFF
--- a/azkaban-web-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-web-server/src/main/resources/conf/azkaban.properties
@@ -34,6 +34,7 @@ lockdown.create.projects=false
 cache.directory=cache
 # JMX stats
 jetty.connector.stats=true
+# jetty.disable.http-methods=
 executor.connector.stats=true
 # Azkaban mysql settings by default. Users should configure their own username and password.
 database.type=mysql


### PR DESCRIPTION
Possibility to disable TRACE.
Before when
curl -v -X TRACE localhost:8081 we have got 200
After we can add TRACE to jetty.disable.http-methods and curl will return 403
