### PR TITLE
Removes graph centering after expanding/collapsing flows

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -85,13 +85,11 @@ var nodeClickCallback = function (event, model, node) {
         {
           title: "Collapse Flow...", callback: function () {
             model.trigger("collapseFlow", node);
-            model.trigger("resetPanZoom");
           }
         },
         {
           title: "Collapse All Flows...", callback: function () {
             model.trigger("collapseAllFlows", node);
-            model.trigger("resetPanZoom");
           }
         }
       ];
@@ -101,13 +99,11 @@ var nodeClickCallback = function (event, model, node) {
         {
           title: "Expand Flow...", callback: function () {
             model.trigger("expandFlow", node);
-            model.trigger("resetPanZoom");
           }
         },
         {
           title: "Expand All Flows...", callback: function () {
             model.trigger("expandAllFlows", node);
-            model.trigger("resetPanZoom");
           }
         }
       ];

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -638,13 +638,11 @@ var expanelNodeClickCallback = function (event, model, node) {
         {
           title: "Collapse Flow...", callback: function () {
             model.trigger("collapseFlow", node);
-            model.trigger("resetPanZoom");
           }
         },
         {
           title: "Collapse All Flows...", callback: function () {
             model.trigger("collapseAllFlows", node);
-            model.trigger("resetPanZoom");
           }
         },
         {
@@ -660,13 +658,11 @@ var expanelNodeClickCallback = function (event, model, node) {
         {
           title: "Expand Flow...", callback: function () {
             model.trigger("expandFlow", node);
-            model.trigger("resetPanZoom");
           }
         },
         {
           title: "Expand All Flows...", callback: function () {
             model.trigger("expandAllFlows", node);
-            model.trigger("resetPanZoom");
           }
         },
         {


### PR DESCRIPTION
Removes graph centering event after expanding/collapsing flows at node level (it makes sense to keep it at the graph level).

In most cases the centering event causes a zoom out so users need to zoom in the graph again to return to previous view.

