### PR TITLE
Revert "Optimize gradle build time"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,9 +179,7 @@ subprojects {
         test {
             // Set maxParallelForks to a large number and let gradle to force it to a the
             // max-workers number when needed.
-            // NOTE! For some reason anything more than 1 doesn't work well for azkaban build:
-            // any maxParallelForks > 1 seems to make `./gradlew cleanTest test` ~4 times slower
-            maxParallelForks = 1
+            maxParallelForks = 12
         }
     }
 


### PR DESCRIPTION
Reverts azkaban/azkaban#2113.

Quote from @ypadron-in 
This change exposed unit tests failures when tests are run using MacOS's console with ./gradlew cleanTest test command. We will revert it temporarily until we fix the tests.

Failing tests: createErrorEmail, createFirstErrorMessage, createSuccessEmail and testDispatchMultipleRetries