### PR TITLE
When flow trigger fails to be scheduled/unscheduled, throw exception to terminate the subsequent steps

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -118,13 +118,13 @@ public class FlowTriggerScheduler {
     }
   }
 
-  public boolean pauseFlowTrigger(final int projectId, final String flowId)
+  public boolean pauseFlowTriggerIfPresent(final int projectId, final String flowId)
       throws SchedulerException {
     return this.scheduler
         .pauseJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));
   }
 
-  public boolean resumeFlowTrigger(final int projectId, final String flowId) throws
+  public boolean resumeFlowTriggerIfPresent(final int projectId, final String flowId) throws
       SchedulerException {
     return this.scheduler
         .resumeJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -118,14 +118,15 @@ public class FlowTriggerScheduler {
     }
   }
 
-  public void pauseFlowTrigger(final int projectId, final String flowId) throws SchedulerException {
-    this.scheduler
+  public boolean pauseFlowTrigger(final int projectId, final String flowId)
+      throws SchedulerException {
+    return this.scheduler
         .pauseJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));
   }
 
-  public void resumeFlowTrigger(final int projectId, final String flowId) throws
+  public boolean resumeFlowTrigger(final int projectId, final String flowId) throws
       SchedulerException {
-    this.scheduler
+    return this.scheduler
         .resumeJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.gson.GsonBuilder;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,10 +63,10 @@ public class FlowTriggerScheduler {
   }
 
   /**
-   * Schedule flows containing flow triggers
+   * Schedule flows containing flow triggers for this project.
    */
-  public void scheduleAll(final Project project, final String submitUser)
-      throws ProjectManagerException {
+  public void schedule(final Project project, final String submitUser)
+      throws ProjectManagerException, IOException, SchedulerException {
 
     for (final Flow flow : project.getFlows()) {
       //todo chengren311: we should validate embedded flow shouldn't have flow trigger defined.
@@ -94,16 +95,22 @@ public class FlowTriggerScheduler {
                     FlowTriggerQuartzJob.FLOW_ID, flow.getId(),
                     FlowTriggerQuartzJob.FLOW_VERSION, latestFlowVersion,
                     FlowTriggerQuartzJob.PROJECT_ID, project.getId());
-            logger.info("scheduling flow " + flow.getProjectId() + "." + flow.getId());
-            this.scheduler
+            final boolean scheduleSuccess = this.scheduler
                 .scheduleJobIfAbsent(flowTrigger.getSchedule().getCronExpression(),
                     new QuartzJobDescription
                     (FlowTriggerQuartzJob.class, FlowTriggerQuartzJob.JOB_NAME,
                         generateGroupName(flow), contextMap));
+            if (scheduleSuccess) {
+              logger.info("Successfully registered flow {}.{} to scheduler", project.getName(),
+                  flow.getId());
+            } else {
+              logger.info("Fail to register a duplicate flow {}.{} to scheduler", project.getName(),
+                  flow.getId());
+            }
           }
-        } catch (final Exception ex) {
-          logger.error(String.format("error in registering flow [project: %s, flow: %s]", project
-              .getName(), flow.getId()), ex);
+        } catch (final SchedulerException | IOException ex) {
+          logger.error("Error in registering flow {}.{}", project.getName(), flow.getId(), ex);
+          throw ex;
         } finally {
           FlowLoaderUtils.cleanUpDir(tempDir);
         }
@@ -112,16 +119,12 @@ public class FlowTriggerScheduler {
   }
 
   public void pauseFlowTrigger(final int projectId, final String flowId) throws SchedulerException {
-    logger.info(String.format("pausing flow trigger for [projectId:%s, flowId:%s]", projectId,
-        flowId));
     this.scheduler
         .pauseJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));
   }
 
   public void resumeFlowTrigger(final int projectId, final String flowId) throws
       SchedulerException {
-    logger.info(
-        String.format("resuming flow trigger for [projectId:%s, flowId:%s]", projectId, flowId));
     this.scheduler
         .resumeJobIfPresent(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(projectId, flowId));
   }
@@ -155,7 +158,7 @@ public class FlowTriggerScheduler {
               flowId, flowTrigger, submitUser, quartzTriggers.isEmpty() ? null
               : quartzTriggers.get(0), isPaused);
         } catch (final Exception ex) {
-          logger.error(String.format("unable to get flow trigger by job key %s", jobKey), ex);
+          logger.error("Unable to get flow trigger by job key {}", jobKey, ex);
           scheduledFlowTrigger = null;
         }
 
@@ -163,7 +166,7 @@ public class FlowTriggerScheduler {
       }
       return flowTriggerJobDetails;
     } catch (final Exception ex) {
-      logger.error("unable to get scheduled flow triggers", ex);
+      logger.error("Unable to get scheduled flow triggers", ex);
       return new ArrayList<>();
     }
   }
