### PR TITLE
Percentage-based project cache size

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -233,8 +233,9 @@ public class Constants {
 
     public static final String SESSION_TIME_TO_LIVE = "session.time.to.live";
 
-    // allowed max size of shared project dir in MB
-    public static final String PROJECT_DIR_MAX_SIZE_IN_MB = "azkaban.project_cache_max_size_in_mb";
+    // allowed max size of shared project dir (percentage of partition size), e.g 0.8
+    public static final String PROJECT_CACHE_SIZE_PERCENTAGE = "azkaban"
+        + ".project_cache_size_percentage_of_disk";
 
     // how many older versions of project files are kept in DB before deleting them
     public static final String PROJECT_VERSION_RETENTION = "project.version.retention";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -133,7 +133,11 @@ class FlowPreparer {
           // Rename temp dir to a proper project directory name.
           Files.move(tempDir.toPath(), project.getInstalledDir().toPath());
         }
+
+        final long start = System.currentTimeMillis();
         execDir = setupExecutionDir(project.getInstalledDir(), flow);
+        final long end = System.currentTimeMillis();
+        log.info("Setting up execution dir {} took {} sec(s)", execDir, (end - start) / 1000);
       }
 
       final long flowPrepCompletionTime = System.currentTimeMillis();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -109,14 +109,9 @@ class FlowPreparer {
 
       final long flowPrepStartTime = System.currentTimeMillis();
 
-      // Download project to a temp dir if not exists in local cache.
-      final long start = System.currentTimeMillis();
 
       tempDir = downloadProjectIfNotExists(project, flow.getExecutionId());
 
-      log.info("Downloading zip file for project {} when preparing execution [execid {}] "
-              + "completed in {} second(s)", project, flow.getExecutionId(),
-          (System.currentTimeMillis() - start) / 1000);
 
       // With synchronization, only one thread is allowed to proceed to avoid complicated race
       // conditions which could arise when multiple threads are downloading/deleting/hard-linking
@@ -245,8 +240,17 @@ class FlowPreparer {
     }
 
     this.projectCacheHitRatio.markMiss();
+
+    final long start = System.currentTimeMillis();
+
+    // Download project to a temp dir if not exists in local cache.
     final File tempDir = createTempDir(proj);
     downloadAndUnzipProject(proj, tempDir);
+
+    log.info("Downloading zip file for project {} when preparing execution [execid {}] "
+            + "completed in {} second(s)", proj, execId,
+        (System.currentTimeMillis() - start) / 1000);
+
     return tempDir;
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -212,11 +212,11 @@ public class FlowRunnerManager implements EventListener,
             JobTypeManager.DEFAULT_JOBTYPEPLUGINDIR), this.globalProps,
             getClass().getClassLoader());
 
-    Long projectDirMaxSize = null;
     ProjectCacheCleaner cleaner = null;
     try {
-      projectDirMaxSize = props.getLong(ConfigurationKeys.PROJECT_DIR_MAX_SIZE_IN_MB);
-      cleaner = new ProjectCacheCleaner(this.projectDirectory, projectDirMaxSize);
+      final double projectCacheSizePercentage =
+          props.getDouble(ConfigurationKeys.PROJECT_CACHE_SIZE_PERCENTAGE);
+      cleaner = new ProjectCacheCleaner(this.projectDirectory, projectCacheSizePercentage);
     } catch (final UndefinedPropertyException ex) {
     }
 
@@ -387,7 +387,7 @@ public class FlowRunnerManager implements EventListener,
     this.commonMetrics.addQueueWait(System.currentTimeMillis() -
         flow.getExecutableFlow().getSubmitTime());
 
-    final Timer.Context flowPrepTimerContext = execMetrics.getFlowSetupTimerContext();
+    final Timer.Context flowPrepTimerContext = this.execMetrics.getFlowSetupTimerContext();
 
     try {
       if (this.active || isExecutorSpecified(flow)) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
@@ -74,7 +74,7 @@ class ProjectCacheCleaner {
       if (project.exists() && project.isDirectory()) {
         projects.add(project.toPath());
       } else {
-        log.debug("project {} doesn't exist or is non-dir.", project.getName());
+        log.debug("Project {} doesn't exist or is non-dir.", project.getName());
       }
     }
     return projects;
@@ -101,7 +101,7 @@ class ProjectCacheCleaner {
                 FlowPreparer.PROJECT_DIR_SIZE_FILE_NAME)));
         allProjects.add(projectDirMetadata);
       } catch (final Exception e) {
-        log.warn("error while loading project dir metadata for project {}",
+        log.warn("Error while loading project dir metadata for project {}",
             project.getFileName(), e);
       }
     }
@@ -130,7 +130,7 @@ class ProjectCacheCleaner {
 
     for (final File toDelete : projectDirsToDelete) {
       deletionService.submit(() -> {
-        log.info("deleting project dir {} from project cache to free up space", toDelete);
+        log.info("Deleting project dir {} from project cache to free up space", toDelete);
         FileIOUtils.deleteDirectorySilently(toDelete);
       });
     }
@@ -138,7 +138,7 @@ class ProjectCacheCleaner {
     try {
       new ExecutorServiceUtils().gracefulShutdown(deletionService, Duration.ofDays(1));
     } catch (final InterruptedException e) {
-      log.warn("error when deleting files", e);
+      log.warn("Error when deleting files", e);
     }
   }
 
@@ -172,7 +172,7 @@ class ProjectCacheCleaner {
     final long start = System.currentTimeMillis();
     deleteProjectDirsInParallel(ImmutableSet.copyOf(projectDirsToDelete));
     final long end = System.currentTimeMillis();
-    log.info("deleting {} project dir(s) took {} sec(s)", projectDirsToDelete.size(),
+    log.info("Deleting {} project dir(s) took {} sec(s)", projectDirsToDelete.size(),
         (end - start) / 1000);
   }
 
@@ -185,13 +185,13 @@ class ProjectCacheCleaner {
 
     final long start = System.currentTimeMillis();
     final List<ProjectDirectoryMetadata> allProjects = loadAllProjects();
-    log.info("loading {} project dirs metadata completed in {} sec(s)",
+    log.info("Loading {} project dirs metadata completed in {} sec(s)",
         allProjects.size(), (System.currentTimeMillis() - start) / 1000);
 
     final long currentSpaceInBytes = getProjectDirsTotalSizeInBytes(allProjects);
     if (currentSpaceInBytes + newProjectSizeInBytes >= projectCacheMaxSizeInByte) {
       log.info(
-          "project cache usage[{} MB] >= cache limit[{} MB], start cleaning up project dirs",
+          "Project cache usage[{} MB] >= cache limit[{} MB], start cleaning up project dirs",
           (currentSpaceInBytes + newProjectSizeInBytes) / (1024 * 1024),
           projectCacheMaxSizeInByte / (1024 * 1024));
 


### PR DESCRIPTION
Currently project cache size is an absolute value indicating how large the project cache could be in MB. This PR makes it a percentage-based value which is a percentage of total size of the disk partition where project cache belongs to. So when disk partition is manually resized, this property won't need to be adjusted.

This PR also:
1. adds more detailed logging
2. use Set instead of List to keep the project directories to delete to guarantee no duplication.