### PR TITLE
Switch two checks from runningExecutions cache to DB.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -39,6 +39,12 @@ public interface ExecutorLoader {
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException;
 
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException;
+
+  Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+      throws ExecutorManagerException;
+
   List<ExecutableFlow> fetchFlowHistory(int skip, int num)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -44,13 +44,90 @@ public class FetchActiveFlowDao {
     this.dbOperator = dbOperator;
   }
 
+  private static Pair<ExecutionReference, ExecutableFlow> getExecutableFlowHelper(
+      final ResultSet rs) throws SQLException {
+    final int id = rs.getInt(1);
+    final int encodingType = rs.getInt(2);
+    final byte[] data = rs.getBytes(3);
+    final String host = rs.getString(4);
+    final int port = rs.getInt(5);
+    final int executorId = rs.getInt(6);
+    final boolean executorStatus = rs.getBoolean(7);
+
+    if (data == null) {
+      logger.warn("Execution id " + id + " has flow_data = null. To clean up, update status to "
+          + "FAILED manually, eg. "
+          + "SET status = " + Status.FAILED.getNumVal() + " WHERE id = " + id);
+    } else {
+      final EncodingType encType = EncodingType.fromInteger(encodingType);
+      try {
+        final ExecutableFlow exFlow =
+            ExecutableFlow.createExecutableFlowFromObject(
+                GZIPUtils.transformBytesToObject(data, encType));
+        final Executor executor;
+        if (host == null) {
+          logger.warn("Executor id " + executorId + " (on execution " +
+              id + ") wasn't found");
+          executor = null;
+        } else {
+          executor = new Executor(executorId, host, port, executorStatus);
+        }
+        final ExecutionReference ref = new ExecutionReference(id, executor);
+        return new Pair<>(ref, exFlow);
+      } catch (final IOException e) {
+        throw new SQLException("Error retrieving flow data " + id, e);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Fetch flows that are not in finished status, including both dispatched and non-dispatched
+   * flows.
+   *
+   * @return unfinished flows map
+   * @throws ExecutorManagerException the executor manager exception
+   */
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_UNFINISHED_EXECUTABLE_FLOWS,
+          new FetchActiveExecutableFlows());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching unfinished flows", e);
+    }
+  }
+
+  /**
+   * Fetch flows that are dispatched and not yet finished.
+   *
+   * @return active flows map
+   * @throws ExecutorManagerException the executor manager exception
+   */
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
     try {
-      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOW,
+      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOWS,
           new FetchActiveExecutableFlows());
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  /**
+   * Fetch the flow that is dispatched and not yet finished by execution id.
+   *
+   * @return active flow pair
+   * @throws ExecutorManagerException the executor manager exception
+   */
+  Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchActiveExecutableFlow
+              .FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXEC_ID,
+          new FetchActiveExecutableFlow(), execId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flow by exec id" + execId, e);
     }
   }
 
