### PR TITLE
Optimize slow test TriggerInstanceProcessorTest#testProcessTermination

### DIFF
--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -18,6 +18,7 @@ package azkaban.flowtrigger;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -117,7 +118,7 @@ public class TriggerInstanceProcessorTest {
     doAnswer(invocation -> {
       this.sendEmailLatch.countDown();
       return null;
-    }).when(this.emailer).sendEmail(any(), any(), any());
+    }).when(this.emailer).sendEmail(any(EmailMessage.class), anyBoolean(), anyString());
 
     this.submitFlowLatch = new CountDownLatch(1);
     doAnswer(invocation -> {

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -16,6 +16,7 @@
 package azkaban.flowtrigger;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -149,6 +150,7 @@ public class TriggerInstanceProcessorTest {
     final TriggerInstance triggerInstance = createTriggerInstance();
     this.processor.processTermination(triggerInstance);
     this.sendEmailLatch.await(10L, TimeUnit.SECONDS);
+    assertEquals(0, sendEmailLatch.getCount());
     verify(this.message).setSubject(
         "flow trigger for flow 'flowId', project 'proj' has been cancelled on azkaban");
     assertThat(TestUtils.readResource("/emailTemplate/flowtriggerfailureemail.html", this))


### PR DESCRIPTION
Squashing the lowest hanging fruit from https://github.com/azkaban/azkaban/issues/2114.

1st commit: Prove that sendEmailLatch is not incremented in testProcessTermination
- Adding this assertion makes the test fail

2nd commit: Fix mocking of overloaded method -> test passes quickly now

It's actually best to leave the new assertion on CountdownLatch in place even though the problem was fixed. Because it will make the test fail instead of just being slow & succeeding, if the bug with skipping CountdownLatch is ever introduced again.