@@ -171,15 +174,18 @@ public class FlowTriggerScheduler {
   /**
    * Unschedule all possible flows in a project
    */
-  public void unscheduleAll(final Project project) throws SchedulerException {
+  public void unschedule(final Project project) throws SchedulerException {
     for (final Flow flow : project.getFlows()) {
-      logger.info("unscheduling flow" + flow.getProjectId() + "." + flow.getId() + " if it has "
-          + " schedule");
       if (!flow.isEmbeddedFlow()) {
         try {
-          this.scheduler.unscheduleJob(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow));
-        } catch (final Exception ex) {
-          logger.info("error when unregistering job", ex);
+          if (this.scheduler
+              .unscheduleJob(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow))) {
+            logger.info("Flow {}.{} unregistered from scheduler", project.getName(), flow.getId());
+          }
+        } catch (final SchedulerException e) {
+          logger.error("Fail to unregister flow from scheduler {}.{}", project.getName(),
+              flow.getId(), e);
+          throw e;
         }
       }
     }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
@@ -40,7 +40,7 @@ public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
   private static final long serialVersionUID = 1L;
   private FlowTriggerScheduler scheduler;
   private ProjectManager projectManager;
-  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerScheduler.class);
+  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerServlet.class);
 
   @Override
   public void init(final ServletConfig config) throws ServletException {
@@ -119,13 +119,13 @@ public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
         } else {
           try {
             if (ajaxName.equals("pauseTrigger")) {
-              if (this.scheduler.pauseFlowTrigger(projectId, flowId)) {
+              if (this.scheduler.pauseFlowTriggerIfPresent(projectId, flowId)) {
                 logger.info("Flow trigger for flow {}.{} is paused", project.getName(), flowId);
               } else {
                 logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
               }
             } else {
-              if (this.scheduler.resumeFlowTrigger(projectId, flowId)) {
+              if (this.scheduler.resumeFlowTriggerIfPresent(projectId, flowId)) {
                 logger.info("Flow trigger for flow {}.{} is resumed", project.getName(), flowId);
               } else {
                 logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
@@ -32,12 +32,15 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
   private FlowTriggerScheduler scheduler;
   private ProjectManager projectManager;
+  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerScheduler.class);
 
   @Override
   public void init(final ServletConfig config) throws ServletException {
@@ -116,9 +119,17 @@ public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
         } else {
           try {
             if (ajaxName.equals("pauseTrigger")) {
-              this.scheduler.pauseFlowTrigger(projectId, flowId);
+              if (this.scheduler.pauseFlowTrigger(projectId, flowId)) {
+                logger.info("Flow trigger for flow {}.{} is paused", project.getName(), flowId);
+              } else {
+                logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
+              }
             } else {
-              this.scheduler.resumeFlowTrigger(projectId, flowId);
+              if (this.scheduler.resumeFlowTrigger(projectId, flowId)) {
+                logger.info("Flow trigger for flow {}.{} is resumed", project.getName(), flowId);
+              } else {
+                logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
+              }
             }
             ret.put("status", "success");
           } catch (final SchedulerException ex) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -621,7 +621,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     // remove flow trigger schedules
     try {
       if (this.enableQuartz) {
-        this.scheduler.unscheduleAll(project);
+        this.scheduler.unschedule(project);
       }
     } catch (final SchedulerException e) {
       throw new ServletException(e);
@@ -1715,21 +1715,19 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         IOUtils.copy(item.getInputStream(), out);
         out.close();
 
-        //unscheduleall/scheduleall should only work with flow which has defined flow trigger
-        //unschedule all flows within the old project
         if (this.enableQuartz) {
           //todo chengren311: should maintain atomicity,
           // e.g, if uploadProject fails, associated schedule shouldn't be added.
-          this.scheduler.unscheduleAll(project);
+          this.scheduler.unschedule(project);
         }
         final Map<String, ValidationReport> reports =
             this.projectManager.uploadProject(project, archiveFile, type, user,
                 props);
 
         if (this.enableQuartz) {
-          //schedule the new project
-          this.scheduler.scheduleAll(project, user.getUserId());
+          this.scheduler.schedule(project, user.getUserId());
         }
+
         final StringBuffer errorMsgs = new StringBuffer();
         final StringBuffer warnMsgs = new StringBuffer();
         for (final Entry<String, ValidationReport> reportEntry : reports.entrySet()) {

--- a/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/ProjectManagerResource.java
@@ -129,7 +129,7 @@ public class ProjectManagerResource extends ResourceContextHolder {
       if (enableQuartz) {
         //todo chengren311: should maintain atomicity,
         // e.g, if uploadProject fails, associated schedule shouldn't be added.
-        scheduler.unscheduleAll(project);
+        scheduler.unschedule(project);
       }
       // Check if project upload runs into any errors, such as the file
       // having blacklisted jars
@@ -138,14 +138,14 @@ public class ProjectManagerResource extends ResourceContextHolder {
           .uploadProject(project, archiveFile, "zip", user, props);
 
       if (enableQuartz) {
-        scheduler.scheduleAll(project, user.getUserId());
+        scheduler.schedule(project, user.getUserId());
       }
 
       checkReports(reports);
       logger.info("Deploy: project " + projectName + " version is " + project.getVersion()
           + ", reference is " + System.identityHashCode(project));
       return Integer.toString(project.getVersion());
-    } catch (final ProjectManagerException | SchedulerException | ExecutorManagerException e) {
+    } catch (final ProjectManagerException | ExecutorManagerException e) {
       final String errorMsg = "Upload of project " + project + " from " + archiveFile + " failed";
       logger.error(errorMsg, e);
       throw e;


### PR DESCRIPTION
When scheduling/unscheduling fails(E.g quartz database connection issue), fail fast to avoid inconsistent situation where unscheduling last version of flow trigger fails, but project with new version of flow trigger gets uploaded successfully.