@@ -58,8 +135,20 @@ public class FetchActiveFlowDao {
   static class FetchActiveExecutableFlows implements
       ResultSetHandler<Map<Integer, Pair<ExecutionReference, ExecutableFlow>>> {
 
-    // Select running and executor assigned flows
-    private static final String FETCH_ACTIVE_EXECUTABLE_FLOW =
+    // Select flows that are not in finished status
+    private static final String FETCH_UNFINISHED_EXECUTABLE_FLOWS =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " LEFT JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")";
+
+    // Select flows that are dispatched and not in finished status
+    private static final String FETCH_ACTIVE_EXECUTABLE_FLOWS =
         "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
             + "et.port port, ex.executor_id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
@@ -86,40 +175,44 @@ public class FetchActiveFlowDao {
       final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> execFlows =
           new HashMap<>();
       do {
-        final int id = rs.getInt(1);
-        final int encodingType = rs.getInt(2);
-        final byte[] data = rs.getBytes(3);
-        final String host = rs.getString(4);
-        final int port = rs.getInt(5);
-        final int executorId = rs.getInt(6);
-        final boolean executorStatus = rs.getBoolean(7);
-
-        if (data == null) {
-          logger.warn("Execution id " + id + " has flow_data=null. To clean up, update status to "
-              + "FAILED manually, eg. "
-              + "SET status = " + Status.FAILED.getNumVal() + " WHERE id = " + id);
-        } else {
-          final EncodingType encType = EncodingType.fromInteger(encodingType);
-          try {
-            final ExecutableFlow exFlow =
-                ExecutableFlow.createExecutableFlowFromObject(
-                    GZIPUtils.transformBytesToObject(data, encType));
-            final Executor executor;
-            if (host == null) {
-              logger.warn("Executor id " + executorId + " (on execution " + id + ") wasn't found");
-              executor = null;
-            } else {
-              executor = new Executor(executorId, host, port, executorStatus);
-            }
-            final ExecutionReference ref = new ExecutionReference(id, executor);
-            execFlows.put(id, new Pair<>(ref, exFlow));
-          } catch (final IOException e) {
-            throw new SQLException("Error retrieving flow data " + id, e);
-          }
+        final Pair<ExecutionReference, ExecutableFlow> exFlow = getExecutableFlowHelper(rs);
+        if (exFlow != null) {
+          execFlows.put(rs.getInt(1), exFlow);
         }
       } while (rs.next());
 
       return execFlows;
+    }
+  }
+
+  private static class FetchActiveExecutableFlow implements
+      ResultSetHandler<Pair<ExecutionReference, ExecutableFlow>> {
+
+    // Select the flow that is dispatched and not in finished status by execution id
+    private static final String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXEC_ID =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " LEFT JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.exec_id = ? AND ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")"
+            // exclude queued flows that haven't been assigned yet -- this is the opposite of
+            // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
+            + " AND NOT ("
+            + "   ex.executor_id IS NULL"
+            + "   AND ex.status = " + Status.PREPARING.getNumVal()
+            + " )";
+
+    @Override
+    public Pair<ExecutionReference, ExecutableFlow> handle(
+        final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return null;
+      }
+      return getExecutableFlowHelper(rs);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -97,8 +97,19 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
-
     return this.fetchActiveFlowDao.fetchActiveFlows();
+  }
+
+  @Override
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchUnfinishedFlows();
+  }
+
+  @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
+      throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchActiveFlowByExecId(execId);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Assert;
@@ -383,6 +384,9 @@ public class ExecutorManagerTest {
   @Test(expected = ExecutorManagerException.class)
   public void testTooManySubmitFlows() throws Exception {
     testSetUpForRunningFlows();
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = new
+        ConcurrentHashMap<>();
+    when(this.loader.fetchUnfinishedFlows()).thenReturn(unfinishedFlows);
     final ExecutableFlow flow1 = TestUtils
         .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
     flow1.setExecutionId(101);
@@ -395,11 +399,15 @@ public class ExecutorManagerTest {
     final ExecutableFlow flow4 = TestUtils
         .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
     flow4.setExecutionId(104);
+    unfinishedFlows.put(101, new Pair<>(new ExecutionReference(101), flow1));
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
     verify(this.loader).uploadExecutableFlow(flow1);
+    unfinishedFlows.put(102, new Pair<>(new ExecutionReference(102), flow1));
     this.manager.submitExecutableFlow(flow2, this.user.getUserId());
     verify(this.loader).uploadExecutableFlow(flow2);
+    unfinishedFlows.put(103, new Pair<>(new ExecutionReference(103), flow1));
     this.manager.submitExecutableFlow(flow3, this.user.getUserId());
+    unfinishedFlows.put(104, new Pair<>(new ExecutionReference(104), flow1));
     this.manager.submitExecutableFlow(flow4, this.user.getUserId());
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -76,6 +76,17 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    return new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId) {
+    return new Pair<>(null, null);
+  }
+
+  @Override
   public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
       final int skip, final int num) throws ExecutorManagerException {
     return null;


### PR DESCRIPTION
There is a critical issue that `RunningExecutionsUpdaterThread` runs out of memory occasionally. The UpdaterThread stops updating `runningExecutions` cache, causing new flows not able to be submitted and flow/job logs not showing up. 
This fix is to switch two checks in submitting flows and fetching flow/job logs from cache to DB. This would mitigate the current problem while we are figuring out the root cause of the OOM issue.
This fix is also part of new AZ dispatching design which aims to remove all the cache from web server. All the places where `runningExecutions` cache is fetched will ultimately be replaced by direct DB calls. See #2038
To test the performance of DB queries, I launched ~ 1000 flows in solo-server at the same time and captured the time of calling `fetchUnfinishedFlows` and `fetchActiveFlowByExecId`. When the number of running flows is small, they are similar around 1-3 ms. When the number of running flows grows to ~ 1000, time of `fetchActiveFlowByExecId` remains the same, and `fetchUnfinishedFlows` is ~ 50 ms, sometimes reach ~ 100 ms. It will slightly affect the time to submit a flow, but still within an acceptable range. 
