### PR TITLE
Fix issue with validator fix link in upload modal

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectmodals.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectmodals.vm
@@ -39,7 +39,7 @@
               <div class="form-group">
                 <label for="fix" class="col-sm-3 control-label">
                   $validatorFixLabel.toString()
-                  <a href=$validatorFixLink.toString()target="_blank">
+                  <a href=$validatorFixLink.toString() target="_blank">
                     <span class="ui-icon ui-icon-info" style="display:inline-block;"></span>
                   </a>
                 </label>


### PR DESCRIPTION
The auto formatting performed in #1397 led to an issue with the validator fix link in the upload modal, where it's appended to the target parameter and thus breaks the link. This commit adds the missing space back.