### PR TITLE
Project shared cache race condition fix

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -271,8 +272,13 @@ public class FlowPreparer {
       if (this.projectDirCleaner != null) {
         this.projectDirCleaner.deleteProjectDirsIfNecessary(pv.getDirSizeInBytes());
       }
-      Files.move(tempDir.toPath(), pv.getInstalledDir().toPath(), StandardCopyOption.ATOMIC_MOVE);
+      try {
+        Files.move(tempDir.toPath(), pv.getInstalledDir().toPath(), StandardCopyOption.ATOMIC_MOVE);
+      } catch (final FileAlreadyExistsException ex) {
+        log.warn(ex);
+      }
       log.warn(String.format("Project preparation completes. [%s]", pv));
+
     } finally {
       if (projectFileHandler != null) {
         projectFileHandler.deleteLocalFile();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -27,6 +27,7 @@ import azkaban.storage.StorageManager;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Utils;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -111,6 +112,7 @@ public class FlowPreparer {
    * @param pv the projectVersion whose size needs to updated.
    */
   static void updateDirSize(final File dir, final ProjectVersion pv) {
+    Preconditions.checkArgument(dir.exists() && dir.isDirectory());
     try {
       final Path path = Paths.get(dir.getPath(), FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME);
       if (!Files.exists(path)) {
@@ -118,7 +120,7 @@ public class FlowPreparer {
         FileIOUtils.dumpNumberToFile(path, sizeInByte);
       }
       pv.setDirSizeInBytes(FileIOUtils.readNumberFromFile(path));
-    } catch (final IOException | IllegalArgumentException e) {
+    } catch (final IOException e) {
       log.error("error when dumping dir size to file", e);
     }
   }
@@ -130,6 +132,7 @@ public class FlowPreparer {
    * @param pv the projectVersion whose size needs to updated.
    */
   static void updateFileCount(final File dir, final ProjectVersion pv) {
+    Preconditions.checkArgument(dir.exists() && dir.isDirectory());
     try {
       final Path path = Paths.get(dir.getPath(), PROJECT_DIR_COUNT_FILE_NAME);
       if (!Files.exists(path)) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -117,7 +117,7 @@ public class FlowPreparer {
         FileIOUtils.dumpNumberToFile(path, sizeInByte);
       }
       pv.setDirSizeInBytes(FileIOUtils.readNumberFromFile(path));
-    } catch (final IOException e) {
+    } catch (final IOException | IllegalArgumentException e) {
       log.error("error when dumping dir size to file", e);
     }
   }
@@ -137,7 +137,7 @@ public class FlowPreparer {
         FileIOUtils.dumpNumberToFile(path, fileCount);
       }
       pv.setFileCount((int) FileIOUtils.readNumberFromFile(path));
-    } catch (final IOException e) {
+    } catch (final IOException | IllegalArgumentException e) {
       log.error("error when updating file count", e);
     }
   }


### PR DESCRIPTION
This PR 
1. handles race condition where two threads are downloading the same project, and renaming temp directory at the same time, the latter renaming operation would throw exception since destination directory is already created by the first renaming operation. If this is the case, renaming should ignore the exception and move on with next steps.

2. adds the existence check of project dir for updateDirSize/updateFileCount to avoid project dir is deleted in the middle by another thread that is being setup.

Long term fix: https://github.com/azkaban/azkaban/issues/2020 