### PR TITLE
Implement "flowPriority" (at the time of polling) feature for new Dispatching Logic

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2018 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.executor;
 
 import azkaban.Constants.ConfigurationKeys;
@@ -589,6 +589,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
 
       final int projectId = exflow.getProjectId();
       exflow.setSubmitUser(userId);
+      exflow.setStatus(Status.PREPARING);
       exflow.setSubmitTime(System.currentTimeMillis());
 
       final List<Integer> running = getRunningFlows(projectId, flowId);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -61,9 +61,7 @@ public class ExecutionFlowDao {
     final String INSERT_EXECUTABLE_FLOW = "INSERT INTO execution_flows "
         + "(project_id, flow_id, version, status, submit_time, submit_user, update_time, "
         + "use_executor, flow_priority) values (?,?,?,?,?,?,?,?,?)";
-    final long submitTime = System.currentTimeMillis();
-    flow.setStatus(Status.PREPARING);
-    flow.setSubmitTime(submitTime);
+    final long submitTime = flow.getSubmitTime();
 
     /**
      * Why we need a transaction to get last insert ID?
@@ -73,7 +71,7 @@ public class ExecutionFlowDao {
      */
     final SQLTransaction<Long> insertAndGetLastID = transOperator -> {
       transOperator.update(INSERT_EXECUTABLE_FLOW, flow.getProjectId(),
-          flow.getFlowId(), flow.getVersion(), Status.PREPARING.getNumVal(),
+          flow.getFlowId(), flow.getVersion(), flow.getStatus().getNumVal(),
           submitTime, flow.getSubmitUser(), submitTime, executorId, flowPriority);
       transOperator.getConnection().commit();
       return transOperator.getLastInsertId();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -53,9 +53,14 @@ public class ExecutionFlowDao {
         flow.getExecutionOptions().getFlowParameters().get(ExecutionOptions.USE_EXECUTOR);
     final String executorId = StringUtils.isNotEmpty(useExecutorParam) ? useExecutorParam : null;
 
+    final String flowPriorityParam =
+        flow.getExecutionOptions().getFlowParameters().get(ExecutionOptions.FLOW_PRIORITY);
+    final int flowPriority = StringUtils.isNotEmpty(flowPriorityParam) ?
+        Integer.parseInt(flowPriorityParam) : ExecutionOptions.DEFAULT_FLOW_PRIORITY;
+
     final String INSERT_EXECUTABLE_FLOW = "INSERT INTO execution_flows "
         + "(project_id, flow_id, version, status, submit_time, submit_user, update_time, "
-        + "use_executor) values (?,?,?,?,?,?,?,?)";
+        + "use_executor, flow_priority) values (?,?,?,?,?,?,?,?,?)";
     final long submitTime = System.currentTimeMillis();
     flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(submitTime);
@@ -69,7 +74,7 @@ public class ExecutionFlowDao {
     final SQLTransaction<Long> insertAndGetLastID = transOperator -> {
       transOperator.update(INSERT_EXECUTABLE_FLOW, flow.getProjectId(),
           flow.getFlowId(), flow.getVersion(), Status.PREPARING.getNumVal(),
-          submitTime, flow.getSubmitUser(), submitTime, executorId);
+          submitTime, flow.getSubmitUser(), submitTime, executorId, flowPriority);
       transOperator.getConnection().commit();
       return transOperator.getLastInsertId();
     };
@@ -337,7 +342,7 @@ public class ExecutionFlowDao {
     private static final String SELECT_EXECUTION_FOR_UPDATE_FORMAT =
         "SELECT exec_id from execution_flows WHERE status = " + Status.PREPARING.getNumVal()
             + " and executor_id is NULL and flow_data is NOT NULL and %s"
-            + " ORDER BY submit_time ASC LIMIT 1 FOR UPDATE";
+            + " ORDER BY flow_priority DESC, submit_time ASC, exec_id ASC LIMIT 1 FOR UPDATE";
 
     public static final String SELECT_EXECUTION_FOR_UPDATE_ACTIVE =
         String.format(SELECT_EXECUTION_FOR_UPDATE_FORMAT,

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -953,6 +953,7 @@ public class ExecutorManager extends EventHandler implements
       } else {
         final int projectId = exflow.getProjectId();
         exflow.setSubmitUser(userId);
+        exflow.setStatus(Status.PREPARING);
         exflow.setSubmitTime(System.currentTimeMillis());
 
         // Get collection of running flows given a project and a specific flow name

--- a/azkaban-db/src/main/sql/create.execution_flows.sql
+++ b/azkaban-db/src/main/sql/create.execution_flows.sql
@@ -13,7 +13,7 @@ CREATE TABLE execution_flows (
   flow_data   LONGBLOB,
   executor_id INT                   DEFAULT NULL,
   use_executor INT                  DEFAULT NULL,
-  flow_priority INT                 DEFAULT 5,
+  flow_priority INT        NOT NULL DEFAULT 5,
   PRIMARY KEY (exec_id)
 );
 

--- a/azkaban-db/src/main/sql/create.execution_flows.sql
+++ b/azkaban-db/src/main/sql/create.execution_flows.sql
@@ -13,6 +13,7 @@ CREATE TABLE execution_flows (
   flow_data   LONGBLOB,
   executor_id INT                   DEFAULT NULL,
   use_executor INT                  DEFAULT NULL,
+  flow_priority INT                 DEFAULT 5,
   PRIMARY KEY (exec_id)
 );
 

--- a/azkaban-db/src/main/sql/create.execution_flows.sql
+++ b/azkaban-db/src/main/sql/create.execution_flows.sql
@@ -13,7 +13,7 @@ CREATE TABLE execution_flows (
   flow_data   LONGBLOB,
   executor_id INT                   DEFAULT NULL,
   use_executor INT                  DEFAULT NULL,
-  flow_priority INT        NOT NULL DEFAULT 5,
+  flow_priority TINYINT    NOT NULL DEFAULT 5,
   PRIMARY KEY (exec_id)
 );
 

--- a/azkaban-db/src/main/sql/upgrade.3.68.0.to.3.69.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.68.0.to.3.69.0.sql
@@ -3,4 +3,4 @@
 -- use_executor column contains the id of the executor that should handle the execution.
 -- This id is a parameter an Azkaban admin can specify when launching a new execution.
 --
-ALTER TABLE execution_flows ADD COLUMN use_executor INT;
+ALTER TABLE execution_flows ADD COLUMN use_executor INT DEFAULT NULL;

--- a/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
@@ -1,0 +1,8 @@
+-- DB Migration from release 3.69.0 to 3.70.0
+-- PR #xxxx Implement “flowPriority” (at the time of polling) feature for new dispatching logic.
+-- flow_priority column can hold a positive int, negative int or 5 which is the default flow
+-- priority set in ExecutionOptions.DEFAULT_FLOW_PRIORITY for all flows.
+-- "flowPriority" is an execution option an Azkaban admin can specify when launching a new execution.
+-- It will allow a flow to be dispatched or polled first.
+--
+ALTER TABLE execution_flows ADD COLUMN flow_priority INT DEFAULT 5;

--- a/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
@@ -1,5 +1,5 @@
 -- DB Migration from release 3.69.0 to 3.70.0
--- PR #2140 Implement “flowPriority” (at the time of polling) feature for new dispatching logic.
+-- PR #2140 Implements “flowPriority” (at the time of polling) feature for new dispatching logic.
 -- flow_priority column can hold a positive int, negative int or 5 which is the default flow
 -- priority set in ExecutionOptions.DEFAULT_FLOW_PRIORITY for all flows.
 -- "flowPriority" is an execution option an Azkaban admin can specify when launching a new execution.

--- a/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
@@ -5,4 +5,4 @@
 -- "flowPriority" is an execution option an Azkaban admin can specify when launching a new execution.
 -- It will allow a flow to be dispatched or polled first.
 --
-ALTER TABLE execution_flows ADD COLUMN flow_priority INT NOT NULL DEFAULT 5;
+ALTER TABLE execution_flows ADD COLUMN flow_priority TINYINT NOT NULL DEFAULT 5;

--- a/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.70.0.sql
@@ -1,8 +1,8 @@
 -- DB Migration from release 3.69.0 to 3.70.0
--- PR #xxxx Implement “flowPriority” (at the time of polling) feature for new dispatching logic.
+-- PR #2140 Implement “flowPriority” (at the time of polling) feature for new dispatching logic.
 -- flow_priority column can hold a positive int, negative int or 5 which is the default flow
 -- priority set in ExecutionOptions.DEFAULT_FLOW_PRIORITY for all flows.
 -- "flowPriority" is an execution option an Azkaban admin can specify when launching a new execution.
 -- It will allow a flow to be dispatched or polled first.
 --
-ALTER TABLE execution_flows ADD COLUMN flow_priority INT DEFAULT 5;
+ALTER TABLE execution_flows ADD COLUMN flow_priority INT NOT NULL DEFAULT 5;


### PR DESCRIPTION
"flowPriority" is one of the execution options of a flow, which only takes effect if set by an Azkaban admin. By default all flows have a priority of 5 but if a bigger number is specified from the UI that flow will be dispatched for execution first.

With the new Dispatching Logic(#2038) setting a high "flowPriority" means that flow will be polled first by executors.
Note that it has been said "polled first" not "executed first". On the executor server there is a queue to hold executions when the maximum number of threads availables/setup to run flows is reached. This queue is NOT a priority queue.

To implement this feature for the new Dispatching Logic, a new column "flow_priority" needs to be added to table "execution_flows" to speed up access to this info (currently flowPriority is stored in "flow_data" longblob column). When new executions are inserted into "execution_flows" table, user-specified or default flow priority will be inserted as well. Later, executors will poll executions sorting by
`flow_priority DESC, submit_time ASC, exec_id ASC`

Adding an index on flow_priority column or a multicolumn index on (flow_priority, submit_time) for example, is not necessary because "status" column is already indexed and this column is more selective than "flow_priority" so MySQL should pick this index over the rest whenever polling executions.