### PR TITLE
Quartz scheduler refactor

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -96,7 +96,8 @@ public class FlowTriggerScheduler {
                     FlowTriggerQuartzJob.PROJECT_ID, project.getId());
             logger.info("scheduling flow " + flow.getProjectId() + "." + flow.getId());
             this.scheduler
-                .schedule(flowTrigger.getSchedule().getCronExpression(), new QuartzJobDescription
+                .scheduleIfAbsent(flowTrigger.getSchedule().getCronExpression(),
+                    new QuartzJobDescription
                     (FlowTriggerQuartzJob.class, FlowTriggerQuartzJob.JOB_NAME,
                         generateGroupName(flow), contextMap));
           }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -96,7 +96,7 @@ public class FlowTriggerScheduler {
                     FlowTriggerQuartzJob.PROJECT_ID, project.getId());
             logger.info("scheduling flow " + flow.getProjectId() + "." + flow.getId());
             this.scheduler
-                .scheduleIfAbsent(flowTrigger.getSchedule().getCronExpression(),
+                .scheduleJobIfAbsent(flowTrigger.getSchedule().getCronExpression(),
                     new QuartzJobDescription
                     (FlowTriggerQuartzJob.class, FlowTriggerQuartzJob.JOB_NAME,
                         generateGroupName(flow), contextMap));
@@ -177,7 +177,7 @@ public class FlowTriggerScheduler {
           + " schedule");
       if (!flow.isEmbeddedFlow()) {
         try {
-          this.scheduler.unschedule(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow));
+          this.scheduler.unscheduleJob(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow));
         } catch (final Exception ex) {
           logger.info("error when unregistering job", ex);
         }

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -149,7 +149,7 @@ public class QuartzScheduler {
    * @return true if job is found and unscheduled.
    * @throws SchedulerException
    */
-  public synchronized boolean unschedule(final String jobName, final String groupName) throws
+  public synchronized boolean unscheduleJob(final String jobName, final String groupName) throws
       SchedulerException {
     return this.scheduler.deleteJob(new JobKey(jobName, groupName));
   }
@@ -169,7 +169,7 @@ public class QuartzScheduler {
    *
    * @return true if job has been scheduled, false if the same job exists already.
    */
-  public synchronized boolean scheduleIfAbsent(final String cronExpression, final QuartzJobDescription
+  public synchronized boolean scheduleJobIfAbsent(final String cronExpression, final QuartzJobDescription
       jobDescription) throws SchedulerException {
 
     requireNonNull(jobDescription, "jobDescription is null");

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -69,72 +70,49 @@ public class QuartzScheduler {
     this.scheduler.setJobFactory(SERVICE_PROVIDER.getInstance(SchedulerJobFactory.class));
   }
 
-  public void start() {
-    try {
-      this.scheduler.start();
-    } catch (final SchedulerException e) {
-      logger.error("Error starting Quartz scheduler: ", e);
-    }
+  public void start() throws SchedulerException {
+    this.scheduler.start();
     logger.info("Quartz Scheduler started.");
   }
 
-  public void cleanup() {
-    logger.info("Cleaning up schedules in scheduler");
-    try {
-      this.scheduler.clear();
-    } catch (final SchedulerException e) {
-      logger.error("Exception clearing scheduler: ", e);
-    }
+  @VisibleForTesting
+  void cleanup() throws SchedulerException {
+    this.scheduler.clear();
   }
 
-  public void pause() {
-    logger.info("pausing all schedules in Quartz");
-    try {
-      this.scheduler.pauseAll();
-    } catch (final SchedulerException e) {
-      logger.error("Exception pausing scheduler: ", e);
-    }
+  public void shutdown() throws SchedulerException {
+    this.scheduler.shutdown();
+    logger.info("Quartz Scheduler shut down.");
   }
-
-  public void resume() {
-    logger.info("resuming all schedules in Quartz");
-    try {
-      this.scheduler.resumeAll();
-    } catch (final SchedulerException e) {
-      logger.error("Exception resuming scheduler: ", e);
-    }
-  }
-
-  public void shutdown() {
-    logger.info("Shutting down scheduler");
-    try {
-      this.scheduler.shutdown();
-    } catch (final SchedulerException e) {
-      logger.error("Exception shutting down scheduler: ", e);
-    }
-  }
-
-  private void checkJobExistence(final String jobName, final String groupName)
-      throws SchedulerException {
-    if (!ifJobExist(jobName, groupName)) {
-      throw new SchedulerException(String.format("can not find job with job name: %s and group "
-          + "name %s: in quartz.", jobName, groupName));
-    }
-  }
-
 
   /**
-   * pause a job given the groupname. since pausing request might be issued concurrently,
-   * so synchronized is added to ensure thread safety.
+   * Pause a job if it's present.
+   * @param jobName
+   * @param groupName
+   * @return true if job has been paused, no if job doesn't exist.
+   * @throws SchedulerException
    */
-  public synchronized void pauseJob(final String jobName, final String groupName)
+  public synchronized boolean pauseJobIfPresent(final String jobName, final String groupName)
       throws SchedulerException {
-    checkJobExistence(jobName, groupName);
-    this.scheduler.pauseJob(new JobKey(jobName, groupName));
+    if (ifJobExist(jobName, groupName)) {
+      this.scheduler.pauseJob(new JobKey(jobName, groupName));
+      return true;
+    } else {
+      return false;
+    }
   }
 
+  /**
+   * Check if job is paused.
+   *
+   * @return true if job is paused, false otherwise.
+   */
   public synchronized boolean isJobPaused(final String jobName, final String groupName)
       throws SchedulerException {
+    if (!ifJobExist(jobName, groupName)) {
+      throw new SchedulerException(String.format("Job (job name %s, group name %s) doesn't "
+          + "exist'", jobName, groupName));
+    }
     final JobKey jobKey = new JobKey(jobName, groupName);
     final JobDetail jobDetail = this.scheduler.getJobDetail(jobKey);
     final List<? extends Trigger> triggers = this.scheduler.getTriggersOfJob(jobDetail.getKey());
@@ -148,23 +126,32 @@ public class QuartzScheduler {
   }
 
   /**
-   * resume a paused job given the groupname. since resuming request might be issued concurrently,
-   * so synchronized is added to ensure thread safety.
+   * Resume a job.
+   * @param jobName
+   * @param groupName
+   * @return true the job has been resumed, no if the job doesn't exist.
+   * @throws SchedulerException
    */
-  public synchronized void resumeJob(final String jobName, final String groupName)
+  public synchronized boolean resumeJobIfPresent(final String jobName, final String groupName)
       throws SchedulerException {
-    checkJobExistence(jobName, groupName);
-    this.scheduler.resumeJob(new JobKey(jobName, groupName));
+    if (ifJobExist(jobName, groupName)) {
+      this.scheduler.resumeJob(new JobKey(jobName, groupName));
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /**
-   * Unregister a job given the groupname. Since unregister might be called when
-   * concurrently removing projects, so synchronized is added to ensure thread safety.
+   * Unschedule a job.
+   * @param jobName
+   * @param groupName
+   * @return true if job is found and unscheduled.
+   * @throws SchedulerException
    */
-  public synchronized void unregisterJob(final String jobName, final String groupName) throws
+  public synchronized boolean unschedule(final String jobName, final String groupName) throws
       SchedulerException {
-    checkJobExistence(jobName, groupName);
-    this.scheduler.deleteJob(new JobKey(jobName, groupName));
+    return this.scheduler.deleteJob(new JobKey(jobName, groupName));
   }
 
   /**
@@ -179,16 +166,18 @@ public class QuartzScheduler {
    * <li>Quartz schedule for AZ internal use: the groupName should start with letters, rather
    * than
    * number, which is the first case.</ul>
+   *
+   * @return true if job has been scheduled, false if the same job exists already.
    */
-  public synchronized void registerJob(final String cronExpression, final QuartzJobDescription
-      jobDescription)
-      throws SchedulerException {
+  public synchronized boolean schedule(final String cronExpression, final QuartzJobDescription
+      jobDescription) throws SchedulerException {
 
     requireNonNull(jobDescription, "jobDescription is null");
 
     if (ifJobExist(jobDescription.getJobName(), jobDescription.getGroupName())) {
-      throw new SchedulerException(String.format("can not register existing job with job name: "
+      logger.warn(String.format("can not register existing job with job name: "
           + "%s and group name: %s", jobDescription.getJobName(), jobDescription.getGroupName()));
+      return false;
     }
 
     if (!CronExpression.isValidExpression(cronExpression)) {
@@ -216,10 +205,12 @@ public class QuartzScheduler {
 
     this.scheduler.scheduleJob(job, trigger);
     logger.info("Quartz Schedule with jobDetail " + job.getDescription() + " is registered.");
+    return true;
   }
 
 
-  public boolean ifJobExist(final String jobName, final String groupName)
+  @VisibleForTesting
+  boolean ifJobExist(final String jobName, final String groupName)
       throws SchedulerException {
     return this.scheduler.getJobDetail(new JobKey(jobName, groupName)) != null;
   }

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -169,7 +169,7 @@ public class QuartzScheduler {
    *
    * @return true if job has been scheduled, false if the same job exists already.
    */
-  public synchronized boolean schedule(final String cronExpression, final QuartzJobDescription
+  public synchronized boolean scheduleIfAbsent(final String cronExpression, final QuartzJobDescription
       jobDescription) throws SchedulerException {
 
     requireNonNull(jobDescription, "jobDescription is null");

--- a/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
@@ -91,7 +91,7 @@ public class QuartzSchedulerTest {
 
   @Test
   public void testCreateScheduleAndRun() throws Exception {
-    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
+    scheduler.scheduleJobIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
     TestUtils.await().untilAsserted(() -> assertThat(SampleQuartzJob.COUNT_EXECUTION)
         .isNotNull().isGreaterThan(1));
@@ -99,31 +99,31 @@ public class QuartzSchedulerTest {
 
   @Test
   public void testSchedulingDuplicateJob() throws Exception {
-    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
-    assertThat(scheduler.scheduleIfAbsent("0 5 * * * ?", createJobDescription())).isFalse();
+    scheduler.scheduleJobIfAbsent("* * * * * ?", createJobDescription());
+    assertThat(scheduler.scheduleJobIfAbsent("0 5 * * * ?", createJobDescription())).isFalse();
   }
 
   @Test
   public void testInvalidCron() {
     assertThatThrownBy(
-        () -> scheduler.scheduleIfAbsent("0 5 * * * *", createJobDescription()))
+        () -> scheduler.scheduleJobIfAbsent("0 5 * * * *", createJobDescription()))
         .isInstanceOf(SchedulerException.class)
         .hasMessageContaining("The cron expression string");
   }
 
   @Test
   public void testUnschedule() throws Exception {
-    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
+    scheduler.scheduleJobIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
-    assertThat(scheduler.unschedule("SampleJob", "SampleService")).isTrue();
+    assertThat(scheduler.unscheduleJob("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(false);
-    assertThat(scheduler.unschedule("SampleJob", "SampleService")).isFalse();
+    assertThat(scheduler.unscheduleJob("SampleJob", "SampleService")).isFalse();
   }
 
   @Test
   public void testPauseSchedule() throws Exception {
     assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isFalse();
-    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
+    scheduler.scheduleJobIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
     assertThat(scheduler.resumeJobIfPresent("SampleJob", "SampleService")).isTrue();

--- a/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
@@ -91,7 +91,7 @@ public class QuartzSchedulerTest {
 
   @Test
   public void testCreateScheduleAndRun() throws Exception {
-    scheduler.schedule("* * * * * ?", createJobDescription());
+    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
     TestUtils.await().untilAsserted(() -> assertThat(SampleQuartzJob.COUNT_EXECUTION)
         .isNotNull().isGreaterThan(1));
@@ -99,21 +99,21 @@ public class QuartzSchedulerTest {
 
   @Test
   public void testSchedulingDuplicateJob() throws Exception {
-    scheduler.schedule("* * * * * ?", createJobDescription());
-    assertThat(scheduler.schedule("0 5 * * * ?", createJobDescription())).isFalse();
+    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
+    assertThat(scheduler.scheduleIfAbsent("0 5 * * * ?", createJobDescription())).isFalse();
   }
 
   @Test
   public void testInvalidCron() {
     assertThatThrownBy(
-        () -> scheduler.schedule("0 5 * * * *", createJobDescription()))
+        () -> scheduler.scheduleIfAbsent("0 5 * * * *", createJobDescription()))
         .isInstanceOf(SchedulerException.class)
         .hasMessageContaining("The cron expression string");
   }
 
   @Test
   public void testUnschedule() throws Exception {
-    scheduler.schedule("* * * * * ?", createJobDescription());
+    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
     assertThat(scheduler.unschedule("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(false);
@@ -123,7 +123,7 @@ public class QuartzSchedulerTest {
   @Test
   public void testPauseSchedule() throws Exception {
     assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isFalse();
-    scheduler.schedule("* * * * * ?", createJobDescription());
+    scheduler.scheduleIfAbsent("* * * * * ?", createJobDescription());
     assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
     assertThat(scheduler.resumeJobIfPresent("SampleJob", "SampleService")).isTrue();

--- a/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/scheduler/QuartzSchedulerTest.java
@@ -30,12 +30,10 @@ import azkaban.webapp.AzkabanWebServerModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import java.io.File;
-import java.sql.SQLException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.quartz.SchedulerException;
 
@@ -76,7 +74,7 @@ public class QuartzSchedulerTest {
       scheduler.shutdown();
       dbOperator.update("DROP ALL OBJECTS");
       dbOperator.update("SHUTDOWN");
-    } catch (final SQLException e) {
+    } catch (final Exception e) {
       e.printStackTrace();
     }
   }
@@ -87,72 +85,58 @@ public class QuartzSchedulerTest {
   }
 
   @After
-  public void cleanup() {
+  public void cleanup() throws SchedulerException {
     scheduler.cleanup();
   }
 
   @Test
   public void testCreateScheduleAndRun() throws Exception {
-    scheduler.registerJob("* * * * * ?", createJobDescription());
+    scheduler.schedule("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
     TestUtils.await().untilAsserted(() -> assertThat(SampleQuartzJob.COUNT_EXECUTION)
         .isNotNull().isGreaterThan(1));
   }
 
   @Test
-  public void testNotAllowDuplicateJobRegister() throws Exception {
-    scheduler.registerJob("* * * * * ?", createJobDescription());
-    assertThatThrownBy(
-        () -> scheduler.registerJob("0 5 * * * ?", createJobDescription()))
-        .isInstanceOf(SchedulerException.class)
-        .hasMessageContaining("can not register existing job");
+  public void testSchedulingDuplicateJob() throws Exception {
+    scheduler.schedule("* * * * * ?", createJobDescription());
+    assertThat(scheduler.schedule("0 5 * * * ?", createJobDescription())).isFalse();
   }
 
   @Test
-  public void testInvalidCron() throws Exception {
+  public void testInvalidCron() {
     assertThatThrownBy(
-        () -> scheduler.registerJob("0 5 * * * *", createJobDescription()))
+        () -> scheduler.schedule("0 5 * * * *", createJobDescription()))
         .isInstanceOf(SchedulerException.class)
         .hasMessageContaining("The cron expression string");
   }
 
   @Test
-  public void testUnregisterSchedule() throws Exception {
-    scheduler.registerJob("* * * * * ?", createJobDescription());
+  public void testUnschedule() throws Exception {
+    scheduler.schedule("* * * * * ?", createJobDescription());
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(true);
-    scheduler.unregisterJob("SampleJob", "SampleService");
+    assertThat(scheduler.unschedule("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.ifJobExist("SampleJob", "SampleService")).isEqualTo(false);
+    assertThat(scheduler.unschedule("SampleJob", "SampleService")).isFalse();
   }
 
   @Test
   public void testPauseSchedule() throws Exception {
-    scheduler.registerJob("* * * * * ?", createJobDescription());
-    scheduler.pauseJob("SampleJob", "SampleService");
+    assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isFalse();
+    scheduler.schedule("* * * * * ?", createJobDescription());
+    assertThat(scheduler.pauseJobIfPresent("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
-    scheduler.resumeJob("SampleJob", "SampleService");
+    assertThat(scheduler.resumeJobIfPresent("SampleJob", "SampleService")).isTrue();
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(false);
 
     // test pausing a paused job
-    scheduler.pauseJob("SampleJob", "SampleService");
-    scheduler.pauseJob("SampleJob", "SampleService");
+    scheduler.pauseJobIfPresent("SampleJob", "SampleService");
+    scheduler.pauseJobIfPresent("SampleJob", "SampleService");
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(true);
     // test resuming a non-paused job
-    scheduler.resumeJob("SampleJob", "SampleService");
-    scheduler.resumeJob("SampleJob", "SampleService");
+    scheduler.resumeJobIfPresent("SampleJob", "SampleService");
+    scheduler.resumeJobIfPresent("SampleJob", "SampleService");
     assertThat(scheduler.isJobPaused("SampleJob", "SampleService")).isEqualTo(false);
-  }
-
-  @Ignore("Flaky test, slow too. Don't use Thread.sleep in unit tests.")
-  @Test
-  public void testPauseAndResume() throws Exception {
-    scheduler.registerJob("* * * * * ?", createJobDescription());
-    scheduler.pause();
-    final int count = SampleQuartzJob.COUNT_EXECUTION;
-    Thread.sleep(1500);
-    assertThat(SampleQuartzJob.COUNT_EXECUTION).isEqualTo(count);
-    scheduler.resume();
-    Thread.sleep(1200);
-    assertThat(SampleQuartzJob.COUNT_EXECUTION).isGreaterThan(count);
   }
 
   private QuartzJobDescription createJobDescription() {


### PR DESCRIPTION
This PR refactors quartz scheduler:
1. Remove unused methods.
2. Reduce visibility of methods that are only used in unit tests.
3. When pause/resume/unschedule a non-existing job, make them return false instead of throwing exception to distinguish this case from exceptional cases. Same apply for schedule an existing job.