### PR TITLE
Cache cleanup chunking MVP

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
@@ -155,7 +155,7 @@ class ProjectCacheCleaner {
     final Set<File> projectDirsToDelete = new HashSet<>();
 
     for (final ProjectDirectoryMetadata proj : projectDirMetadataList) {
-      if (sizeToFreeInBytes > 0) {
+      if (sizeToFreeInBytes > 0 || projectDirsToDelete.size() < 5) {
         // Delete the project directory even if flow within is running. It's OK to
         // delete the directory since execution dir is HARD linked to project dir. Note that even
         // if project is deleted, disk space will be freed up only when all associated execution


### PR DESCRIPTION
Currently, for regularly scheduled jobs that are scheduled/dispatched via the web server dispatch thread, dispatch is single threaded through web server and executor. The web server makes an ajax call to the executor (ExecutorManager.dispatch()), to execute the flow. On the executor (ExecutorServlet.handleAjaxExecute()), before it can return from the call, it does the work for flow preparation. There is no timeout on the web server, and it will wait until the call to the executor returns before continuing. Thus no other flows are dispatched to any executors while it is waiting.

In order to reduce blocking and make executors more responsive, this change limits the time executor spends cleaning up the project cache in each invocation of FlowPreparer.setup().

This is a concept demonstration only. A more robust implementation would probably allow max # of dirs cleaned up per invocation to be parameterised, with some reasonable default provided as well. Tests, too, would need to be added.