### PR TITLE
[REFACTOR] Dedupe common codes

### DIFF
--- a/az-core/src/main/java/azkaban/utils/PluginUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PluginUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.utils;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
+
+
+public class PluginUtils {
+  private static final Logger logger = Logger.getLogger(PluginUtils.class);
+
+  /**
+   * Private constructor.
+   */
+  private PluginUtils() {
+  }
+
+
+  public static ArrayList<URL> getUrls(File[] files) {
+    final ArrayList<URL> urls = new ArrayList<>();
+    for (int i = 0; i < files.length; ++i) {
+      try {
+        final URL url = files[i].toURI().toURL();
+        urls.add(url);
+      } catch (final MalformedURLException e) {
+        logger.error(e);
+      }
+    }
+    return urls;
+  }
+
+  /**
+   * Get URLClassLoader
+   * @param pluginDir
+   * @param extLibClasspath
+   * @param parentLoader
+   * @return
+   */
+  public static URLClassLoader getURLClassLoader(final File pluginDir, List<String> extLibClasspath, ClassLoader parentLoader) {
+    final File libDir = new File(pluginDir, "lib");
+    if (libDir.exists() && libDir.isDirectory()) {
+      final File[] files = libDir.listFiles();
+      final ArrayList<URL> urls = getUrls(files);
+
+      if (extLibClasspath != null) {
+        for (final String extLib : extLibClasspath) {
+          try {
+            final File extLibFile = new File(pluginDir, extLib);
+            if (extLibFile.exists()) {
+              if (extLibFile.isDirectory()) {
+                // extLibFile is a directory; load all the files in the
+                // directory.
+                final File[] extLibFiles = extLibFile.listFiles();
+                urls.addAll(getUrls(extLibFiles));
+              } else {
+                final URL url = extLibFile.toURI().toURL();
+                urls.add(url);
+              }
+            } else {
+              logger.error("External library path " + extLibFile.getAbsolutePath() + " not found.");
+              return null;
+            }
+          } catch (final MalformedURLException e) {
+            logger.error(e);
+          }
+        }
+      }
+      return new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
+    } else {
+      logger.error("Library path " + libDir + " not found.");
+      return null;
+    }
+  }
+
+  public static Class<?> getPluginClass(final URLClassLoader urlClassLoader, String pluginClass) {
+    if (urlClassLoader == null) {
+      return null;
+    }
+
+    try {
+      return urlClassLoader.loadClass(pluginClass);
+    } catch (final ClassNotFoundException e) {
+      logger.error("Class " + pluginClass + " not found.");
+      return null;
+    }
+  }
+}

--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -743,21 +743,41 @@ public class Props {
   }
 
   /**
-   * Get a map of all properties by string prefix
+   * Get a flattened map of all properties by given prefix
    *
-   * @param prefix The string prefix
+   * @param prefix the prefix string
+   * @param ignoreCase if allows case sensitive checking for the given prefix string
+   * @return a flattened map with all properties with the given prefix
    */
