### PR TITLE
Refactor and bug fix on Job History page pagination

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -74,6 +74,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -1198,7 +1199,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       final List<ExecutableJobInfo> jobInfo =
           this.executorManagerAdapter.getExecutableJobs(project, jobId, elementsToSkip, pageSize);
 
-      if (jobInfo != null && !jobInfo.isEmpty()) {
+      if (CollectionUtils.isNotEmpty(jobInfo)) {
         page.add("history", jobInfo);
 
         final ArrayList<Object> dataSeries = new ArrayList<>();

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
@@ -23,6 +23,7 @@
 
   <script type="text/javascript" src="${context}/js/raphael.min.js"></script>
   <script type="text/javascript" src="${context}/js/morris.min.js"></script>
+  <script type="text/javascript" src="${context}/js/jquery.twbsPagination.min.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/time-graph.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/job-history.js"></script>
@@ -35,8 +36,22 @@
 
     var projectId = "$projectId";
     var projectName = "$projectName";
-    var jobName = "$jobid";
+    var jobName = "$jobId";
     var dataSeries = $dataSeries;
+
+    var jobHistoryPageSettings = {
+      projectName: "${projectName}",
+      jobId: "${jobId}",
+      dataSeries: ${dataSeries},
+      page: ${page},
+      pageSize: ${pageSize},
+      recordCount: ${recordCount},
+      fetchJobHistoryUrl: contextURL + "/manager"
+    };
+
+    $(function () {
+      initJobHistoryPage(jobHistoryPageSettings);
+    });
   </script>
   <link rel="stylesheet" type="text/css" href="${context}/css/morris.css"/>
 </head>
@@ -53,8 +68,8 @@
 
   <div class="az-page-header page-header-bare">
     <div class="container-full">
-      <h1><a href="${context}/manager?project=${projectName}&job=${jobid}&history">Job History
-        <small>$jobid</small>
+      <h1><a href="${context}/manager?project=${projectName}&job=${jobId}&history">Job History
+        <small>$jobId</small>
       </a></h1>
     </div>
   </div>
@@ -64,7 +79,7 @@
         <li><a
             href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName
         </a></li>
-        <li class="active"><strong>Job History</strong> $jobid</li>
+        <li class="active"><strong>Job History</strong> $jobId</li>
       </ol>
     </div>
   </div>
@@ -106,7 +121,9 @@
                   #end
                 </td>
                 <td>
-                  <a href="${context}/manager?project=${projectName}&flow=${job.immediateFlowId}&job=${jobid}">${jobid}</a>
+                  <a href="${context}/manager?project=${projectName}&flow=${job.immediateFlowId}&job=${jobId}">
+                    ${jobId}
+                  </a>
                 </td>
                 <td>
                   <a href="${context}/manager?project=${projectName}&flow=${job.immediateFlowId}">${job.immediateFlowId}</a>
@@ -132,35 +149,7 @@
           </tbody>
         </table>
 
-        <ul class="pagination" id="pageSelection">
-          <li id="previous" class="first"><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${previous.nextPage}&size=${previous.size}"><span
-              class="arrow">&larr;</span>Previous</a></li>
-          <li id="page1" #if($page1.selected) class="active" #elseif ($page1.disabled)
-              class="disabled" #end><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${page1.nextPage}&size=${page1.size}">${page1.page}</a>
-          </li>
-          <li id="page2" #if($page2.selected) class="active" #elseif ($page2.disabled)
-              class="disabled" #end><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${page2.nextPage}&size=${page2.size}">${page2.page}</a>
-          </li>
-          <li id="page3" #if($page3.selected) class="active" #elseif ($page3.disabled)
-              class="disabled" #end><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${page3.nextPage}&size=${page3.size}">${page3.page}</a>
-          </li>
-          <li id="page4" #if($page4.selected) class="active" #elseif ($page4.disabled)
-              class="disabled" #end><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${page4.nextPage}&size=${page4.size}">${page4.page}</a>
-          </li>
-          <li id="page5" #if($page5.selected) class="active" #elseif ($page5.disabled)
-              class="disabled" #end><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${page5.nextPage}&size=${page5.size}">${page5.page}</a>
-          </li>
-          <li id="next"><a
-              href="${context}/manager?project=${projectName}&job=${jobid}&history&page=${next.nextPage}&size=${next.size}">Next<span
-              class="arrow">&rarr;</span></a></li>
-        </ul>
-
+        <ul id="jobHistoryPagination" class="pagination"></ul>
       </div><!-- /.col-xs-12 -->
     </div><!-- /.row -->
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobhistorypage.vm
@@ -45,6 +45,7 @@
       dataSeries: ${dataSeries},
       page: ${page},
       pageSize: ${pageSize},
+      visiblePages: 5,
       recordCount: ${recordCount},
       fetchJobHistoryUrl: contextURL + "/manager"
     };

--- a/azkaban-web-server/src/web/js/azkaban/view/job-history.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-history.js
@@ -21,18 +21,44 @@ var jobHistoryView;
 var dataModel;
 azkaban.DataModel = Backbone.Model.extend({});
 
-$(function () {
-  var selected;
-  var series = dataSeries;
-  dataModel = new azkaban.DataModel();
-  dataModel.set({
-    "data": series
+var initJobHistoryPage = function (settings) {
+  dataModel = new azkaban.DataModel({
+    page: settings.page,
+    pageSize: settings.pageSize,
+    visiblePages: 5,
+    recordCount: settings.recordCount,
+    dataSeries: settings.dataSeries,
+    projectName: settings.projectName,
+    jobId: settings.jobId,
+    fetchJobHistoryUrl: settings.fetchJobHistoryUrl
   });
+
   dataModel.trigger('render');
 
   jobHistoryView = new azkaban.TimeGraphView({
     el: $('#timeGraph'),
     model: dataModel,
-    modelField: "data"
+    modelField: "dataSeries"
   });
-});
+
+  if (settings.recordCount) {
+    $('#jobHistoryPagination').twbsPagination({
+      totalPages: Math.ceil(
+          dataModel.get("recordCount") / dataModel.get("pageSize")),
+      startPage: dataModel.get("page"),
+      initiateStartPageClick: false,
+      visiblePages: dataModel.get("visiblePages"),
+      onPageClick: function (event, page) {
+        var qparams = {
+          "project": dataModel.get("projectName"),
+          "job": dataModel.get("jobId"),
+          "page": page,
+          "size": dataModel.get("pageSize")
+        };
+        window.location.href = dataModel.get("fetchJobHistoryUrl") + "?history&"
+            + $.param(qparams);
+      }
+    });
+  }
+
+};

--- a/azkaban-web-server/src/web/js/azkaban/view/job-history.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-history.js
@@ -25,7 +25,7 @@ var initJobHistoryPage = function (settings) {
   dataModel = new azkaban.DataModel({
     page: settings.page,
     pageSize: settings.pageSize,
-    visiblePages: 5,
+    visiblePages: settings.visiblePages,
     recordCount: settings.recordCount,
     dataSeries: settings.dataSeries,
     projectName: settings.projectName,


### PR DESCRIPTION
Fixes a pagination issue on Job History page where it would show an additional empty page if the last page was full. For example:
 -with page size 10 and 30 elements it would show 4 pages with the last one being empty.

Simplifies implementation by delegating common pagination functionality to [https://github.com/josecebe/twbs-pagination](https://github.com/josecebe/twbs-pagination) jQuery pagination plugin instead of doing it manually.

With this change we are still loading the entire page every time a user interacts with the pagination controls. Ultimately we want to create an API endpoint that returns pages as data and that we only need to update the view with the new data, but this will not be done now because we are planning to redesign existing APIs soon.