### PR TITLE
fix bug about the Krb5ccname path include ':'

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -338,7 +338,7 @@ public class ProcessJob extends AbstractProcessJob {
     final String execId = jobProps.getString(CommonJobProperties.EXEC_ID);
     final String krb5ccname =
         String.format("/tmp/krb5cc__%s__%s__%s__%s__%s", projectName, flowId,
-            jobId, execId, effectiveUser);
+            jobId, execId, effectiveUser).replace(":", "_");
 
     return krb5ccname;
   }


### PR DESCRIPTION
https://github.com/azkaban/azkaban/issues/2040
fix bug about the Krb5ccname path include ':'  ,lead to kinit command failed