### PR TITLE
AZNewDispatchingLogic - Submit flow in Polling Model

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -92,6 +92,7 @@ public class Constants {
 
     // Configures Azkaban to use new polling model for dispatching
     public static final String AZKABAN_POLL_MODEL = "azkaban.poll.model";
+    public static final String AZKABAN_POLLING_INTERVAL_MS = "azkaban.polling.interval.ms";
 
     // Configures Azkaban Flow Version in project YAML file
     public static final String AZKABAN_FLOW_VERSION = "azkaban-flow-version";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -277,4 +277,6 @@ public interface ExecutorLoader {
 
   int removeExecutionLogsByTime(long millis)
       throws ExecutorManagerException;
+
+  int selectAndUpdateExecution(final int executorId) throws ExecutorManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -339,4 +339,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   public void unassignExecutor(final int executionId) throws ExecutorManagerException {
     this.assignExecutorDao.unassignExecutor(executionId);
   }
+
+  @Override
+  public int selectAndUpdateExecution(final int executorId) throws ExecutorManagerException {
+    return this.executionFlowDao.selectAndUpdateExecution(executorId);
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -469,6 +469,18 @@ public class ExecutionFlowDaoTest {
     assertThat(inOutProps.getSecond().get("hello")).isEqualTo("output");
   }
 
+  @Test
+  public void testSelectAndUpdateExecution() throws Exception {
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    flow.setExecutionId(1);
+    this.executionFlowDao.uploadExecutableFlow(flow);
+    final Executor executor = this.executorDao.addExecutor("localhost", 12345);
+    assertThat(this.executionFlowDao.selectAndUpdateExecution(executor.getId())).isEqualTo(flow
+        .getExecutionId());
+    assertThat(this.executorDao.fetchExecutorByExecutionId(flow.getExecutionId())).isEqualTo
+        (executor);
+  }
+
   private void assertTwoFlowSame(final ExecutableFlow flow1, final ExecutableFlow flow2) {
     assertThat(flow1.getExecutionId()).isEqualTo(flow2.getExecutionId());
     assertThat(flow1.getStatus()).isEqualTo(flow2.getStatus());

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -420,4 +420,9 @@ public class MockExecutorLoader implements ExecutorLoader {
       throws ExecutorManagerException {
     return new ArrayList<>();
   }
+
+  @Override
+  public int selectAndUpdateExecution(final int executorId) throws ExecutorManagerException {
+    return 1;
+  }
 }


### PR DESCRIPTION
In the new AZ dispatching design #2038, one important change is to switch from pushing model to polling(pulling) model. Instead of web server selecting an executor and pushing new execution to that executor, now web server will just insert the new executions into DB queue and then executors will take turns to poll new executions from DB.
The PR implements the polling model for submitting new executions. Tested on solo server. Plan to test it on multi-executor mode later. 