### PR TITLE
AZNewDispatchingLogic - Switch fetching running flows from cache to DB.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -39,6 +39,12 @@ public interface ExecutorLoader {
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException;
 
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException;
+
+  Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(int execId)
+      throws ExecutorManagerException;
+
   List<ExecutableFlow> fetchFlowHistory(int skip, int num)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -44,13 +44,90 @@ public class FetchActiveFlowDao {
     this.dbOperator = dbOperator;
   }
 
+  private static Pair<ExecutionReference, ExecutableFlow> getExecutableFlowHelper(
+      final ResultSet rs) throws SQLException {
+    final int id = rs.getInt(1);
+    final int encodingType = rs.getInt(2);
+    final byte[] data = rs.getBytes(3);
+    final String host = rs.getString(4);
+    final int port = rs.getInt(5);
+    final int executorId = rs.getInt(6);
+    final boolean executorStatus = rs.getBoolean(7);
+
+    if (data == null) {
+      logger.warn("Execution id " + id + " has flow_data = null. To clean up, update status to "
+          + "FAILED manually, eg. "
+          + "SET status = " + Status.FAILED.getNumVal() + " WHERE id = " + id);
+    } else {
+      final EncodingType encType = EncodingType.fromInteger(encodingType);
+      try {
+        final ExecutableFlow exFlow =
+            ExecutableFlow.createExecutableFlowFromObject(
+                GZIPUtils.transformBytesToObject(data, encType));
+        final Executor executor;
+        if (host == null) {
+          logger.warn("Executor id " + executorId + " (on execution " +
+              id + ") wasn't found");
+          executor = null;
+        } else {
+          executor = new Executor(executorId, host, port, executorStatus);
+        }
+        final ExecutionReference ref = new ExecutionReference(id, executor);
+        return new Pair<>(ref, exFlow);
+      } catch (final IOException e) {
+        throw new SQLException("Error retrieving flow data " + id, e);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Fetch flows that are not in finished status, including both dispatched and non-dispatched
+   * flows.
+   *
+   * @return unfinished flows map
+   * @throws ExecutorManagerException the executor manager exception
+   */
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_UNFINISHED_EXECUTABLE_FLOWS,
+          new FetchActiveExecutableFlows());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching unfinished flows", e);
+    }
+  }
+
+  /**
+   * Fetch flows that are dispatched and not yet finished.
+   *
+   * @return active flows map
+   * @throws ExecutorManagerException the executor manager exception
+   */
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
     try {
-      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOW,
+      return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOWS,
           new FetchActiveExecutableFlows());
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Error fetching active flows", e);
+    }
+  }
+
+  /**
+   * Fetch the flow that is dispatched and not yet finished by execution id.
+   *
+   * @return active flow pair
+   * @throws ExecutorManagerException the executor manager exception
+   */
+  Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchActiveExecutableFlow
+              .FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXEC_ID,
+          new FetchActiveExecutableFlow(), execId);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching active flow by exec id" + execId, e);
     }
   }
 
