### PR TITLE
Logs kill command failures and removes unused code

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/ProcessFailureException.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/ProcessFailureException.java
@@ -20,20 +20,7 @@ public class ProcessFailureException extends RuntimeException {
 
   private static final long serialVersionUID = 1;
 
-  private final int exitCode;
-  private final String logSnippet;
-
-  public ProcessFailureException(final int exitCode, final String logSnippet) {
-    this.exitCode = exitCode;
-    this.logSnippet = logSnippet;
-  }
-
-  public int getExitCode() {
-    return this.exitCode;
-  }
-
-  public String getLogSnippet() {
-    return this.logSnippet;
+  public ProcessFailureException() {
   }
 
 }


### PR DESCRIPTION
There have been times when killing an execution has taken over an hour to complete without an apparent reason to do so. This PR helps to debug this type of issues by adding logs to detect kill command failures.

Also we are removing a piece of code that was not in use and was potentially adding a bit of delay to the killing process. The functionality of this piece of code was verified on a test server as well as in solo server. It was repeating logs that are already in the job logs. 