### PR TITLE
AZNewDispatchingLogic - Cancel flow

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -134,18 +134,6 @@ public class ExecutorManager extends EventHandler implements
     this.executorInfoRefresherService = createExecutorInfoRefresherService();
   }
 
-  // TODO move to some common place
-  static boolean isFinished(final ExecutableFlow flow) {
-    switch (flow.getStatus()) {
-      case SUCCEEDED:
-      case FAILED:
-      case KILLED:
-        return true;
-      default:
-        return false;
-    }
-  }
-
   private int getMaxConcurrentRunsOneFlow(final Props azkProps) {
     // The default threshold is set to 30 for now, in case some users are affected. We may
     // decrease this number in future, to better prevent DDos attacks.

--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import azkaban.alert.Alerter;
+import azkaban.executor.selector.ExecutionControllerUtils;
 import azkaban.metrics.CommonMetrics;
 import azkaban.utils.Pair;
 import java.util.ArrayList;
@@ -35,13 +36,12 @@ import org.joda.time.DateTime;
 public class RunningExecutionsUpdater {
 
   private static final Logger logger = Logger.getLogger(RunningExecutionsUpdater.class);
-
-  // When we have an http error, for that flow, we'll check every 10 secs, 360
-  // times (3600 seconds = 1 hour) before we send an email about unresponsive executor.
-  private final int numErrorsBetweenUnresponsiveEmail = 360;
   // First email is sent after 1 minute of unresponsiveness
   final int numErrorsBeforeUnresponsiveEmail = 6;
   final long errorThreshold = 10000;
+  // When we have an http error, for that flow, we'll check every 10 secs, 360
+  // times (3600 seconds = 1 hour) before we send an email about unresponsive executor.
+  private final int numErrorsBetweenUnresponsiveEmail = 360;
   private final ExecutorManagerUpdaterStage updaterStage;
   private final AlerterHolder alerterHolder;
   private final CommonMetrics commonMetrics;
@@ -108,7 +108,7 @@ public class RunningExecutionsUpdater {
 
             this.updaterStage.set("Updated flow " + flow.getExecutionId());
 
-            if (ExecutorManager.isFinished(flow)) {
+            if (ExecutionControllerUtils.isFinished(flow)) {
               finalizeFlows.add(flow);
             }
           } catch (final ExecutorManagerException e) {
@@ -169,7 +169,7 @@ public class RunningExecutionsUpdater {
   }
 
   private boolean isExecutorRemoved(final int id) {
-    Executor fetchedExecutor;
+    final Executor fetchedExecutor;
     try {
       fetchedExecutor = this.executorLoader.fetchExecutor(id);
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/selector/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/ExecutionControllerUtils.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.executor.selector;
+
+import azkaban.alert.Alerter;
+import azkaban.executor.AlerterHolder;
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.ExecutionOptions;
+import azkaban.executor.ExecutorLoader;
+import azkaban.executor.ExecutorManagerException;
+import azkaban.executor.Status;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utils for controlling executions.
+ */
+public class ExecutionControllerUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ExecutionControllerUtils.class);
+
+  /**
+   * If the current status of the execution is not one of the finished statuses, mark the execution
+   * as failed in the DB.
+   *
+   * @param executorLoader the executor loader
+   * @param alerterHolder the alerter holder
+   * @param flow the execution
+   * @param reason reason for finalizing the execution
+   * @param originalError the cause, if execution is being finalized because of an error
+   */
+  public static void finalizeFlow(final ExecutorLoader executorLoader, final AlerterHolder
+      alerterHolder, final ExecutableFlow flow, final String reason,
+      @Nullable final Throwable originalError) {
+    boolean alertUser = true;
+
+    // First check if the execution in the datastore is finished.
+    try {
+      final ExecutableFlow dsFlow;
+      if (isFinished(flow)) {
+        dsFlow = flow;
+      } else {
+        dsFlow = executorLoader.fetchExecutableFlow(flow.getExecutionId());
+
+        // If it's marked finished, we're good. If not, we fail everything and then mark it
+        // finished.
+        if (!isFinished(dsFlow)) {
+          failEverything(dsFlow);
+          executorLoader.updateExecutableFlow(dsFlow);
+        }
+      }
+
+      if (flow.getEndTime() == -1) {
+        flow.setEndTime(System.currentTimeMillis());
+        executorLoader.updateExecutableFlow(dsFlow);
+      }
+    } catch (final ExecutorManagerException e) {
+      // If failed due to azkaban internal error, do not alert user.
+      alertUser = false;
+      logger.error("Failed to finalize flow " + flow.getExecutionId() + ", do not alert user.", e);
+    }
+
+    if (alertUser) {
+      alertUser(flow, alerterHolder, getFinalizeFlowReasons(reason, originalError));
+    }
+  }
+
+  /**
+   * When a flow is finished, alert the user as is configured in the execution options.
+   *
+   * @param flow the execution
+   * @param alerterHolder the alerter holder
+   * @param extraReasons the extra reasons for alerting
+   */
+  public static void alertUser(final ExecutableFlow flow, final AlerterHolder alerterHolder,
+      final String[] extraReasons) {
+    final ExecutionOptions options = flow.getExecutionOptions();
+    final Alerter mailAlerter = alerterHolder.get("email");
+    if (flow.getStatus() != Status.SUCCEEDED) {
+      if (options.getFailureEmails() != null && !options.getFailureEmails().isEmpty()) {
+        try {
+          mailAlerter.alertOnError(flow, extraReasons);
+        } catch (final Exception e) {
+          logger.error("Failed to alert on error for execution " + flow.getExecutionId(), e);
+        }
+      }
+      if (options.getFlowParameters().containsKey("alert.type")) {
+        final String alertType = options.getFlowParameters().get("alert.type");
+        final Alerter alerter = alerterHolder.get(alertType);
+        if (alerter != null) {
+          try {
+            alerter.alertOnError(flow, extraReasons);
+          } catch (final Exception e) {
+            logger.error("Failed to alert on error by " + alertType + " for execution " + flow
+                .getExecutionId(), e);
+          }
+        } else {
+          logger.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
+        }
+      }
+    } else {
+      if (options.getSuccessEmails() != null && !options.getSuccessEmails().isEmpty()) {
+        try {
+          mailAlerter.alertOnSuccess(flow);
+        } catch (final Exception e) {
+          logger.error("Failed to alert on success for execution " + flow.getExecutionId(), e);
+        }
+      }
+      if (options.getFlowParameters().containsKey("alert.type")) {
+        final String alertType = options.getFlowParameters().get("alert.type");
+        final Alerter alerter = alerterHolder.get(alertType);
+        if (alerter != null) {
+          try {
+            alerter.alertOnSuccess(flow);
+          } catch (final Exception e) {
+            logger.error("Failed to alert on success by " + alertType + " for execution " + flow
+                .getExecutionId(), e);
+          }
+        } else {
+          logger.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the reasons to finalize the flow.
+   *
+   * @param reason the reason
+   * @param originalError the original error
+   * @return the reasons to finalize the flow
+   */
+  public static String[] getFinalizeFlowReasons(final String reason, final Throwable
+      originalError) {
+    final List<String> reasons = new LinkedList<>();
+    reasons.add(reason);
+    if (originalError != null) {
+      reasons.add(ExceptionUtils.getStackTrace(originalError));
+    }
+    return reasons.toArray(new String[reasons.size()]);
+  }
+
+  /**
+   * Set the flow status to failed and fail every node inside the flow.
+   *
+   * @param exFlow the executable flow
+   */
+  public static void failEverything(final ExecutableFlow exFlow) {
+    final long time = System.currentTimeMillis();
+    for (final ExecutableNode node : exFlow.getExecutableNodes()) {
+      switch (node.getStatus()) {
+        case SUCCEEDED:
+        case FAILED:
+        case KILLED:
+        case SKIPPED:
+        case DISABLED:
+          continue;
+          // case UNKNOWN:
+        case READY:
+          node.setStatus(Status.KILLING);
+          break;
+        default:
+          node.setStatus(Status.FAILED);
+          break;
+      }
+
+      if (node.getStartTime() == -1) {
+        node.setStartTime(time);
+      }
+      if (node.getEndTime() == -1) {
+        node.setEndTime(time);
+      }
+    }
+
+    if (exFlow.getEndTime() == -1) {
+      exFlow.setEndTime(time);
+    }
+
+    exFlow.setStatus(Status.FAILED);
+  }
+
+  /**
+   * Check if the flow status is finished.
+   *
+   * @param flow the executable flow
+   * @return the boolean
+   */
+  public static boolean isFinished(final ExecutableFlow flow) {
+    switch (flow.getStatus()) {
+      case SUCCEEDED:
+      case FAILED:
+      case KILLED:
+        return true;
+      default:
+        return false;
+    }
+  }
+}


### PR DESCRIPTION
In the new AZ dispatching design #2038, we no longer maintain any cache on web server side. Instead, we fetch all the running flows/ queued flows info from DB directly.
When user cancels a flow, we check DB to see if the flow is already dispatched to an executor. If yes, the executor will be called to cancel the flow. If the flow is still queued in DB, we finalize the flow and update its status in DB.
Testing:
1. Verified integration tests are passing on solo server.
2. Modified the polling interval and verified different canceling scenarios where a flow is already dispatched and is queued in DB. 