### PR TITLE
adding plugin.dir to plugin job property set

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -191,6 +191,10 @@ public class JobTypeManager {
 
       pluginLoadProps = new Props(commonPluginLoadProps, pluginLoadPropsFile);
       pluginLoadProps.put("plugin.dir", pluginDir.getAbsolutePath());
+
+      // Adding "plugin.dir" to allow plugin.properties file could read this property. Also, user
+      // code could leverage this property as well.
+      pluginJobProps.put("plugin.dir", pluginDir.getAbsolutePath());
       pluginLoadProps = PropsUtils.resolveProps(pluginLoadProps);
     } catch (final Exception e) {
       logger.error("pluginLoadProps to help with debugging: " + pluginLoadProps);


### PR DESCRIPTION
We recently received a new requirement that "plugin.dir" must be exposed to user code to navigate the classpath folder. This change make it happen.