### PR TITLE
Change ExecutorManager to ExecutorManagerAdapter in Flow Trigger

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -68,6 +68,7 @@ import org.joda.time.DateTime;
 
 /**
  * Executor manager used to manage the client side job.
+ * @deprecated replaced by {@link ExecutionController}
  */
 @Singleton
 @Deprecated

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -70,6 +70,7 @@ import org.joda.time.DateTime;
  * Executor manager used to manage the client side job.
  */
 @Singleton
+@Deprecated
 public class ExecutorManager extends EventHandler implements
     ExecutorManagerAdapter {
 

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
@@ -18,7 +18,7 @@ package azkaban.flowtrigger;
 
 import azkaban.Constants;
 import azkaban.executor.ExecutableFlow;
-import azkaban.executor.ExecutorManager;
+import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowUtils;
 import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
@@ -45,13 +45,13 @@ public class TriggerInstanceProcessor {
   private static final String FAILURE_EMAIL_SUBJECT = "flow trigger for flow '%s', project '%s' "
       + "has been cancelled on %s";
   private final static int THREAD_POOL_SIZE = 32;
-  private final ExecutorManager executorManager;
+  private final ExecutorManagerAdapter executorManager;
   private final FlowTriggerInstanceLoader flowTriggerInstanceLoader;
   private final Emailer emailer;
   private final ExecutorService executorService;
 
   @Inject
-  public TriggerInstanceProcessor(final ExecutorManager executorManager,
+  public TriggerInstanceProcessor(final ExecutorManagerAdapter executorManager,
       final FlowTriggerInstanceLoader flowTriggerInstanceLoader,
       final Emailer emailer) {
     Preconditions.checkNotNull(executorManager);

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerServiceTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import azkaban.executor.ExecutorManager;
+import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.flow.Flow;
 import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
@@ -56,7 +56,7 @@ public class FlowTriggerServiceTest {
       MockFlowTriggerInstanceLoader();
   private static TestDependencyCheck testDepCheck;
   private static FlowTriggerService flowTriggerService;
-  private static ExecutorManager executorManager;
+  private static ExecutorManagerAdapter executorManager;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -66,7 +66,7 @@ public class FlowTriggerServiceTest {
     when(pluginManager.getDependencyCheck(ArgumentMatchers.eq("TestDependencyCheck")))
         .thenReturn(testDepCheck);
 
-    executorManager = mock(ExecutorManager.class);
+    executorManager = mock(ExecutorManagerAdapter.class);
     when(executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");
 
     final Emailer emailer = mock(Emailer.class);

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.MockExecutorLoader;
@@ -108,7 +107,7 @@ public class TriggerInstanceProcessorTest {
     this.message = EmailerTest.mockEmailMessage();
     this.messageCreator = EmailerTest.mockMessageCreator(this.message);
     this.triggerInstLoader = mock(FlowTriggerInstanceLoader.class);
-    this.executorManager = mock(ExecutionController.class);
+    this.executorManager = mock(ExecutorManagerAdapter.class);
     this.executorLoader = new MockExecutorLoader();
     when(this.executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");
     final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -25,8 +25,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutorLoader;
-import azkaban.executor.ExecutorManager;
+import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.MockExecutorLoader;
 import azkaban.flow.Flow;
 import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
@@ -62,7 +63,7 @@ public class TriggerInstanceProcessorTest {
 
   private static final String EMAIL = "test@email.com";
   private FlowTriggerInstanceLoader triggerInstLoader;
-  private ExecutorManager executorManager;
+  private ExecutorManagerAdapter executorManager;
   private Emailer emailer;
   private EmailMessage message;
   private EmailMessageCreator messageCreator;
@@ -107,7 +108,7 @@ public class TriggerInstanceProcessorTest {
     this.message = EmailerTest.mockEmailMessage();
     this.messageCreator = EmailerTest.mockMessageCreator(this.message);
     this.triggerInstLoader = mock(FlowTriggerInstanceLoader.class);
-    this.executorManager = mock(ExecutorManager.class);
+    this.executorManager = mock(ExecutionController.class);
     this.executorLoader = new MockExecutorLoader();
     when(this.executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");
     final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
@@ -151,7 +152,7 @@ public class TriggerInstanceProcessorTest {
     final TriggerInstance triggerInstance = createTriggerInstance();
     this.processor.processTermination(triggerInstance);
     this.sendEmailLatch.await(10L, TimeUnit.SECONDS);
-    assertEquals(0, sendEmailLatch.getCount());
+    assertEquals(0, this.sendEmailLatch.getCount());
     verify(this.message).setSubject(
         "flow trigger for flow 'flowId', project 'proj' has been cancelled on azkaban");
     assertThat(TestUtils.readResource("/emailTemplate/flowtriggerfailureemail.html", this))


### PR DESCRIPTION
Given ExecutorManager is no longer used in new dispatch logic and replaced with ExecutionController(https://github.com/azkaban/azkaban/pull/2039), replace it with ExecutorManagerAdapter  in flow trigger-related code.