### PR TITLE
Support `AZKABAN_OPTS` env for `azkaban-solo-server`

### DIFF
--- a/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
+++ b/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [[ -z "$AZKABAN_OPTS" ]]; then
+  AZKABAN_OPTS="-Xmx512M"
+fi
+
 # This script starts the solo server
 set -o nounset   # exit the script if you try to use an uninitialised variable
 set -o errexit   # exit the script if any statement returns a non-true return value
@@ -47,7 +51,7 @@ echo "CLASSPATH: ${CLASSPATH}";
 executorport=$(grep executor.port "${conf}/azkaban.properties" | cut -d = -f 2)
 serverpath=$(pwd)
 
-AZKABAN_OPTS=" -Xmx512M -server -Djava.io.tmpdir=$tmpdir -Dexecutorport=${executorport} \
+AZKABAN_OPTS="$AZKABAN_OPTS -server -Djava.io.tmpdir=$tmpdir -Dexecutorport=${executorport} \
     -Dserverpath=${serverpath} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 
 if [[ -f "${conf}/log4j.properties" ]]; then


### PR DESCRIPTION
When use `azkaban-solo-server` with MySQL, default heap memory size(512M) cannot be enough.
So modified shell script to set more heap size without modify shell script.