### PR TITLE
Fix access to flow and job definition from Job History page

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
@@ -104,8 +104,10 @@ public class ExecutableJobInfo {
     final String[] flowPairs = this.flowId.split(",");
 
     for (final String flowPair : flowPairs) {
-      // splitting last pair of flow (name,path) by first occurrence of ':' only
-      // because embeddedFlowPath also uses ':' as delimiter
+      // splitting each embeddedFlowName:embeddedFlowPath pair by the first occurrence of ':'
+      // only because embeddedFlowPath also uses ':' as delimiter.
+      // Ex: "embeddedFlow3:rootFlow:embeddedFlow1:embeddedFlow2:embeddedFlow3" will result in
+      // ["embeddedFlow3", "rootFlow:embeddedFlow1:embeddedFlow2:embeddedFlow3"]
       final String[] pairSplit = flowPair.split(":", 2);
       final Pair<String, String> pair;
       if (pairSplit.length == 1) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
@@ -74,12 +74,6 @@ public class ExecutableJobInfo {
     return this.immediateFlowId;
   }
 
-  public String getHeadFlowId() {
-    final Pair<String, String> pair = this.jobPath.get(0);
-
-    return pair.getFirst();
-  }
-
   public String getJobId() {
     return this.jobId;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableJobInfo.java
@@ -35,6 +35,7 @@ public class ExecutableJobInfo {
   private final int attempt;
 
   private ArrayList<Pair<String, String>> jobPath;
+  private String immediateFlowId;
 
   public ExecutableJobInfo(final int execId, final int projectId, final int version,
       final String flowId, final String jobId, final long startTime, final long endTime,
@@ -70,11 +71,7 @@ public class ExecutableJobInfo {
   }
 
   public String getImmediateFlowId() {
-    if (this.jobPath.size() == 1) {
-      return this.flowId;
-    }
-    final Pair<String, String> pair = this.jobPath.get(this.jobPath.size() - 1);
-    return pair.getSecond();
+    return this.immediateFlowId;
   }
 
   public String getHeadFlowId() {
@@ -109,10 +106,13 @@ public class ExecutableJobInfo {
 
   private void parseFlowId() {
     this.jobPath = new ArrayList<>();
+    // parsing pattern: flowRootName[,embeddedFlowName:embeddedFlowPath]*
     final String[] flowPairs = this.flowId.split(",");
 
     for (final String flowPair : flowPairs) {
-      final String[] pairSplit = flowPair.split(":");
+      // splitting last pair of flow (name,path) by first occurrence of ':' only
+      // because embeddedFlowPath also uses ':' as delimiter
+      final String[] pairSplit = flowPair.split(":", 2);
       final Pair<String, String> pair;
       if (pairSplit.length == 1) {
         pair = new Pair<>(pairSplit[0], pairSplit[0]);
@@ -122,6 +122,8 @@ public class ExecutableJobInfo {
 
       this.jobPath.add(pair);
     }
+
+    this.immediateFlowId = this.jobPath.get(this.jobPath.size() - 1).getSecond();
   }
 
   public String getJobIdPath() {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableJobInfoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableJobInfoTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.executor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExecutableJobInfoTest {
+
+  private String parseImmediateFlowId(final String flowId) {
+    // flowId pattern: flowRootName[,embeddedFlowName:embeddedFlowPath]*
+    final ExecutableJobInfo jobInfo = new ExecutableJobInfo(1, 1, 1,
+        flowId, "job", 0, 0, null, 0);
+
+    return jobInfo.getImmediateFlowId();
+  }
+
+  @Test
+  public void testParseFlowId() throws Exception {
+    // flowId pattern: flowRootName[,embeddedFlowName:embeddedFlowPath]*
+    Assert.assertEquals("Unexpected immediate flow id",
+        "embedded", parseImmediateFlowId("embedded"));
+
+    Assert.assertEquals("Unexpected immediate flow id",
+        "embedded:emb_1", parseImmediateFlowId("embedded,emb_1:embedded:emb_1"));
+
+    Assert.assertEquals("Unexpected immediate flow id",
+        "embedded:emb_2:emb_3:emb_4",
+        parseImmediateFlowId(
+            "embedded,emb_2:embedded:emb_2,emb_3:embedded:emb_2:emb_3,emb_4:embedded:emb_2:emb_3:emb_4"));
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableJobInfoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableJobInfoTest.java
@@ -33,14 +33,14 @@ public class ExecutableJobInfoTest {
   public void testParseFlowId() throws Exception {
     // flowId pattern: flowRootName[,embeddedFlowName:embeddedFlowPath]*
     Assert.assertEquals("Unexpected immediate flow id",
-        "embedded", parseImmediateFlowId("embedded"));
+        "root", parseImmediateFlowId("root"));
 
     Assert.assertEquals("Unexpected immediate flow id",
-        "embedded:emb_1", parseImmediateFlowId("embedded,emb_1:embedded:emb_1"));
+        "root:emb_1", parseImmediateFlowId("root,emb_1:root:emb_1"));
 
     Assert.assertEquals("Unexpected immediate flow id",
-        "embedded:emb_2:emb_3:emb_4",
+        "root:emb_1:emb_2:emb_3",
         parseImmediateFlowId(
-            "embedded,emb_2:embedded:emb_2,emb_3:embedded:emb_2:emb_3,emb_4:embedded:emb_2:emb_3:emb_4"));
+            "root,emb_1:root:emb_1,emb_2:root:emb_1:emb_2,emb_3:root:emb_1:emb_2:emb_3"));
   }
 }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
@@ -109,7 +109,7 @@
                   <a href="${context}/manager?project=${projectName}&flow=${job.immediateFlowId}&job=${jobid}">${jobid}</a>
                 </td>
                 <td>
-                  <a href="${context}/manager?project=${projectName}&flow=${job.headFlowId}">${job.flowId}</a>
+                  <a href="${context}/manager?project=${projectName}&flow=${job.immediateFlowId}">${job.immediateFlowId}</a>
                 </td>
                 <td>$utils.formatDate(${job.startTime})</td>
                 <td>$utils.formatDate(${job.endTime})</td>


### PR DESCRIPTION

Issue: when a user tried to access a Job page from the Job History page the application was throwing the error below. This happened only for jobs within an embedded flow.
<img width="322" alt="screen shot 2018-12-03 at 11 33 02 am" src="https://user-images.githubusercontent.com/44478711/49397385-44b38600-f6f0-11e8-8c78-093e0263c3bb.png">

Also the link to the job's flow in this page was loading the root flow. This PR sets that link to refer to the immediate flow which would be a more expected action here.
