### PR TITLE
fix getExecutorManager method not found.

### DIFF
--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -87,7 +87,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
   public void init(final ServletConfig config) throws ServletException {
     super.init(config);
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
-    this.executorManagerAdapter = server.getExecutorManagerAdapter();
+    this.executorManagerAdapter = server.getExecutorManager();
     this.projectManager = server.getProjectManager();
   }
 

--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -288,7 +288,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
       final int offset = getIntParam(req, "offset");
       final int length = getIntParam(req, "length");
       final ExecutableFlow exec;
-      final ExecutorManagerAdapter executorManagerAdapter = this.server.getExecutorManagerAdapter();
+      final ExecutorManagerAdapter executorManagerAdapter = this.server.getExecutorManager();
       try {
         exec = executorManagerAdapter.getExecutableFlow(execId);
       } catch (final Exception e) {
@@ -364,7 +364,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     preparePage(page, session);
 
     final ProjectManager projectManager = this.server.getProjectManager();
-    final ExecutorManagerAdapter executorManagerAdapter = this.server.getExecutorManagerAdapter();
+    final ExecutorManagerAdapter executorManagerAdapter = this.server.getExecutorManager();
 
     final Project project = projectManager.getProject(id);
     final Reportal reportal = Reportal.loadFromProject(project);
@@ -1218,7 +1218,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 
     try {
       final String message =
-          this.server.getExecutorManagerAdapter().submitExecutableFlow(exflow,
+          this.server.getExecutorManager().submitExecutableFlow(exflow,
               session.getUser().getUserId())
               + ".";
       ret.put("message", message);

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -66,11 +66,11 @@ public class ExecuteFlowAction implements TriggerAction {
     ExecuteFlowAction.logger = logger;
   }
 
-  public static ExecutorManagerAdapter getExecutorManagerAdapter() {
+  public static ExecutorManagerAdapter getExecutorManager() {
     return executorManagerAdapter;
   }
 
-  public static void setExecutorManagerAdapter(
+  public static void setExecutorManager(
       final ExecutorManagerAdapter executorManagerAdapter) {
     ExecuteFlowAction.executorManagerAdapter = executorManagerAdapter;
   }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecutionChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecutionChecker.java
@@ -43,7 +43,7 @@ public class ExecutionChecker implements ConditionChecker {
     this.wantedStatus = wantedStatus;
   }
 
-  public static void setExecutorManagerAdapter(final ExecutorManagerAdapter em) {
+  public static void setExecutorManager(final ExecutorManagerAdapter em) {
     executorManagerAdapter = em;
   }
 

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/KillExecutionAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/KillExecutionAction.java
@@ -48,7 +48,7 @@ public class KillExecutionAction implements TriggerAction {
     this.actionId = actionId;
   }
 
-  public static void setExecutorManagerAdapter(final ExecutorManagerAdapter em) {
+  public static void setExecutorManager(final ExecutorManagerAdapter em) {
     executorManagerAdapter = em;
   }
 

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
@@ -68,7 +68,7 @@ public class TriggerManagerTest {
     when(executorManagerAdapter.submitExecutableFlow(any(), any()))
         .thenThrow(new ExecutorManagerException("Flow is already running. Skipping execution.",
             ExecutorManagerException.Reason.SkippedExecution));
-    ExecuteFlowAction.setExecutorManagerAdapter(this.executorManagerAdapter);
+    ExecuteFlowAction.setExecutorManager(this.executorManagerAdapter);
     ExecuteFlowAction.setProjectManager(this.projectManager);
     ExecuteFlowAction.setTriggerManager(this.triggerManager);
     final Props props = new Props();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -616,12 +616,12 @@ public class AzkabanWebServer extends AzkabanServer {
 
   private void loadBuiltinCheckersAndActions() {
     logger.info("Loading built-in checker and action types");
-    ExecuteFlowAction.setExecutorManagerAdapter(this.executorManagerAdapter);
+    ExecuteFlowAction.setExecutorManager(this.executorManagerAdapter);
     ExecuteFlowAction.setProjectManager(this.projectManager);
     ExecuteFlowAction.setTriggerManager(this.triggerManager);
-    KillExecutionAction.setExecutorManagerAdapter(this.executorManagerAdapter);
+    KillExecutionAction.setExecutorManager(this.executorManagerAdapter);
     CreateTriggerAction.setTriggerManager(this.triggerManager);
-    ExecutionChecker.setExecutorManagerAdapter(this.executorManagerAdapter);
+    ExecutionChecker.setExecutorManager(this.executorManagerAdapter);
 
     this.triggerManager.registerCheckerType(BasicTimeChecker.type, BasicTimeChecker.class);
     this.triggerManager.registerCheckerType(SlaChecker.type, SlaChecker.class);
@@ -657,7 +657,7 @@ public class AzkabanWebServer extends AzkabanServer {
     return this.projectManager;
   }
 
-  public ExecutorManagerAdapter getExecutorManagerAdapter() {
+  public ExecutorManagerAdapter getExecutorManager() {
     return this.executorManagerAdapter;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -84,7 +84,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
     this.userManager = server.getUserManager();
     this.projectManager = server.getProjectManager();
-    this.executorManagerAdapter = server.getExecutorManagerAdapter();
+    this.executorManagerAdapter = server.getExecutorManager();
     this.scheduleManager = server.getScheduleManager();
     this.flowTriggerService = server.getFlowTriggerService();
     // TODO: reallocf fully guicify

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/HistoryServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/HistoryServlet.java
@@ -42,7 +42,7 @@ public class HistoryServlet extends LoginAbstractAzkabanServlet {
   public void init(final ServletConfig config) throws ServletException {
     super.init(config);
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
-    this.executorManagerAdapter = server.getExecutorManagerAdapter();
+    this.executorManagerAdapter = server.getExecutorManager();
     this.projectManager = server.getProjectManager();
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -60,7 +60,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
     this.server = (AzkabanWebServer) getApplication();
     this.userManager = this.server.getUserManager();
-    this.executorManagerAdapter = this.server.getExecutorManagerAdapter();
+    this.executorManagerAdapter = this.server.getExecutorManager();
 
     this.triggerManager = this.server.getTriggerManager();
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -118,7 +118,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
     this.projectManager = server.getProjectManager();
-    this.executorManagerAdapter = server.getExecutorManagerAdapter();
+    this.executorManagerAdapter = server.getExecutorManager();
     this.scheduleManager = server.getScheduleManager();
     this.userManager = server.getUserManager();
     this.scheduler = server.getScheduler();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
@@ -54,7 +54,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
     super.init(config);
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
     this.userManager = server.getUserManager();
-    this.execManagerAdapter = server.getExecutorManagerAdapter();
+    this.execManagerAdapter = server.getExecutorManager();
   }
 
   @Override


### PR DESCRIPTION
When trying to deploy the new azkaban-distribution internally, we found the issue:
```
2018/12/05 04:12:27.976 +0000 WARN [log] [Azkaban] failed azkaban.viewer.jobsummary.JobSummaryServlet-108774737: java.lang.NoSuchMethodError: azkaban.webapp.AzkabanWebServer.getExecutorManager()Lazkaban/executor/ExecutorManager;
2018/12/05 04:12:27.976 +0000 WARN [log] [Azkaban] failed azkaban.viewer.pigvisualizer.PigVisualizerServlet-1897940586: java.lang.NoSuchMethodError: azkaban.webapp.AzkabanWebServer.getExecutorManager()Lazkaban/executor/ExecutorManager;
```
The method name `getExecutorManager` was changed in #2039 and not found by some plugins.

In this PR, temporarily revert the method name back to unblock the release.
Need to further work on two things later:
1. check the azkaban-distribution repo and see why new changes are not picked up in jobsummary plugin.
2. Move pigvisualizer plugin from azkaban-plugins repo to the main azkaban repo for better maintenance and development. 