### PR TITLE
add JobProperties in log when prepare job

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -695,7 +695,7 @@ public class JobRunner extends EventHandler implements Runnable {
       } else {
         final String submitUser = this.getNode().getExecutableFlow().getSubmitUser();
         this.props.put(JobProperties.USER_TO_PROXY, submitUser);
-        this.logger.info("user.to.proxy property was not set, defaulting to submit user " +
+        this.logger.info("JobProperties: user.to.proxy property was not set, defaulting to submit user " +
             submitUser);
       }
 


### PR DESCRIPTION
"user.to.proxy" is ambiguous，In the configuration file "commonprivate.properties"  has been configured, but log is "user.to.proxy property was not set, defaulting to submit user azkaban"