-  public Map<String, String> getMapByPrefix(final String prefix) {
-    final Map<String, String> values = this._parent == null ? new HashMap<>() :
-        this._parent.getMapByPrefix(prefix);
+  public Map<String, String> getMapByPrefix(final String prefix, boolean ignoreCase) {
+    final Map<String, String> values = (this._parent == null)
+        ? new HashMap<>()
+        : this._parent.getMapByPrefix(prefix, ignoreCase);
 
     // when there is a conflict, value from the child takes the priority.
+    if (prefix == null) { // when prefix is null, return an empty map
+      return values;
+    }
+
     for (final String key : this.localKeySet()) {
-      if (key.startsWith(prefix)) {
-        values.put(key.substring(prefix.length()), get(key));
+      if (key != null && key.length() >= prefix.length()) {
+        final String keyPrefix = key.substring(0, prefix.length());
+        if ((ignoreCase ? keyPrefix.equalsIgnoreCase(prefix) : keyPrefix.equals(prefix))) {
+          values.put(key.substring(prefix.length()), get(key));
+        }
       }
     }
     return values;
+  }
+
+  /**
+   * Get a flattened map of all properties by given prefix
+   *
+   * @param prefix the prefix string
+   * @return a flattened map with all properties with the given prefix
+   */
+  public Map<String, String> getMapByPrefix(final String prefix) {
+    return getMapByPrefix(prefix, false);
   }
 
   /**

--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import com.google.common.collect.MapDifference;
@@ -36,10 +35,16 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 public class PropsUtils {
-
   private static final Logger logger = Logger.getLogger(PropsUtils.class);
   private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
       .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
+
+  /**
+   * Private constructor.
+   */
+  private PropsUtils() {
+  }
+
 
   /**
    * Load job schedules from the given directories
@@ -90,6 +95,45 @@ public class PropsUtils {
       return props;
     } catch (final IOException e) {
       throw new RuntimeException("Error loading properties.", e);
+    }
+  }
+
+  /**
+   * Load plugin properties
+   * @param pluginDir  plugin's Base Directory
+   * @param pluginType plugin type (viewer, trigger, alter)
+   * @return The properties
+   */
+  public static Props loadPluginProps(final File pluginDir, String pluginType) {
+    if (!pluginDir.exists()) {
+      logger.error("Error! " + pluginType + " plugin path " + pluginDir.getPath() + " doesn't exist.");
+      return null;
+    }
+
+    if (!pluginDir.isDirectory()) {
+      logger.error("The plugin path " + pluginDir + " is not a directory.");
+      return null;
+    }
+
+    final File propertiesDir = new File(pluginDir, "conf");
+    if (propertiesDir.exists() && propertiesDir.isDirectory()) {
+      final File propertiesFile = new File(propertiesDir, "plugin.properties");
+      final File propertiesOverrideFile =
+          new File(propertiesDir, "override.properties");
+
+      if (propertiesFile.exists()) {
+        if (propertiesOverrideFile.exists()) {
+          return loadProps(null, propertiesFile, propertiesOverrideFile);
+        } else {
+          return loadProps(null, propertiesFile);
+        }
+      } else {
+        logger.error("Plugin conf file " + propertiesFile + " not found.");
+        return null;
+      }
+    } else {
+      logger.error("Plugin conf path " + propertiesDir + " not found.");
+      return null;
     }
   }
 

--- a/az-core/src/main/java/azkaban/utils/TimeUtils.java
+++ b/az-core/src/main/java/azkaban/utils/TimeUtils.java
@@ -169,7 +169,7 @@ public class TimeUtils {
     String periodStr = "null";
 
     if (period == null) {
-      return "null";
+      return periodStr;
     }
 
     if (period.get(DurationFieldType.years()) > 0) {

--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -23,15 +22,14 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.time.Duration;
-import java.time.Period;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
@@ -44,6 +42,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
+
 
 /**
  * A util helper class full of static methods that are commonly used.
@@ -59,6 +58,7 @@ public class Utils {
    */
   private Utils() {
   }
+
 
   /**
    * Equivalent to Object.equals except that it handles nulls. If a and b are both null, true is
@@ -97,6 +97,18 @@ public class Utils {
       }
     }
     return null;
+  }
+
+  /**
+   * Return the value itself if it is non-null, otherwise return the default value
+   *
+   * @param value  The object
+   * @param defaultValue default value if object == null
+   * @param <T> The type of the object
+   * @return The object itself or default value when it is null
+   */
+  public static <T> T ifNull(final T value, final T defaultValue) {
+    return (value == null) ? defaultValue : value;
   }
 
   /**
@@ -395,10 +407,34 @@ public class Utils {
      * e.g. <0 0 3 ? * * 22> OR <0 0 3 ? * 8>. Under these cases, the below code is able to tell.
      */
     final CronExpression cronExecutionTime = parseCronExpression(cronExpression, timezone);
-    if (cronExecutionTime == null || cronExecutionTime.getNextValidTimeAfter(new Date()) == null) {
-      return false;
-    }
-    return true;
+    return (!(cronExecutionTime == null || cronExecutionTime.getNextValidTimeAfter(new Date()) == null));
   }
 
+  /**
+   * Run a sequence of commands
+   *
+   * @param commands sequence of commands
+   * @return list of output result
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  public static ArrayList<String> runProcess(String... commands)
+      throws InterruptedException, IOException {
+    final java.lang.ProcessBuilder processBuilder = new java.lang.ProcessBuilder(commands);
+    final ArrayList<String> output = new ArrayList<>();
+    final Process process = processBuilder.start();
+    process.waitFor();
+    final InputStream inputStream = process.getInputStream();
+    try {
+      final java.io.BufferedReader reader = new java.io.BufferedReader(
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        output.add(line);
+      }
+    } finally {
+      inputStream.close();
+    }
+    return output;
+  }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -1,0 +1,135 @@
+package azkaban.jobtype;
+
+import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.Props;
+import java.io.File;
+import java.util.List;
+import org.apache.log4j.Logger;
+
+import static org.apache.hadoop.security.UserGroupInformation.*;
+
+
+/**
+ * Abstract Hadoop Job for Job PlugIn
+ */
+public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob {
+
+  protected HadoopSecurityManager hadoopSecurityManager;
+
+  //TODO: Refactoring the code and move the following attributes into the HadoopSecurityManager
+  protected boolean shouldProxy = false;
+  protected boolean obtainTokens = false;
+  protected File tokenFile = null;
+  protected String userToProxy = null;
+
+  public AbstractHadoopJavaProcessJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
+    super(jobid, sysProps, jobProps, logger);
+    shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
+    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
+    obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+    if (shouldProxy) {
+      getLog().info("Initiating hadoop security manager.");
+      try {
+        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), logger);
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        throw new RuntimeException("Failed to get hadoop security manager!"
+            + e.getCause());
+      }
+    }
+  }
+
+
+  @Override
+  public void run() throws Exception {
+    setupPropsForProxy();
+
+    try {
+      super.run();
+    } catch (Throwable t) {
+      t.printStackTrace();
+      getLog().error("caught error running the job", t);
+      throw new Exception(t);
+    } finally {
+      HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
+    }
+  }
+
+  protected String getJVMProxySecureArgument() {
+    String secure = "";
+
+    if (shouldProxy) {
+      info("Setting up secure proxy info for child process");
+      secure = " -D" + HadoopSecurityManager.USER_TO_PROXY
+          + "=" + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
+
+      String extraToken = getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, "false");
+      if (extraToken != null) {
+        secure += " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "=" + extraToken;
+      }
+      info("Secure settings = " + secure);
+    } else {
+      info("Not setting up secure proxy info for child process");
+    }
+
+    return secure;
+  }
+
+  protected void setupPropsForProxy() throws Exception {
+    if (shouldProxy && obtainTokens) {
+      userToProxy = getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
+      getLog().info("Need to proxy. Getting tokens.");
+      // get tokens in to a file, and put the location in props
+      Props props = new Props();
+      props.putAll(getJobProps());
+      props.putAll(getSysProps());
+
+      addAdditionalNamenodesToProps(props);
+
+      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
+      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+    }
+  }
+
+  protected void addAdditionalNamenodesToProps(final Props props) {
+    HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
+  }
+
+  /**
+   * Merge typeClassPath List into the classPath List
+   * @param classPath destination list
+   * @param typeClassPath source list
+   */
+  protected void mergeTypeClassPaths(List<String>  classPath, final List<String> typeClassPath) {
+    if (typeClassPath != null) {
+      // fill in this when load this jobtype
+      final String pluginDir = getSysProps().get("plugin.dir");
+      for (String jar : typeClassPath) {
+        File jarFile = new File(jar);
+        if (!jarFile.isAbsolute()) {
+          jarFile = new File(pluginDir + File.separatorChar + jar);
+        }
+
+        if (!classPath.contains(jarFile.getAbsolutePath())) {
+          classPath.add(jarFile.getAbsolutePath());
+        }
+      }
+    }
+  }
+
+  /**
+   * Merge typeGlobalClassPath List into the classPath List
+   * @param classPath destination list
+   * @param typeGlobalClassPath source list
+   */
+  protected void mergeTypeGlobalClassPaths(List<String> classPath, final List<String> typeGlobalClassPath) {
+    if (typeGlobalClassPath != null) {
+      for (String jar : typeGlobalClassPath) {
+        if (!classPath.contains(jar)) {
+          classPath.add(jar);
+        }
+      }
+    }
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
@@ -13,34 +13,23 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.PrivilegedExceptionAction;
+import azkaban.utils.FileIOUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
-
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 
-public class HadoopHiveJob extends JavaProcessJob {
+
+public class HadoopHiveJob extends AbstractHadoopJavaProcessJob {
 
   public static final String HIVE_SCRIPT = "hive.script";
   private static final String HIVECONF_PARAM_PREFIX = "hiveconf.";
@@ -48,35 +37,12 @@ public class HadoopHiveJob extends JavaProcessJob {
   public static final String HADOOP_SECURE_HIVE_WRAPPER =
       "azkaban.jobtype.HadoopSecureHiveWrapper";
 
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
-
   private boolean debug = false;
 
-  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log)
-      throws IOException {
+  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-
-    shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
-    obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
-
     debug = getJobProps().getBoolean("debug", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
   @Override
@@ -84,38 +50,12 @@ public class HadoopHiveJob extends JavaProcessJob {
     String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
         CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
     getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
+            + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
         HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
     HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
         getWorkingDirectory());
 
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-
-    try {
-      super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job");
-      throw new Exception(t);
-    } finally {
-      if (tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
+    super.run();
   }
 
   @Override
@@ -146,25 +86,7 @@ public class HadoopHiveJob extends JavaProcessJob {
       args += " " + typeSysJVMArgs;
     }
 
-    if (shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
 
     return args;
   }
@@ -210,41 +132,23 @@ public class HadoopHiveJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecureHiveWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
+
     List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    mergeTypeClassPaths(classPath, typeClassPath);
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    mergeTypeGlobalClassPaths(classPath, typeGlobalClassPath);
 
     return classPath;
   }
@@ -259,26 +163,6 @@ public class HadoopHiveJob extends JavaProcessJob {
 
   protected Map<String, String> getHiveVar() {
     return getJobProps().getMapByPrefix(HIVEVAR_PARAM_PREFIX);
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
@@ -13,12 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
+import azkaban.utils.FileIOUtils;
 import java.io.File;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import org.apache.log4j.Logger;
 
@@ -68,18 +67,18 @@ public class JavaJob extends JavaProcessJob {
   protected List<String> getClassPaths() {
     List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(SecurityUtils.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(SecurityUtils.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
-    String loggerPath = getSourcePathFromClass(Logger.class);
+    String loggerPath = FileIOUtils.getSourcePathFromClass(Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }
@@ -121,25 +120,6 @@ public class JavaJob extends JavaProcessJob {
     }
 
     return classPath;
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   @Override

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.SecurityUtils;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import java.io.File;
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import org.apache.log4j.Logger;
 
 public class PigProcessJob extends JavaProcessJob {
@@ -47,26 +46,6 @@ public class PigProcessJob extends JavaProcessJob {
   public PigProcessJob(final String jobid, final Props sysProps, final Props jobProps,
       final Logger log) {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
-  }
-
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   @Override
@@ -138,7 +117,7 @@ public class PigProcessJob extends JavaProcessJob {
       for (final Map.Entry<String, String> entry : map.entrySet()) {
         list.add("-param "
             + StringUtils.shellQuote(entry.getKey() + "=" + entry.getValue(),
-                StringUtils.SINGLE_QUOTE));
+            StringUtils.SINGLE_QUOTE));
       }
     }
 
@@ -172,9 +151,9 @@ public class PigProcessJob extends JavaProcessJob {
       classPath.add(new File(hadoopHome, "conf").getPath());
     }
 
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
     if (SecurityUtils.shouldProxy(getSysProps().toProperties())) {
-      classPath.add(getSourcePathFromClass(SecurePigWrapper.class));
+      classPath.add(FileIOUtils.getSourcePathFromClass(SecurePigWrapper.class));
     }
 
     final List<String> typeClassPath =

--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.jobsummary;
 
 import azkaban.executor.ExecutableFlow;
@@ -23,7 +22,6 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.server.session.Session;
-import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Props;
@@ -40,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+
 
 public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
   private static final String PROXY_USER_SESSION_KEY =
@@ -69,18 +68,6 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
             "web");
     this.webResourcesPath.mkdirs();
     setResourceDirectory(this.webResourcesPath);
-  }
-
-  private Project getProjectByPermission(final int projectId, final User user,
-      final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-    if (project == null) {
-      return null;
-    }
-    if (!hasPermission(project, user, type)) {
-      return null;
-    }
-    return project;
   }
 
   @Override
@@ -138,7 +125,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
     }
 
     final int projectId = flow.getProjectId();
-    final Project project = getProjectByPermission(projectId, user, Type.READ);
+    final Project project = filterProjectByPermission(this.projectManager.getProject(projectId), user, Type.READ);
     if (project == null) {
       page.render();
       return;

--- a/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
@@ -13,21 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-
 package azkaban.executor;
 
 import azkaban.alert.Alerter;
 import azkaban.utils.Emailer;
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,39 +66,15 @@ public class AlerterHolder {
       return Collections.<String, Alerter>emptyMap();
     }
 
-    final Map<String, Alerter> installedAlerterPlugins =
-        new HashMap<>();
+    final Map<String, Alerter> installedAlerterPlugins = new HashMap<>();
     final ClassLoader parentLoader = getClass().getClassLoader();
     final File[] pluginDirs = alerterPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.isDirectory()) {
-        logger.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          logger.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        logger.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir, "Alter");
+      if (pluginProps == null) {
         continue;
       }
 
@@ -113,48 +86,18 @@ public class AlerterHolder {
       final String pluginClass = pluginProps.getString("alerter.class");
       if (pluginClass == null) {
         logger.error("Alerter class is not set.");
+        continue;
       } else {
         logger.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            logger.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              logger.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        logger.error("Library path " + propertiesDir + " not found.");
+      URLClassLoader urlClassLoader = PluginUtils.getURLClassLoader(pluginDir, extLibClasspath, parentLoader);
+      if (urlClassLoader == null) {
         continue;
       }
 
-      Class<?> alerterClass = null;
-      try {
-        alerterClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        logger.error("Class " + pluginClass + " not found.");
+      Class<?> alerterClass = PluginUtils.getPluginClass(urlClassLoader, pluginClass);
+      if (alerterClass == null) {
         continue;
       }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 public interface ConnectorParams {
@@ -106,6 +105,4 @@ public interface ConnectorParams {
   public static final String STATS_MAP_REPORTINGINTERVAL = "interval";
   public static final String STATS_MAP_CLEANINGINTERVAL = "interval";
   public static final String STATS_MAP_EMITTERNUMINSTANCES = "numInstances";
-
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
@@ -13,12 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.Props;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Base Job
+ */
 public abstract class AbstractJob implements Job {
 
   public static final String JOB_TYPE = "type";
@@ -56,6 +59,19 @@ public abstract class AbstractJob implements Job {
     throw new RuntimeException("Job " + this._id + " does not support cancellation!");
   }
 
+  @Override
+  public Props getJobGeneratedProperties() {
+    return new Props();
+  }
+
+  @Override
+  public abstract void run() throws Exception;
+
+  @Override
+  public boolean isCanceled() {
+    return false;
+  }
+
   public Logger getLog() {
     return this._log;
   }
@@ -91,18 +107,4 @@ public abstract class AbstractJob implements Job {
   public void error(final String message, final Throwable t) {
     this._log.error(message, t);
   }
-
-  @Override
-  public Props getJobGeneratedProperties() {
-    return new Props();
-  }
-
-  @Override
-  public abstract void run() throws Exception;
-
-  @Override
-  public boolean isCanceled() {
-    return false;
-  }
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import azkaban.utils.Utils;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,7 +36,6 @@ import org.apache.log4j.Logger;
 public abstract class AbstractProcessJob extends AbstractJob {
 
   public static final String ENV_PREFIX = "env.";
-  public static final String ENV_PREFIX_UCASE = "ENV.";
   public static final String WORKING_DIR = "working.dir";
   public static final String JOB_PROP_ENV = "JOB_PROP_FILE";
   public static final String JOB_NAME_ENV = "JOB_NAME";
@@ -44,40 +43,37 @@ public abstract class AbstractProcessJob extends AbstractJob {
   private static final String SENSITIVE_JOB_PROP_NAME_SUFFIX = "_X";
   private static final String SENSITIVE_JOB_PROP_VALUE_PLACEHOLDER = "[MASKED]";
   private static final String JOB_DUMP_PROPERTIES_IN_LOG = "job.dump.properties";
+
   protected final String _jobPath;
-  private final Logger log;
+  protected String _cwd;
   protected volatile Props jobProps;
   protected volatile Props sysProps;
 
-  protected String _cwd;
-
   private volatile Props generatedProperties;
 
-  protected AbstractProcessJob(final String jobid, final Props sysProps,
-      final Props jobProps, final Logger log) {
+  protected AbstractProcessJob(final String jobid, final Props sysProps, final Props jobProps, final Logger log) {
     super(jobid, log);
 
     this.jobProps = jobProps;
     this.sysProps = sysProps;
     this._cwd = getWorkingDirectory();
     this._jobPath = this._cwd;
-
-    this.log = log;
   }
 
+  /**
+   * TODO: Review to see if this function can be private
+   */
   public File createOutputPropsFile(final String id, final String workingDir) {
     this.info("cwd=" + workingDir);
 
-    final File directory = new File(workingDir);
-    File tempFile = null;
     try {
-      tempFile = File.createTempFile(id + "_output_", "_tmp", directory);
+      final File directory = new File(workingDir);
+      final File tempFile = File.createTempFile(id + "_output_", "_tmp", directory);
+      return tempFile;
     } catch (final IOException e) {
       this.error("Failed to create temp output property file :", e);
-      throw new RuntimeException("Failed to create temp output property file ",
-          e);
+      throw new RuntimeException("Failed to create temp output property file ", e);
     }
-    return tempFile;
   }
 
   public Props getJobProps() {
@@ -116,7 +112,7 @@ public abstract class AbstractProcessJob extends AbstractJob {
         }
         this.info("****** End Job properties  ******");
       } catch (final Exception ex) {
-        this.log.error("failed to log job properties ", ex);
+        this.error("failed to log job properties ", ex);
       }
     }
   }
@@ -139,7 +135,7 @@ public abstract class AbstractProcessJob extends AbstractJob {
     this.jobProps.put(ENV_PREFIX + JOB_PROP_ENV, files[0].getAbsolutePath());
     this.jobProps.put(ENV_PREFIX + JOB_NAME_ENV, getId());
 
-    files[1] = this.createOutputPropsFile(getId(), this._cwd);
+    files[1] = createOutputPropsFile(getId(), this._cwd);
     this.jobProps.put(ENV_PREFIX + JOB_OUTPUT_PROP_FILE, files[1].getAbsolutePath());
     return files;
   }
@@ -148,22 +144,28 @@ public abstract class AbstractProcessJob extends AbstractJob {
     return this._cwd;
   }
 
+  /**
+   * Get Environment Variables from the Job Properties Table
+   * @return All Job Properties with "env." prefix
+   */
   public Map<String, String> getEnvironmentVariables() {
     final Props props = getJobProps();
-    final Map<String, String> envMap = props.getMapByPrefix(ENV_PREFIX);
-    envMap.putAll(props.getMapByPrefix(ENV_PREFIX_UCASE));
+    final Map<String, String> envMap = props.getMapByPrefix(ENV_PREFIX, true);
     return envMap;
   }
 
+  /**
+   * Get Working Directory from Job Properties when it is presented. Otherwise, the working directory is the jobPath
+   * @return working directory property
+   */
   public String getWorkingDirectory() {
     final String workingDir = getJobProps().getString(WORKING_DIR, this._jobPath);
-    if (workingDir == null) {
-      return "";
-    }
-
-    return workingDir;
+    return Utils.ifNull(workingDir, "");
   }
 
+  /**
+   * TODO: Review to see if this function can be private
+   */
   public Props loadOutputFileProps(final File outputPropertiesFile) {
     InputStream reader = null;
     try {
@@ -184,12 +186,11 @@ public abstract class AbstractProcessJob extends AbstractJob {
       }
       return outputProps;
     } catch (final FileNotFoundException e) {
-      this.log.info(String.format("File[%s] wasn't found, returning empty props.",
-          outputPropertiesFile));
+      this.info(String.format("File[%s] wasn't found, returning empty props.", outputPropertiesFile));
       return new Props();
     } catch (final Exception e) {
-      this.log.error(
-          "Exception thrown when trying to load output file props.  Returning empty Props instead of failing.  Is this really the best thing to do?",
+      this.error(
+          "Exception thrown when trying to load output file props.  Returning empty Props instead of failing. Is this really the best thing to do?",
           e);
       return new Props();
     } finally {
@@ -197,22 +198,26 @@ public abstract class AbstractProcessJob extends AbstractJob {
     }
   }
 
+  /**
+   * TODO: Review to see if this function can be private
+   */
   public File createFlattenedPropsFile(final String workingDir) {
-    final File directory = new File(workingDir);
-    File tempFile = null;
     try {
+      final File directory = new File(workingDir);
       // The temp file prefix must be at least 3 characters.
-      tempFile = File.createTempFile(getId() + "_props_", "_tmp", directory);
+      final File tempFile = File.createTempFile(getId() + "_props_", "_tmp", directory);
       this.jobProps.storeFlattened(tempFile);
+      return tempFile;
     } catch (final IOException e) {
       throw new RuntimeException("Failed to create temp property file ", e);
     }
-
-    return tempFile;
   }
 
+  /**
+   * Generate properties from output file and set to props tables
+   * @param outputFile explain
+   */
   public void generateProperties(final File outputFile) {
     this.generatedProperties = loadOutputFileProps(outputFile);
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_GROUP_NAME;
@@ -62,10 +61,10 @@ public class ProcessJob extends AbstractProcessJob {
   private static final String CREATE_FILE = "touch";
   private static final int SUCCESSFUL_EXECUTION = 0;
   private static final String TEMP_FILE_NAME = "user_can_write";
+
   private final CommonMetrics commonMetrics;
   private volatile AzkabanProcess process;
   private volatile boolean killed = false;
-
   // For testing only. True if the job process exits successfully.
   private volatile boolean success;
 

--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import azkaban.executor.ExecutionOptions;
@@ -25,6 +24,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class Schedule {
 

--- a/azkaban-common/src/main/java/azkaban/server/AbstractMBeanRegistrableServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AbstractMBeanRegistrableServer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.log4j.Logger;
+
+
+/**
+ * Abstract class which can register MBeans
+ */
+public abstract class AbstractMBeanRegistrableServer {
+  private static final Logger logger = Logger.getLogger(AbstractMBeanRegistrableServer.class);
+
+  private List<ObjectName> registeredMBeans = new ArrayList<>();
+  private MBeanServer mbeanServer = null;
+
+  protected abstract void configureMBeanServer();
+
+  protected void registerMBean(final String name, final Object mbean) {
+    final Class<?> mbeanClass = mbean.getClass();
+    final ObjectName mbeanName;
+    try {
+      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
+      getMbeanServer().registerMBean(mbean, mbeanName);
+      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
+      this.registeredMBeans.add(mbeanName);
+    } catch (final Exception e) {
+      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(), e);
+    }
+  }
+
+  protected MBeanServer getMbeanServer() {
+    return (mbeanServer == null)
+        ? ManagementFactory.getPlatformMBeanServer()
+        : mbeanServer;
+  }
+
+  protected void closeMBeans() {
+    try {
+      for (final ObjectName name : registeredMBeans) {
+        getMbeanServer().unregisterMBean(name);
+        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
+      }
+    } catch (final Exception e) {
+      logger.error("Failed to cleanup MBeanServer", e);
+    }
+  }
+
+  public List<ObjectName> getMBeanNames() {
+    return registeredMBeans;
+  }
+
+  public MBeanInfo getMBeanInfo(final ObjectName name) {
+    try {
+      return getMbeanServer().getMBeanInfo(name);
+    } catch (final Exception e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
+    try {
+      return getMbeanServer().getAttribute(name, attribute);
+    } catch (final Exception e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  public Map<String, Object> getMBeanResult(final String mbeanName) {
+    final Map<String, Object> ret = new HashMap<>();
+    try {
+      final ObjectName name = new ObjectName(mbeanName);
+      final MBeanInfo info = getMBeanInfo(name);
+
+      final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
+      final Map<String, Object> attributes = new TreeMap<>();
+
+      for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
+        final Object obj = getMBeanAttribute(name, attrInfo.getName());
+        attributes.put(attrInfo.getName(), obj);
+      }
+
+      ret.put("attributes", attributes);
+    } catch (final Exception e) {
+      logger.error(e);
+      ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
+    }
+
+    return ret;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.server;
 
 import static azkaban.Constants.DEFAULT_PORT_NUMBER;
@@ -34,7 +33,7 @@ import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 
 
-public abstract class AzkabanServer {
+public abstract class AzkabanServer extends AbstractMBeanRegistrableServer {
 
   private static final Logger logger = Logger.getLogger(AzkabanServer.class);
   private static Props azkabanProperties = null;
@@ -152,5 +151,4 @@ public abstract class AzkabanServer {
   public abstract VelocityEngine getVelocityEngine();
 
   public abstract UserManager getUserManager();
-
 }

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -13,18 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.sla;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.sla.SlaType.ComponentType;
-import azkaban.utils.Utils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,6 +132,17 @@ public class SlaOption {
 
     this.emails = ImmutableList.copyOf((List<String>)slaOption.getInfo().get(SlaOptionDeprecated
         .INFO_EMAIL_LIST));
+  }
+
+  public static List<Object> convertToObjects(List<SlaOption> slaOptions) {
+    if (slaOptions != null) {
+      final List<Object> slaOptionsObject = new ArrayList<>();
+      for (final SlaOption sla : slaOptions) {
+        slaOptionsObject.add(sla.toObject());
+      }
+      return slaOptionsObject;
+    }
+    return null;
   }
 
   private Duration parseDuration(final String durationStr) {

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.trigger.ConditionChecker;
@@ -27,6 +26,7 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class BasicTimeChecker implements ConditionChecker {
 
@@ -215,5 +215,4 @@ public class BasicTimeChecker implements ConditionChecker {
   @Override
   public void setContext(final Map<String, Object> context) {
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.executor.ExecutableFlow;
@@ -31,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
+
 
 public class ExecuteFlowAction implements TriggerAction {
 
@@ -175,11 +175,8 @@ public class ExecuteFlowAction implements TriggerAction {
     if (this.executionOptions != null) {
       jsonObj.put("executionOptions", this.executionOptions.toObject());
     }
-    if (this.executionOptions.getSlaOptions() != null) {
-      final List<Object> slaOptionsObj = new ArrayList<>();
-      for (final SlaOption sla : this.executionOptions.getSlaOptions()) {
-        slaOptionsObj.add(sla.toObject());
-      }
+    List<Object> slaOptionsObj = SlaOption.convertToObjects(this.executionOptions.getSlaOptions());
+    if (slaOptionsObj != null) {
       jsonObj.put("slaOptions", slaOptionsObj);
     }
     return jsonObj;
@@ -229,5 +226,4 @@ public class ExecuteFlowAction implements TriggerAction {
   public String getId() {
     return this.actionId;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -26,10 +25,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,9 +124,9 @@ public class FileIOUtils {
   }
 
   public static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
+    final String containedClassPath = containedClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+    File file = new File(containedClassPath);
 
     if (!file.isDirectory() && file.getName().endsWith(".class")) {
       final String name = containedClass.getName();
@@ -134,8 +137,7 @@ public class FileIOUtils {
       }
       return file.getPath();
     } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
+      return containedClassPath;
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import java.io.File;
 import java.util.List;
@@ -43,33 +44,14 @@ public class JavaJob extends JavaProcessJob {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
   }
 
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   @Override
   protected List<String> getClassPaths() {
     final List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
-    final String loggerPath = getSourcePathFromClass(org.apache.log4j.Logger.class);
+    final String loggerPath = FileIOUtils.getSourcePathFromClass(org.apache.log4j.Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static azkaban.Constants.ConfigurationKeys;
@@ -43,6 +42,7 @@ import azkaban.metric.MetricException;
 import azkaban.metric.MetricReportManager;
 import azkaban.metric.inmemoryemitter.InMemoryMetricEmitter;
 import azkaban.metrics.MetricsManager;
+import azkaban.server.AbstractMBeanRegistrableServer;
 import azkaban.server.AzkabanServer;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
@@ -54,7 +54,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -63,15 +62,10 @@ import java.security.Permission;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
@@ -79,8 +73,9 @@ import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 
+
 @Singleton
-public class AzkabanExecutorServer {
+public class AzkabanExecutorServer extends AbstractMBeanRegistrableServer {
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
@@ -96,9 +91,6 @@ public class AzkabanExecutorServer {
   private final Props props;
   private final Server server;
   private final Context root;
-
-  private final ArrayList<ObjectName> registeredMBeans = new ArrayList<>();
-  private MBeanServer mbeanServer;
 
   @Inject
   public AzkabanExecutorServer(final Props props,
@@ -397,70 +389,6 @@ public class AzkabanExecutorServer {
     return this.runnerManager;
   }
 
-  private void configureMBeanServer() {
-    logger.info("Registering MBeans...");
-    this.mbeanServer = ManagementFactory.getPlatformMBeanServer();
-
-    registerMbean("executorJetty", new JmxJettyServer(this.server));
-    registerMbean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
-    registerMbean("jobJMXMBean", JmxJobMBeanManager.getInstance());
-
-    if (JobCallbackManager.isInitialized()) {
-      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
-      registerMbean("jobCallbackJMXMBean",
-          jobCallbackMgr.getJmxJobCallbackMBean());
-    }
-  }
-
-  public void close() {
-    try {
-      for (final ObjectName name : this.registeredMBeans) {
-        this.mbeanServer.unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
-      }
-    } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
-    }
-  }
-
-  private void registerMbean(final String name, final Object mbean) {
-    final Class<?> mbeanClass = mbean.getClass();
-    final ObjectName mbeanName;
-    try {
-      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
-      this.mbeanServer.registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
-      this.registeredMBeans.add(mbeanName);
-    } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(),
-          e);
-    }
-
-  }
-
-  public List<ObjectName> getMbeanNames() {
-    return this.registeredMBeans;
-  }
-
-  public MBeanInfo getMBeanInfo(final ObjectName name) {
-    try {
-      return this.mbeanServer.getMBeanInfo(name);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
-    try {
-      return this.mbeanServer.getAttribute(name, attribute);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-
   /**
    * Get the hostname
    *
@@ -546,6 +474,20 @@ public class AzkabanExecutorServer {
     this.server.stop();
     this.server.destroy();
     getFlowRunnerManager().shutdownNow();
-    close();
+    closeMBeans();
+  }
+
+  @Override
+  protected void configureMBeanServer() {
+    logger.info("Registering MBeans...");
+
+    registerMBean("executorJetty", new JmxJettyServer(this.server));
+    registerMBean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
+    registerMBean("jobJMXMBean", JmxJobMBeanManager.getInstance());
+
+    if (JobCallbackManager.isInitialized()) {
+      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
+      registerMBean("jobCallbackJMXMBean", jobCallbackMgr.getJmxJobCallbackMBean());
+    }
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.Constants;
@@ -23,16 +22,13 @@ import azkaban.utils.JSONUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+
 
 public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
 
@@ -72,29 +68,12 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
     final Map<String, Object> ret = new HashMap<>();
 
     if (hasParam(req, JMX_GET_MBEANS)) {
-      ret.put("mbeans", this.server.getMbeanNames());
+      ret.put("mbeans", this.server.getMBeanNames());
     } else if (hasParam(req, JMX_GET_ALL_MBEAN_ATTRIBUTES)) {
       if (!hasParam(req, JMX_MBEAN)) {
         ret.put("error", "Parameters 'mbean' must be set");
       } else {
-        final String mbeanName = getParam(req, JMX_MBEAN);
-        try {
-          final ObjectName name = new ObjectName(mbeanName);
-          final MBeanInfo info = this.server.getMBeanInfo(name);
-
-          final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-          final Map<String, Object> attributes = new TreeMap<>();
-
-          for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-            final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-            attributes.put(attrInfo.getName(), obj);
-          }
-
-          ret.put("attributes", attributes);
-        } catch (final Exception e) {
-          logger.error(e);
-          ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-        }
+        ret.putAll(this.server.getMBeanResult(getParam(req, JMX_MBEAN)));
       }
     }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -13,16 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.executor.ExecutorInfo;
 import azkaban.utils.JSONUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -83,24 +80,9 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillRemainingMemoryPercent(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_Grep && exists_Meminfo) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c",
-              "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils.runProcess("/bin/bash", "-c",
+            "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
 
         long totalMemory = 0;
         long totalFreeMemory = 0;
@@ -241,23 +223,8 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillCpuUsage(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_LoadAvg) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c", "/bin/cat /proc/loadavg");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils.runProcess("/bin/bash", "-c", "/bin/cat /proc/loadavg");
 
         // process the output from bash call.
         if (output.size() > 0) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
@@ -13,14 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.Status;
 
+
 public class BlockingStatus {
 
-  private static final long WAIT_TIME = 5 * 60 * 1000;
+  private static final long WAIT_TIME = 300000;  // 5 * 60 * 1000
   private final int execId;
   private final String jobId;
   private Status status;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.ExecutableFlow;
@@ -24,9 +23,10 @@ import azkaban.executor.Status;
 import java.util.ArrayList;
 import java.util.Map;
 
+
 public class RemoteFlowWatcher extends FlowWatcher {
 
-  private final static long CHECK_INTERVAL_MS = 60 * 1000;
+  private final static long CHECK_INTERVAL_MS = 60000; // 60 * 1000
 
   private int execId;
   private ExecutorLoader loader;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
@@ -14,20 +14,19 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.Utils;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+
 
 public class PluginCheckerAndActionsLoader {
 
@@ -44,40 +43,11 @@ public class PluginCheckerAndActionsLoader {
     final ClassLoader parentLoader = getClass().getClassLoader();
     final File[] pluginDirs = triggerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        log.error("Error! Trigger plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        log.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          log.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        log.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir, "Trigger");
+      if (pluginProps == null) {
         continue;
       }
 
@@ -88,48 +58,18 @@ public class PluginCheckerAndActionsLoader {
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
         log.error("Trigger class is not set.");
+        continue;
       } else {
-        log.error("Plugin class " + pluginClass);
+        log.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            log.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              log.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        log.error("Library path " + propertiesDir + " not found.");
+      URLClassLoader urlClassLoader = PluginUtils.getURLClassLoader(pluginDir, extLibClasspath, parentLoader);
+      if (urlClassLoader == null) {
         continue;
       }
 
-      Class<?> triggerClass = null;
-      try {
-        triggerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        log.error("Class " + pluginClass + " not found.");
+      Class<?> triggerClass = PluginUtils.getPluginClass(urlClassLoader, pluginClass);
+      if (triggerClass == null) {
         continue;
       }
 
@@ -152,8 +92,6 @@ public class PluginCheckerAndActionsLoader {
         log.error("Unable to initiate action types for " + pluginClass);
         continue;
       }
-
     }
   }
-
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -293,7 +292,6 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("timezone", TimeZone.getDefault().getID());
     page.add("currentTime", (new DateTime()).getMillis());
     page.add("size", getDisplayExecutionPageSize());
-
     page.add("System", System.class);
     page.add("TimeUtils", TimeUtils.class);
     page.add("WebUtils", WebUtils.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -488,36 +487,12 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final String projectName, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectName);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectName), user, type, ret);
   }
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void ajaxRestartFailed(final HttpServletRequest req,
@@ -550,8 +525,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
     final long startMs = System.currentTimeMillis();
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -562,17 +536,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     resp.setCharacterEncoding("utf-8");
 
     try {
-      final LogData data =
-          this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
@@ -592,8 +558,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private void ajaxFetchJobLogs(final HttpServletRequest req,
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -607,27 +572,33 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     try {
       final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
       if (node == null) {
-        ret.put("error",
-            "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
+        ret.put("error", "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
         return;
       }
 
       final int attempt = this.getIntParam(req, "attempt", node.getAttempt());
-      final LogData data =
-          this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length,
-              attempt);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length, attempt);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
+  }
+
+  private Map<String, Object> appendLogData(final LogData data, final int defaultOffset) {
+    Map<String, Object> parameters = new HashMap<>();
+
+    if (data == null) {
+      parameters.put("length", 0);
+      parameters.put("offset", defaultOffset);
+      parameters.put("data", "");
+    } else {
+      parameters.put("length", data.getLength());
+      parameters.put("offset", data.getOffset());
+      parameters.put("data", StringEscapeUtils.escapeHtml(data.getData()));
+    }
+
+    return parameters;
   }
 
   private void ajaxFetchJobStats(final HttpServletRequest req,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.executor.ConnectorParams;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
@@ -35,17 +33,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 
+
 /**
  * Limited set of jmx calls for when you cannot attach to the jvm
  */
 public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     ConnectorParams {
 
-  /**
-   *
-   */
   private static final long serialVersionUID = 1L;
-
   private static final Logger logger = Logger.getLogger(JMXHttpServlet.class
       .getName());
 
@@ -94,7 +89,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         }
         ret = result;
       } else if (JMX_GET_MBEANS.equals(ajax)) {
-        ret.put("mbeans", this.server.getMbeanNames());
+        ret.put("mbeans", this.server.getMBeanNames());
       } else if (JMX_GET_MBEAN_INFO.equals(ajax)) {
         if (hasParam(req, JMX_MBEAN)) {
           final String mbeanName = getParam(req, JMX_MBEAN);
@@ -130,24 +125,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         if (!hasParam(req, JMX_MBEAN)) {
           ret.put("error", "Parameters 'mbean' must be set");
         } else {
-          final String mbeanName = getParam(req, JMX_MBEAN);
-          try {
-            final ObjectName name = new ObjectName(mbeanName);
-            final MBeanInfo info = this.server.getMBeanInfo(name);
-
-            final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-            final Map<String, Object> attributes = new TreeMap<>();
-
-            for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-              final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-              attributes.put(attrInfo.getName(), obj);
-            }
-
-            ret.put("attributes", attributes);
-          } catch (final Exception e) {
-            logger.error(e);
-            ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-          }
+          ret.putAll(this.server.getMBeanResult(getParam(req, JMX_MBEAN)));
         }
       } else {
         ret.put("commands", new String[]{
@@ -168,7 +146,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/jmxpage.vm");
 
-    page.add("mbeans", this.server.getMbeanNames());
+    page.add("mbeans", this.server.getMBeanNames());
 
     final Map<String, Object> executorMBeans = new HashMap<>();
     for (final String hostPort : this.executorManagerAdapter.getAllActiveExecutorServerHosts()) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -46,11 +45,11 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+
 /**
  * Abstract Servlet that handles auto login when the session hasn't been verified.
  */
-public abstract class LoginAbstractAzkabanServlet extends
-    AbstractAzkabanServlet {
+public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
 
@@ -394,6 +393,30 @@ public abstract class LoginAbstractAzkabanServlet extends
     }
 
     return false;
+  }
+
+  protected Project filterProjectByPermission(final Project project, final User user,
+      final Permission.Type type) {
+    return filterProjectByPermission(project, user, type, null);
+  }
+
+  protected Project filterProjectByPermission(final Project project, final User user,
+      final Permission.Type type, final Map<String, Object> ret) {
+    if (project == null) {
+      if (ret != null) {
+        ret.put("error", "Project 'null' not found.");
+      }
+    } else if (!hasPermission(project, user, type)) {
+      if (ret != null) {
+        ret.put("error",
+            "User '" + user.getUserId() + "' doesn't have " + type.name()
+                + " permissions on " + project.getName());
+      }
+    } else {
+      return project;
+    }
+
+    return null;
   }
 
   protected void handleAjaxLoginAction(final HttpServletRequest req,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -58,6 +58,7 @@ import org.joda.time.Minutes;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
 
+
 public class ScheduleServlet extends LoginAbstractAzkabanServlet {
   public static final String PARAM_SLA_EMAILS = "slaEmails";
   public static final String PARAM_SCHEDULE_ID = "scheduleId";
@@ -381,19 +382,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put(PARAM_ERROR, "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put(STATUS_ERROR,
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void handleGetAllSchedules(final HttpServletRequest req,


### PR DESCRIPTION
There are no logic changes besides 2 tiny bugfixes, which I will list as below,

1. Create AbstractHadoopJavaProcessJob class to share common codes which are used by
        HadoopHiveJob, HadoopJavaJob, HadoopPigJob & HadoopSparkJob.
2. Create AbstractMBeanRegistrableServer class to share common codes which are used by AzkabanExecServer, AzkabanWebServer.
3. Clean some non-referenced import files to improve the code quality
4. Remove duplicate code if it can be replaced by FileIOUtils.getSourcePathFromClass() function
5. Introduce PropsUtils.loadPluginProps() Utility function for removing duplicate code in the following classes (AlerterHolder, AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader)
6. Add private constructor for PropsUtils class to match the singleton pattern for Utility Class.
7. Create new PluginUtils class includes getUrls, getURLClassLoader, getPluginClass Utils which are used by AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader.
8. Add default parameter for Utils.createPeriodString() function, which make it be reusable in Schedule.class, BasicTimeChecker.class, ScheduleServlet.calss
9. Introduce Props.getMapByPrefix(final String prefix, boolean ignoreCase) function to simplify the AbstractProcessJob.getEnvironmentVariables() function
10. Introduce SlaOption.convertToObjects static function which can be shared by ExecuteFlowAction.class and Schedule.class
11. Move check and delete tokenFile logic into the HadoopJobUtils.cancelHadoopTokens Util since it is duplicated in all callers
12. Create Utils.runProcess Utils to reduce duplicate code in ServerStatisticsServlet class.
13. Create FilterProjectByPermission function in LoginAbstractAzkabanServlet for making it be reusable in all extended classes.

BUG:
1. Remove Logger log in AbstractProcessJob since log object has been existed in the parent AbstractJob class. 
2 In both PluginCheckerAndActionsLoader.load() and TriggerPluginLoader.load() function., error log was fired regardless if(pluginClass == null) is true/false. Fix this bug. log.error when (plugClass == null) and skip the following unnecessary logic. log.info when (plugClass != null) and run the following expected logic

Will Introduce more test cases to cover the logic soon.




