### PR TITLE
Executor Tags

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -94,6 +94,9 @@ public class Constants {
     public static final String AZKABAN_POLL_MODEL = "azkaban.poll.model";
     public static final String AZKABAN_POLLING_INTERVAL_MS = "azkaban.polling.interval.ms";
 
+    // Configures comma-separated executor tags provided by a particular executor
+    public static final String AZKABAN_EXECUTOR_TAGS = "azkaban.executor.tags";
+
     // Configures properties for Azkaban executor health check
     public static final String AZKABAN_EXECUTOR_HEALTHCHECK_INTERVAL_MIN = "azkaban.executor.healthcheck.interval.min";
     public static final String AZKABAN_EXECUTOR_MAX_FAILURE_COUNT = "azkaban.executor.max.failurecount";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -125,7 +125,7 @@ public interface ExecutorLoader {
    *
    * @return Executor
    */
-  Executor addExecutor(String host, int port)
+  Executor addExecutor(String host, int port, ExecutorTags tags)
       throws ExecutorManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorTags.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorTags.java
@@ -1,0 +1,34 @@
+package azkaban.executor;
+
+import azkaban.utils.Props;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A set of tags (strings) that describe the capabilities of an executor or the requirements of a
+ * flow. Flows are only executed by executors that provide (at least) all of their requirements.
+ */
+public class ExecutorTags implements Iterable<String> {
+
+  private final Set<String> tags;
+
+  public ExecutorTags(final Collection<? extends String> tags) {
+    this.tags = Collections.unmodifiableSet(new TreeSet<>(tags));
+  }
+
+  public static ExecutorTags getTagsFromProps(final Props props, final String key) {
+    return new ExecutorTags(props.getStringList(key));
+  }
+
+  public static ExecutorTags empty() {
+    return new ExecutorTags(Collections.emptyList());
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    return this.tags.iterator();
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -300,9 +300,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor addExecutor(final String host, final int port)
+  public Executor addExecutor(final String host, final int port, final ExecutorTags tags)
       throws ExecutorManagerException {
-    return this.executorDao.addExecutor(host, port);
+    return this.executorDao.addExecutor(host, port, tags);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -61,6 +61,11 @@ public class CommonJobProperties {
    */
   public static final String FAILURE_EMAILS = "failure.emails";
 
+  /**
+   * Comma delimited list of executor tags that are required by this flow
+   */
+  public static final String REQUIRED_EXECUTOR_TAGS = "required.executor.tags";
+
   /*
    * The following are the common props that will be added to the job by azkaban
    */

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -17,6 +17,7 @@
 package azkaban.flow;
 
 import azkaban.Constants;
+import azkaban.executor.ExecutorTags;
 import azkaban.executor.mail.DefaultMailCreator;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,6 +44,7 @@ public class Flow {
   private List<String> failureEmail = new ArrayList<>();
   private List<String> successEmail = new ArrayList<>();
   private String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
+  private ExecutorTags requiredExecutorTags = ExecutorTags.empty();
   private ArrayList<String> errors;
   private int version = -1;
   private Map<String, Object> metadata = new HashMap<>();
@@ -232,6 +234,14 @@ public class Flow {
 
   public void addFailureEmails(final Collection<String> emails) {
     this.failureEmail.addAll(emails);
+  }
+
+  public ExecutorTags getRequiredExecutorTags() {
+    return this.requiredExecutorTags;
+  }
+
+  public void setRequiredExecutorTags(final ExecutorTags tags) {
+    this.requiredExecutorTags = tags;
   }
 
   public int getNumLevels() {

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -324,6 +324,7 @@ public class DirectoryFlowLoader implements FlowLoader {
         final Props jobProp = this.jobPropsMap.get(base.getId());
 
         FlowLoaderUtils.addEmailPropsToFlow(flow, jobProp);
+        FlowLoaderUtils.addRequiredExecutorTagsToFlow(flow, jobProp);
 
         flow.addAllFlowProperties(this.flowPropsList);
         final Set<String> visitedNodesOnPath = new HashSet<>();

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -151,6 +151,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     flow.setAzkabanFlowVersion(Constants.AZKABAN_FLOW_VERSION_2_0);
     final Props props = azkabanFlow.getProps();
     FlowLoaderUtils.addEmailPropsToFlow(flow, props);
+    FlowLoaderUtils.addRequiredExecutorTagsToFlow(flow, props);
     props.setSource(flowFile.getName());
 
     flow.addAllFlowProperties(ImmutableList.of(new FlowProps(props)));

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
@@ -1,21 +1,22 @@
 /*
-* Copyright 2017 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.project;
 
 import azkaban.Constants;
+import azkaban.executor.ExecutorTags;
 import azkaban.flow.CommonJobProperties;
 import azkaban.flow.Flow;
 import azkaban.jobcallback.JobCallbackValidator;
@@ -51,6 +52,7 @@ public class FlowLoaderUtils {
   private static final Logger logger = LoggerFactory.getLogger(FlowLoaderUtils.class);
   private static final String XMS = "Xms";
   private static final String XMX = "Xmx";
+
   /**
    * Sets props in flow yaml file.
    *
@@ -223,6 +225,18 @@ public class FlowLoaderUtils {
 
     flow.addFailureEmails(failureEmail);
     flow.addSuccessEmails(successEmail);
+  }
+
+  /**
+   * Adds required executor tags properties to a flow.
+   *
+   * @param flow the flow
+   * @param props the props
+   */
+  public static void addRequiredExecutorTagsToFlow(final Flow flow, final Props props) {
+    final ExecutorTags tags = ExecutorTags
+        .getTagsFromProps(props, CommonJobProperties.REQUIRED_EXECUTOR_TAGS);
+    flow.setRequiredExecutorTags(tags);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -523,7 +523,7 @@ public class JdbcProjectImpl implements ProjectLoader {
     }
 
     // Check md5.
-    byte[] md5;
+    final byte[] md5;
     try {
       md5 = Md5Hasher.md5Hash(file);
     } catch (final IOException e) {
@@ -801,10 +801,19 @@ public class JdbcProjectImpl implements ProjectLoader {
     logger.info("Flow upload " + flow.getId() + " is byte size " + data.length);
     final String INSERT_FLOW =
         "INSERT INTO project_flows (project_id, version, flow_id, modified_time, encoding_type, json) values (?,?,?,?,?,?)";
+    final String INSERT_FLOW_REQUIRED_TAGS =
+        "INSERT INTO project_flow_required_tags (project_id, version, flow_id, tag) values (?,?,?,?)";
     try {
-      this.dbOperator
-          .update(INSERT_FLOW, project.getId(), version, flow.getId(), System.currentTimeMillis(),
-              encType.getNumVal(), data);
+      this.dbOperator.transaction(transOperator -> {
+        final int rows = transOperator
+            .update(INSERT_FLOW, project.getId(), version, flow.getId(), System.currentTimeMillis(),
+                encType.getNumVal(), data);
+        for (final String tag : flow.getRequiredExecutorTags()) {
+          transOperator
+              .update(INSERT_FLOW_REQUIRED_TAGS, project.getId(), version, flow.getId(), tag);
+        }
+        return rows;
+      });
     } catch (final SQLException e) {
       logger.error("Error inserting flow", e);
       throw new ProjectManagerException("Error inserting flow " + flow.getId(), e);
@@ -969,6 +978,8 @@ public class JdbcProjectImpl implements ProjectLoader {
         .map(excluded -> " AND version != " + excluded).collect(Collectors.joining());
     final String VERSION_FILTER = " AND version < ?" + EXCLUDED_VERSIONS_FILTER;
 
+    final String DELETE_FLOW_REQUIRED_TAGS =
+        "DELETE FROM project_flow_required_tags WHERE project_id=?" + VERSION_FILTER;
     final String DELETE_FLOW = "DELETE FROM project_flows WHERE project_id=?" + VERSION_FILTER;
     final String DELETE_PROPERTIES =
         "DELETE FROM project_properties WHERE project_id=?" + VERSION_FILTER;
@@ -979,6 +990,7 @@ public class JdbcProjectImpl implements ProjectLoader {
     // Todo jamiesjc: delete flow files
 
     final SQLTransaction<Integer> cleanOlderProjectTransaction = transOperator -> {
+      transOperator.update(DELETE_FLOW_REQUIRED_TAGS, projectId, version);
       transOperator.update(DELETE_FLOW, projectId, version);
       transOperator.update(DELETE_PROPERTIES, projectId, version);
       transOperator.update(DELETE_PROJECT_FILES, projectId, version);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -89,6 +89,7 @@ public class ExecutionFlowDaoTest {
   public void clearDB() {
     try {
       dbOperator.update("DELETE FROM execution_flows");
+      dbOperator.update("DELETE FROM executor_tags");
       dbOperator.update("DELETE FROM executors");
       dbOperator.update("DELETE FROM projects");
     } catch (final SQLException e) {
@@ -274,7 +275,7 @@ public class ExecutionFlowDaoTest {
   public void testAssignAndUnassignExecutor() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    final Executor executor = this.executorDao.addExecutor(host, port);
+    final Executor executor = this.executorDao.addExecutor(host, port, ExecutorTags.empty());
     final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.executionFlowDao.uploadExecutableFlow(flow);
     this.assignExecutor.assignExecutor(executor.getId(), flow.getExecutionId());
@@ -305,7 +306,7 @@ public class ExecutionFlowDaoTest {
   public void testAssignExecutorInvalidExecution() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    final Executor executor = this.executorDao.addExecutor(host, port);
+    final Executor executor = this.executorDao.addExecutor(host, port, ExecutorTags.empty());
 
     // Make 99 a random non-existent execution id.
     assertThatThrownBy(
@@ -377,7 +378,7 @@ public class ExecutionFlowDaoTest {
   }
 
   private List<ExecutableFlow> createExecutions() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("test", 1);
+    final Executor executor = this.executorDao.addExecutor("test", 1, ExecutorTags.empty());
 
     final ExecutableFlow flow1 = createExecutionAndAssign(Status.PREPARING, executor);
 
@@ -393,7 +394,7 @@ public class ExecutionFlowDaoTest {
     flow4.setEndTime(System.currentTimeMillis() - 1);
     this.executionFlowDao.updateExecutableFlow(flow4);
 
-    final Executor executor2 = this.executorDao.addExecutor("test2", 2);
+    final Executor executor2 = this.executorDao.addExecutor("test2", 2, ExecutorTags.empty());
     // flow5 is assigned to an executor that is then removed
     final ExecutableFlow flow5 = createExecutionAndAssign(Status.RUNNING, executor2);
     flow5.setStartTime(System.currentTimeMillis() + 1);
@@ -438,7 +439,7 @@ public class ExecutionFlowDaoTest {
   public void testFetchActiveFlowsStatusChanged() throws Exception {
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.executionFlowDao.uploadExecutableFlow(flow1);
-    final Executor executor = this.executorDao.addExecutor("test", 1);
+    final Executor executor = this.executorDao.addExecutor("test", 1, ExecutorTags.empty());
     this.assignExecutor.assignExecutor(executor.getId(), flow1.getExecutionId());
 
     Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
@@ -509,7 +510,8 @@ public class ExecutionFlowDaoTest {
     flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(System.currentTimeMillis());
     this.executionFlowDao.uploadExecutableFlow(flow);
-    final Executor executor = this.executorDao.addExecutor("localhost", 12345);
+    final Executor executor = this.executorDao
+        .addExecutor("localhost", 12345, ExecutorTags.empty());
     assertThat(this.executionFlowDao.selectAndUpdateExecution(executor.getId(), true))
         .isEqualTo(flow.getExecutionId());
     assertThat(this.executorDao.fetchExecutorByExecutionId(flow.getExecutionId())).isEqualTo

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorDaoTest.java
@@ -97,8 +97,8 @@ public class ExecutorDaoTest {
   public void testDuplicateAddExecutor() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    this.executorDao.addExecutor(host, port);
-    assertThatThrownBy(() -> this.executorDao.addExecutor(host, port))
+    this.executorDao.addExecutor(host, port, ExecutorTags.empty());
+    assertThatThrownBy(() -> this.executorDao.addExecutor(host, port, ExecutorTags.empty()))
         .isInstanceOf(ExecutorManagerException.class)
         .hasMessageContaining("already exist");
   }
@@ -160,16 +160,17 @@ public class ExecutorDaoTest {
   private List<Executor> addTestExecutors()
       throws ExecutorManagerException {
     final List<Executor> executors = new ArrayList<>();
-    executors.add(this.executorDao.addExecutor("localhost1", 12345));
-    executors.add(this.executorDao.addExecutor("localhost2", 12346));
-    executors.add(this.executorDao.addExecutor("localhost1", 12347));
+    executors.add(this.executorDao.addExecutor("localhost1", 12345, ExecutorTags.empty()));
+    executors.add(this.executorDao.addExecutor("localhost2", 12346, ExecutorTags.empty()));
+    executors.add(this.executorDao.addExecutor("localhost1", 12347, ExecutorTags.empty()));
     return executors;
   }
 
   /* Test Removing Executor */
   @Test
   public void testRemovingExecutor() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("localhost1", 12345);
+    final Executor executor = this.executorDao
+        .addExecutor("localhost1", 12345, ExecutorTags.empty());
     assertThat(executor).isNotNull();
     this.executorDao.removeExecutor("localhost1", 12345);
     final Executor fetchedExecutor = this.executorDao.fetchExecutor("localhost1", 12345);
@@ -179,7 +180,8 @@ public class ExecutorDaoTest {
   /* Test Executor reactivation */
   @Test
   public void testExecutorActivation() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("localhost1", 12345);
+    final Executor executor = this.executorDao
+        .addExecutor("localhost1", 12345, ExecutorTags.empty());
     assertThat(executor.isActive()).isFalse();
 
     executor.setActive(true);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -99,8 +99,8 @@ public class ExecutorManagerTest {
   private ExecutorManager createMultiExecutorManagerInstance() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     this.props.put(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, "false");
-    this.loader.addExecutor("localhost", 12345);
-    this.loader.addExecutor("localhost", 12346);
+    this.loader.addExecutor("localhost", 12345, ExecutorTags.empty());
+    this.loader.addExecutor("localhost", 12346, ExecutorTags.empty());
     return createExecutorManager();
   }
 
@@ -132,8 +132,8 @@ public class ExecutorManagerTest {
   @Test
   public void testMultipleExecutorScenario() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, ExecutorTags.empty());
+    final Executor executor2 = this.loader.addExecutor("localhost", 12346, ExecutorTags.empty());
 
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
@@ -168,7 +168,7 @@ public class ExecutorManagerTest {
   @Test
   public void testSetupExecutorsSucess() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, ExecutorTags.empty());
     final ExecutorManager manager = createExecutorManager();
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
         new Executor[]{executor1});
@@ -176,8 +176,8 @@ public class ExecutorManagerTest {
     // mark older executor as inactive
     executor1.setActive(false);
     this.loader.updateExecutor(executor1);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
-    final Executor executor3 = this.loader.addExecutor("localhost", 12347);
+    final Executor executor2 = this.loader.addExecutor("localhost", 12346, ExecutorTags.empty());
+    final Executor executor3 = this.loader.addExecutor("localhost", 12347, ExecutorTags.empty());
     manager.setupExecutors();
 
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
@@ -191,7 +191,7 @@ public class ExecutorManagerTest {
   @Test(expected = ExecutorManagerException.class)
   public void testSetupExecutorsException() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, ExecutorTags.empty());
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
         new HashSet(manager.getAllActiveExecutors());

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -353,7 +353,7 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor addExecutor(final String host, final int port)
+  public Executor addExecutor(final String host, final int port, final ExecutorTags tags)
       throws ExecutorManagerException {
     Executor executor = null;
     if (fetchExecutor(host, port) == null) {

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -454,11 +454,13 @@ public class JdbcProjectImplTest {
   @After
   public void clearDB() {
     try {
+      dbOperator.update("TRUNCATE TABLE project_flow_required_tags");
       dbOperator.update("TRUNCATE TABLE projects");
       dbOperator.update("TRUNCATE TABLE project_versions");
       dbOperator.update("TRUNCATE TABLE project_properties");
       dbOperator.update("TRUNCATE TABLE project_permissions");
-      dbOperator.update("TRUNCATE TABLE project_flows");
+      // can't use TRUNCATE due to foreign key constraints
+      dbOperator.update("DELETE FROM project_flows");
       dbOperator.update("TRUNCATE TABLE project_files");
       dbOperator.update("TRUNCATE TABLE project_events");
       dbOperator.update("TRUNCATE TABLE project_flow_files");

--- a/azkaban-db/src/main/sql/create.executors.sql
+++ b/azkaban-db/src/main/sql/create.executors.sql
@@ -9,3 +9,9 @@ CREATE TABLE executors (
 
 CREATE INDEX executor_connection
   ON executors (host, port);
+
+CREATE TABLE executor_tags (
+  executor_id INT         NOT NULL REFERENCES executors (id),
+  tag         VARCHAR(64) NOT NULL,
+  PRIMARY KEY (executor_id, tag)
+);

--- a/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.69.0-WSL.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.69.0.to.3.69.0-WSL.sql
@@ -1,15 +1,11 @@
-CREATE TABLE project_flows (
-  project_id    INT    NOT NULL,
-  version       INT    NOT NULL,
-  flow_id       VARCHAR(128),
-  modified_time BIGINT NOT NULL,
-  encoding_type TINYINT,
-  json          BLOB,
-  PRIMARY KEY (project_id, version, flow_id)
+-- TODO DB Migration from release 3.69.0 to 3.69.0-WSL
+-- PR #???? Implement "executor tags" feature for new dispatching Logic (Poll model).
+--
+CREATE TABLE executor_tags (
+  executor_id INT         NOT NULL REFERENCES executors (id),
+  tag         VARCHAR(64) NOT NULL,
+  PRIMARY KEY (executor_id, tag)
 );
-
-CREATE INDEX flow_index
-  ON project_flows (project_id, version);
 
 CREATE TABLE project_flow_required_tags (
   project_id    INT           NOT NULL,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -37,6 +37,7 @@ import azkaban.execapp.metric.NumRunningJobMetric;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
+import azkaban.executor.ExecutorTags;
 import azkaban.jmx.JmxJettyServer;
 import azkaban.metric.IMetricEmitter;
 import azkaban.metric.MetricException;
@@ -274,7 +275,9 @@ public class AzkabanExecutorServer {
       final Executor executor = this.executionLoader.fetchExecutor(host, port);
       if (executor == null) {
         logger.info("This executor wasn't found in the DB. Adding self.");
-        this.executionLoader.addExecutor(host, port);
+        final ExecutorTags tags = ExecutorTags
+            .getTagsFromProps(this.props, ConfigurationKeys.AZKABAN_EXECUTOR_TAGS);
+        this.executionLoader.addExecutor(host, port, tags);
       } else {
         logger.info("This executor is already in the DB. Found: " + executor);
       }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -39,6 +39,7 @@ import azkaban.executor.ExecutorDao;
 import azkaban.executor.ExecutorEventsDao;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerAdapter;
+import azkaban.executor.ExecutorTags;
 import azkaban.executor.FetchActiveFlowDao;
 import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManager;
@@ -128,7 +129,7 @@ public class AzkabanWebServerTest {
     final ExecutorLoader executorLoader = injector.getInstance(ExecutorLoader.class);
     assertNotNull(executorLoader);
 
-    final Executor executor = executorLoader.addExecutor("localhost", 60000);
+    final Executor executor = executorLoader.addExecutor("localhost", 60000, ExecutorTags.empty());
     executor.setActive(true);
     executorLoader.updateExecutor(executor);
 


### PR DESCRIPTION
NOT COMPLETE - missing tests and documentation

Here's a draft of a feature that we would like in Azkaban - executor tags.

The problem that we want to solve is that not all of our executors are the same - there might be some running on Linux and some running on Windows (a separate PR with improvements to Windows support will come later) and there might be different external tools installed on different executors. Our flows require different things from their execution environments, for example some might involve running PowerShell scripts and require a Windows machine while others involve bash scripts and require a Linux machine.

The solution that I'm proposing is to associate with each executor a set of "executor tags" (where a tag is just a string) that represent the capabilities of that executor and to associate with each flow a set of executor tags that represent the requirements of that flow. Then, when an executor looks for flows to execute (I've only considered the polling model) it only considers those flows whose requirements it can satisfy.

I'd like to contribute this change to Azkaban when it's ready, so please let me know if the approach I'm taking makes sense and stands a chance of being merged. Any suggestions on how to go about this differently would also be appreciated.