@@ -58,8 +135,20 @@ public class FetchActiveFlowDao {
   static class FetchActiveExecutableFlows implements
       ResultSetHandler<Map<Integer, Pair<ExecutionReference, ExecutableFlow>>> {
 
-    // Select running and executor assigned flows
-    private static final String FETCH_ACTIVE_EXECUTABLE_FLOW =
+    // Select flows that are not in finished status
+    private static final String FETCH_UNFINISHED_EXECUTABLE_FLOWS =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " LEFT JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")";
+
+    // Select flows that are dispatched and not in finished status
+    private static final String FETCH_ACTIVE_EXECUTABLE_FLOWS =
         "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
             + "et.port port, ex.executor_id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
@@ -86,40 +175,44 @@ public class FetchActiveFlowDao {
       final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> execFlows =
           new HashMap<>();
       do {
-        final int id = rs.getInt(1);
-        final int encodingType = rs.getInt(2);
-        final byte[] data = rs.getBytes(3);
-        final String host = rs.getString(4);
-        final int port = rs.getInt(5);
-        final int executorId = rs.getInt(6);
-        final boolean executorStatus = rs.getBoolean(7);
-
-        if (data == null) {
-          logger.warn("Execution id " + id + " has flow_data=null. To clean up, update status to "
-              + "FAILED manually, eg. "
-              + "SET status = " + Status.FAILED.getNumVal() + " WHERE id = " + id);
-        } else {
-          final EncodingType encType = EncodingType.fromInteger(encodingType);
-          try {
-            final ExecutableFlow exFlow =
-                ExecutableFlow.createExecutableFlowFromObject(
-                    GZIPUtils.transformBytesToObject(data, encType));
-            final Executor executor;
-            if (host == null) {
-              logger.warn("Executor id " + executorId + " (on execution " + id + ") wasn't found");
-              executor = null;
-            } else {
-              executor = new Executor(executorId, host, port, executorStatus);
-            }
-            final ExecutionReference ref = new ExecutionReference(id, executor);
-            execFlows.put(id, new Pair<>(ref, exFlow));
-          } catch (final IOException e) {
-            throw new SQLException("Error retrieving flow data " + id, e);
-          }
+        final Pair<ExecutionReference, ExecutableFlow> exFlow = getExecutableFlowHelper(rs);
+        if (exFlow != null) {
+          execFlows.put(rs.getInt(1), exFlow);
         }
       } while (rs.next());
 
       return execFlows;
+    }
+  }
+
+  private static class FetchActiveExecutableFlow implements
+      ResultSetHandler<Pair<ExecutionReference, ExecutableFlow>> {
+
+    // Select the flow that is dispatched and not in finished status by execution id
+    private static final String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXEC_ID =
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
+            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+            + " FROM execution_flows ex"
+            + " LEFT JOIN "
+            + " executors et ON ex.executor_id = et.id"
+            + " Where ex.exec_id = ? AND ex.status NOT IN ("
+            + Status.SUCCEEDED.getNumVal() + ", "
+            + Status.KILLED.getNumVal() + ", "
+            + Status.FAILED.getNumVal() + ")"
+            // exclude queued flows that haven't been assigned yet -- this is the opposite of
+            // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
+            + " AND NOT ("
+            + "   ex.executor_id IS NULL"
+            + "   AND ex.status = " + Status.PREPARING.getNumVal()
+            + " )";
+
+    @Override
+    public Pair<ExecutionReference, ExecutableFlow> handle(
+        final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return null;
+      }
+      return getExecutableFlowHelper(rs);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -97,8 +97,19 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
-
     return this.fetchActiveFlowDao.fetchActiveFlows();
+  }
+
+  @Override
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchUnfinishedFlows();
+  }
+
+  @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId)
+      throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchActiveFlowByExecId(execId);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -1,0 +1,126 @@
+/*
+* Copyright 2018 LinkedIn Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the “License”); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+package azkaban.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import azkaban.utils.Pair;
+import azkaban.utils.TestUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutionControllerTest {
+
+  private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows = new HashMap<>();
+  private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = new
+      HashMap<>();
+  private List<Executor> activeExecutors = new ArrayList<>();
+  private List<Executor> allExecutors = new ArrayList<>();
+  private ExecutionController controller;
+  private ExecutorLoader loader;
+  private ExecutorApiGateway apiGateway;
+
+  @Before
+  public void setup() throws Exception {
+    this.loader = mock(ExecutorLoader.class);
+    this.apiGateway = mock(ExecutorApiGateway.class);
+    this.controller = new ExecutionController(this.loader, this.apiGateway);
+
+    final Executor executor1 = new Executor(1, "localhost", 12345, true);
+    final Executor executor2 = new Executor(2, "localhost", 12346, true);
+    final Executor executor3 = new Executor(3, "localhost", 12347, false);
+    this.activeExecutors = ImmutableList.of(executor1, executor2);
+    this.allExecutors = ImmutableList.of(executor1, executor2, executor3);
+    when(this.loader.fetchActiveExecutors()).thenReturn(this.activeExecutors);
+
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    final ExecutableFlow flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    flow1.setExecutionId(1);
+    flow2.setExecutionId(2);
+    flow3.setExecutionId(3);
+    final ExecutionReference ref1 =
+        new ExecutionReference(flow1.getExecutionId(), null);
+    final ExecutionReference ref2 =
+        new ExecutionReference(flow2.getExecutionId(), executor2);
+    final ExecutionReference ref3 =
+        new ExecutionReference(flow3.getExecutionId(), executor3);
+
+    this.activeFlows = ImmutableMap
+        .of(flow2.getExecutionId(), new Pair<>(ref2, flow2), flow3.getExecutionId(),
+            new Pair<>(ref3, flow3));
+    when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
+
+    this.unfinishedFlows = ImmutableMap.of(flow1.getExecutionId(), new Pair<>(ref1, flow1),
+        flow2.getExecutionId(), new Pair<>(ref2, flow2), flow3.getExecutionId(), new Pair<>(ref3,
+            flow3));
+    when(this.loader.fetchUnfinishedFlows()).thenReturn(this.unfinishedFlows);
+  }
+
+  @After
+  public void tearDown() {
+    if (this.controller != null) {
+      this.controller.shutdown();
+    }
+  }
+
+  @Test
+  public void testFetchAllActiveFlows() throws Exception {
+    final List<ExecutableFlow> flows = this.controller.getRunningFlows();
+    this.unfinishedFlows.values()
+        .forEach(pair -> assertThat(flows.contains(pair.getSecond())).isTrue());
+  }
+
+  @Test
+  public void testFetchActiveFlowByProject() throws Exception {
+    final ExecutableFlow flow2 = this.unfinishedFlows.get(2).getSecond();
+    final ExecutableFlow flow3 = this.unfinishedFlows.get(3).getSecond();
+    final List<Integer> executions = this.controller.getRunningFlows(flow2.getProjectId(), flow2
+        .getFlowId());
+    assertThat(executions.contains(flow2.getExecutionId())).isTrue();
+    assertThat(executions.contains(flow3.getExecutionId())).isTrue();
+    assertThat(this.controller.isFlowRunning(flow2.getProjectId(), flow2.getFlowId())).isTrue();
+    assertThat(this.controller.isFlowRunning(flow3.getProjectId(), flow3.getFlowId())).isTrue();
+  }
+
+  @Test
+  public void testFetchActiveFlowWithExecutor() throws Exception {
+    final List<Pair<ExecutableFlow, Optional<Executor>>> activeFlowsWithExecutor =
+        this.controller.getActiveFlowsWithExecutor();
+    this.unfinishedFlows.values().forEach(pair -> assertThat(activeFlowsWithExecutor
+        .contains(new Pair<>(pair.getSecond(), pair.getFirst().getExecutor()))).isTrue());
+  }
+
+  @Test
+  public void testFetchAllActiveExecutorServerHosts() throws Exception {
+    final Set<String> activeExecutorServerHosts = this.controller.getAllActiveExecutorServerHosts();
+    assertThat(activeExecutorServerHosts.size()).isEqualTo(3);
+    this.allExecutors.forEach(executor -> assertThat(
+        activeExecutorServerHosts.contains(executor.getHost() + ":" + executor.getPort()))
+        .isTrue());
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -76,6 +76,17 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
+      throws ExecutorManagerException {
+    return new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchActiveFlowByExecId(final int execId) {
+    return new Pair<>(null, null);
+  }
+
+  @Override
   public List<ExecutableFlow> fetchFlowHistory(final int projectId, final String flowId,
       final int skip, final int num) throws ExecutorManagerException {
     return null;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
@@ -184,6 +184,10 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
       final Collection<Executor> executors = this.execManagerAdapter.getAllActiveExecutors();
       page.add("executorList", executors);
 
+      if (executors.isEmpty()) {
+        throw new ExecutorManagerException("Executor list is empty.");
+      }
+
       final Map<String, Object> result =
           this.execManagerAdapter.callExecutorStats(executors.iterator().next().getId(),
               ConnectorParams.STATS_GET_ALLMETRICSNAME,


### PR DESCRIPTION
As part of the new design in #2038, we want to remove the cache from web server so that it can be stateless. This is also an important step towards the ultimate goal of web server HA.
In this PR, we replaced fetching from cache to direct DB calls in the new module `ExecutionController`. Also created new DB queries for performance improvement. 
Other than that, most of the functionalities remain the same as those in `ExecutorManager`. 
