### PR TITLE
getProjectId api no longer returns IDs of deleted/inactive projects.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
@@ -40,9 +40,6 @@ class JdbcProjectHandlerSet {
 
   public static class ProjectResultHandler implements ResultSetHandler<List<Project>> {
 
-    public static String SELECT_PROJECT_BY_NAME =
-        "SELECT id, name, active, modified_time, create_time, version, last_modified_by, description, enc_type, settings_blob FROM projects WHERE name=?";
-
     public static String SELECT_PROJECT_BY_ID =
         "SELECT id, name, active, modified_time, create_time, version, last_modified_by, description, enc_type, settings_blob FROM projects WHERE id=?";
 

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -106,8 +106,8 @@ public class JdbcProjectImpl implements ProjectLoader {
         }
       });
     } catch (final SQLException ex) {
-      logger.error(ProjectResultHandler.SELECT_PROJECT_BY_ID + " failed.", ex);
-      throw new ProjectManagerException("Error retrieving all projects", ex);
+      logger.error(ProjectResultHandler.SELECT_ALL_ACTIVE_PROJECTS + " failed.", ex);
+      throw new ProjectManagerException("Error retrieving all active projects", ex);
     }
     return projects;
   }
@@ -155,17 +155,12 @@ public class JdbcProjectImpl implements ProjectLoader {
     Project project = null;
     final ProjectResultHandler handler = new ProjectResultHandler();
 
-    // select active project from db first, if not exist, select inactive one.
     // At most one active project with the same name exists in db.
     try {
-      List<Project> projects = this.dbOperator
+      final List<Project> projects = this.dbOperator
           .query(ProjectResultHandler.SELECT_ACTIVE_PROJECT_BY_NAME, handler, name);
       if (projects.isEmpty()) {
-        projects = this.dbOperator
-            .query(ProjectResultHandler.SELECT_PROJECT_BY_NAME, handler, name);
-        if (projects.isEmpty()) {
-          throw new ProjectManagerException("No project with name " + name + " exists in db.");
-        }
+        throw new ProjectManagerException("No active project with name " + name + " exists in db.");
       }
       project = projects.get(0);
       for (final Triple<String, Boolean, Permission> perm : fetchPermissionsForProject(project)) {
@@ -523,7 +518,7 @@ public class JdbcProjectImpl implements ProjectLoader {
     }
 
     // Check md5.
-    byte[] md5;
+    final byte[] md5;
     try {
       md5 = Md5Hasher.md5Hash(file);
     } catch (final IOException e) {

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -160,7 +160,7 @@ public class JdbcProjectImpl implements ProjectLoader {
       final List<Project> projects = this.dbOperator
           .query(ProjectResultHandler.SELECT_ACTIVE_PROJECT_BY_NAME, handler, name);
       if (projects.isEmpty()) {
-        throw new ProjectManagerException("No active project with name " + name + " exists in db.");
+        return null;
       }
       project = projects.get(0);
       for (final Triple<String, Boolean, Permission> perm : fetchPermissionsForProject(project)) {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -227,7 +227,7 @@ public class ProjectManager {
   }
 
   /**
-   * fetch active project from cache and inactive projects from db by project_name
+   * fetch active project by project name. Queries the cache first then db if not found
    */
   public Project getProject(final String name) {
     Project fetchedProject = this.projectsByName.get(name);

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -233,8 +233,12 @@ public class ProjectManager {
     Project fetchedProject = this.projectsByName.get(name);
     if (fetchedProject == null) {
       try {
-        logger.info("Project " + name + " doesn't exist in cache, fetching from DB now.");
         fetchedProject = this.projectLoader.fetchProjectByName(name);
+        if (fetchedProject != null) {
+          logger.info("Project " + name + " not found in cache, fetched from DB.");
+        } else {
+          logger.info("No active project with name " + name + " exists in cache or DB.");
+        }
       } catch (final ProjectManagerException e) {
         logger.error("Could not load project from store.", e);
       }

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -254,9 +254,7 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     Assert.assertEquals(project.isActive(), true);
     this.loader.removeProject(project, "testUser1");
-    assertThatThrownBy(() -> this.loader.fetchProjectByName("mytestProject"))
-        .isInstanceOf(ProjectManagerException.class)
-        .hasMessageContaining("No active project with name mytestProject exists in db.");
+    Assert.assertNull(this.loader.fetchProjectByName("mytestProject"));
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -254,8 +254,9 @@ public class JdbcProjectImplTest {
     final Project project = this.loader.fetchProjectByName("mytestProject");
     Assert.assertEquals(project.isActive(), true);
     this.loader.removeProject(project, "testUser1");
-    final Project removedProject = this.loader.fetchProjectByName("mytestProject");
-    Assert.assertEquals(removedProject.isActive(), false);
+    assertThatThrownBy(() -> this.loader.fetchProjectByName("mytestProject"))
+        .isInstanceOf(ProjectManagerException.class)
+        .hasMessageContaining("No active project with name mytestProject exists in db.");
   }
 
   @Test


### PR DESCRIPTION
Before, users couldn't know for sure if a certain project existed or not.
With this changes getProjectId api will either return:
-if project “ABC” exists
```
{
  "project" : "ABC",
  "projectId" : 29
}
```
-if project “ABC” doesn't exist (either never existed or was deleted)
```
{
  "project" : "ABC",
  "error" : "Project ABC doesn't exist."
}
```
Follow up work: Verify permissions to access project id information.