### PR TITLE
Fix local conf template to work out of the box

### DIFF
--- a/test/local-conf-templates/conf/azkaban.properties
+++ b/test/local-conf-templates/conf/azkaban.properties
@@ -54,3 +54,4 @@ executor.connector.stats=true
 # uncomment to enable inmemory stats for azkaban
 executor.metric.reports=true
 executor.metric.milisecinterval.default=60000
+azkaban.use.multiple.executors=true


### PR DESCRIPTION
`azkaban.use.multiple.executors=true` is now the only supported mode, so add it to the default template that is copied & used when one runs AzkabanSingleServer for the first time (in IDE, typically).

This property is required to be explicitly set to true in properties, so that users don't accidentally miss that the mode is switched, when they upgrade Azkaban. That's why it's better to have it like this for now instead of defaulting to true.