### PR TITLE
Support concurrent flow preparation and cache cleanup using a locking cache

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCache.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCache.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A locking, loading, concurrent cache. Entries are returned with a read lock, as
+ * {@link LockingCacheEntry}. While holding the read lock, users are guaranteed that
+ * the value is value. Values can be read concurrently by mulitple readers.
+ * If a value isn't already in the cache, then it will be loaded with the specified
+ * {@link LockingCacheLoader}. There is an option provided for asynchronous cleanup,
+ * which will try to maintain the cache between a min and max size, approximately.
+ * Entries are only removed if they are not locked (no threads currently holding a read or
+ * write lock). {@link LockingCacheSizer} is used to get the size of values, which are used to
+ * calculate the size of the cache.
+ *
+ * @param <K> the class type for the key
+ * @param <V> the class type for the value
+ * @param <L> the class type for the {@link LockingCacheLoader}
+ * @param <S> the class type for the {@link LockingCacheSizer}
+ */
+public class LockingCache<K, V, L extends LockingCacheLoader<K,V>, S extends LockingCacheSizer<V>> {
+  private final ConcurrentHashMap<K, LockingCacheEntry<V>> cacheMap;
+  private final AtomicLong cacheSize;
+  private final L cacheLoader;
+  private final S sizer;
+  private final ScheduledExecutorService cleanupPool;
+  private static final Logger log = LoggerFactory.getLogger(LockingCache.class);
+
+  /**
+   * Constructor, without automated cleanup.
+   *
+   * @param cacheLoader the {@link LockingCacheLoader} for loading values by key
+   * @param sizer the {@link LockingCacheSizer} for getting the size of a value
+   */
+  public LockingCache(L cacheLoader, S sizer) {
+    this(cacheLoader, sizer, 0, 0, 0);
+   }
+
+   /**
+    * Constructor, with separate auto cleaning thread.
+    * @param cacheLoader the {@link LockingCacheLoader} for loading values by key
+    * @param sizer the {@link LockingCacheSizer} for getting the size of a value
+    * @param minSize the threshold for stopping cleanup
+    * @param maxSize the threshold for starting cleanup
+    * @param intervalSec the interval in seconds for running cleanup
+    */
+  public LockingCache(L cacheLoader, S sizer, long minSize, long maxSize, long intervalSec) {
+    this.cacheMap = new ConcurrentHashMap<>();
+    this.cacheSize = new AtomicLong(0);
+    this.cacheLoader = cacheLoader;
+    this.sizer = sizer;
+    if (intervalSec > 0) {
+      // create the cleanup thread
+      this.cleanupPool = Executors.newScheduledThreadPool(1);
+      cleanupPool.scheduleAtFixedRate(new Cleaner(minSize, maxSize), intervalSec, intervalSec,
+          TimeUnit.SECONDS);
+    }
+    else {
+      this.cleanupPool = null;
+    }
+  }
+
+  /** @return the current size of the cache */
+  public long getCacheSize() { return cacheSize.get(); }
+
+  /**
+   * Load any initial entries. This assumes that no entries are in the cache already, and
+   * that no entries are added during initialization. If concurrent access is needed during
+   * initialization, then further work is needed for this method.
+   */
+  public void initialize() {
+    final Map<K, V> initialEntries = cacheLoader.loadAll();
+    initialEntries.forEach((key, entry) ->
+    {
+      long size = sizer.getSize(entry);
+      cacheMap.putIfAbsent(key, new LockingCacheEntry(entry, size));
+
+      // note that adding the size would be inaccurate if the entry already exists in the cache
+      cacheSize.addAndGet(size);
+    });
+  }
+
+  /** stop cleanup */
+  public void shutdownCleanup() {
+    if (cleanupPool != null) {
+      cleanupPool.shutdown();
+    }
+  }
+
+  /**
+   * Try to remove an entry, if it is not currently locked.
+   *
+   * @param key the key
+   * @return true if the entry was removed, false otherwise
+   */
+  public boolean tryRemove(K key) throws Exception {
+    LockingCacheEntry<V> entry = cacheMap.get(key);
+    if (entry == null) {
+      // entry is already gone from the cache
+      return true;
+    }
+    ReentrantReadWriteLock lock = entry.getLock();
+    if (lock.writeLock().tryLock()) {
+      // remove the entry from the in memory map and loader
+      try {
+        cacheMap.remove(key);
+        cacheLoader.remove(key, entry.getValue());
+        cacheSize.addAndGet(-1 * entry.getSize());
+        entry.invalidate();
+      } finally {
+        lock.writeLock().unlock();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Gets the entry with a read lock. Users must call {@link LockingCacheEntry#close()} on
+   * the returned entry when done using the value, in order to release the read lock.
+   * Alternatively, try with resources can be used, so that it will be closed automatically.
+   *
+   * @param key the key
+   * @return the read locked project cache entry, with the associated value
+   */
+  public LockingCacheEntry<V> get(K key) throws Exception {
+    LockingCacheEntry<V> entry = null;
+
+    while (entry == null) {
+      entry = cacheMap.computeIfAbsent(key, k -> new LockingCacheEntry());
+      ReentrantReadWriteLock lock = entry.getLock();
+      lock.readLock().lock();
+      if (entry.isEntryInvalidated()) {
+        // this project was removed. Try getting the entry again.
+        entry = null;
+        continue;
+      }
+      if (entry.isEntryUninitialized()) {
+        // need to load the entry
+        lock.readLock().unlock();
+        if (lock.writeLock().tryLock()) {
+          try {
+            // double check to make sure no one has modified the entry in between releasing
+            // the read lock and acquiring the write lock
+            if (entry.isEntryInvalidated()) {
+              // the project was removed, so retry getting/loading it
+              entry = null;
+              continue;
+            } else if (entry.isEntryValid()) {
+              // another thread has already loaded the entry, so downgrade to a read lock
+              lock.readLock().lock();
+            } else {
+              // need to initialize/download the project
+              V value = cacheLoader.load(key);
+              entry.set(value, sizer.getSize(value));
+              lock.readLock().lock();
+              cacheSize.addAndGet(entry.getSize());
+            }
+          } finally {
+            lock.writeLock().unlock();
+          }
+        } else {
+          // unable to get the write lock, so another thread must have the write lock and is
+          // either creating the entry or removing it
+          entry = null;
+          continue;
+        }
+      }
+    }
+    return entry;
+  }
+
+  /**
+   * Cleanup the cache.
+   *
+   * @param targetSize the size of the cache for stopping cleanup
+   */
+  public void cleanup(long targetSize) {
+    if (cacheSize.get() < targetSize) {
+      return;
+    }
+    // get the list of projects, sorted by last access time ascending.
+    List<Entry<K,LockingCacheEntry<V>>> entries = new ArrayList(cacheMap.entrySet());
+    Collections.sort(entries, (x, y) -> {
+      if (x.getValue().getLastAccessTime() < y.getValue().getLastAccessTime()) {
+        return -1;
+      } else if (x.getValue().getLastAccessTime() == y.getValue().getLastAccessTime()) {
+        return 0;
+      } else {
+        return 1;
+      }
+    });
+
+    for(Entry<K,LockingCacheEntry<V>> entry : entries) {
+      if (cacheSize.get() < targetSize) {
+        // cache is below the min threshold, so stop
+        break;
+      }
+      try {
+        tryRemove(entry.getKey());
+      } catch (Exception e) {
+        // don't want to stop the cleanup thread, so just log any exceptions.
+        log.error("error encountered during cleanup for " + entry.getKey(), e);
+      }
+    }
+  }
+
+  /**
+   * Cleaner for the project cache. Cleanup is initiated if the cache size exceeds
+   * maxSizeBytes, and continues until the cache size is below minSizeBytes. Locked
+   * entries that are currently in use will not be removed. Cache cleanup may
+   * stop before the cache size is below minSizeBytes if the total size of locked
+   * entries is greater.
+   */
+  private class Cleaner implements Runnable {
+    private final long minSizeBytes;
+    private final long maxSizeBytes;
+
+    /**
+     * Constructor.
+     *
+     * @param minSizeBytes the threshold for stopping cleanup
+     * @param maxSizeBytes the threshold for starting cleanup
+     */
+    Cleaner(long minSizeBytes, long maxSizeBytes) {
+      this.minSizeBytes = minSizeBytes;
+      this.maxSizeBytes = maxSizeBytes;
+     }
+
+    @Override
+    public void run()
+    {
+      if (cacheSize.get() > maxSizeBytes) {
+        cleanup(minSizeBytes);
+      }
+    }
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheEntry.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheEntry.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Entry in the {@link LockingCache}.
+ *
+ * @param <V> class type for the value
+ */
+public class LockingCacheEntry<V>  implements AutoCloseable{
+  private V value;
+  private long size;
+  private long lastAccessTime;
+  private final ReentrantReadWriteLock lock;
+  private static final Logger log = LoggerFactory.getLogger(LockingCache.class);
+
+  /**
+   * Constructor for creating an uninitialized loading cache entry.
+   */
+  LockingCacheEntry() {
+    this(null, 0);
+  }
+
+  /**
+   * Constructor for creating an initialized loading cache entry.
+   *
+   * @param value the value
+   * @param size the size of the value
+   */
+  LockingCacheEntry(V value, long size) {
+    this.value = value;
+    this.size = size;
+    if (size > 0) {
+      this.lastAccessTime = System.currentTimeMillis();
+    } else {
+      this.lastAccessTime = 0;
+    }
+    this.lock = new ReentrantReadWriteLock();
+  }
+
+  /** @return the size of the value */
+  public long getSize() {
+    Preconditions.checkState(isLocked(), "must hold lock to get size");
+    Preconditions.checkState(!isEntryInvalidated(), "entry must be valid");
+    return this.size;
+  }
+
+  /** @return the value */
+  public V getValue() {
+    Preconditions.checkState(isLocked(), "must hold lock to get value");
+    Preconditions.checkState(!isEntryInvalidated(), "entry must be valid");
+    Preconditions.checkNotNull(value);
+    lastAccessTime = System.currentTimeMillis();
+    return value;
+  }
+
+  /** @return the last access time for the entry */
+  long getLastAccessTime() { return lastAccessTime; }
+
+  @Override
+  public void close() { lock.readLock().unlock(); }
+
+  /** @return the lock */
+  ReentrantReadWriteLock getLock() { return lock; }
+
+  /**
+   * Set the value and size for the entry.
+   *
+   * @param value the value
+   * @param size the size of the value
+   */
+  void set(V value, long size) {
+    Preconditions.checkNotNull(value);
+    Preconditions.checkArgument(size > 0, "size must be positive");
+    Preconditions.checkState(lock.isWriteLocked(), "must have write lock to modify element");
+    Preconditions.checkState(!isEntryInvalidated(), "entry must be valid");
+    this.value = value;
+    this.size = size;
+    this.lastAccessTime = System.currentTimeMillis();
+  }
+
+  /** @return true if the cache entry has been invalidated, false otherwise */
+  boolean isEntryInvalidated() { return size == -1; }
+
+  /** @return true if the cache has a valid initialized value, false otherwise */
+  boolean isEntryValid() { return value != null && this.size > 0; }
+
+  /** @return true if the cache entry is uninitialized */
+  boolean isEntryUninitialized() { return size == 0; }
+
+  /** Invalidate the cache entry. */
+  void invalidate() {
+    Preconditions.checkState(lock.isWriteLocked(), "must hold write lock to invalidate");
+    lastAccessTime = -1;
+    size = -1;
+    value = null;
+  }
+
+  /** @return true if the thread is holding a read or write lock on the entry */
+  private boolean isLocked() {
+    return lock.isWriteLockedByCurrentThread() || (lock.getReadHoldCount() > 0);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheLoader.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheLoader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+import java.util.Map;
+
+/**
+ * Used by the {@link LockingCache} to load values, and do any additional cleanup when a key/value
+ * is removed from the cache.
+ *
+ * @param <K> class type for the key
+ * @param <V> class type for the value
+ */
+public interface LockingCacheLoader<K, V> {
+
+  /**
+   * Loads the value for the specified key.
+   *
+   * @param key the key
+   * @return the value
+   */
+  public V load(K key) throws Exception;
+
+  /**
+   * @return a map of initial key/values and their sizes.
+   */
+  public Map<K, V> loadAll();
+
+  /**
+   * Called when a key/value is removed from the cache. This should do any additional cleanup
+   * needed when an entry is removed from the cache.
+   *
+   * @param key the key
+   * @param value the value
+   */
+  public void remove(K key, V value) throws Exception;
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheSizer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/lockingcache/LockingCacheSizer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+/**
+ * Used by the {@link LockingCache} to get the size for a value stored in the cache.
+ *
+ * @param <V> class type for the value
+ */
+public interface LockingCacheSizer<V> {
+
+  /** @return the size of the specified value. */
+  long getSize(V value);
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/projectcache/ProjectCacheKey.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/projectcache/ProjectCacheKey.java
@@ -1,0 +1,39 @@
+package azkaban.execapp.projectcache;
+
+import java.util.Objects;
+
+public class ProjectCacheKey {
+  private final int projectId;
+  private final int version;
+
+  public ProjectCacheKey(int projectId, int version) {
+    this.projectId = projectId;
+    this.version = version;
+  }
+
+  public int getProjectId() {
+    return projectId;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProjectCacheKey that = (ProjectCacheKey) o;
+    return projectId == that.projectId &&
+        version == that.version;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(projectId, version);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/projectcache/ProjectDirectoryInfo.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/projectcache/ProjectDirectoryInfo.java
@@ -1,0 +1,28 @@
+package azkaban.execapp.projectcache;
+
+import azkaban.execapp.projectcache.ProjectCacheKey;
+import java.io.File;
+
+public class ProjectDirectoryInfo {
+  private final ProjectCacheKey key;
+  private final File directory;
+  private final long sizeInBytes;
+
+  public ProjectDirectoryInfo(ProjectCacheKey key, File directory, long sizeInBytes) {
+    this.key = key;
+    this.directory = directory;
+    this.sizeInBytes = sizeInBytes;
+  }
+
+  public ProjectCacheKey getKey() {
+    return key;
+  }
+
+  public File getDirectory() {
+    return directory;
+  }
+
+  public long getSizeInBytes() {
+    return sizeInBytes;
+  }
+}

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/lockingcache/LockingCacheEntryTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/lockingcache/LockingCacheEntryTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class LockingCacheEntryTest {
+
+  @Test
+  public void testUninitalizedEntryState() {
+    LockingCacheEntry<String> entry = new LockingCacheEntry<>();
+    assertThat(entry.isEntryUninitialized()).isTrue();
+    assertThat(entry.isEntryInvalidated()).isFalse();
+    assertThat(entry.isEntryValid()).isFalse();
+    entry.getLock().readLock().lock();
+    assertThatThrownBy(() -> entry.getValue()).isInstanceOf(NullPointerException.class);
+    assertThat(entry.getSize()).isEqualTo(0);
+    assertThat(entry.getLastAccessTime()).isEqualTo(0);
+    entry.getLock().readLock().unlock();
+  }
+
+  @Test
+  public void testInitializedEntryState() throws InterruptedException {
+    final String val = "testing";
+    final long size = 7;
+
+    LockingCacheEntry<String> entry = new LockingCacheEntry<>(val, size);
+    assertThat(entry.isEntryUninitialized()).isFalse();
+    assertThat(entry.isEntryInvalidated()).isFalse();
+    assertThat(entry.isEntryValid()).isTrue();
+    long initialTime = entry.getLastAccessTime();
+    entry.getLock().readLock().lock();
+    Thread.sleep(2);
+
+    // calling getValue should update the access time
+    assertThat(entry.getValue()).isEqualTo(val);
+    assertThat(entry.getSize()).isEqualTo(size);
+    assertThat(entry.getLastAccessTime()).isGreaterThan(initialTime);
+    assertThat(entry.getLastAccessTime()).isLessThanOrEqualTo(System.currentTimeMillis());
+    entry.getLock().readLock().unlock();
+  }
+
+  @Test
+  public void testSettingEntry() {
+    LockingCacheEntry<String> entry = new LockingCacheEntry<>();
+    final String val = "hi there";
+    final long size = 8;
+
+    // must have write lock to set the entry
+    assertThatThrownBy(() -> entry.set(val, size)).isInstanceOf(IllegalStateException.class);
+
+    // read lock is insufficient
+    entry.getLock().readLock().lock();
+    assertThatThrownBy(() -> entry.set(val, size)).isInstanceOf(IllegalStateException.class);
+    entry.getLock().readLock().unlock();
+
+    // now get the write lock
+    entry.getLock().writeLock().lock();
+
+    // can't set value to null
+    assertThatThrownBy(() -> entry.set(null, size)).isInstanceOf(NullPointerException.class);
+
+    // can't set size to 0
+    assertThatThrownBy(() -> entry.set(val, 0)).isInstanceOf(IllegalArgumentException.class);
+
+    entry.set(val, size);
+    assertThat(entry.getValue()).isEqualTo(val);
+    assertThat(entry.getSize()).isEqualTo(size);
+    assertThat(entry.getLastAccessTime()).isLessThanOrEqualTo(System.currentTimeMillis());
+    entry.getLock().writeLock().unlock();
+    assertThat(entry.isEntryUninitialized()).isFalse();
+    assertThat(entry.isEntryInvalidated()).isFalse();
+    assertThat(entry.isEntryValid()).isTrue();
+
+    // must have read lock to read the entry
+    assertThatThrownBy(() -> entry.getValue()).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> entry.getSize()).isInstanceOf(IllegalStateException.class);
+
+    // try again with read lock
+    entry.getLock().readLock().lock();
+    assertThat(entry.getValue()).isEqualTo(val);
+    assertThat(entry.getSize()).isEqualTo(size);
+    assertThat(entry.getLastAccessTime()).isLessThanOrEqualTo(System.currentTimeMillis());
+    entry.getLock().readLock().unlock();
+  }
+
+  @Test
+  public void testInvalidation() {
+    LockingCacheEntry<String> entry = new LockingCacheEntry<>("more testing", 13);
+
+    // must be write locked
+    assertThatThrownBy(() -> entry.invalidate()).isInstanceOf(IllegalStateException.class);
+    entry.getLock().readLock().lock();
+    assertThatThrownBy(() -> entry.invalidate()).isInstanceOf(IllegalStateException.class);
+    entry.getLock().readLock().unlock();
+
+    entry.getLock().writeLock().lock();
+    entry.invalidate();
+    assertThatThrownBy(() -> entry.getValue()).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> entry.getSize()).isInstanceOf(IllegalStateException.class);
+
+    entry.getLock().writeLock().unlock();
+    assertThat(entry.isEntryUninitialized()).isFalse();
+    assertThat(entry.isEntryInvalidated()).isTrue();
+    assertThat(entry.isEntryValid()).isFalse();
+  }
+}

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/lockingcache/LockingCacheTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/lockingcache/LockingCacheTest.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp.lockingcache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+public class LockingCacheTest {
+
+  private static class TestLoader implements LockingCacheLoader<Integer, String> {
+    protected final ConcurrentHashMap<Integer, AtomicInteger> loadCountMap = new
+        ConcurrentHashMap<>();
+    protected final ConcurrentHashMap<Integer, AtomicInteger> removeCountMap = new
+        ConcurrentHashMap<>();
+    protected int loadInterval;
+    protected int removeInterval;
+
+    TestLoader() {
+      this(0, 0);
+    }
+
+    TestLoader(int loadInterval, int removeInterval) {
+      this.loadInterval = loadInterval;
+      this.removeInterval = removeInterval;
+    }
+
+    @Override
+    public String load(Integer key) throws Exception {
+      updateCountAndSleep(key, loadCountMap, loadInterval);
+      return getValue(key);
+    }
+
+    @Override
+    public Map<Integer, String> loadAll() {
+      Map<Integer, String> map = Stream.of(new Object[][] {
+          { 7, "bbbbbbb" },
+          { 5, "ccccc" },
+      }).collect(Collectors.toMap(data -> (Integer) data[0], data -> (String) data[1]));
+      return map;
+    }
+
+    @Override public void remove(Integer key, String value) throws Exception {
+      updateCountAndSleep(key, removeCountMap, removeInterval);
+    }
+
+    protected void updateCountAndSleep(Integer key, ConcurrentHashMap<Integer, AtomicInteger> map,
+        int interval) throws InterruptedException {
+      map.compute(key, (k, v) -> {
+        if (v != null) {
+          v.incrementAndGet();
+          return v;
+        } else
+          return new AtomicInteger(1);
+      });
+      if (interval > 0) {
+        Thread.sleep(interval);
+      }
+    }
+
+    protected String getValue(int key) {
+      char[] val = new char[key];
+      Arrays.fill(val, 'a');
+      return new String(val);
+    }
+
+    protected int getRemovalCount(int key) {
+      AtomicInteger count = removeCountMap.get(key);
+      return count == null ? 0 : count.get();
+    }
+
+    protected int getLoadCount(int key) {
+      AtomicInteger count = loadCountMap.get(key);
+      return count == null ? 0 : count.get();
+    }
+  }
+
+  private static class TestSizer implements LockingCacheSizer<String> {
+    @Override public long getSize(String value) { return value.length(); }
+  }
+
+  @Test
+  public void testUnlock() throws Exception {
+    final TestLoader loader = new TestLoader();
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+
+    LockingCacheEntry<String> entry = cache.get(20);
+    assertThat(entry.getValue().length()).isEqualTo(20);
+
+    // can't remove a locked entry
+    assertThat(cache.tryRemove(20)).isFalse();
+    assertThat(cache.getCacheSize()).isEqualTo(20);
+    entry.close();
+
+    // can't get the value after releasing the lock
+    assertThatThrownBy(() -> entry.getValue()).isInstanceOf(IllegalStateException.class);
+
+    // get the entry again
+    LockingCacheEntry<String> entry2 = cache.get(20);
+    assertThat(entry2.getValue().length()).isEqualTo(20);
+    assertThat(cache.getCacheSize()).isEqualTo(20);
+    entry2.close();
+
+    assertThat(cache.tryRemove(20)).isTrue();
+    assertThat(cache.getCacheSize()).isEqualTo(0);
+
+    // get the entry after removal
+    LockingCacheEntry<String> entry3 = cache.get(20);
+    assertThat(entry3.getValue().length()).isEqualTo(20);
+    assertThat(cache.getCacheSize()).isEqualTo(20);
+    entry3.close();
+
+    assertThat(loader.getLoadCount(20)).isEqualTo(2);
+    assertThat(loader.getRemovalCount(20)).isEqualTo(1);
+  }
+
+  @Test
+  public void testTryWithResources() throws Exception {
+    final TestLoader loader = new TestLoader();
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+
+    try (LockingCacheEntry<String> entry = cache.get(20)) {
+      assertThat(entry.getValue().length()).isEqualTo(20);
+      assertThat(cache.tryRemove(20)).isFalse();
+      assertThat(cache.getCacheSize()).isEqualTo(20);
+    }
+
+    try (LockingCacheEntry<String> entry = cache.get(20)) {
+      assertThat(entry.getValue().length()).isEqualTo(20);
+      assertThat(cache.getCacheSize()).isEqualTo(20);
+    }
+
+    assertThat(cache.tryRemove(20)).isTrue();
+    assertThat(cache.getCacheSize()).isEqualTo(0);
+    assertThat(loader.getLoadCount(20)).isEqualTo(1);
+    assertThat(loader.getRemovalCount(20)).isEqualTo(1);
+  }
+
+  @Test
+  public void testCacheCleanup() throws Exception{
+    final TestLoader loader = new TestLoader();
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+
+    // cache should start empty
+    assertThat(cache.getCacheSize()).isEqualTo(0);
+
+    // get some values
+    LockingCacheEntry<String> entry3 = cache.get(3);
+    assertThat(entry3.getValue().length()).isEqualTo(3);
+    assertThat(cache.getCacheSize()).isEqualTo(3);
+    Thread.sleep(1);
+    LockingCacheEntry<String> entry19 = cache.get(19);
+    assertThat(entry19.getValue().length()).isEqualTo(19);
+    entry19.close();
+    Thread.sleep(1);
+    assertThat(cache.getCacheSize()).isEqualTo(22);
+    LockingCacheEntry<String> entry11 = cache.get(11);
+    assertThat(entry11.getValue().length()).isEqualTo(11);
+    Thread.sleep(1);
+    assertThat(cache.getCacheSize()).isEqualTo(33);
+    LockingCacheEntry<String> entry13 = cache.get(13);
+    assertThat(cache.getCacheSize()).isEqualTo(46);
+    assertThat(entry13.getValue().length()).isEqualTo(13);
+    Thread.sleep(1);
+    entry13.close();
+    entry11.close();
+
+    // bump up the time for entry 19
+    LockingCacheEntry<String> entry19b = cache.get(19);
+    assertThat(entry19b.getValue().length()).isEqualTo(19);
+    assertThat(cache.getCacheSize()).isEqualTo(46);
+    entry19b.close();
+
+    // cleanup
+    cache.cleanup(30);
+    assertThat(cache.getCacheSize()).isEqualTo(27);
+
+    // cleanup all, except locked entries (3)
+    cache.cleanup(0);
+    assertThat(cache.getCacheSize()).isEqualTo(3);
+
+    entry3.close();
+
+    // cleanup all
+    cache.cleanup(0);
+    assertThat(cache.getCacheSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void testInitialize() throws Exception {
+    final TestLoader loader = new TestLoader();
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+
+    cache.initialize();
+    assertThat(cache.getCacheSize()).isEqualTo(12);
+
+    // get a value in the cache
+    try(LockingCacheEntry<String> entry5 = cache.get(5)) {
+      assertThat(entry5.getValue().length()).isEqualTo(5);
+    }
+    assertThat(cache.getCacheSize()).isEqualTo(12);
+
+    // get a value not already in the cache
+    try(LockingCacheEntry<String> entry11 = cache.get(11)) {
+      assertThat(entry11.getValue().length()).isEqualTo(11);
+    }
+    assertThat(cache.getCacheSize()).isEqualTo(23);
+
+    assertThat(loader.getLoadCount(5)).isEqualTo(0);
+    assertThat(loader.getLoadCount(7)).isEqualTo(0);
+    assertThat(loader.getLoadCount(11)).isEqualTo(1);
+  }
+
+  /**
+   * Test only one thread is loading at a time. Create 5 threads that try to get the same value,
+   * with a sleep in the load so that they will need to wait for each other. Load should only be
+   * called once for any value, and the later threads should get the pre-loaded value.
+   */
+  @Test
+  public void testConcurrentLoad() throws Exception {
+    final TestLoader loader = new TestLoader(10, 0);
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+    final ExecutorService executor= Executors.newFixedThreadPool(5);
+    final CyclicBarrier barrier = new CyclicBarrier(5);
+    for (int i = 0; i < 5; i++) {
+      executor.execute(() -> {
+        for (int key = 10; key < 15; key++)
+        try (LockingCacheEntry<String> entry = cache.get(key)) {
+          assertThat(entry.getValue().length()).isEqualTo(key);
+          barrier.await();
+        } catch (Exception e) {
+          assertThat(e).doesNotThrowAnyException();
+        }
+      });
+    }
+    executor.shutdown();
+    try {
+      executor.awaitTermination(1, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      assertThat(e).doesNotThrowAnyException();
+    }
+    assertThat(cache.getCacheSize()).isEqualTo(60);
+    for (int i = 10; i < 15; i++) {
+      assertThat(loader.getLoadCount(i)).isEqualTo(1);
+    }
+  }
+
+  /** Used by testConcurrentGetRemove */
+  private static class BlockingLoader extends TestLoader {
+    private int loadCount = 0;
+    private final CyclicBarrier barrier;
+
+    BlockingLoader(CyclicBarrier barrier) {
+      super(2, 20);
+      this.barrier = barrier;
+    }
+    @Override
+    public String load(Integer key) throws Exception {
+      updateCountAndSleep(key, loadCountMap, loadInterval);
+      // barriers 2 and 3 occur during the first load
+      // barrier 7 occurs during the second load
+      if (loadCount == 0) {
+        loadCount++;
+        barrier.await();
+      }
+      barrier.await();
+      return getValue(key);
+    }
+
+    @Override
+    public void remove(Integer key, String value) throws Exception {
+      updateCountAndSleep(key, removeCountMap, removeInterval);
+      // barrier 6 occurs inside remove
+      barrier.await();
+    }
+  }
+
+  /**
+   * Test loading and cleanup do not step on each other, and that the value is reloaded after
+   * cleanup as needed.
+   * Thread 1 is loading, and Thread 2 is cleaning. Use {@link CyclicBarrier} to sync the threads.
+   *
+   *                Thread 1                    Thread2
+   * barrier 0
+   *                call get() to start load
+   * barrier 1      inside load
+   *                                            call tryRemove(), returns false
+   * barrier 2      inside load
+   *                exit load
+   * barrier 3      holding read lock
+   *                                            call tryRemove(), returns false
+   * barrier 4      holding read lock
+   *                call close()
+   * barrier 5
+   *                                            call tryRemove()
+   * barrier 6                                  inside remove
+   *                call get(), block
+   *                                            exit remove
+   * barrier 7      inside load                 back in main thread
+   * barrier 8      done                        done
+   */
+  @Test
+  public void testConcurrentGetRemove() throws Exception {
+    final CyclicBarrier barrier = new CyclicBarrier(2);
+    final BlockingLoader loader = new BlockingLoader(barrier);
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer());
+    final ExecutorService executor= Executors.newFixedThreadPool(2);
+    final int key = 10;
+
+    // create loading thread
+      executor.execute(() -> {
+        try {
+          barrier.await(); // initial sync up at barrier 0
+          try (LockingCacheEntry<String> entry = cache.get(key)) {
+            // value is loaded, and we are holding the read lock
+            assertThat(entry.getValue().length()).isEqualTo(key);
+            assertThat(cache.getCacheSize()).isEqualTo(key);
+            barrier.await(); // barrier 3, notify that we have read lock
+            barrier.await(); // barrier 4, other thread has tried to remove
+          }
+          // read lock released
+          barrier.await(); // barrier 5, notify that we have released the lock
+          barrier.await(); // barrier 6 other thread removing the value
+          try (LockingCacheEntry<String> entry = cache.get(key)) {
+            // value is loaded, and we are holding the read lock
+            assertThat(entry.getValue().length()).isEqualTo(key);
+            Thread.sleep(2);
+          }
+          assertThat(cache.getCacheSize()).isEqualTo(key);
+          barrier.await(); //barrier 8, done
+         } catch (Exception e) {
+          assertThat(e).doesNotThrowAnyException();
+        }
+      });
+
+    // create removing thread
+    executor.execute(() -> {
+      try {
+        barrier.await(); // initial sync up at barrier 0
+        barrier.await(); // barrier 1, other thread is loading
+        assertThat(cache.tryRemove(key)).isFalse(); // remove should fail, since loading
+        assertThat(cache.getCacheSize()).isEqualTo(0);
+        barrier.await(); // barrier 2, notify loader that remove was called
+        barrier.await(); // barier 3, other thread has read lock
+        assertThat(cache.tryRemove(key)).isFalse(); // remove should fail, since loading
+        assertThat(cache.getCacheSize()).isEqualTo(key);
+        barrier.await(); // barrier 4, notify other thread that remove was called
+        barrier.await(); // barrier 5, other thread has released the lock
+        assertThat(cache.tryRemove(key)).isTrue(); // remove should suceed
+        assertThat(cache.getCacheSize()).isEqualTo(0);
+        barrier.await(); // barrier 7, other thread is loading
+        barrier.await(); // barrier 8, done
+      } catch (Exception e) {
+        assertThat(e).doesNotThrowAnyException();
+      }
+    });
+
+    executor.shutdown();
+    try {
+      executor.awaitTermination(1, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      assertThat(e).doesNotThrowAnyException();
+    }
+    assertThat(cache.getCacheSize()).isEqualTo(key);
+    assertThat(loader.getLoadCount(key)).isEqualTo(2);
+  }
+
+  /** Used by testConcurrentGetRemove */
+  private static class CleanupLoader extends TestLoader {
+    static final String VALUE = "aaaaa";
+
+    CleanupLoader() {
+      super();
+    }
+    @Override
+    protected String getValue(int key) {
+      return VALUE;
+    }
+  }
+
+  /** Test cleanup thread. Verify that it will wait if entries are locked, and will remove
+   *  them when finally unlocked. Also check that it will remove up to the min size, and won't
+   *  start until the max size is reached.
+   */
+  @Test
+  public void testCleanupThread() throws Exception {
+    final int numThreads = 4;
+    final CyclicBarrier barrier = new CyclicBarrier(numThreads);
+    final CleanupLoader loader = new CleanupLoader();
+    final int minSize = 50;
+    final int maxSize = 100;
+    final LockingCache<Integer, String, TestLoader, TestSizer> cache = new LockingCache(loader,
+        new TestSizer(), minSize, maxSize, 1);
+    final ExecutorService executor= Executors.newFixedThreadPool(numThreads);
+
+    for (int i = 0; i < numThreads; i ++) {
+      final int threadId = i;
+      executor.execute(() -> {
+        try {
+          final int mod = threadId % 2;
+          Map<Integer, LockingCacheEntry> entryMap = new HashMap<>();
+
+          for (int j = 0; j < 8; j++) {
+            int key = 2 * j + mod;
+            try (LockingCacheEntry<String> entry = cache.get(key)) {
+              assertThat(entry.getValue()).isEqualTo(CleanupLoader.VALUE);
+            }
+          }
+          barrier.await();
+          Thread.sleep(2000);
+          // since we are staying under the max threshold, no entries should be removed
+          assertThat(cache.getCacheSize()).isEqualTo(80);
+          // insert some more values to go over the max, and keep the lock on these
+          for (int j = 8; j < 15; j++) {
+            int key = 2 * j + mod;
+            LockingCacheEntry<String> entry = cache.get(key);
+            entryMap.put(key, entry);
+            assertThat(entry.getValue()).isEqualTo(CleanupLoader.VALUE);
+          }
+          barrier.await();
+          Thread.sleep(2000);
+          // the cleanup thread should remove all unlocked entries, but will still be above the
+          // min threshold. Size can vary depending on when the cleanup thread kicks in, but should
+          // be greater than or equal to the size of locked entries, and less than the max.
+          assertThat(cache.getCacheSize()).isGreaterThanOrEqualTo(70);
+          assertThat(cache.getCacheSize()).isLessThan(maxSize);
+
+          // now go over the max threshold with locked entries
+          for (int j = 15; j < 20; j++) {
+            int key = 2 * j + mod;
+            LockingCacheEntry<String> entry = cache.get(key);
+            entryMap.put(key, entry);
+            assertThat(entry.getValue()).isEqualTo(CleanupLoader.VALUE);
+          }
+          barrier.await();
+          Thread.sleep(2000);
+          // only the locked entries should be left
+          assertThat(cache.getCacheSize()).isEqualTo(120);
+
+          // now unlock entries
+          entryMap.values().forEach(e -> e.close());
+          barrier.await();
+          Thread.sleep(2000);
+          // cache size should be below the threshold
+          assertThat(cache.getCacheSize()).isLessThanOrEqualTo(maxSize);
+
+          // call cleanup ourselves, so that it runs in parallel
+          barrier.await();
+          cache.cleanup(20);
+          barrier.await();
+          assertThat(cache.getCacheSize()).isLessThan(20);
+        } catch (Exception e) {
+          assertThat(e).doesNotThrowAnyException();
+        }
+      });
+    }
+
+    executor.shutdown();
+    try {
+      executor.awaitTermination(1, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      assertThat(e).doesNotThrowAnyException();
+    }
+    assertThat(cache.getCacheSize()).isLessThan(20);
+  }
+ }


### PR DESCRIPTION
This is an initial version of code for the locking cache, and some tests for it. Integration with the current Azkaban code will be added.

More information at: [Azkaban Dispatch](https://docs.google.com/document/d/1t4NuIuhq-vDt9Zt564fCKr6xFjGlx_Bj3j1icWK1-V0/edit?usp=sharing)