### PR TITLE
Adding an AJAX endpoint to check if user has WRITE access to a given respective project

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -303,6 +303,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         if (handleAjaxPermission(project, user, Type.WRITE, ret)) {
           ajaxSetJobOverrideProperty(project, ret, req, user);
         }
+      } else if (ajaxName.equals("checkForWritePermission")) {
+        ajaxCheckForWritePermission(project, user, ret);
       } else {
         ret.put("error", "Cannot execute command " + ajaxName);
       }
@@ -1088,6 +1090,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private void ajaxGetProxyUsers(final Project project, final HashMap<String, Object> ret) {
     final String[] proxyUsers = project.getProxyUsers().toArray(new String[0]);
     ret.put("proxyUsers", proxyUsers);
+  }
+
+  private void ajaxCheckForWritePermission(final Project project, final User user,
+      final HashMap<String, Object> ret) {
+    ret.put("hasWritePermission", hasPermission(project, user, Type.WRITE));
   }
 
   private void handleProjectLogsPage(final HttpServletRequest req,


### PR DESCRIPTION
In this PR changes are done to add an AJAX endpoint which will provide the information if the user have WRITE access to a given project. This API will be useful for **TuneIn** which is a part of **Dr.Elephant**. Currently, TuneIn show many details like suggested parameters for the job, algorithm etc on the job page and the user would be able to modify these parameters. But since these properties are used by Azkaban(one of the supported Workflow managers by Dr.Elephant), so the user must be authorized to change these properties. For this purpose, Dr.Elephant will call this API with **session_id**(provided by Azkaban after successful authentication) and **project_name** as query params.

This API will have Azkaban user session_id and the project name as query params and as a result a Boolean value will be returned determining if the user whose session_id was passed as query param have WRITE access to the project which was also passed as a query param. So to know if some user have Write permission in the respective project the client calling the API must have the user's session_id. In this manner, this API cannot be used by any client to expose other Azkaban users' access to a project.

There are some other existing APIs like ```getPermission``` and ```fetchprojectusers``` which provide users and their permissions in a project, but these APIs doesn't provide information about ```user who is not owner/user of project but is a part of group which has WRITE or greater permissions``` in the project, so eventually this user will also be able to WRITE in the project but we won't be able to determine with these mentioned APIs.