### PR TITLE
AZNewDispatchingLogic - Handle active/inactive executors

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -145,6 +145,8 @@ public class FlowRunnerManager implements EventListener,
   private long executionDirRetention = 1 * 24 * 60 * 60 * 1000; // 1 Day
   // date time of the the last flow submitted.
   private long lastFlowSubmittedDate = 0;
+  // Indicate if the executor is set to active.
+  private boolean active;
 
   @Inject
   public FlowRunnerManager(final Props props,
@@ -277,6 +279,7 @@ public class FlowRunnerManager implements EventListener,
       logger.info(
           "Set active action ignored. Executor is already " + (isActive ? "active" : "inactive"));
     }
+    this.active = isActive;
   }
 
   public long getLastFlowSubmittedTime() {
@@ -417,7 +420,6 @@ public class FlowRunnerManager implements EventListener,
     }
 
   }
-
 
   public void cancelJobBySLA(final int execId, final String jobId)
       throws ExecutorManagerException {
@@ -960,7 +962,7 @@ public class FlowRunnerManager implements EventListener,
             logger.error("Failed to fetch executor ", e);
           }
         }
-      } else {
+      } else if (FlowRunnerManager.this.active) {
         try {
           // Todo jamiesjc: check executor capacity before polling from DB
           final int execId = FlowRunnerManager.this.executorLoader


### PR DESCRIPTION
During deployment, we call `activate` API to set the new executors to active in DB and `deactivate` API to set the old ones to inactive.
With the new change in #2038 design, the new executors should start polling from DB after they are set to active and the old executors should stop polling from DB after set to inactive. 
Todo:
If we want to support `useExecutor `flow parameter in the future, this behavior has to be modified. A new column called `use_executor` will be added to the execution_flows table. Both old and new executors will poll from execution_flows table. The old executors can only poll executions with `use_executor == <polling_executor_id>` while new executors can poll executions with `use_executor == <polling_executor_id> or use_executor is null`.