### PR TITLE
[DEDUPE] Refactor and Deduplicate the common codes

### DIFF
--- a/az-core/src/main/java/azkaban/utils/PluginUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PluginUtils.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.utils;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PluginUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(PluginUtils.class);
+  private static String LIBRARY_FOLDER_NAME = "lib";
+
+  /**
+   * Private constructor.
+   */
+  private PluginUtils() {
+  }
+
+  /**
+   * Convert a list of files to a list of files' URLs
+   *
+   * @param files list of file handles
+   * @return an arrayList of the corresponding files' URLs
+   */
+  private static ArrayList<URL> getUrls(File[] files) {
+    final ArrayList<URL> urls = new ArrayList<>();
+    for (File file : files) {
+      try {
+        final URL url = file.toURI().toURL();
+        urls.add(url);
+      } catch (final MalformedURLException e) {
+        logger.error("File is not convertible to URL.", e);
+      }
+    }
+    return urls;
+  }
+
+  /**
+   * Get URLClassLoader
+   */
+  public static URLClassLoader getURLClassLoader(final File pluginDir,
+      List<String> extLibClassPaths,
+      ClassLoader parentLoader) {
+    final File libDir = new File(pluginDir, LIBRARY_FOLDER_NAME);
+    if (libDir.exists() && libDir.isDirectory()) {
+      final File[] files = libDir.listFiles();
+      final ArrayList<URL> urls = getUrls(files);
+
+      if (extLibClassPaths != null) {
+        for (final String extLibClassPath : extLibClassPaths) {
+          try {
+            final File extLibFile = new File(pluginDir, extLibClassPath);
+            if (extLibFile.exists()) {
+              if (extLibFile.isDirectory()) {
+                // extLibFile is a directory; load all the files in the
+                // directory.
+                final File[] extLibFiles = extLibFile.listFiles();
+                urls.addAll(getUrls(extLibFiles));
+              } else {
+                final URL url = extLibFile.toURI().toURL();
+                urls.add(url);
+              }
+            } else {
+              logger.error(
+                  "External library path not found. path = " + extLibFile.getAbsolutePath()
+              );
+              continue;
+            }
+          } catch (final MalformedURLException e) {
+            logger.error(
+                "Invalid External library path. path = " + extLibClassPath + " dir = " + pluginDir,
+                e
+            );
+          }
+        }
+      }
+      return new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
+    } else {
+      logger.error("Library path not found. path = " + libDir);
+      return null;
+    }
+  }
+
+  /**
+   * Get Plugin Class
+   *
+   * @param pluginClass plugin class name
+   * @param pluginDir plugin root directory
+   * @param extLibClassPaths external Library Class Paths
+   * @param parentClassLoader parent class loader
+   * @return Plugin class or Null
+   */
+  public static Class<?> getPluginClass(final String pluginClass, final File pluginDir,
+      final List<String> extLibClassPaths, ClassLoader parentClassLoader) {
+
+    URLClassLoader urlClassLoader =
+        getURLClassLoader(pluginDir, extLibClassPaths, parentClassLoader);
+
+    return getPluginClass(pluginClass, urlClassLoader);
+  }
+
+  /**
+   * Get Plugin Class
+   *
+   * @param pluginClass plugin class name
+   * @param urlClassLoader url class loader
+   * @return Plugin class or Null
+   */
+  public static Class<?> getPluginClass(final String pluginClass, URLClassLoader urlClassLoader) {
+
+    if (urlClassLoader == null) {
+      return null;
+    }
+
+    try {
+      return urlClassLoader.loadClass(pluginClass);
+    } catch (final ClassNotFoundException e) {
+      logger.error("Class not found. class = " + pluginClass);
+      return null;
+    }
+  }
+}

--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -37,6 +36,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.log4j.Logger;
+
 
 /**
  * Hashmap implementation of a hierarchical properties with helpful converter functions and
@@ -158,9 +158,10 @@ public class Props {
   }
 
   /**
+   * Recursive Clone function of Props
    *
-   * @param source
-   * @return
+   * @param source the source Props object
+   * @return the cloned Props object
    */
   private static Props copyNext(final Props source) {
     Props priorNodeCopy = null;
@@ -176,9 +177,10 @@ public class Props {
   }
 
   /**
+   * load this Prop Object from a @Properties formatted InputStream
    *
-   * @param inputStream
-   * @throws IOException
+   * @param inputStream inputStream for loading Properties Object
+   * @throws IOException read exception
    */
   private void loadFrom(final InputStream inputStream) throws IOException {
     final Properties properties = new Properties();
@@ -186,6 +188,11 @@ public class Props {
     this.put(properties);
   }
 
+  /**
+   * Get the Root Props Object
+   *
+   * @return the root Props Object or this Props itself
+   */
   public Props getEarliestAncestor() {
     if (this._parent == null) {
       return this;
@@ -194,6 +201,11 @@ public class Props {
     return this._parent.getEarliestAncestor();
   }
 
+  /**
+   * Set the Props Object as the root of this Props Object
+   *
+   * @param parent the earliest ancestor Props Object
+   */
   public void setEarliestAncestor(final Props parent) {
     final Props props = getEarliestAncestor();
     props.setParent(parent);
@@ -433,7 +445,8 @@ public class Props {
   /**
    * Returns a list of clusters with the comma as the separator of the value
    * e.g., for input string: "thrift://hcat1:port,thrift://hcat2:port;thrift://hcat3:port,thrift://hcat4:port;"
-   * we will get ["thrift://hcat1:port,thrift://hcat2:port", "thrift://hcat3:port,thrift://hcat4:port"] as output
+   * we will get ["thrift://hcat1:port,thrift://hcat2:port", "thrift://hcat3:port,thrift://hcat4:port"]
+   * as output
    */
   public List<String> getStringListFromCluster(final String key) {
     List<String> curlist = getStringList(key, "\\s*;\\s*");
@@ -621,6 +634,9 @@ public class Props {
     }
   }
 
+  /**
+   * Convert a URI-formatted string value to URI object
+   */
   public URI getUri(final String name, final String defaultValue) {
     try {
       return getUri(name, new URI(defaultValue));
@@ -689,8 +705,9 @@ public class Props {
     allProp.putAll(toProperties());
 
     // import parent properties
-    if(_parent != null)
+    if (_parent != null) {
       allProp.putAll(_parent.toProperties());
+    }
 
     return allProp;
   }
@@ -731,10 +748,11 @@ public class Props {
   }
 
   /**
-   * Returns a map of all the flattened properties, the item in the returned map is sorted
-   * alphabetically by the key value.
+   * Returns a new constructed map of all the flattened properties, the item in the returned
+   * map is sorted alphabetically by the key value.
    *
-   * @Return
+   * @Return a new constructed TreeMap (sorted map) of all properties (including parents'
+   * properties)
    */
   public Map<String, String> getFlattened() {
     final TreeMap<String, String> returnVal = new TreeMap<>();
@@ -743,18 +761,28 @@ public class Props {
   }
 
   /**
-   * Get a map of all properties by string prefix
+   * Get a new de-duplicated map of all the flattened properties by given prefix. The prefix will
+   * be removed in the return map's keySet.
    *
-   * @param prefix The string prefix
+   * @param prefix the prefix string
+   * @return a new constructed de-duplicated HashMap of all properties (including parents'
+   * properties) with the give prefix
    */
   public Map<String, String> getMapByPrefix(final String prefix) {
-    final Map<String, String> values = this._parent == null ? new HashMap<>() :
-        this._parent.getMapByPrefix(prefix);
+    final Map<String, String> values = (this._parent == null)
+        ? new HashMap<>()
+        : this._parent.getMapByPrefix(prefix);
 
     // when there is a conflict, value from the child takes the priority.
+    if (prefix == null) { // when prefix is null, return an empty map
+      return values;
+    }
+
     for (final String key : this.localKeySet()) {
-      if (key.startsWith(prefix)) {
-        values.put(key.substring(prefix.length()), get(key));
+      if (key != null && key.length() >= prefix.length()) {
+        if (key.startsWith(prefix)) {
+          values.put(key.substring(prefix.length()), get(key));
+        }
       }
     }
     return values;
@@ -787,6 +815,7 @@ public class Props {
   }
 
   /**
+   * override object's default equal function
    */
   @Override
   public boolean equals(final Object o) {
@@ -803,25 +832,7 @@ public class Props {
   }
 
   /**
-   * Returns true if the properties are equivalent, regardless of the hierarchy.
-   */
-  public boolean equalsProps(final Props p) {
-    if (p == null) {
-      return false;
-    }
-
-    final Set<String> myKeySet = getKeySet();
-    for (final String s : myKeySet) {
-      if (!get(s).equals(p.get(s))) {
-        return false;
-      }
-    }
-
-    return myKeySet.size() == p.getKeySet().size();
-  }
-
-  /**
-   *
+   * override object's default hash code function
    */
   @Override
   public int hashCode() {
@@ -833,7 +844,7 @@ public class Props {
   }
 
   /**
-   *
+   * override object's default toString function
    */
   @Override
   public String toString() {
@@ -852,10 +863,16 @@ public class Props {
     return builder.toString();
   }
 
+  /**
+   * Get Source information
+   */
   public String getSource() {
     return this.source;
   }
 
+  /**
+   * Set Source information
+   */
   public void setSource(final String source) {
     this.source = source;
   }

--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -13,9 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -35,11 +35,22 @@ import org.apache.commons.jexl2.MapContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Utility Functions related to Prop Operations
+ */
 public class PropsUtils {
 
   private static final Logger logger = Logger.getLogger(PropsUtils.class);
   private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
       .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
+
+  /**
+   * Private constructor.
+   */
+  private PropsUtils() {
+  }
+
 
   /**
    * Load job schedules from the given directories
@@ -78,6 +89,13 @@ public class PropsUtils {
     }
   }
 
+  /**
+   * Load Props
+   *
+   * @param parent parent prop
+   * @param propFiles prop files
+   * @return constructed new Prop
+   */
   public static Props loadProps(final Props parent, final File... propFiles) {
     try {
       Props props = new Props(parent);
@@ -90,6 +108,45 @@ public class PropsUtils {
       return props;
     } catch (final IOException e) {
       throw new RuntimeException("Error loading properties.", e);
+    }
+  }
+
+  /**
+   * Load plugin properties
+   *
+   * @param pluginDir plugin's Base Directory
+   * @return The properties
+   */
+  public static Props loadPluginProps(final File pluginDir) {
+    if (!pluginDir.exists()) {
+      logger.error("Error! Plugin path " + pluginDir.getPath() + " doesn't exist.");
+      return null;
+    }
+
+    if (!pluginDir.isDirectory()) {
+      logger.error("The plugin path " + pluginDir + " is not a directory.");
+      return null;
+    }
+
+    final File propertiesDir = new File(pluginDir, "conf");
+    if (propertiesDir.exists() && propertiesDir.isDirectory()) {
+      final File propertiesFile = new File(propertiesDir, "plugin.properties");
+      final File propertiesOverrideFile =
+          new File(propertiesDir, "override.properties");
+
+      if (propertiesFile.exists()) {
+        if (propertiesOverrideFile.exists()) {
+          return loadProps(null, propertiesFile, propertiesOverrideFile);
+        } else {
+          return loadProps(null, propertiesFile);
+        }
+      } else {
+        logger.error("Plugin conf file " + propertiesFile + " not found.");
+        return null;
+      }
+    } else {
+      logger.error("Plugin conf path " + propertiesDir + " not found.");
+      return null;
     }
   }
 
@@ -133,7 +190,7 @@ public class PropsUtils {
     }
   }
 
-  public static boolean endsWith(final File file, final String... suffixes) {
+  private static boolean endsWith(final File file, final String... suffixes) {
     for (final String suffix : suffixes) {
       if (file.getName().endsWith(suffix)) {
         return true;
@@ -142,11 +199,20 @@ public class PropsUtils {
     return false;
   }
 
-  public static boolean isVariableReplacementPattern(final String str) {
-    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(str);
+  /**
+   * Check if the prop value is a variable replacement pattern
+   */
+  public static boolean isVariableReplacementPattern(final String value) {
+    final Matcher matcher = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
     return matcher.matches();
   }
 
+  /**
+   * Resolve Props
+   *
+   * @param props props
+   * @return resolved props
+   */
   public static Props resolveProps(final Props props) {
     if (props == null) {
       return null;
@@ -280,11 +346,25 @@ public class PropsUtils {
     return resolveVariableExpression(newValue, lastIndex, jexl);
   }
 
+  /**
+   * Convert props to json string
+   *
+   * @param props props
+   * @param localOnly include local prop sets only or not
+   * @return json string format of props
+   */
   public static String toJSONString(final Props props, final boolean localOnly) {
     final Map<String, String> map = toStringMap(props, localOnly);
     return JSONUtils.toJSON(map);
   }
 
+  /**
+   * Convert props to Map
+   *
+   * @param props props
+   * @param localOnly include local prop sets only or not
+   * @return String Map of props
+   */
   public static Map<String, String> toStringMap(final Props props, final boolean localOnly) {
     final HashMap<String, String> map = new HashMap<>();
     final Set<String> keyset = localOnly ? props.localKeySet() : props.getKeySet();
@@ -297,12 +377,25 @@ public class PropsUtils {
     return map;
   }
 
+  /**
+   * Convert json String to Prop Object
+   *
+   * @param json json formatted string
+   * @return a new constructed Prop Object
+   * @throws IOException exception on parsing json string to prop object
+   */
   public static Props fromJSONString(final String json) throws IOException {
     final Map<String, String> obj = (Map<String, String>) JSONUtils.parseJSONFromString(json);
     final Props props = new Props(null, obj);
     return props;
   }
 
+  /**
+   * Convert a hierarchical Map to Prop Object
+   *
+   * @param propsMap a hierarchical Map
+   * @return a new constructed Props Object
+   */
   public static Props fromHierarchicalMap(final Map<String, Object> propsMap) {
     if (propsMap == null) {
       return null;
@@ -320,6 +413,12 @@ public class PropsUtils {
     return props;
   }
 
+  /**
+   * Convert a Props object to a hierarchical Map
+   *
+   * @param props props object
+   * @return a hierarchical Map presented Props object
+   */
   public static Map<String, Object> toHierarchicalMap(final Props props) {
     final Map<String, Object> propsMap = new HashMap<>();
     propsMap.put("source", props.getSource());
@@ -333,7 +432,11 @@ public class PropsUtils {
   }
 
   /**
-   * @return the difference between oldProps and newProps.
+   * The difference between old and new Props
+   *
+   * @param oldProps old Props
+   * @param newProps new Props
+   * @return string formatted difference
    */
   public static String getPropertyDiff(Props oldProps, Props newProps) {
 

--- a/az-core/src/main/java/azkaban/utils/TimeUtils.java
+++ b/az-core/src/main/java/azkaban/utils/TimeUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.time.Instant;
@@ -30,10 +29,14 @@ import org.joda.time.Seconds;
 import org.joda.time.Weeks;
 import org.joda.time.Years;
 
+
+/**
+ * Utilities for Time Operations
+ */
 public class TimeUtils {
 
-  public static final String DATE_TIME_ZONE_PATTERN = "yyyy/MM/dd HH:mm:ss z";
-  public static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+  private static final String DATE_TIME_ZONE_PATTERN = "yyyy/MM/dd HH:mm:ss z";
+  private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
 
   /**
    * Formats the given millisecond instant into a string using the pattern "yyyy/MM/dd HH:mm:ss z"
@@ -59,6 +62,13 @@ public class TimeUtils {
     return formatter.format(zonedDateTime);
   }
 
+  /**
+   * Format time period pair to Duration String
+   *
+   * @param startTime start time
+   * @param endTime end time
+   * @return Duration String
+   */
   public static String formatDuration(final long startTime, final long endTime) {
     if (startTime == -1) {
       return "-";
@@ -93,6 +103,12 @@ public class TimeUtils {
     return days + "d " + hours + "h " + minutes + "m";
   }
 
+  /**
+   * Format ReadablePeriod object to string
+   *
+   * @param period readable period object
+   * @return String presentation of ReadablePeriod Object
+   */
   public static String formatPeriod(final ReadablePeriod period) {
     String periodStr = "null";
 
@@ -126,6 +142,12 @@ public class TimeUtils {
     return periodStr;
   }
 
+  /**
+   * Parse Period String to a ReadablePeriod Object
+   *
+   * @param periodStr string formatted period
+   * @return ReadablePeriod Object
+   */
   public static ReadablePeriod parsePeriodString(final String periodStr) {
     final ReadablePeriod period;
     final char periodUnit = periodStr.charAt(periodStr.length() - 1);
@@ -165,11 +187,17 @@ public class TimeUtils {
     return period;
   }
 
+  /**
+   * Convert ReadablePeriod Object to string
+   *
+   * @param period ReadablePeriod Object
+   * @return string formatted ReadablePeriod Object
+   */
   public static String createPeriodString(final ReadablePeriod period) {
     String periodStr = "null";
 
     if (period == null) {
-      return "null";
+      return periodStr;
     }
 
     if (period.get(DurationFieldType.years()) > 0) {
@@ -197,5 +225,4 @@ public class TimeUtils {
 
     return periodStr;
   }
-
 }

--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -23,18 +22,18 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.time.Duration;
-import java.time.Period;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Random;
 import java.util.TimeZone;
 import java.util.zip.ZipEntry;
@@ -45,20 +44,21 @@ import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
 
+
 /**
  * A util helper class full of static methods that are commonly used.
  */
 public class Utils {
 
-  public static final Random RANDOM = new Random();
-  private static final Logger logger = Logger
-      .getLogger(Utils.class);
+  private static final Random RANDOM = new Random();
+  private static final Logger logger = Logger.getLogger(Utils.class);
 
   /**
    * Private constructor.
    */
   private Utils() {
   }
+
 
   /**
    * Equivalent to Object.equals except that it handles nulls. If a and b are both null, true is
@@ -97,6 +97,18 @@ public class Utils {
       }
     }
     return null;
+  }
+
+  /**
+   * Return the value itself if it is non-null, otherwise return the default value
+   *
+   * @param value The object
+   * @param defaultValue default value if object == null
+   * @param <T> The type of the object
+   * @return The object itself or default value when it is null
+   */
+  public static <T> T ifNull(final T value, final T defaultValue) {
+    return (value == null) ? defaultValue : value;
   }
 
   /**
@@ -237,7 +249,6 @@ public class Utils {
     if (obj instanceof String) {
       return Double.parseDouble((String) obj);
     }
-
     return (Double) obj;
   }
 
@@ -257,12 +268,23 @@ public class Utils {
   }
 
   /**
+   * Construct a class object with the given arguments
+   *
+   * @param cls The class
+   * @param args The arguments
+   * @return Constructed Object
+   */
+  public static Object callConstructor(final Class<?> cls, final Object... args) {
+    return callConstructor(cls, getTypes(args), args);
+  }
+
+  /**
    * Get the Class of all the objects
    *
    * @param args The objects to get the Classes from
    * @return The classes as an array
    */
-  public static Class<?>[] getTypes(final Object... args) {
+  private static Class<?>[] getTypes(final Object... args) {
     final Class<?>[] argTypes = new Class<?>[args.length];
     for (int i = 0; i < argTypes.length; i++) {
       argTypes[i] = args[i].getClass();
@@ -270,29 +292,21 @@ public class Utils {
     return argTypes;
   }
 
-  public static Object callConstructor(final Class<?> c, final Object... args) {
-    return callConstructor(c, getTypes(args), args);
-  }
-
   /**
    * Call the class constructor with the given arguments
    *
-   * @param c The class
+   * @param cls The class
    * @param args The arguments
    * @return The constructed object
    */
-  public static Object callConstructor(final Class<?> c, final Class<?>[] argTypes,
+  private static Object callConstructor(final Class<?> cls, final Class<?>[] argTypes,
       final Object[] args) {
     try {
-      final Constructor<?> cons = c.getConstructor(argTypes);
+      final Constructor<?> cons = cls.getConstructor(argTypes);
       return cons.newInstance(args);
     } catch (final InvocationTargetException e) {
       throw getCause(e);
-    } catch (final IllegalAccessException e) {
-      throw new IllegalStateException(e);
-    } catch (final NoSuchMethodException e) {
-      throw new IllegalStateException(e);
-    } catch (final InstantiationException e) {
+    } catch (final IllegalAccessException | NoSuchMethodException | InstantiationException e) {
       throw new IllegalStateException(e);
     }
   }
@@ -395,10 +409,74 @@ public class Utils {
      * e.g. <0 0 3 ? * * 22> OR <0 0 3 ? * 8>. Under these cases, the below code is able to tell.
      */
     final CronExpression cronExecutionTime = parseCronExpression(cronExpression, timezone);
-    if (cronExecutionTime == null || cronExecutionTime.getNextValidTimeAfter(new Date()) == null) {
-      return false;
-    }
-    return true;
+    return (!(cronExecutionTime == null
+        || cronExecutionTime.getNextValidTimeAfter(new Date()) == null));
   }
 
+  /**
+   * Run a sequence of commands
+   *
+   * @param commands sequence of commands
+   * @return list of output result
+   */
+  public static ArrayList<String> runProcess(String... commands)
+      throws InterruptedException, IOException {
+    final java.lang.ProcessBuilder processBuilder = new java.lang.ProcessBuilder(commands);
+    final ArrayList<String> output = new ArrayList<>();
+    final Process process = processBuilder.start();
+    process.waitFor();
+    final InputStream inputStream = process.getInputStream();
+    try {
+      final java.io.BufferedReader reader = new java.io.BufferedReader(
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        output.add(line);
+      }
+    } finally {
+      inputStream.close();
+    }
+    return output;
+  }
+
+  /**
+   * Merge the absolute paths of source paths into the list of destination paths
+   *
+   * @param destinationPaths the path list which the source paths will be merged into
+   * @param sourcePaths source paths
+   * @param rootPath defined root path for source paths when they are not absolute path
+   */
+  public static void mergeTypeClassPaths(
+      List<String> destinationPaths, final List<String> sourcePaths, final String rootPath) {
+    if (sourcePaths != null) {
+      for (String jar : sourcePaths) {
+        File file = new File(jar);
+        if (!file.isAbsolute()) {
+          file = new File(rootPath + File.separatorChar + jar);
+        }
+
+        String path = file.getAbsolutePath();
+        if (!destinationPaths.contains(path)) {
+          destinationPaths.add(path);
+        }
+      }
+    }
+  }
+
+  /**
+   * Merge elements in Source List into the Destination List
+   *
+   * @param destinationList the list which the source elements will be merged into
+   * @param sourceList source List
+   */
+  public static void mergeStringList(
+      final List<String> destinationList, final List<String> sourceList) {
+    if (sourceList != null) {
+      for (String item : sourceList) {
+        if (!destinationList.contains(item)) {
+          destinationList.add(item);
+        }
+      }
+    }
+  }
 }

--- a/az-core/src/test/java/azkaban/utils/UtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/UtilsTest.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2018 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.utils;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,10 +20,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import org.junit.Assert;
 import org.junit.Test;
+
 
 /**
  * Test class for azkaban.utils.Utils
@@ -56,5 +59,12 @@ public class UtilsTest {
         zipFile.delete();
       }
     }
+  }
+
+  @Test
+  public void testRunProcess() throws IOException, InterruptedException {
+    ArrayList<String> result =
+        Utils.runProcess("/bin/bash", "-c", "ls");
+    Assert.assertNotEquals(result.size(), 0);
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.utils.Props;
+import org.apache.log4j.Logger;
+
+
+/**
+ * Abstract Hadoop Java Process Job for Job PlugIn
+ */
+public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implements IHadoopJob {
+
+  public AbstractHadoopJavaProcessJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
+    super(jobid, sysProps, jobProps, logger);
+    hadoopProxy.init(sysProps, jobProps, logger);
+  }
+
+  @Override
+  public void run() throws Exception {
+    try {
+      super.run();
+    } catch (Throwable t) {
+      t.printStackTrace();
+      getLog().error("caught error running the job", t);
+      throw t;
+    } finally {
+      hadoopProxy.cancelHadoopTokens(getLog());
+    }
+  }
+
+  @Override
+  public void setupHadoopJobProperties() {
+    String[] tagKeys = new String[]{
+        CommonJobProperties.EXEC_ID,
+        CommonJobProperties.FLOW_ID,
+        CommonJobProperties.PROJECT_NAME
+    };
+    getJobProps().put(
+        HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
+        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys)
+    );
+  }
+
+  protected String getJVMProxySecureArgument() {
+    return hadoopProxy.getJVMArgument(getSysProps(), getJobProps(), getLog());
+  }
+
+  @Override
+  public Props appendExtraProps(Props props) {
+    HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
+    return props;
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AzkabanPigListener.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AzkabanPigListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.IOException;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobID;
@@ -42,13 +40,17 @@ import org.apache.pig.tools.pigstats.OutputStats;
 import org.apache.pig.tools.pigstats.PigProgressNotificationListener;
 import org.apache.pig.tools.pigstats.PigStats;
 import org.apache.pig.tools.pigstats.ScriptState;
-
 import azkaban.jobtype.pig.PigJobDagNode;
 import azkaban.jobtype.pig.PigJobStats;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 
+
+/**
+ * Pig Listener Implementation
+ */
 public class AzkabanPigListener implements PigProgressNotificationListener {
+
   private static Logger logger = Logger.getLogger(AzkabanPigListener.class);
   private String statsFile;
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -15,17 +15,14 @@
  */
 package azkaban.jobtype;
 
-import azkaban.flow.CommonJobProperties;
-import azkaban.utils.Props;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.Properties;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
+import azkaban.flow.CommonJobProperties;
+import azkaban.utils.Props;
 
 
 /**
@@ -40,16 +37,15 @@ import org.apache.log4j.Logger;
  * constructed.
  */
 public class HadoopConfigurationInjector {
-  private static Logger _logger = Logger.getLogger(HadoopConfigurationInjector.class);
 
+  private static Logger _logger = Logger.getLogger(HadoopConfigurationInjector.class);
   // File to which the Hadoop configuration to inject will be written.
   private static final String INJECT_FILE = "hadoop-inject.xml";
-
   // Prefix for properties to be automatically injected into the Hadoop conf.
   public static final String INJECT_PREFIX = "hadoop-inject.";
-
   public static final String WORKFLOW_ID_SEPERATOR = "$";
   private static final String WORKFLOW_ID_CONFIG = "yarn.workflow.id";
+
   /*
    * To be called by the forked process to load the generated links and Hadoop
    * configuration properties to automatically inject.
@@ -114,7 +110,7 @@ public class HadoopConfigurationInjector {
   }
 
   private static void addHadoopProperty(Props props, String propertyName) {
-      props.put(INJECT_PREFIX + propertyName, props.get(propertyName));
+    props.put(INJECT_PREFIX + propertyName, props.get(propertyName));
   }
 
   private static void addHadoopWorkflowProperty(Props props, String propertyName) {
@@ -142,7 +138,7 @@ public class HadoopConfigurationInjector {
         CommonJobProperties.SUBMIT_USER
     };
 
-    for(String propertyName : propsToInject) {
+    for (String propertyName : propsToInject) {
       addHadoopProperty(props, propertyName);
     }
     addHadoopWorkflowProperty(props, WORKFLOW_ID_CONFIG);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
@@ -13,109 +13,47 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
-
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.log4j.Logger;
 
-public class HadoopHiveJob extends JavaProcessJob {
 
-  public static final String HIVE_SCRIPT = "hive.script";
+/**
+ * Hadoop Hive Job Plugin
+ */
+public class HadoopHiveJob extends AbstractHadoopJavaProcessJob {
+
+  private static final String HIVE_SCRIPT = "hive.script";
   private static final String HIVECONF_PARAM_PREFIX = "hiveconf.";
   private static final String HIVEVAR_PARAM_PREFIX = "hivevar.";
-  public static final String HADOOP_SECURE_HIVE_WRAPPER =
+  private static final String HADOOP_SECURE_HIVE_WRAPPER =
       "azkaban.jobtype.HadoopSecureHiveWrapper";
-
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
 
   private boolean debug = false;
 
-  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log)
-      throws IOException {
+  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-
-    shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
-    obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
-
     debug = getJobProps().getBoolean("debug", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-
-    try {
-      super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job");
-      throw new Exception(t);
-    } finally {
-      if (tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -146,25 +84,7 @@ public class HadoopHiveJob extends JavaProcessJob {
       args += " " + typeSysJVMArgs;
     }
 
-    if (shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
 
     return args;
   }
@@ -210,79 +130,42 @@ public class HadoopHiveJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecureHiveWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
+
     List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(HIVE_SCRIPT);
   }
 
-  protected Map<String, String> getHiveConf() {
+  private Map<String, String> getHiveConf() {
     return getJobProps().getMapByPrefix(HIVECONF_PARAM_PREFIX);
   }
 
-  protected Map<String, String> getHiveVar() {
+  private Map<String, String> getHiveVar() {
     return getJobProps().getMapByPrefix(HIVEVAR_PARAM_PREFIX);
   }
 
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   /**
-   * This cancel method, in addition to the default canceling behavior, also kills the MR jobs launched by Hive
+   * This cancel method, in addition to the default canceling behavior, also kills the MR jobs
+   * launched by Hive
    * on Hadoop
    */
   @Override
@@ -291,9 +174,6 @@ public class HadoopHiveJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the Hive launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
@@ -13,77 +13,35 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.StringTokenizer;
-
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
+import azkaban.utils.Utils;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
 
-public class HadoopJavaJob extends JavaProcessJob {
 
-  public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String CANCEL_METHOD_PARAM = "method.cancel";
-  public static final String PROGRESS_METHOD_PARAM = "method.progress";
+/**
+ * Hadoop Java Job Plugin
+ */
+public class HadoopJavaJob extends AbstractHadoopJavaProcessJob {
 
-  public static final String JOB_CLASS = "job.class";
-  public static final String DEFAULT_CANCEL_METHOD = "cancel";
-  public static final String DEFAULT_RUN_METHOD = "run";
-  public static final String DEFAULT_PROGRESS_METHOD = "getProgress";
-
-  private String _runMethod;
-  private String _cancelMethod;
-  private String _progressMethod;
-
+  private String _runMethod = "";
+  private String _cancelMethod = "";
+  private String _progressMethod = "";
   private Object _javaObject = null;
-
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
   private boolean noUserClasspath = false;
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
 
   public HadoopJavaJob(String jobid, Props sysProps, Props jobProps, Logger log)
       throws RuntimeException {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-    shouldProxy =
-        getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING,
-        Boolean.toString(shouldProxy));
-    obtainTokens =
-        getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-            false);
-    noUserClasspath =
-        getSysProps().getBoolean("azkaban.no.user.classpath", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager =
-            HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        e.printStackTrace();
-        throw new RuntimeException("Failed to get hadoop security manager!"
-            + e.getCause());
-      }
-    }
+    noUserClasspath = getSysProps().getBoolean("azkaban.no.user.classpath", false);
   }
 
   @Override
@@ -121,7 +79,7 @@ public class HadoopJavaJob extends JavaProcessJob {
       classPath = new ArrayList<String>();
     }
 
-    classPath.add(getSourcePathFromClass(HadoopJavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopJavaJobRunnerMain.class));
 
     /**
      * Todo kunkun-tang: The legacy code uses a quite outdated method to resolve
@@ -129,116 +87,36 @@ public class HadoopJavaJob extends JavaProcessJob {
      */
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
     // merging classpaths from plugin.properties
-    mergeClassPaths(classPath,
-        getJobProps().getStringList("jobtype.classpath", null, ","));
+    List<String> jobTypeClassPath = getJobProps().getStringList("jobtype.classpath", null, ",");
+    Utils.mergeTypeClassPaths(classPath, jobTypeClassPath, getSysProps().get("plugin.dir"));
+
     // merging classpaths from private.properties
-    mergeClassPaths(classPath,
-        getSysProps().getStringList("jobtype.classpath", null, ","));
+    List<String> sysTypeClassPath = getSysProps().getStringList("jobtype.classpath", null, ",");
+    Utils.mergeTypeClassPaths(classPath, sysTypeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  private void mergeClassPaths(List<String> classPath,
-      List<String> typeClassPath) {
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
-  }
-
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile =
-          HadoopJobUtils
-              .getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-    try {
-      super.run();
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new Exception(e);
-    } finally {
-      if (tokenFile != null) {
-        try {
-          HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy,
-              tokenFile, getLog());
-        } catch (Throwable t) {
-          t.printStackTrace();
-          getLog().error("Failed to cancel tokens.");
-        }
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -264,10 +142,6 @@ public class HadoopJavaJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps,
-        tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -13,17 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import static azkaban.security.commons.SecurityUtils.MAPREDUCE_JOB_CREDENTIALS_BINARY;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Writer;
@@ -39,7 +35,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -48,11 +43,11 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
-
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
+
 
 public class HadoopJavaJobRunnerMain {
 
@@ -67,8 +62,8 @@ public class HadoopJavaJobRunnerMain {
 
   public static final String CANCEL_METHOD_PARAM = "method.cancel";
   public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String[] PROPS_CLASSES = new String[] {
-      "azkaban.utils.Props", "azkaban.common.utils.Props" };
+  public static final String[] PROPS_CLASSES = new String[]{
+      "azkaban.utils.Props", "azkaban.common.utils.Props"};
 
   private static final Layout DEFAULT_LAYOUT = new PatternLayout("%p %m\n");
 
@@ -194,17 +189,17 @@ public class HadoopJavaJobRunnerMain {
       try {
         final Method generatedPropertiesMethod =
             _javaObject.getClass().getMethod(GET_GENERATED_PROPERTIES_METHOD,
-                new Class<?>[] {});
+                new Class<?>[]{});
         Object outputGendProps =
-            generatedPropertiesMethod.invoke(_javaObject, new Object[] {});
+            generatedPropertiesMethod.invoke(_javaObject, new Object[]{});
 
         if (outputGendProps != null) {
           final Method toPropertiesMethod =
               outputGendProps.getClass().getMethod("toProperties",
-                  new Class<?>[] {});
+                  new Class<?>[]{});
           Properties properties =
               (Properties) toPropertiesMethod.invoke(outputGendProps,
-                  new Object[] {});
+                  new Object[]{});
 
           Props outputProps = new Props(null, properties);
           outputGeneratedProperties(outputProps);
@@ -247,7 +242,7 @@ public class HadoopJavaJobRunnerMain {
   private void runMethod(Object obj, String runMethod)
       throws IllegalAccessException, InvocationTargetException,
       NoSuchMethodException {
-    obj.getClass().getMethod(runMethod, new Class<?>[] {}).invoke(obj);
+    obj.getClass().getMethod(runMethod, new Class<?>[]{}).invoke(obj);
   }
 
   private void outputGeneratedProperties(Props outputProperties) {
@@ -305,7 +300,7 @@ public class HadoopJavaJobRunnerMain {
       } catch (NoSuchMethodException e) {
       }
 
-      if (method != null)
+      if (method != null) {
         try {
           method.invoke(_javaObject);
         } catch (Exception e) {
@@ -313,7 +308,7 @@ public class HadoopJavaJobRunnerMain {
             _logger.error("Cancel method failed! ", e);
           }
         }
-      else {
+      } else {
         throw new RuntimeException("Job " + _jobName
             + " does not have cancel method " + _cancelMethod);
       }
@@ -369,7 +364,7 @@ public class HadoopJavaJobRunnerMain {
       Constructor<?> propsCon =
           getConstructor(propsClass, propsClass, Properties[].class);
       Object props =
-          propsCon.newInstance(null, new Properties[] { properties });
+          propsCon.newInstance(null, new Properties[]{properties});
 
       Constructor<?> con =
           getConstructor(runningClass, String.class, propsClass);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -13,30 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
-
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 import org.apache.pig.PigRunner;
-
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
+
 
 /*
  * need lib:
@@ -46,99 +40,37 @@ import azkaban.utils.StringUtils;
  * HadoopSecurityManager(corresponding version with hadoop)
  * abandon support for pig 0.8 and prior versions. don't see a use case here.
  */
+public class HadoopPigJob extends AbstractHadoopJavaProcessJob {
 
-public class HadoopPigJob extends JavaProcessJob {
-
-  public static final String PIG_SCRIPT = "pig.script";
-  public static final String UDF_IMPORT = "udf.import.list";
-  public static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
-  public static final String DEFAULT_PIG_ADDITIONAL_JARS =
+  private static final String PIG_SCRIPT = "pig.script";
+  private static final String UDF_IMPORT = "udf.import.list";
+  private static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
+  private static final String DEFAULT_PIG_ADDITIONAL_JARS =
       "default.pig.additional.jars";
-  public static final String PIG_PARAM_PREFIX = "param.";
-  public static final String PIG_PARAM_FILES = "paramfile";
-  public static final String HADOOP_UGI = "hadoop.job.ugi";
-  public static final String DEBUG = "debug";
+  private static final String PIG_PARAM_PREFIX = "param.";
+  private static final String PIG_PARAM_FILES = "paramfile";
+  private static final String HADOOP_UGI = "hadoop.job.ugi";
+  private static final String DEBUG = "debug";
 
-  public static String HADOOP_SECURE_PIG_WRAPPER =
+  private static String HADOOP_SECURE_PIG_WRAPPER =
       "azkaban.jobtype.HadoopSecurePigWrapper";
 
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
-  File tokenFile = null;
-
   private final boolean userPigJar;
-
-  private HadoopSecurityManager hadoopSecurityManager;
-
   private File pigLogFile = null;
 
-  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger log)
-      throws IOException {
+  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
-
-    HADOOP_SECURE_PIG_WRAPPER = HadoopSecurePigWrapper.class.getName();
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-    shouldProxy =
-        getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING,
-        Boolean.toString(shouldProxy));
-    obtainTokens =
-        getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-            false);
+    HADOOP_SECURE_PIG_WRAPPER = HadoopSecurePigWrapper.class.getName();
     userPigJar = getJobProps().getBoolean("use.user.pig.jar", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager =
-            HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile =
-          HadoopJobUtils
-              .getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-    try {
-      super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job", t);
-      throw new Exception(t);
-    } finally {
-      if (tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy,
-            tokenFile, getLog());
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -173,38 +105,20 @@ public class HadoopPigJob extends JavaProcessJob {
       args += " -Dhadoop.job.ugi=" + hadoopUGI;
     }
 
-    if (shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
 
     return args;
   }
 
   @Override
   protected String getMainArguments() {
-    ArrayList<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Map<String, String> map = getPigParams();
     if (map != null) {
       for (Map.Entry<String, String> entry : map.entrySet()) {
         list.add("-param "
             + StringUtils.shellQuote(entry.getKey() + "=" + entry.getValue(),
-                StringUtils.SINGLE_QUOTE));
+            StringUtils.SINGLE_QUOTE));
       }
     }
 
@@ -223,7 +137,7 @@ public class HadoopPigJob extends JavaProcessJob {
       pigLogFile =
           File.createTempFile("piglogfile", ".log", new File(
               getWorkingDirectory()));
-      jobProps.put("env." + "PIG_LOG_FILE", pigLogFile.getAbsolutePath());
+      getJobProps().put("env." + "PIG_LOG_FILE", pigLogFile.getAbsolutePath());
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -243,79 +157,51 @@ public class HadoopPigJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurePigWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurePigWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
     // assuming pig 0.8 and up
     if (!userPigJar) {
-      classPath.add(getSourcePathFromClass(PigRunner.class));
+      classPath.add(FileIOUtils.getSourcePathFromClass(PigRunner.class));
     }
 
     // merging classpaths from plugin.properties
-    mergeClassPaths(classPath,
-        getJobProps().getStringList("jobtype.classpath", null, ","));
+    Utils.mergeTypeClassPaths(classPath,
+        getJobProps().getStringList("jobtype.classpath", null, ","),
+        getSysProps().get("plugin.dir"));
     // merging classpaths from private.properties
-    mergeClassPaths(classPath,
-        getSysProps().getStringList("jobtype.classpath", null, ","));
+    Utils.mergeTypeClassPaths(classPath,
+        getSysProps().getStringList("jobtype.classpath", null, ","),
+        getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  private void mergeClassPaths(List<String> classPath,
-      List<String> typeClassPath) {
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
-  }
-
-  protected boolean getDebug() {
+  private boolean getDebug() {
     return getJobProps().getBoolean(DEBUG, false);
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(PIG_SCRIPT);
   }
 
-  protected List<String> getUDFImportList() {
-    List<String> udfImports = new ArrayList<String>();
-    List<String> typeImports =
-        getSysProps().getStringList(UDF_IMPORT, null, ",");
-    List<String> jobImports =
-        getJobProps().getStringList(UDF_IMPORT, null, ",");
-    if (typeImports != null) {
-      udfImports.addAll(typeImports);
-    }
-    if (jobImports != null) {
-      udfImports.addAll(jobImports);
-    }
+  private List<String> getUDFImportList() {
+    List<String> udfImports = new ArrayList<>();
+    //append typeImports
+    Utils.mergeStringList(udfImports, getSysProps().getStringList(UDF_IMPORT, null, ","));
+    //append jobImports
+    Utils.mergeStringList(udfImports, getJobProps().getStringList(UDF_IMPORT, null, ","));
     return udfImports;
   }
 
@@ -325,7 +211,7 @@ public class HadoopPigJob extends JavaProcessJob {
    * TODO kunkun-tang: A refactor is necessary here. Recommend using Java Optional to better handle
    * parsing exceptions.
    */
-  protected List<String> getAdditionalJarsList() {
+  private List<String> getAdditionalJarsList() {
 
     List<String> wholeAdditionalJarsList = new ArrayList<>();
 
@@ -354,36 +240,16 @@ public class HadoopPigJob extends JavaProcessJob {
     return wholeAdditionalJarsList;
   }
 
-  protected String getHadoopUGI() {
+  private String getHadoopUGI() {
     return getJobProps().getString(HADOOP_UGI, null);
   }
 
-  protected Map<String, String> getPigParams() {
+  private Map<String, String> getPigParams() {
     return getJobProps().getMapByPrefix(PIG_PARAM_PREFIX);
   }
 
-  protected List<String> getPigParamFiles() {
+  private List<String> getPigParamFiles() {
     return getJobProps().getStringList(PIG_PARAM_FILES, null, ",");
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   /**
@@ -396,10 +262,6 @@ public class HadoopPigJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the Pig launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps,
-        tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+
+import java.io.File;
+import org.apache.log4j.Logger;
+import azkaban.flow.CommonJobProperties;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.Props;
+
+
+/**
+ * Hadoop Proxy
+ */
+public class HadoopProxy {
+
+  private HadoopSecurityManager hadoopSecurityManager;
+  private boolean shouldProxy = false;
+  private boolean obtainTokens = false;
+  private String userToProxy = null;
+  private File tokenFile = null;
+
+  public HadoopProxy() {
+  }
+
+  public boolean isProxyEnabled() {
+    return this.shouldProxy && this.obtainTokens;
+  }
+
+  /**
+   * Initialize the Hadoop Proxy Object
+   *
+   * @param sysProps system properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void init(Props sysProps, Props jobProps, final Logger logger) {
+    shouldProxy = sysProps.getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
+    jobProps.put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
+    obtainTokens = sysProps.getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+    if (shouldProxy) {
+      logger.info("Initiating hadoop security manager.");
+      try {
+        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(sysProps, logger);
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        throw new RuntimeException("Failed to get hadoop security manager!"
+            + e.getCause());
+      }
+    }
+  }
+
+  /**
+   * Setup Job Properties when the proxy is enabled
+   *
+   * @param props all properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void setupPropsForProxy(Props props, Props jobProps, final Logger logger)
+      throws Exception {
+    if (isProxyEnabled()) {
+      userToProxy = jobProps.getString(HadoopSecurityManager.USER_TO_PROXY);
+      logger.info("Need to proxy. Getting tokens.");
+      // get tokens in to a file, and put the location in props
+      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, logger);
+      jobProps.put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+    }
+  }
+
+  /**
+   * Generate JVM Proxy Secure Argument
+   *
+   * @param sysProps system properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   * @return proxy secure JVM argument string
+   */
+  public String getJVMArgument(Props sysProps, Props jobProps, final Logger logger) {
+    String secure = "";
+
+    if (shouldProxy) {
+      logger.info("Setting up secure proxy info for child process");
+      secure = " -D" + HadoopSecurityManager.USER_TO_PROXY
+          + "=" + jobProps.getString(HadoopSecurityManager.USER_TO_PROXY);
+
+      String extraToken = sysProps.getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, "false");
+      if (extraToken != null) {
+        secure += " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "=" + extraToken;
+      }
+      logger.info("Secure settings = " + secure);
+    } else {
+      logger.info("Not setting up secure proxy info for child process");
+    }
+
+    return secure;
+  }
+
+  /**
+   * Cancel Hadoop Tokens
+   *
+   * @param logger logger handler
+   */
+  public void cancelHadoopTokens(final Logger logger) {
+    if (tokenFile == null) {
+      return;
+    }
+    try {
+      hadoopSecurityManager.cancelTokens(tokenFile, userToProxy, logger);
+    } catch (HadoopSecurityManagerException e) {
+      logger.error(e.getCause() + e.getMessage());
+    } catch (Exception e) {
+      logger.error(e.getCause() + e.getMessage());
+    }
+    if (tokenFile.exists()) {
+      tokenFile.delete();
+    }
+  }
+
+  /**
+   * Kill all Spawned Hadoop Jobs
+   *
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void killAllSpawnedHadoopJobs(Props jobProps, final Logger logger) {
+    if (tokenFile == null) {
+      return; // do null check for tokenFile
+    }
+
+    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
+    logger.info("Log file path is: " + logFilePath);
+
+    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, logger);
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.cli.CliDriver;
 import org.apache.hadoop.hive.cli.CliSessionState;
@@ -39,9 +38,9 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
-
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.utils.Props;
+
 
 public class HadoopSecureHiveWrapper {
 
@@ -108,7 +107,7 @@ public class HadoopSecureHiveWrapper {
 
     OptionsProcessor op = new OptionsProcessor();
 
-    if (!op.process_stage1(new String[] {})) {
+    if (!op.process_stage1(new String[]{})) {
       throw new IllegalArgumentException("Can't process empty args?!?");
     }
 
@@ -174,8 +173,9 @@ public class HadoopSecureHiveWrapper {
    * Also, surround the files with uri niceities.
    */
   static String expandHiveAuxJarsPath(String original) throws IOException {
-    if (original == null || original.contains(".jar"))
+    if (original == null || original.contains(".jar")) {
       return original;
+    }
 
     File[] files = new File(original).listFiles();
 
@@ -193,8 +193,9 @@ public class HadoopSecureHiveWrapper {
     StringBuffer sb = new StringBuffer();
     for (int i = 0; i < files.length; i++) {
       sb.append("file:///").append(files[i].getCanonicalPath());
-      if (i != files.length - 1)
+      if (i != files.length - 1) {
         sb.append(",");
+      }
     }
 
     return sb.toString();
@@ -205,9 +206,6 @@ public class HadoopSecureHiveWrapper {
    * HiveConf
    *
    * An example: -hiveconf 'zipcode=10', -hiveconf hive.root.logger=INFO,console
-   *
-   * @param hiveConf
-   * @param args
    */
   private static void populateHiveConf(HiveConf hiveConf, String[] args) {
 
@@ -261,7 +259,6 @@ public class HadoopSecureHiveWrapper {
   /**
    * Strip single quote or double quote at either end of the string
    *
-   * @param input
    * @return string with w/o leading or trailing single or double quote
    */
   private static String stripSingleDoubleQuote(String input) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
@@ -26,8 +25,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
-
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
@@ -35,9 +32,8 @@ import org.apache.pig.PigRunner;
 import org.apache.pig.tools.pigstats.JobStats;
 import org.apache.pig.tools.pigstats.PigStats;
 import org.apache.pig.tools.pigstats.PigStats.JobGraph;
-
-import azkaban.jobExecutor.ProcessJob;
 import azkaban.utils.Props;
+
 
 public class HadoopSecurePigWrapper {
 
@@ -116,8 +112,6 @@ public class HadoopSecurePigWrapper {
 
   /**
    * Dump Hadoop counters for each of the M/R jobs in the given PigStats.
-   *
-   * @param pigStats
    */
   private static void dumpHadoopCounters(PigStats pigStats) {
     try {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
@@ -13,12 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
+
+import static azkaban.flow.CommonJobProperties.ATTEMPT_LINK;
+import static azkaban.flow.CommonJobProperties.EXECUTION_LINK;
+import static azkaban.flow.CommonJobProperties.JOB_LINK;
+import static azkaban.flow.CommonJobProperties.WORKFLOW_LINK;
+import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import azkaban.utils.Props;
 import com.google.common.collect.Maps;
-
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -37,11 +40,6 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 
-import static azkaban.flow.CommonJobProperties.ATTEMPT_LINK;
-import static azkaban.flow.CommonJobProperties.EXECUTION_LINK;
-import static azkaban.flow.CommonJobProperties.JOB_LINK;
-import static azkaban.flow.CommonJobProperties.WORKFLOW_LINK;
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 /**
  * <pre>
@@ -81,9 +79,6 @@ public class HadoopSecureSparkWrapper {
   /**
    * Entry point: a Java wrapper to the spark-submit command
    * Args is built in HadoopSparkJob.
-   *
-   * @param args
-   * @throws Exception
    */
   public static void main(final String[] args) throws Exception {
 
@@ -108,8 +103,6 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * Actually adjusts cmd args based on execution environment and calls the spark-submit command
-   *
-   * @param args
    */
   private static void runSpark(String[] args) {
 
@@ -157,16 +150,17 @@ public class HadoopSecureSparkWrapper {
     // So if user gives --conf spark.driver.extraJavaOptions=XX, we append the value in --driver-java-options
     for (int i = 0; i < argArray.length; i++) {
       if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName)
-        && argArray[i+1].startsWith(SPARK_CONF_EXTRA_DRIVER_OPTIONS)) {
-        driverJavaOptions.append(" ").append(argArray[++i].substring(SPARK_CONF_EXTRA_DRIVER_OPTIONS.length() + 1));
+          && argArray[i + 1].startsWith(SPARK_CONF_EXTRA_DRIVER_OPTIONS)) {
+        driverJavaOptions.append(" ")
+            .append(argArray[++i].substring(SPARK_CONF_EXTRA_DRIVER_OPTIONS.length() + 1));
       }
     }
 
     // Append addtional driver java opts about azkaban context
-    String[] requiredJavaOpts = { WORKFLOW_LINK, JOB_LINK, EXECUTION_LINK, ATTEMPT_LINK };
+    String[] requiredJavaOpts = {WORKFLOW_LINK, JOB_LINK, EXECUTION_LINK, ATTEMPT_LINK};
     for (int i = 0; i < requiredJavaOpts.length; i++) {
-        driverJavaOptions.append(" ").append(HadoopJobUtils.javaOptStringFromHadoopConfiguration(conf,
-                  requiredJavaOpts[i]));
+      driverJavaOptions.append(" ").append(HadoopJobUtils.javaOptStringFromHadoopConfiguration(conf,
+          requiredJavaOpts[i]));
     }
     // Update driver java opts
     argArray[1] = driverJavaOptions.toString();
@@ -179,7 +173,8 @@ public class HadoopSecureSparkWrapper {
     // feature for Spark. This config inside Spark jobtype is to enforce dynamic allocation feature is used for all
     // Spark applications submitted via Azkaban Spark job type.
     String dynamicAllocProp = System.getenv(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR);
-    boolean dynamicAllocEnabled = dynamicAllocProp != null && dynamicAllocProp.equals(Boolean.TRUE.toString());
+    boolean dynamicAllocEnabled =
+        dynamicAllocProp != null && dynamicAllocProp.equals(Boolean.TRUE.toString());
     if (dynamicAllocEnabled) {
       for (int i = 0; i < argArray.length; i++) {
         if (argArray[i] == null) {
@@ -190,12 +185,15 @@ public class HadoopSecureSparkWrapper {
         // by setting some conf params to false, we need to ignore these settings to enforce the application
         // uses dynamic allocation for spark
         if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) // --conf
-            && (argArray[i + 1].startsWith(SPARK_CONF_SHUFFLE_SERVICE_ENABLED) // spark.shuffle.service.enabled
-            || argArray[i + 1].startsWith(SPARK_CONF_DYNAMIC_ALLOC_ENABLED)) // spark.dynamicAllocation.enabled
-            ) {
+            && (argArray[i + 1].startsWith(SPARK_CONF_SHUFFLE_SERVICE_ENABLED)
+            // spark.shuffle.service.enabled
+            || argArray[i + 1]
+            .startsWith(SPARK_CONF_DYNAMIC_ALLOC_ENABLED)) // spark.dynamicAllocation.enabled
+        ) {
 
           logger.info(
-              "Azbakan enforces dynamic resource allocation. Ignore user param: " + argArray[i] + " " + argArray[i
+              "Azbakan enforces dynamic resource allocation. Ignore user param: " + argArray[i]
+                  + " " + argArray[i
                   + 1]);
           argArray[i] = null;
           argArray[++i] = null;
@@ -209,14 +207,16 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * This method is used to enforce queue for Spark application. Rules are explained below.
-   * a) If dynamic resource allocation is enabled for selected spark version and application requires large container
-   *    then schedule it into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
-   * b) If dynamic resource allocation is enabled for selected spark version and application requires small container
-   *    then schedule it into Org specific queue.
-   * c) If dynamic resource allocation is disabled for selected spark version then schedule application into default
-   *    queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
-   * @param argArray
-   * @return
+   * a) If dynamic resource allocation is enabled for selected spark version and application
+   * requires large container
+   * then schedule it into default queue by a default conf(spark.yarn.queue) in
+   * spark-defaults.conf.
+   * b) If dynamic resource allocation is enabled for selected spark version and application
+   * requires small container
+   * then schedule it into Org specific queue.
+   * c) If dynamic resource allocation is disabled for selected spark version then schedule
+   * application into default
+   * queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
    */
   protected static String[] handleQueueEnforcement(String[] argArray) {
     SparkConf sparkConf = getSparkProperties();
@@ -228,8 +228,9 @@ public class HadoopSecureSparkWrapper {
       if (isLargeContainerRequired(argArray, conf, sparkConf)) {
         // Case A
         requiredSparkDefaultQueue = true;
-        logger.info("Spark application requires Large containers. Scheduling this application into default queue by a "
-            + "default conf(spark.yarn.queue) in spark-defaults.conf.");
+        logger.info(
+            "Spark application requires Large containers. Scheduling this application into default queue by a "
+                + "default conf(spark.yarn.queue) in spark-defaults.conf.");
       } else {
         // Case B
         logger.info(
@@ -244,13 +245,15 @@ public class HadoopSecureSparkWrapper {
       }
     } else {
       // Case C
-      logger.info("Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
-          + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
+      logger.info(
+          "Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
+              + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
       requiredSparkDefaultQueue = true;
     }
 
     if (queueParameterIndex != -1 && requiredSparkDefaultQueue) {
-      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: " + argArray[queueParameterIndex] + " "
+      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: "
+          + argArray[queueParameterIndex] + " "
           + argArray[queueParameterIndex + 1]);
       argArray[queueParameterIndex] = null;
       argArray[queueParameterIndex + 1] = null;
@@ -261,15 +264,15 @@ public class HadoopSecureSparkWrapper {
   /**
    * This method is used to check whether large container is required for application or not.
    * To decide that, it is using parameters like
-   * User Job parameters/default value for : spark.executor.cores, spark.executor.memory, spark.yarn.executor.memoryOverhead
+   * User Job parameters/default value for : spark.executor.cores, spark.executor.memory,
+   * spark.yarn.executor.memoryOverhead
    * Jobtype Plugin parameters: spark.min.mem.vore.ratio, spark.min.memory-gb.size
-   * If rounded memory / spark.executor.cores >= spark.min.mem.vore.ratio or rounded memory >= spark.min.memory-gb.size
+   * If rounded memory / spark.executor.cores >= spark.min.mem.vore.ratio or rounded memory >=
+   * spark.min.memory-gb.size
    * then large container is required to schedule this application.
-   * @param conf
-   * @param sparkConf
-   * @return
    */
-  private static boolean isLargeContainerRequired(String[] argArray, Configuration conf, SparkConf sparkConf) {
+  private static boolean isLargeContainerRequired(String[] argArray, Configuration conf,
+      SparkConf sparkConf) {
     Map<String, String> executorParameters = getUserSpecifiedExecutorParameters(argArray);
     String executorVcore = executorParameters.get(SPARK_EXECUTOR_CORES);
     String executorMem = executorParameters.get(SPARK_EXECUTOR_MEMORY);
@@ -286,11 +289,14 @@ public class HadoopSecureSparkWrapper {
 
     double roundedMemoryGbSize = getRoundedMemoryGb(executorMem, executorMemOverhead, conf);
 
-    double minRatio = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR));
-    double minMemSize = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
+    double minRatio = Double
+        .parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR));
+    double minMemSize = Double
+        .parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
 
     logger.info(
-        "RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore + ", MinRatio: " + minRatio
+        "RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore
+            + ", MinRatio: " + minRatio
             + ", MinMemSize: " + minMemSize);
     return roundedMemoryGbSize / (double) Integer.parseInt(executorVcore) >= minRatio
         || roundedMemoryGbSize >= minMemSize;
@@ -305,9 +311,11 @@ public class HadoopSecureSparkWrapper {
     Configuration conf = new Configuration();
     boolean nodeLabelingYarn = conf.getBoolean(YARN_CONF_NODE_LABELING_ENABLED, false);
     String nodeLabelingProp = System.getenv(HadoopSparkJob.SPARK_NODE_LABELING_ENV_VAR);
-    boolean nodeLabelingPolicy = nodeLabelingProp != null && nodeLabelingProp.equals(Boolean.TRUE.toString());
+    boolean nodeLabelingPolicy =
+        nodeLabelingProp != null && nodeLabelingProp.equals(Boolean.TRUE.toString());
     String autoNodeLabelProp = System.getenv(HadoopSparkJob.SPARK_AUTO_NODE_LABELING_ENV_VAR);
-    boolean autoNodeLabeling = autoNodeLabelProp != null && autoNodeLabelProp.equals(Boolean.TRUE.toString());
+    boolean autoNodeLabeling =
+        autoNodeLabelProp != null && autoNodeLabelProp.equals(Boolean.TRUE.toString());
     String desiredNodeLabel = System.getenv(HadoopSparkJob.SPARK_DESIRED_NODE_LABEL_ENV_VAR);
 
     SparkConf sparkConf = getSparkProperties();
@@ -330,12 +338,12 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to ignore user specified node label Parameter. When auto node labeling is enabled,
+   * This method is used to ignore user specified node label Parameter. When auto node labeling is
+   * enabled,
    * job type should ignore user supplied node label expression for Spark executors.
-   * @param argArray
-   * @param autoNodeLabeling
    */
-  private static void ignoreUserSpecifiedNodeLabelParameter(String[] argArray, boolean autoNodeLabeling) {
+  private static void ignoreUserSpecifiedNodeLabelParameter(String[] argArray,
+      boolean autoNodeLabeling) {
     for (int i = 0; i < argArray.length; i++) {
       if (argArray[i] == null) {
         continue;
@@ -346,7 +354,8 @@ public class HadoopSecureSparkWrapper {
         if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
             .startsWith(SPARK_EXECUTOR_NODE_LABEL_EXP)) {
           logger.info(
-              "Azbakan auto-sets node label expression. Ignore user param: " + argArray[i] + " " + argArray[i + 1]);
+              "Azbakan auto-sets node label expression. Ignore user param: " + argArray[i] + " "
+                  + argArray[i + 1]);
           argArray[i] = null;
           argArray[++i] = null;
           continue;
@@ -356,10 +365,9 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to get User specified executor parameters. It is capturing executor-memory, executor-cores and
+   * This method is used to get User specified executor parameters. It is capturing executor-memory,
+   * executor-cores and
    * spark.yarn.executor.memoryOverhead.
-   * @param argArray
-   * @return
    */
   private static Map<String, String> getUserSpecifiedExecutorParameters(String[] argArray) {
     Map<String, String> executorParameters = Maps.newHashMap();
@@ -375,7 +383,8 @@ public class HadoopSecureSparkWrapper {
       }
       if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
           .startsWith(SPARK_EXECUTOR_MEMORY_OVERHEAD)) {
-        executorParameters.put(SPARK_EXECUTOR_MEMORY_OVERHEAD, argArray[i + 1].split("=")[1].trim());
+        executorParameters
+            .put(SPARK_EXECUTOR_MEMORY_OVERHEAD, argArray[i + 1].split("=")[1].trim());
       }
     }
     return executorParameters;
@@ -383,8 +392,6 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * This method is used to retrieve index of queue parameter passed by User.
-   * @param argArray
-   * @return
    */
   private static int getUserSpecifiedQueueParameterIndex(String[] argArray) {
     int queueParameterIndex = -1;
@@ -395,7 +402,8 @@ public class HadoopSecureSparkWrapper {
       // Fetch index of queue parameter passed by User.
       // (--queue test or --conf spark.yarn.queue=test)
       if ((argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
-          .startsWith(SPARK_CONF_QUEUE)) || (argArray[i].equals(SparkJobArg.QUEUE.sparkParamName))) {
+          .startsWith(SPARK_CONF_QUEUE)) || (argArray[i]
+          .equals(SparkJobArg.QUEUE.sparkParamName))) {
         queueParameterIndex = i++;
         break;
       }
@@ -404,8 +412,8 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to get Spark properties which will fetch properties from spark-defaults.conf file.
-   * @return
+   * This method is used to get Spark properties which will fetch properties from
+   * spark-defaults.conf file.
    */
   private static SparkConf getSparkProperties() {
     String sparkPropertyFile = HadoopSecureSparkWrapper.class.getClassLoader()
@@ -424,6 +432,7 @@ public class HadoopSecureSparkWrapper {
    * 3) Use the logic inside YARN to round up the container size according to defined min
    * allocation for memory size.
    * 4) Return the memory GB size.
+   *
    * @param mem requested executor memory size, of the format 2G or 1024M
    * @param memOverhead user defined memory overhead
    * @param config Hadoop Configuration object

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -13,25 +13,20 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.log4j.Logger;
-
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
+
 
 /**
  * <pre>
@@ -48,21 +43,20 @@ public class HadoopSecureWrapperUtils {
   /**
    * Perform all the magic required to get the proxyUser in a securitized grid
    *
-   * @param userToProxy
    * @return a UserGroupInformation object for the specified userToProxy, which will also contain
-   *         the logged in user's tokens
-   * @throws IOException
+   * the logged in user's tokens
    */
-  private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy, String filelocation, Logger log
-          ) throws IOException {
+  private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy,
+      String fileLocation, Logger log
+  ) throws IOException {
 
-    if (!new File(filelocation).exists()) {
+    if (!new File(fileLocation).exists()) {
       throw new RuntimeException("hadoop token file doesn't exist.");
     }
 
     log.info("Found token file.  Setting " + HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY
-            + " to " + filelocation);
-    System.setProperty(HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY, filelocation);
+        + " to " + fileLocation);
+    System.setProperty(HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY, fileLocation);
 
     UserGroupInformation loginUser = null;
 
@@ -82,13 +76,12 @@ public class HadoopSecureWrapperUtils {
    * Sets up the UserGroupInformation proxyUser object so that calling code can do doAs returns null
    * if the jobProps does not call for a proxyUser
    *
-   * @param jobPropsIn
-   * @param tokenFile
-   *          pass tokenFile if known. Pass null if the tokenFile is in the environmental variable
-   *          already.
-   * @param log
+   * @param jobProps job properties
+   * @param tokenFile pass tokenFile if known. Pass null if the tokenFile is in the environmental
+   * variable
+   * already.
    * @return returns null if no need to run as proxyUser, otherwise returns valid proxyUser that can
-   *         doAs
+   * doAs
    */
   public static UserGroupInformation setupProxyUser(Properties jobProps,
       String tokenFile, Logger log) {
@@ -125,16 +118,14 @@ public class HadoopSecureWrapperUtils {
     return proxyUser;
   }
 
-   /**
+  /**
    * Loading the properties file, which is a combination of the jobProps file and sysProps file
    *
    * @return a Property file, which is the combination of the jobProps file and sysProps file
-   * @throws IOException
-   * @throws FileNotFoundException
    */
 
-   @SuppressWarnings("DefaultCharset")
-  public static Properties loadAzkabanProps() throws IOException, FileNotFoundException {
+  @SuppressWarnings("DefaultCharset")
+  public static Properties loadAzkabanProps() throws IOException {
     String propsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
     Properties props = new Properties();
     props.load(new BufferedReader(new FileReader(propsFile)));
@@ -145,12 +136,10 @@ public class HadoopSecureWrapperUtils {
    * Looks for particular properties inside the Properties object passed in, and determines whether
    * proxying should happen or not
    *
-   * @param props
    * @return a boolean value of whether the job should proxy or not
    */
   public static boolean shouldProxy(Properties props) {
     String shouldProxy = props.getProperty(HadoopSecurityManager.ENABLE_PROXYING);
     return shouldProxy != null && shouldProxy.equals("true");
   }
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
@@ -13,133 +13,89 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Pattern;
-
 import org.apache.log4j.Logger;
-
-import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.ProcessJob;
-import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.Props;
+
 
 /**
  * HadoopShell is a Hadoop security enabled "command" jobtype. This jobtype
  * adheres to same format and other details as "command" jobtype.
  *
  * @author gaggarwa
- *
  */
-public class HadoopShell extends ProcessJob {
-	private String userToProxy = null;
-	private boolean shouldProxy = false;
-	private boolean obtainTokens = false;
-	private File tokenFile = null;
-	public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
-	public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
-	public static final String WHITELIST_REGEX = "command.whitelist.regex";
-	public static final String BLACKLIST_REGEX = "command.blacklist.regex";
+public class HadoopShell extends ProcessJob implements IHadoopJob {
 
-	private HadoopSecurityManager hadoopSecurityManager;
+  public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
+  public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
+  public static final String WHITELIST_REGEX = "command.whitelist.regex";
+  public static final String BLACKLIST_REGEX = "command.blacklist.regex";
 
-	public HadoopShell(String jobid, Props sysProps, Props jobProps, Logger log) throws RuntimeException {
-		super(jobid, sysProps, jobProps, log);
+  public HadoopShell(String jobid, Props sysProps, Props jobProps, Logger logger)
+      throws RuntimeException {
+    super(jobid, sysProps, jobProps, logger);
+    hadoopProxy.init(sysProps, jobProps, logger);
+  }
 
-		shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-		getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
-		obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+  @Override
+  public void run() throws Exception {
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
 
-		if (shouldProxy) {
-			getLog().info("Initiating hadoop security manager.");
-			try {
-				hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-			} catch (RuntimeException e) {
-				e.printStackTrace();
-				throw new RuntimeException("Failed to get hadoop security manager!" + e.getCause());
-			}
-		}
-	}
+    try {
+      super.run();
+    } catch (Throwable e) {
+      e.printStackTrace();
+      getLog().error("caught error running the job");
+      throw e;
+    } finally {
+      hadoopProxy.cancelHadoopTokens(getLog());
+    }
+  }
 
-	@Override
-	public void run() throws Exception {
-		setupHadoopOpts(getJobProps());
-		HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
-		if (shouldProxy && obtainTokens) {
-			userToProxy = getJobProps().getString("user.to.proxy");
-			getLog().info("Need to proxy. Getting tokens.");
-			Props props = new Props();
-			props.putAll(getJobProps());
-			props.putAll(getSysProps());
+  /**
+   * Append HADOOP_GLOBAL_OPTS with HADOOP_OPTS in the given props
+   **/
+  @Override
+  public void setupHadoopJobProperties() {
+    if (getJobProps().containsKey(HADOOP_GLOBAL_OPTS)) {
+      String hadoopGlobalOps = getJobProps().getString(HADOOP_GLOBAL_OPTS);
+      if (getJobProps().containsKey(HADOOP_OPTS)) {
+        String hadoopOps = getJobProps().getString(HADOOP_OPTS);
+        getJobProps().put(HADOOP_OPTS, String.format("%s %s", hadoopOps, hadoopGlobalOps));
+      } else {
+        getJobProps().put(HADOOP_OPTS, hadoopGlobalOps);
+      }
+    }
+  }
 
-			tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
-			getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
-		}
-		try {
-			super.run();
-		} catch (Exception e) {
-			e.printStackTrace();
-			throw new Exception(e);
-		} finally {
-			if (tokenFile != null) {
-				try {
-					HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
-				} catch (Throwable t) {
-					t.printStackTrace();
-					getLog().error("Failed to cancel tokens.");
-				}
-				if (tokenFile.exists()) {
-					tokenFile.delete();
-				}
-			}
-		}
-	}
+  @Override
+  protected List<String> getCommandList() {
+    // Use the same parsing login as in default "command job";
+    List<String> commands = super.getCommandList();
 
-	/**
-	 * Append HADOOP_GLOBAL_OPTS with HADOOP_OPTS in the given props
-	 *
-	 * @param props
-	 */
-	private void setupHadoopOpts(Props props) {
-		if (props.containsKey(HADOOP_GLOBAL_OPTS)) {
-			String hadoopGlobalOps = props.getString(HADOOP_GLOBAL_OPTS);
-			if (props.containsKey(HADOOP_OPTS)) {
-				String hadoopOps = props.getString(HADOOP_OPTS);
-				props.put(HADOOP_OPTS, String.format("%s %s", hadoopOps, hadoopGlobalOps));
-			} else {
-				props.put(HADOOP_OPTS, hadoopGlobalOps);
-			}
-		}
-	}
+    return HadoopJobUtils.filterCommands(
+        commands,
+        // ".*" will match everything
+        getSysProps().getString(WHITELIST_REGEX, HadoopJobUtils.MATCH_ALL_REGEX),
+        // ".^" will match nothing
+        getSysProps().getString(BLACKLIST_REGEX, HadoopJobUtils.MATCH_NONE_REGEX),
+        getLog()
+    );
+  }
 
-	@Override
-	protected List<String> getCommandList() {
-		// Use the same parsing login as in default "command job";
-		List<String> commands = super.getCommandList();
-		return HadoopJobUtils.filterCommands(commands, getSysProps().getString(WHITELIST_REGEX, HadoopJobUtils.MATCH_ALL_REGEX), // ".*" will match everything
-				getSysProps().getString(BLACKLIST_REGEX, HadoopJobUtils.MATCH_NONE_REGEX), getLog()); // ".^" will match nothing
-	}
-
-	/**
-	 * This cancel method, in addition to the default canceling behavior, also
-	 * kills the MR jobs launched by this job on Hadoop
-	 */
-	@Override
-	public void cancel() throws InterruptedException {
-		super.cancel();
-
-		info("Cancel called.  Killing the launched Hadoop jobs on the cluster");
-
-		final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-		info("Log file path is: " + logFilePath);
-
-		HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, getLog());
-	}
+  /**
+   * This cancel method, in addition to the default canceling behavior, also
+   * kills the MR jobs launched by this job on Hadoop
+   */
+  @Override
+  public void cancel() throws InterruptedException {
+    super.cancel();
+    info("Cancel called.  Killing the launched Hadoop jobs on the cluster");
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
+  }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+public interface IHadoopJob {
+
+  /**
+   * Hadoop Proxy Wrapper Object
+   */
+  HadoopProxy hadoopProxy = new HadoopProxy();
+
+  /**
+   * Setup Hadoop-related Job Properties
+   */
+  void setupHadoopJobProperties();
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 LinkedIn Corp.
+ * Copyright 2019 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,41 +13,41 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import java.io.File;
-import java.util.List;
-import java.util.StringTokenizer;
-
-import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.SecurityUtils;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
+import azkaban.utils.Utils;
+import java.io.File;
+import java.util.List;
+import org.apache.log4j.Logger;
 
+
+/**
+ * Java Job Plugin
+ */
 public class JavaJob extends JavaProcessJob {
 
-  public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String CANCEL_METHOD_PARAM = "method.cancel";
-  public static final String PROGRESS_METHOD_PARAM = "method.progress";
+  private static final String RUN_METHOD_PARAM = "method.run";
+  private static final String CANCEL_METHOD_PARAM = "method.cancel";
+  private static final String PROGRESS_METHOD_PARAM = "method.progress";
 
-  public static final String JOB_CLASS = "job.class";
-  public static final String DEFAULT_CANCEL_METHOD = "cancel";
-  public static final String DEFAULT_RUN_METHOD = "run";
-  public static final String DEFAULT_PROGRESS_METHOD = "getProgress";
+  private static final String JOB_CLASS = "job.class";
+  private static final String DEFAULT_CANCEL_METHOD = "cancel";
+  private static final String DEFAULT_RUN_METHOD = "run";
+  private static final String DEFAULT_PROGRESS_METHOD = "getProgress";
 
   private String _runMethod;
   private String _cancelMethod;
   private String _progressMethod;
 
   private Object _javaObject = null;
-  private String props;
 
   public JavaJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
   }
 
@@ -68,18 +68,18 @@ public class JavaJob extends JavaProcessJob {
   protected List<String> getClassPaths() {
     List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(SecurityUtils.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(SecurityUtils.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
-    String loggerPath = getSourcePathFromClass(Logger.class);
+    String loggerPath = FileIOUtils.getSourcePathFromClass(Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }
@@ -95,51 +95,13 @@ public class JavaJob extends JavaProcessJob {
 
     List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsoluteFile())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   @Override
@@ -152,14 +114,15 @@ public class JavaJob extends JavaProcessJob {
     return "JavaJob{" + "_runMethod='" + _runMethod + '\''
         + ", _cancelMethod='" + _cancelMethod + '\'' + ", _progressMethod='"
         + _progressMethod + '\'' + ", _javaObject=" + _javaObject + ", props="
-        + props + '}';
+        + getAllProps().toString() + '}';
   }
 
 
   @Override
   public void run() throws Exception {
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
+    HadoopConfigurationInjector.prepareResourcesToInject(
+        getJobProps(), getWorkingDirectory()
+    );
     super.run();
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
@@ -13,22 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.ProcessJob;
+import azkaban.security.commons.SecurityUtils;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Layout;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-
-import azkaban.security.commons.SecurityUtils;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.FileReader;
@@ -43,6 +33,13 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+
 
 public class JavaJobRunnerMain {
 
@@ -57,9 +54,9 @@ public class JavaJobRunnerMain {
 
   public static final String CANCEL_METHOD_PARAM = "method.cancel";
   public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String[] PROPS_CLASSES = new String[] {
-    "azkaban.utils.Props",
-    "azkaban.common.utils.Props"
+  public static final String[] PROPS_CLASSES = new String[]{
+      "azkaban.utils.Props",
+      "azkaban.common.utils.Props"
   };
 
   private static final Layout DEFAULT_LAYOUT = new PatternLayout("%p %m\n");
@@ -139,16 +136,16 @@ public class JavaJobRunnerMain {
       try {
         final Method generatedPropertiesMethod =
             _javaObject.getClass().getMethod(GET_GENERATED_PROPERTIES_METHOD,
-                new Class<?>[] {});
+                new Class<?>[]{});
         Object outputGendProps =
-            generatedPropertiesMethod.invoke(_javaObject, new Object[] {});
+            generatedPropertiesMethod.invoke(_javaObject, new Object[]{});
         if (outputGendProps != null) {
           final Method toPropertiesMethod =
               outputGendProps.getClass().getMethod("toProperties",
-                  new Class<?>[] {});
+                  new Class<?>[]{});
           Properties properties =
               (Properties) toPropertiesMethod.invoke(outputGendProps,
-                  new Object[] {});
+                  new Object[]{});
 
           Props outputProps = new Props(null, properties);
           outputGeneratedProperties(outputProps);
@@ -190,7 +187,7 @@ public class JavaJobRunnerMain {
   private void runMethod(Object obj, String runMethod)
       throws IllegalAccessException, InvocationTargetException,
       NoSuchMethodException {
-    obj.getClass().getMethod(runMethod, new Class<?>[] {}).invoke(obj);
+    obj.getClass().getMethod(runMethod, new Class<?>[]{}).invoke(obj);
   }
 
   @SuppressWarnings("DefaultCharset")
@@ -311,7 +308,7 @@ public class JavaJobRunnerMain {
       Constructor<?> propsCon =
           getConstructor(propsClass, propsClass, Properties[].class);
       Object props =
-          propsCon.newInstance(null, new Properties[] { properties });
+          propsCon.newInstance(null, new Properties[]{properties});
 
       Constructor<?> con =
           getConstructor(runningClass, String.class, propsClass);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JobDagNode.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JobDagNode.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.util.ArrayList;
@@ -22,15 +21,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-public class JobDagNode {
-  protected String name;
 
+/**
+ * JOB DAG Node
+ */
+public class JobDagNode {
+
+  protected String name;
   protected List<String> parents = new ArrayList<String>();
   protected List<String> successors = new ArrayList<String>();
-
   protected MapReduceJobState mapReduceJobState;
   protected Properties jobConfiguration;
-
   protected int level = 0;
 
   public JobDagNode() {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/MapReduceJobState.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/MapReduceJobState.java
@@ -13,22 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.TIPStatus;
 import org.apache.hadoop.mapred.TaskReport;
 
+
 /**
  * Container that holds state of a MapReduce job
  */
 public class MapReduceJobState {
+
   private String jobId;
   private String jobName;
   private String trackingURL;
@@ -39,13 +39,10 @@ public class MapReduceJobState {
   private float reduceProgress;
   private long jobStartTime;
   private long jobLastUpdateTime;
-
   private int totalMappers;
   private int finishedMappersCount;
-
   private int totalReducers;
   private int finishedReducersCount;
-
   private Counters counters;
 
   public MapReduceJobState() {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
@@ -13,60 +13,42 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.SecurityUtils;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Pig Process Job
+ */
 public class PigProcessJob extends JavaProcessJob {
 
-  public static final String PIG_SCRIPT = "pig.script";
-  public static final String UDF_IMPORT = "udf.import.list";
-  public static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
-  public static final String PIG_PARAM_PREFIX = "param.";
-  public static final String PIG_PARAM_FILES = "paramfile";
-  public static final String HADOOP_UGI = "hadoop.job.ugi";
-  public static final String DEBUG = "debug";
+  private static final String PIG_SCRIPT = "pig.script";
+  private static final String UDF_IMPORT = "udf.import.list";
+  private static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
+  private static final String PIG_PARAM_PREFIX = "param.";
+  private static final String PIG_PARAM_FILES = "paramfile";
+  private static final String HADOOP_UGI = "hadoop.job.ugi";
+  private static final String DEBUG = "debug";
+  private static final String PIG_JAVA_CLASS = "org.apache.pig.Main";
+  private static final String SECURE_PIG_WRAPPER = "azkaban.jobtype.SecurePigWrapper";
 
-  public static final String PIG_JAVA_CLASS = "org.apache.pig.Main";
-  public static final String SECURE_PIG_WRAPPER =
-      "azkaban.jobtype.SecurePigWrapper";
-
-  public PigProcessJob(final String jobid, final Props sysProps, final Props jobProps,
+  public PigProcessJob(final String jobId, final Props sysProps, final Props jobProps,
       final Logger log) {
-    super(jobid, sysProps, new Props(sysProps, jobProps), log);
-  }
-
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
+    super(jobId, sysProps, new Props(sysProps, jobProps), log);
   }
 
   @Override
@@ -138,7 +120,7 @@ public class PigProcessJob extends JavaProcessJob {
       for (final Map.Entry<String, String> entry : map.entrySet()) {
         list.add("-param "
             + StringUtils.shellQuote(entry.getKey() + "=" + entry.getValue(),
-                StringUtils.SINGLE_QUOTE));
+            StringUtils.SINGLE_QUOTE));
       }
     }
 
@@ -172,87 +154,59 @@ public class PigProcessJob extends JavaProcessJob {
       classPath.add(new File(hadoopHome, "conf").getPath());
     }
 
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
     if (SecurityUtils.shouldProxy(getSysProps().toProperties())) {
-      classPath.add(getSourcePathFromClass(SecurePigWrapper.class));
+      classPath.add(FileIOUtils.getSourcePathFromClass(SecurePigWrapper.class));
     }
 
     final List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      final String pluginDir = getSysProps().get("plugin.dir");
-      for (final String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsoluteFile())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     final List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (final String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
     return classPath;
   }
 
-  protected boolean getDebug() {
+  private boolean getDebug() {
     return getJobProps().getBoolean(DEBUG, false);
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(PIG_SCRIPT);
   }
 
-  protected List<String> getUDFImportList() {
+  private List<String> getUDFImportList() {
     final List<String> udfImports = new ArrayList<>();
-    final List<String> typeImports =
-        getSysProps().getStringList(UDF_IMPORT, null, ",");
-    final List<String> jobImports =
-        getJobProps().getStringList(UDF_IMPORT, null, ",");
-    if (typeImports != null) {
-      udfImports.addAll(typeImports);
-    }
-    if (jobImports != null) {
-      udfImports.addAll(jobImports);
-    }
+    // append typeImports
+    Utils.mergeStringList(udfImports, getSysProps().getStringList(UDF_IMPORT, null, ","));
+    // append jobImports
+    Utils.mergeStringList(udfImports, getJobProps().getStringList(UDF_IMPORT, null, ","));
     return udfImports;
   }
 
-  protected List<String> getAdditionalJarsList() {
+  private List<String> getAdditionalJarsList() {
     final List<String> additionalJars = new ArrayList<>();
-    final List<String> typeJars =
-        getSysProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
-    final List<String> jobJars =
-        getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
-    if (typeJars != null) {
-      additionalJars.addAll(typeJars);
-    }
-    if (jobJars != null) {
-      additionalJars.addAll(jobJars);
-    }
+    // append typeJars
+    Utils.mergeStringList(additionalJars,
+        getSysProps().getStringList(PIG_ADDITIONAL_JARS, null, ","));
+    // append jobJars
+    Utils.mergeStringList(additionalJars,
+        getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ","));
+
     return additionalJars;
   }
 
-  protected String getHadoopUGI() {
+  private String getHadoopUGI() {
     return getJobProps().getString(HADOOP_UGI, null);
   }
 
-  protected Map<String, String> getPigParams() {
+  private Map<String, String> getPigParams() {
     return getJobProps().getMapByPrefix(PIG_PARAM_PREFIX);
   }
 
-  protected List<String> getPigParamFiles() {
+  private List<String> getPigParamFiles() {
     return getJobProps().getStringList(PIG_PARAM_FILES, null, ",");
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SecurePigWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SecurePigWrapper.java
@@ -13,9 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
+import azkaban.security.commons.SecurityUtils;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobClient;
@@ -25,14 +31,6 @@ import org.apache.hadoop.mapreduce.security.token.delegation.DelegationTokenIden
 import org.apache.hadoop.security.token.Token;
 import org.apache.log4j.Logger;
 
-import azkaban.security.commons.SecurityUtils;
-
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.security.PrivilegedExceptionAction;
-import java.util.Properties;
 
 public class SecurePigWrapper {
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SparkJobArg.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SparkJobArg.java
@@ -1,7 +1,7 @@
 package azkaban.jobtype;
 
-public enum SparkJobArg {
 
+public enum SparkJobArg {
   // standard spark submit arguments, ordered in the spark-submit --help order
   MASTER("master", false), // just to trick the eclipse formatter
   DEPLOY_MODE("deploy-mode", false), //
@@ -55,5 +55,4 @@ public enum SparkJobArg {
   final String sparkParamName;
 
   final boolean needSpecialTreatment;
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.FileNotFoundException;
@@ -27,7 +26,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -38,12 +36,13 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.log4j.Logger;
 import org.apache.pig.impl.util.ObjectSerializer;
 
+
 public class StatsUtils {
 
   private static Logger logger = Logger.getLogger(StatsUtils.class);
 
   private static final Set<String> JOB_CONF_KEYS = new HashSet<String>(
-      Arrays.asList(new String[] {
+      Arrays.asList(new String[]{
           "mapred.job.map.memory.mb",
           "mapred.job.reduce.memory.mb",
           "mapred.child.java.opts",

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.connectors.gobblin;
 
 import java.io.BufferedInputStream;
@@ -22,14 +21,11 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-
 import com.google.common.collect.Maps;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
-
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobtype.HadoopJavaJob;
 import azkaban.jobtype.connectors.gobblin.helper.HdfsToMySqlValidator;
@@ -37,10 +33,13 @@ import azkaban.jobtype.connectors.gobblin.helper.IPropertiesValidator;
 import azkaban.jobtype.connectors.gobblin.helper.MySqlToHdfsValidator;
 import azkaban.utils.Props;
 
+
 /**
- * Integration Azkaban with Gobblin. It prepares job properties for Gobblin and utilizes HadoopJavaJob to kick off the job
+ * Integration Azkaban with Gobblin. It prepares job properties for Gobblin and utilizes
+ * HadoopJavaJob to kick off the job
  */
 public class GobblinHadoopJob extends HadoopJavaJob {
+
   private static final String GOBBLIN_PRESET_COMMON_PROPERTIES_FILE_NAME = "common.properties";
   private static final String GOBBLIN_QUERY_KEY = "source.querybased.query";
   private static volatile Map<GobblinPresets, Properties> gobblinPresets;
@@ -50,14 +49,15 @@ public class GobblinHadoopJob extends HadoopJavaJob {
     super(jobid, sysProps, jobProps, log);
     initializePresets();
 
-    jobProps.put(HadoopJavaJob.JOB_CLASS, "gobblin.azkaban.AzkabanJobLauncher");
+    jobProps.put("job.class", "gobblin.azkaban.AzkabanJobLauncher");
     jobProps.put("job.name", jobProps.get(CommonJobProperties.JOB_ID));
     jobProps.put("launcher.type", "MAPREDUCE"); //Azkaban only supports MR mode
     jobProps.put("fs.uri", sysProps.get("fs.uri")); //Azkaban should only support HDFS
 
     //If gobblin jars are in HDFS pass HDFS path to Gobblin, otherwise pass local file system path.
     if (sysProps.containsKey(GobblinConstants.GOBBLIN_HDFS_JOB_JARS_KEY)) {
-      jobProps.put(GobblinConstants.GOBBLIN_HDFS_JOB_JARS_KEY, sysProps.getString(GobblinConstants.GOBBLIN_HDFS_JOB_JARS_KEY));
+      jobProps.put(GobblinConstants.GOBBLIN_HDFS_JOB_JARS_KEY,
+          sysProps.getString(GobblinConstants.GOBBLIN_HDFS_JOB_JARS_KEY));
     } else {
       jobProps.put(GobblinConstants.GOBBLIN_JOB_JARS_KEY, sysProps.get("jobtype.classpath"));
     }
@@ -70,7 +70,7 @@ public class GobblinHadoopJob extends HadoopJavaJob {
   /**
    * Factory method that provides IPropertiesValidator based on preset in runtime.
    * Using factory method pattern as it is expected to grow.
-   * @param preset
+   *
    * @return IPropertiesValidator
    */
   private static IPropertiesValidator getValidator(GobblinPresets preset) {
@@ -87,7 +87,6 @@ public class GobblinHadoopJob extends HadoopJavaJob {
 
   /**
    * Print the job properties except property key contains "pass" and "word".
-   * @param jobProps
    */
   @VisibleForTesting
   Map<String, String> printableJobProperties(Props jobProps) {
@@ -115,32 +114,37 @@ public class GobblinHadoopJob extends HadoopJavaJob {
       synchronized (GobblinHadoopJob.class) {
         if (gobblinPresets == null) {
           gobblinPresets = Maps.newHashMap();
-          String gobblinPresetDirName = sysProps.getString(GobblinConstants.GOBBLIN_PRESET_DIR_KEY);
+          String gobblinPresetDirName = getSysProps()
+              .getString(GobblinConstants.GOBBLIN_PRESET_DIR_KEY);
           File gobblinPresetDir = new File(gobblinPresetDirName);
           File[] presetFiles = gobblinPresetDir.listFiles();
           if (presetFiles == null) {
             return;
           }
 
-          File commonPropertiesFile = new File(gobblinPresetDir, GOBBLIN_PRESET_COMMON_PROPERTIES_FILE_NAME);
+          File commonPropertiesFile = new File(gobblinPresetDir,
+              GOBBLIN_PRESET_COMMON_PROPERTIES_FILE_NAME);
           if (!commonPropertiesFile.exists()) {
             throw new IllegalStateException("Gobbline preset common properties file is missing "
                 + commonPropertiesFile.getAbsolutePath());
           }
 
           for (File f : presetFiles) {
-            if (GOBBLIN_PRESET_COMMON_PROPERTIES_FILE_NAME.equals(f.getName())) { //Don't load common one itself.
+            if (GOBBLIN_PRESET_COMMON_PROPERTIES_FILE_NAME
+                .equals(f.getName())) { //Don't load common one itself.
               continue;
             }
 
             if (f.isFile()) {
               Properties prop = new Properties();
-              try (InputStream commonIs = new BufferedInputStream(new FileInputStream(commonPropertiesFile));
+              try (InputStream commonIs = new BufferedInputStream(
+                  new FileInputStream(commonPropertiesFile));
                   InputStream presetIs = new BufferedInputStream(new FileInputStream(f))) {
                 prop.load(commonIs);
                 prop.load(presetIs);
 
-                String presetName = f.getName().substring(0, f.getName().lastIndexOf('.')); //remove extension from the file name
+                String presetName = f.getName().substring(0,
+                    f.getName().lastIndexOf('.')); //remove extension from the file name
                 gobblinPresets.put(GobblinPresets.fromName(presetName), prop);
               } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -153,12 +157,14 @@ public class GobblinHadoopJob extends HadoopJavaJob {
   }
 
   /**
-   * If input parameter has preset value, it will load set of properties into job property for the Gobblin job.
-   * Also, if user wants to validates the job properties(enabled by default), it will validate it based on the preset where
+   * If input parameter has preset value, it will load set of properties into job property for the
+   * Gobblin job.
+   * Also, if user wants to validates the job properties(enabled by default), it will validate it
+   * based on the preset where
    * preset is basically used as a proxy to the use case.
    */
   private void loadPreset() {
-    String presetName = jobProps.get(GobblinConstants.GOBBLIN_PRESET_KEY);
+    String presetName = getJobProps().get(GobblinConstants.GOBBLIN_PRESET_KEY);
     if (presetName == null) {
       return;
     }
@@ -166,53 +172,59 @@ public class GobblinHadoopJob extends HadoopJavaJob {
     GobblinPresets preset = GobblinPresets.fromName(presetName);
     Properties presetProperties = gobblinPresets.get(preset);
     if (presetProperties == null) {
-      throw new IllegalArgumentException("Preset " + presetName + " is not supported. Supported presets: "
-          + gobblinPresets.keySet());
+      throw new IllegalArgumentException(
+          "Preset " + presetName + " is not supported. Supported presets: "
+              + gobblinPresets.keySet());
     }
 
     getLog().info("Loading preset " + presetName + " : " + presetProperties);
     Map<String, String> skipped = Maps.newHashMap();
     for (String key : presetProperties.stringPropertyNames()) {
-      if (jobProps.containsKey(key)) {
+      if (getJobProps().containsKey(key)) {
         skipped.put(key, presetProperties.getProperty(key));
         continue;
       }
-      jobProps.put(key, presetProperties.getProperty(key));
+      getJobProps().put(key, presetProperties.getProperty(key));
     }
     getLog().info("Loaded preset " + presetName);
     if (!skipped.isEmpty()) {
-      getLog().info("Skipped some properties from preset as already exists in job properties. Skipped: " + skipped);
+      getLog().info(
+          "Skipped some properties from preset as already exists in job properties. Skipped: "
+              + skipped);
     }
 
-    if (jobProps.getBoolean(GobblinConstants.GOBBLIN_PROPERTIES_HELPER_ENABLED_KEY, true)) {
-      getValidator(preset).validate(jobProps);
+    if (getJobProps().getBoolean(GobblinConstants.GOBBLIN_PROPERTIES_HELPER_ENABLED_KEY, true)) {
+      getValidator(preset).validate(getJobProps());
     }
   }
 
   /**
    * Transform property to make it work for Gobblin.
    *
-   * e.g: Gobblin fails when there's semicolon in SQL query as it just appends " and 1=1;" into the query,
-   * making the syntax incorrect and fails. As having semicolon is a correct syntax, instead of expecting user to remove it,
+   * e.g: Gobblin fails when there's semicolon in SQL query as it just appends " and 1=1;" into the
+   * query,
+   * making the syntax incorrect and fails. As having semicolon is a correct syntax, instead of
+   * expecting user to remove it,
    * Azkaban will remove it for user to make it work with Gobblin.
    */
   private void transformProperties() {
     //Gobblin does not accept the SQL query ends with semi-colon
-    String query = jobProps.getString(GOBBLIN_QUERY_KEY, null);
-    if(query == null) {
+    String query = getJobProps().getString(GOBBLIN_QUERY_KEY, null);
+    if (query == null) {
       return;
     }
 
     query = query.trim();
     int idx = -1;
     if ((idx = query.indexOf(';')) >= 0) {
-      if(idx < query.length() - 1) {
+      if (idx < query.length() - 1) {
         //Query string has been already trimmed and if index is not end of the query String,
         //it means there's more than one statement.
-        throw new IllegalArgumentException(GOBBLIN_QUERY_KEY + " should consist of one SELECT statement. " + query);
+        throw new IllegalArgumentException(
+            GOBBLIN_QUERY_KEY + " should consist of one SELECT statement. " + query);
       }
       query = query.substring(0, idx);
-      jobProps.put(GOBBLIN_QUERY_KEY, query);
+      getJobProps().put(GOBBLIN_QUERY_KEY, query);
     }
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
@@ -1,29 +1,43 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.jobtype.javautils;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.FileFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.log4j.Logger;
 
 
+/**
+ * Utilities Function of File Related Operations
+ */
 public class FileUtils {
+
   private static Logger logger = Logger.getLogger(FileUtils.class);
 
   /**
    * Delete file or directory.
    * (Apache FileUtils.deleteDirectory has a bug and is not working.)
-   *
-   * @param file
-   * @throws IOException
    */
-  public static void deleteFileOrDirectory(File file) throws IOException {
+  public static void deleteFileOrDirectory(File file) {
     if (!file.isDirectory()) {
       file.delete();
       return;
@@ -42,12 +56,18 @@ public class FileUtils {
     deleteFileOrDirectory(file);
   }
 
+  /**
+   * Try to delete File or Directory
+   *
+   * @param file file object
+   * @return success delete or not
+   */
   public static boolean tryDeleteFileOrDirectory(File file) {
     try {
       deleteFileOrDirectory(file);
       return true;
     } catch (Exception e) {
-      logger.warn("Failed to delete " + file.getAbsolutePath(), e);
+      logger.warn("Failed to delete file. file = " + file.getAbsolutePath(), e);
       return false;
     }
   }
@@ -55,30 +75,31 @@ public class FileUtils {
   /**
    * Find files while input can use wildcard * or ?
    *
-   * @param filesStr File path(s) delimited by delimiter
+   * @param filesString File path(s) delimited by delimiter
    * @param delimiter Separator of file paths.
    * @return List of absolute path of files
    */
-  public static Collection<String> listFiles(String filesStr, String delimiter) {
-    ValidationUtils.validateNotEmpty(filesStr, "fileStr");
+  public static Collection<String> listFiles(String filesString, String delimiter) {
+    ValidationUtils.validateNotEmpty(filesString, "fileStr");
 
     List<String> files = new ArrayList<String>();
-    for (String s : filesStr.split(delimiter)) {
-      File f = new File(s);
-      if (!f.getName().contains("*") && !f.getName().contains("?")) {
-        files.add(f.getAbsolutePath());
-        continue;
-      }
-
-      FileFilter fileFilter = new AndFileFilter(new WildcardFileFilter(f.getName()), FileFileFilter.FILE);
-      File parent = f.getParentFile() == null ? f : f.getParentFile();
-      File[] filteredFiles = parent.listFiles(fileFilter);
-      if(filteredFiles == null) {
-        continue;
-      }
-
-      for (File file : filteredFiles) {
+    for (String fileString : filesString.split(delimiter)) {
+      File file = new File(fileString);
+      if (!file.getName().contains("*") && !file.getName().contains("?")) {
         files.add(file.getAbsolutePath());
+        continue;
+      }
+
+      FileFilter fileFilter = new AndFileFilter(new WildcardFileFilter(file.getName()),
+          FileFileFilter.FILE);
+      File parent = file.getParentFile() == null ? file : file.getParentFile();
+      File[] filteredFiles = parent.listFiles(fileFilter);
+      if (filteredFiles == null) {
+        continue;
+      }
+
+      for (File filteredFile : filteredFiles) {
+        files.add(filteredFile.getAbsolutePath());
       }
     }
     return files;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.javautils;
 
 import java.io.ByteArrayOutputStream;
@@ -22,7 +21,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.Enumeration;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -30,9 +28,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.log4j.Logger;
-
 import azkaban.utils.Props;
 
+
+/**
+ * Utilities of Hadoop Related Operations
+ */
 public class HadoopUtils {
 
   private static final Logger logger = Logger.getLogger(HadoopUtils.class);
@@ -50,7 +51,7 @@ public class HadoopUtils {
   public static String findContainingJar(String fileName, ClassLoader loader) {
     try {
       for (Enumeration<?> itr = loader.getResources(fileName); itr
-          .hasMoreElements();) {
+          .hasMoreElements(); ) {
         URL url = (URL) itr.nextElement();
         logger.info("findContainingJar finds url:" + url);
         if ("jar".equals(url.getProtocol())) {
@@ -73,7 +74,7 @@ public class HadoopUtils {
     return findContainingJar(class_file, loader);
   }
 
-  public static boolean shouldPathBeIgnored(Path path) throws IOException {
+  public static boolean shouldPathBeIgnored(Path path) {
     return path.getName().startsWith("_");
   }
 
@@ -112,10 +113,7 @@ public class HadoopUtils {
 
   public static void saveProps(Props props, String file) throws IOException {
     Path path = new Path(file);
-
-    FileSystem fs = null;
-    fs = path.getFileSystem(new Configuration());
-
+    FileSystem fs = path.getFileSystem(new Configuration());
     saveProps(fs, props, file);
   }
 
@@ -125,8 +123,9 @@ public class HadoopUtils {
 
     // create directory if it does not exist.
     Path parent = path.getParent();
-    if (!fs.exists(parent))
+    if (!fs.exists(parent)) {
       fs.mkdirs(parent);
+    }
 
     // write out properties
     OutputStream output = fs.create(path);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
@@ -11,28 +11,28 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.javautils;
 
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.apache.commons.lang.StringUtils;
-
 import azkaban.utils.Props;
 
+
+/**
+ * Utilities for Validation
+ */
 public class ValidationUtils {
 
   public static void validateNotEmpty(String s, String name) {
-    if(StringUtils.isEmpty(s)) {
+    if (StringUtils.isEmpty(s)) {
       throw new IllegalArgumentException(name + " cannot be empty.");
     }
   }
 
   /**
    * Validates if all of the keys exist of none of them exist
-   * @param props
-   * @param keys
+   *
    * @throws IllegalArgumentException only if some of the keys exist
    */
   public static void validateAllOrNone(Props props, String... keys) {
@@ -40,49 +40,50 @@ public class ValidationUtils {
 
     boolean allExist = true;
     boolean someExist = false;
-    for(String key : keys) {
+    for (String key : keys) {
       Object val = props.get(key);
       allExist &= val != null;
       someExist |= val != null;
     }
 
-    if(someExist && !allExist) {
-      throw new IllegalArgumentException("Either all of properties exist or none of them should exist for " + Arrays.toString(keys));
+    if (someExist && !allExist) {
+      throw new IllegalArgumentException(
+          "Either all of properties exist or none of them should exist for " + Arrays
+              .toString(keys));
     }
   }
 
   /**
    * Validates all keys present in props
-   * @param props
-   * @param keys
-   * @throws UndefinedPropertyException if key does not exist in properties
    */
   public static void validateAllNotEmpty(Props props, String... keys) {
-    for(String key : keys) {
+    for (String key : keys) {
       props.getString(key);
     }
   }
 
   public static void validateAtleastOneNotEmpty(Props props, String... keys) {
     boolean exist = false;
-    for(String key : keys) {
+    for (String key : keys) {
       Object val = props.get(key);
       exist |= val != null;
     }
-    if(!exist) {
-      throw new IllegalArgumentException("At least one of these keys should exist " + Arrays.toString(keys));
+    if (!exist) {
+      throw new IllegalArgumentException(
+          "At least one of these keys should exist " + Arrays.toString(keys));
     }
   }
 
   public static void validateSomeValuesNotEmpty(int notEmptyVals, String... vals) {
     int count = 0;
-    for(String val : vals) {
-      if(!StringUtils.isEmpty(val)) {
+    for (String val : vals) {
+      if (!StringUtils.isEmpty(val)) {
         count++;
       }
     }
     if (count != notEmptyVals) {
-      throw new IllegalArgumentException("Number of not empty vals " + count + " is not desired number " + notEmptyVals);
+      throw new IllegalArgumentException(
+          "Number of not empty vals " + count + " is not desired number " + notEmptyVals);
     }
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
@@ -16,26 +16,26 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
-
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
+
 /**
- * Whitelist util. It uses file (new line separated) to construct whitelist and validates if id is whitelisted.
- * Main use case is to control users onboarding on connector job types via their "user.to.proxy" value.
+ * Whitelist util. It uses file (new line separated) to construct whitelist and validates if id is
+ * whitelisted.
+ * Main use case is to control users onboarding on connector job types via their "user.to.proxy"
+ * value.
  */
 public class Whitelist {
-  public static final String WHITE_LIST_FILE_PATH_KEY = "whitelist.file.path";
 
+  public static final String WHITE_LIST_FILE_PATH_KEY = "whitelist.file.path";
   private static final String PROXY_USER_KEY = "user.to.proxy";
   private static Logger logger = Logger.getLogger(Whitelist.class);
 
@@ -43,14 +43,10 @@ public class Whitelist {
 
   /**
    * Creates whitelist instance.
-   *
-   * @param whitelistFilePath
-   * @param fs
-   * @param pollingPeriodSec
    */
   public Whitelist(String whitelistFilePath, FileSystem fs) {
     this.whitelistSet = retrieveWhitelist(fs, new Path(whitelistFilePath));
-    if(logger.isDebugEnabled()) {
+    if (logger.isDebugEnabled()) {
       logger.debug("Whitelist: " + whitelistSet);
     }
   }
@@ -61,7 +57,7 @@ public class Whitelist {
 
   /**
    * Checks if id is in whitelist.
-   * @param id
+   *
    * @throws UnsupportedOperationException if id is not whitelisted
    */
   public void validateWhitelisted(String id) {
@@ -72,34 +68,40 @@ public class Whitelist {
   }
 
   /**
-   * Use proxy user or submit user(if proxy user does not exist) from property and check if it is whitelisted.
-   * @param props
-   * @return
+   * Use proxy user or submit user(if proxy user does not exist) from property and check if it is
+   * whitelisted.
    */
   public void validateWhitelisted(Props props) {
     String id = null;
     if (props.containsKey(PROXY_USER_KEY)) {
       id = props.get(PROXY_USER_KEY);
-      Preconditions.checkArgument(!StringUtils.isEmpty(id), PROXY_USER_KEY + " is required.");
+      Preconditions.checkArgument(
+          !StringUtils.isEmpty(id), PROXY_USER_KEY + " is required.");
     } else if (props.containsKey(CommonJobProperties.SUBMIT_USER)) {
       id = props.get(CommonJobProperties.SUBMIT_USER);
-      Preconditions.checkArgument(!StringUtils.isEmpty(id), CommonJobProperties.SUBMIT_USER + " is required.");
+      Preconditions.checkArgument(!StringUtils.isEmpty(id),
+          CommonJobProperties.SUBMIT_USER + " is required.");
     } else {
-      throw new IllegalArgumentException("Property neither has " + PROXY_USER_KEY + " nor " + CommonJobProperties.SUBMIT_USER);
+      throw new IllegalArgumentException(
+          "Property neither has " + PROXY_USER_KEY + " nor " + CommonJobProperties.SUBMIT_USER);
     }
     validateWhitelisted(id);
   }
 
   /**
-   * Updates whitelist if there's any change. If it needs to update whitelist, it enforces writelock to make sure
+   * Updates whitelist if there's any change. If it needs to update whitelist, it enforces writelock
+   * to make sure
    * there's an exclusive access on shared variables.
-   *
    */
   @VisibleForTesting
   Set<String> retrieveWhitelist(FileSystem fs, Path path) {
     try {
-      Preconditions.checkArgument(fs.exists(path), "File does not exist at " + path);
-      Preconditions.checkArgument(fs.isFile(path), "Whitelist path is not a file. " + path);
+      Preconditions.checkArgument(
+          fs.exists(path), "File does not exist at " + path
+      );
+      Preconditions.checkArgument(
+          fs.isFile(path), "Whitelist path is not a file. " + path
+      );
 
       Set<String> result = Sets.newHashSet();
       try (BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(path),

--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.jobsummary;
 
 import azkaban.executor.ExecutableFlow;
@@ -23,7 +22,6 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.server.session.Session;
-import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Props;
@@ -33,7 +31,6 @@ import azkaban.webapp.plugin.ViewerPlugin;
 import azkaban.webapp.servlet.LoginAbstractAzkabanServlet;
 import azkaban.webapp.servlet.Page;
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -41,23 +38,18 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 
+
 public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
-  private static final String PROXY_USER_SESSION_KEY =
-      "hdfs.browser.proxy.user";
-  private static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM =
-      "hadoop.security.manager.class";
+
   private static final Logger logger = Logger.getLogger(JobSummaryServlet.class);
 
   private final Props props;
   private final File webResourcesPath;
-
   private final String viewerName;
   private final String viewerPath;
 
   private ExecutorManagerAdapter executorManagerAdapter;
   private ProjectManager projectManager;
-
-  private String outputDir;
 
   public JobSummaryServlet(final Props props) {
     this.props = props;
@@ -71,18 +63,6 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
     setResourceDirectory(this.webResourcesPath);
   }
 
-  private Project getProjectByPermission(final int projectId, final User user,
-      final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-    if (project == null) {
-      return null;
-    }
-    if (!hasPermission(project, user, type)) {
-      return null;
-    }
-    return project;
-  }
-
   @Override
   public void init(final ServletConfig config) throws ServletException {
     super.init(config);
@@ -92,7 +72,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
   }
 
   private void handleViewer(final HttpServletRequest req, final HttpServletResponse resp,
-      final Session session) throws ServletException, IOException {
+      final Session session) throws ServletException {
 
     final Page page =
         newPage(req, resp, session,
@@ -138,7 +118,8 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
     }
 
     final int projectId = flow.getProjectId();
-    final Project project = getProjectByPermission(projectId, user, Type.READ);
+    final Project project = filterProjectByPermission(this.projectManager.getProject(projectId),
+        user, Type.READ);
     if (project == null) {
       page.render();
       return;
@@ -153,8 +134,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
   }
 
   private void handleDefault(final HttpServletRequest request,
-      final HttpServletResponse response, final Session session) throws ServletException,
-      IOException {
+      final HttpServletResponse response, final Session session) {
     final Page page =
         newPage(request, response, session,
             "azkaban/viewer/jobsummary/velocity/jobsummary.vm");
@@ -166,8 +146,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
 
   @Override
   protected void handleGet(final HttpServletRequest request,
-      final HttpServletResponse response, final Session session) throws ServletException,
-      IOException {
+      final HttpServletResponse response, final Session session) throws ServletException {
     if (hasParam(request, "execid") && hasParam(request, "jobid")) {
       handleViewer(request, response, session);
     } else {
@@ -177,7 +156,6 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
 
   @Override
   protected void handlePost(final HttpServletRequest request,
-      final HttpServletResponse response, final Session session) throws ServletException,
-      IOException {
+      final HttpServletResponse response, final Session session) {
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
@@ -13,22 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-
 package azkaban.executor;
 
 import azkaban.alert.Alerter;
 import azkaban.utils.Emailer;
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,92 +65,35 @@ public class AlerterHolder {
       return Collections.<String, Alerter>emptyMap();
     }
 
-    final Map<String, Alerter> installedAlerterPlugins =
-        new HashMap<>();
+    final Map<String, Alerter> installedAlerterPlugins = new HashMap<>();
     final ClassLoader parentLoader = getClass().getClassLoader();
     final File[] pluginDirs = alerterPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.isDirectory()) {
-        logger.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          logger.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        logger.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
       final String pluginName = pluginProps.getString("alerter.name");
-      final List<String> extLibClasspath =
+      final List<String> extLibClassPaths =
           pluginProps.getStringList("alerter.external.classpaths",
               (List<String>) null);
 
       final String pluginClass = pluginProps.getString("alerter.class");
       if (pluginClass == null) {
         logger.error("Alerter class is not set.");
+        continue;
       } else {
         logger.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
+      Class<?> alerterClass =
+          PluginUtils.getPluginClass(pluginClass, pluginDir, extLibClassPaths, parentLoader);
 
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            logger.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              logger.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        logger.error("Library path " + propertiesDir + " not found.");
-        continue;
-      }
-
-      Class<?> alerterClass = null;
-      try {
-        alerterClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        logger.error("Class " + pluginClass + " not found.");
+      if (alerterClass == null) {
         continue;
       }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
+
 
 public interface ConnectorParams {
 
@@ -106,6 +106,4 @@ public interface ConnectorParams {
   public static final String STATS_MAP_REPORTINGINTERVAL = "interval";
   public static final String STATS_MAP_CLEANINGINTERVAL = "interval";
   public static final String STATS_MAP_EMITTERNUMINSTANCES = "numInstances";
-
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
@@ -13,12 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.Props;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Base Job
+ */
 public abstract class AbstractJob implements Job {
 
   public static final String JOB_TYPE = "type";
@@ -43,7 +46,7 @@ public abstract class AbstractJob implements Job {
   }
 
   @Override
-  public double getProgress() throws Exception {
+  public double getProgress() {
     return this._progress;
   }
 
@@ -54,6 +57,19 @@ public abstract class AbstractJob implements Job {
   @Override
   public void cancel() throws Exception {
     throw new RuntimeException("Job " + this._id + " does not support cancellation!");
+  }
+
+  @Override
+  public Props getJobGeneratedProperties() {
+    return new Props();
+  }
+
+  @Override
+  public abstract void run() throws Exception;
+
+  @Override
+  public boolean isCanceled() {
+    return false;
   }
 
   public Logger getLog() {
@@ -91,18 +107,4 @@ public abstract class AbstractJob implements Job {
   public void error(final String message, final Throwable t) {
     this._log.error(message, t);
   }
-
-  @Override
-  public Props getJobGeneratedProperties() {
-    return new Props();
-  }
-
-  @Override
-  public abstract void run() throws Exception;
-
-  @Override
-  public boolean isCanceled() {
-    return false;
-  }
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import azkaban.utils.Utils;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,13 +30,13 @@ import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+
 /**
  * A revised process-based job
  */
 public abstract class AbstractProcessJob extends AbstractJob {
 
   public static final String ENV_PREFIX = "env.";
-  public static final String ENV_PREFIX_UCASE = "ENV.";
   public static final String WORKING_DIR = "working.dir";
   public static final String JOB_PROP_ENV = "JOB_PROP_FILE";
   public static final String JOB_NAME_ENV = "JOB_NAME";
@@ -44,40 +44,34 @@ public abstract class AbstractProcessJob extends AbstractJob {
   private static final String SENSITIVE_JOB_PROP_NAME_SUFFIX = "_X";
   private static final String SENSITIVE_JOB_PROP_VALUE_PLACEHOLDER = "[MASKED]";
   private static final String JOB_DUMP_PROPERTIES_IN_LOG = "job.dump.properties";
-  protected final String _jobPath;
-  private final Logger log;
-  protected volatile Props jobProps;
-  protected volatile Props sysProps;
 
-  protected String _cwd;
-
+  private final String jobPath;
+  protected String cwd;
+  private volatile Props jobProps;
+  private volatile Props sysProps;
   private volatile Props generatedProperties;
 
-  protected AbstractProcessJob(final String jobid, final Props sysProps,
-      final Props jobProps, final Logger log) {
-    super(jobid, log);
+  protected AbstractProcessJob(final String jobId, final Props sysProps, final Props jobProps,
+      final Logger log) {
+    super(jobId, log);
 
     this.jobProps = jobProps;
     this.sysProps = sysProps;
-    this._cwd = getWorkingDirectory();
-    this._jobPath = this._cwd;
-
-    this.log = log;
+    this.cwd = getWorkingDirectory();
+    this.jobPath = this.cwd;
   }
 
-  public File createOutputPropsFile(final String id, final String workingDir) {
+  private File createOutputPropsFile(final String id, final String workingDir) {
     this.info("cwd=" + workingDir);
 
-    final File directory = new File(workingDir);
-    File tempFile = null;
     try {
-      tempFile = File.createTempFile(id + "_output_", "_tmp", directory);
+      final File directory = new File(workingDir);
+      final File tempFile = File.createTempFile(id + "_output_", "_tmp", directory);
+      return tempFile;
     } catch (final IOException e) {
       this.error("Failed to create temp output property file :", e);
-      throw new RuntimeException("Failed to create temp output property file ",
-          e);
+      throw new RuntimeException("Failed to create temp output property file ", e);
     }
-    return tempFile;
   }
 
   public Props getJobProps() {
@@ -88,8 +82,19 @@ public abstract class AbstractProcessJob extends AbstractJob {
     return this.sysProps;
   }
 
+  public Props getAllProps() {
+    Props props = new Props();
+    props.putAll(jobProps);
+    props.putAll(sysProps);
+    return appendExtraProps(props);
+  }
+
+  public Props appendExtraProps(Props props) {
+    return props;
+  }
+
   public String getJobPath() {
-    return this._jobPath;
+    return this.jobPath;
   }
 
   protected void resolveProps() {
@@ -116,7 +121,7 @@ public abstract class AbstractProcessJob extends AbstractJob {
         }
         this.info("****** End Job properties  ******");
       } catch (final Exception ex) {
-        this.log.error("failed to log job properties ", ex);
+        this.error("failed to log job properties ", ex);
       }
     }
   }
@@ -134,37 +139,43 @@ public abstract class AbstractProcessJob extends AbstractJob {
   public File[] initPropsFiles() {
     // Create properties file with additionally all input generated properties.
     final File[] files = new File[2];
-    files[0] = createFlattenedPropsFile(this._cwd);
+    files[0] = createFlattenedPropsFile(this.cwd);
 
     this.jobProps.put(ENV_PREFIX + JOB_PROP_ENV, files[0].getAbsolutePath());
     this.jobProps.put(ENV_PREFIX + JOB_NAME_ENV, getId());
 
-    files[1] = this.createOutputPropsFile(getId(), this._cwd);
+    files[1] = createOutputPropsFile(getId(), this.cwd);
     this.jobProps.put(ENV_PREFIX + JOB_OUTPUT_PROP_FILE, files[1].getAbsolutePath());
     return files;
   }
 
   public String getCwd() {
-    return this._cwd;
+    return this.cwd;
   }
 
+  /**
+   * Get Environment Variables from the Job Properties Table
+   *
+   * @return All Job Properties with "env." prefix
+   */
   public Map<String, String> getEnvironmentVariables() {
     final Props props = getJobProps();
     final Map<String, String> envMap = props.getMapByPrefix(ENV_PREFIX);
-    envMap.putAll(props.getMapByPrefix(ENV_PREFIX_UCASE));
     return envMap;
   }
 
+  /**
+   * Get Working Directory from Job Properties when it is presented. Otherwise, the working
+   * directory is the jobPath
+   *
+   * @return working directory property
+   */
   public String getWorkingDirectory() {
-    final String workingDir = getJobProps().getString(WORKING_DIR, this._jobPath);
-    if (workingDir == null) {
-      return "";
-    }
-
-    return workingDir;
+    final String workingDir = getJobProps().getString(WORKING_DIR, this.jobPath);
+    return Utils.ifNull(workingDir, "");
   }
 
-  public Props loadOutputFileProps(final File outputPropertiesFile) {
+  private Props loadOutputFileProps(final File outputPropertiesFile) {
     InputStream reader = null;
     try {
       this.info("output properties file=" + outputPropertiesFile.getAbsolutePath());
@@ -184,12 +195,12 @@ public abstract class AbstractProcessJob extends AbstractJob {
       }
       return outputProps;
     } catch (final FileNotFoundException e) {
-      this.log.info(String.format("File[%s] wasn't found, returning empty props.",
-          outputPropertiesFile));
+      this.info(
+          String.format("File[%s] wasn't found, returning empty props.", outputPropertiesFile));
       return new Props();
     } catch (final Exception e) {
-      this.log.error(
-          "Exception thrown when trying to load output file props.  Returning empty Props instead of failing.  Is this really the best thing to do?",
+      this.error(
+          "Exception thrown when trying to load output file props.  Returning empty Props instead of failing. Is this really the best thing to do?",
           e);
       return new Props();
     } finally {
@@ -197,22 +208,24 @@ public abstract class AbstractProcessJob extends AbstractJob {
     }
   }
 
-  public File createFlattenedPropsFile(final String workingDir) {
-    final File directory = new File(workingDir);
-    File tempFile = null;
+  private File createFlattenedPropsFile(final String workingDir) {
     try {
+      final File directory = new File(workingDir);
       // The temp file prefix must be at least 3 characters.
-      tempFile = File.createTempFile(getId() + "_props_", "_tmp", directory);
+      final File tempFile = File.createTempFile(getId() + "_props_", "_tmp", directory);
       this.jobProps.storeFlattened(tempFile);
+      return tempFile;
     } catch (final IOException e) {
-      throw new RuntimeException("Failed to create temp property file in " + directory, e);
+      throw new RuntimeException("Failed to create temp property file. workingDir = " + workingDir);
     }
-
-    return tempFile;
   }
 
-  public void generateProperties(final File outputFile) {
+  /**
+   * Generate properties from output file and set to props tables
+   *
+   * @param outputFile explain
+   */
+  protected void generateProperties(final File outputFile) {
     this.generatedProperties = loadOutputFileProps(outputFile);
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import azkaban.executor.ExecutionOptions;
@@ -25,6 +24,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class Schedule {
 

--- a/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.server;
 
 import static azkaban.Constants.DEFAULT_PORT_NUMBER;
@@ -152,5 +151,4 @@ public abstract class AzkabanServer {
   public abstract VelocityEngine getVelocityEngine();
 
   public abstract UserManager getUserManager();
-
 }

--- a/azkaban-common/src/main/java/azkaban/server/IMBeanRegistrable.java
+++ b/azkaban-common/src/main/java/azkaban/server/IMBeanRegistrable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+/**
+ * Interface for MBean Registration
+ */
+public interface IMBeanRegistrable {
+
+  MBeanRegistrationManager mbeanRegistrationManager = new MBeanRegistrationManager();
+
+  /**
+   * Function to configure MBean Server
+   */
+  void configureMBeanServer();
+}

--- a/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
+++ b/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A class to manager MBean Registration tasks
+ */
+public class MBeanRegistrationManager {
+  private static final Logger logger = LoggerFactory.getLogger(MBeanRegistrationManager.class);
+
+  private List<ObjectName> registeredMBeans = new ArrayList<>();
+  private MBeanServer mbeanServer = null;
+
+  public void registerMBean(final String name, final Object mbean) {
+    final Class<?> mbeanClass = mbean.getClass();
+    final ObjectName mbeanName;
+    try {
+      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
+      getMbeanServer().registerMBean(mbean, mbeanName);
+      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
+      this.registeredMBeans.add(mbeanName);
+    } catch (final Exception e) {
+      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(), e);
+    }
+  }
+
+  /**
+   * Get Platform MBeanServer Instance
+   * @return platform MBeanServer Instance
+   */
+  public MBeanServer getMbeanServer() {
+    return (mbeanServer == null)
+        ? ManagementFactory.getPlatformMBeanServer()
+        : mbeanServer;
+  }
+
+  /**
+   * Close all registered MBeans
+   */
+  public void closeMBeans() {
+    try {
+      for (final ObjectName name : registeredMBeans) {
+        getMbeanServer().unregisterMBean(name);
+        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
+      }
+    } catch (final Exception e) {
+      logger.error("Failed to cleanup MBeanServer", e);
+    }
+  }
+
+  /**
+   * Get MBean Names
+   * @return list of MBean Names
+   */
+  public List<ObjectName> getMBeanNames() {
+    return registeredMBeans;
+  }
+
+  /**
+   * Get MBeanInfo
+   * @param name mbean Name
+   * @return MBeanInfo
+   */
+  public MBeanInfo getMBeanInfo(final ObjectName name) {
+    try {
+      return getMbeanServer().getMBeanInfo(name);
+    } catch (final Exception e) {
+      logger.error("Load MBean Information Failure", e);
+      return null;
+    }
+  }
+
+  /**
+   * Get MBean Attribute
+   * @param name mbean name
+   * @param attribute attribute name
+   * @return object of MBean Attribute
+   */
+  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
+    try {
+      return getMbeanServer().getAttribute(name, attribute);
+    } catch (final Exception e) {
+      logger.error(
+          "Retrieve MBeanServer attribute Failure. "
+              + "ObjectName = " + name.toString() + ", "
+              + "attribute = " + attribute,
+          e);
+      return null;
+    }
+  }
+
+  /**
+   * Get MBean Result
+   * @param mbeanName mbeanName
+   * @return Map of MBean
+   */
+  public Map<String, Object> getMBeanResult(final String mbeanName) {
+    final Map<String, Object> ret = new HashMap<>();
+    try {
+      final ObjectName name = new ObjectName(mbeanName);
+      final MBeanInfo info = getMBeanInfo(name);
+
+      final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
+      final Map<String, Object> attributes = new TreeMap<>();
+
+      for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
+        final Object obj = getMBeanAttribute(name, attrInfo.getName());
+        attributes.put(attrInfo.getName(), obj);
+      }
+
+      ret.put("attributes", attributes);
+    } catch (final Exception e) {
+      logger.error("Invalid MBean Name. name = " + mbeanName, e);
+      ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
+    }
+
+    return ret;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.trigger.ConditionChecker;
@@ -27,6 +26,7 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class BasicTimeChecker implements ConditionChecker {
 
@@ -215,5 +215,4 @@ public class BasicTimeChecker implements ConditionChecker {
   @Override
   public void setContext(final Map<String, Object> context) {
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.executor.ExecutableFlow;
@@ -31,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
+
 
 public class ExecuteFlowAction implements TriggerAction {
 
@@ -175,11 +175,8 @@ public class ExecuteFlowAction implements TriggerAction {
     if (this.executionOptions != null) {
       jsonObj.put("executionOptions", this.executionOptions.toObject());
     }
-    if (this.executionOptions.getSlaOptions() != null) {
-      final List<Object> slaOptionsObj = new ArrayList<>();
-      for (final SlaOption sla : this.executionOptions.getSlaOptions()) {
-        slaOptionsObj.add(sla.toObject());
-      }
+    List<Object> slaOptionsObj = SlaOption.convertToObjects(this.executionOptions.getSlaOptions());
+    if (slaOptionsObj != null) {
       jsonObj.put("slaOptions", slaOptionsObj);
     }
     return jsonObj;
@@ -229,5 +226,4 @@ public class ExecuteFlowAction implements TriggerAction {
   public String getId() {
     return this.actionId;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -26,10 +25,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,9 +124,9 @@ public class FileIOUtils {
   }
 
   public static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
+    final String containedClassPath = containedClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+    File file = new File(containedClassPath);
 
     if (!file.isDirectory() && file.getName().endsWith(".class")) {
       final String name = containedClass.getName();
@@ -134,8 +137,7 @@ public class FileIOUtils {
       }
       return file.getPath();
     } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
+      return containedClassPath;
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -99,9 +99,9 @@ public class InteractiveTestJob extends AbstractProcessJob {
       return;
     }
 
-    if (this.jobProps.getBoolean("fail", false)) {
-      final int passRetry = this.jobProps.getInt("passRetry", -1);
-      if (passRetry > 0 && passRetry < this.jobProps.getInt(JOB_ATTEMPT)) {
+    if (this.getJobProps().getBoolean("fail", false)) {
+      final int passRetry = this.getJobProps().getInt("passRetry", -1);
+      if (passRetry > 0 && passRetry < this.getJobProps().getInt(JOB_ATTEMPT)) {
         generateProperties(propFiles[1]);
         succeedJob();
       } else {
@@ -112,11 +112,11 @@ public class InteractiveTestJob extends AbstractProcessJob {
       throw new RuntimeException("Forced failure of " + getId());
     }
 
-    boolean succeedAfterSleep = this.jobProps.containsKey("fail");
+    boolean succeedAfterSleep = this.getJobProps().containsKey("fail");
 
     final long waitMillis;
     if (succeedAfterSleep) {
-      waitMillis = this.jobProps.getInt("seconds", 10) * 1000L;
+      waitMillis = this.getJobProps().getInt("seconds", 10) * 1000L;
     } else {
       // this means that job should not exit without external interaction, so exact wait time
       // doesn't matter. have some non-zero value to avoid busy-looping.
@@ -182,7 +182,7 @@ public class InteractiveTestJob extends AbstractProcessJob {
   }
 
   @Override
-  public void cancel() throws InterruptedException {
+  public void cancel() {
     info("Killing job");
     if (!this.ignoreCancel) {
       failJob();

--- a/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import java.io.File;
 import java.util.List;
@@ -43,33 +44,14 @@ public class JavaJob extends JavaProcessJob {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
   }
 
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   @Override
   protected List<String> getClassPaths() {
     final List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
-    final String loggerPath = getSourcePathFromClass(org.apache.log4j.Logger.class);
+    final String loggerPath = FileIOUtils.getSourcePathFromClass(org.apache.log4j.Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static azkaban.Constants.ConfigurationKeys;
@@ -43,6 +42,7 @@ import azkaban.metric.MetricException;
 import azkaban.metric.MetricReportManager;
 import azkaban.metric.inmemoryemitter.InMemoryMetricEmitter;
 import azkaban.metrics.MetricsManager;
+import azkaban.server.IMBeanRegistrable;
 import azkaban.server.AzkabanServer;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
@@ -54,7 +54,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -63,15 +62,10 @@ import java.security.Permission;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
@@ -79,8 +73,9 @@ import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 
+
 @Singleton
-public class AzkabanExecutorServer {
+public class AzkabanExecutorServer implements IMBeanRegistrable {
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
@@ -96,9 +91,6 @@ public class AzkabanExecutorServer {
   private final Props props;
   private final Server server;
   private final Context root;
-
-  private final ArrayList<ObjectName> registeredMBeans = new ArrayList<>();
-  private MBeanServer mbeanServer;
 
   @Inject
   public AzkabanExecutorServer(final Props props,
@@ -365,8 +357,7 @@ public class AzkabanExecutorServer {
       try {
         logger.info("jmxAttributeEmitter: " + jmxAttributeEmitter);
         final Constructor<Props>[] constructors =
-            (Constructor<Props>[]) Class.forName(jmxAttributeEmitter)
-                .getConstructors();
+            (Constructor<Props>[]) Class.forName(jmxAttributeEmitter).getConstructors();
 
         constructors[0].newInstance(props.toProperties());
       } catch (final Exception e) {
@@ -396,70 +387,6 @@ public class AzkabanExecutorServer {
   public FlowRunnerManager getFlowRunnerManager() {
     return this.runnerManager;
   }
-
-  private void configureMBeanServer() {
-    logger.info("Registering MBeans...");
-    this.mbeanServer = ManagementFactory.getPlatformMBeanServer();
-
-    registerMbean("executorJetty", new JmxJettyServer(this.server));
-    registerMbean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
-    registerMbean("jobJMXMBean", JmxJobMBeanManager.getInstance());
-
-    if (JobCallbackManager.isInitialized()) {
-      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
-      registerMbean("jobCallbackJMXMBean",
-          jobCallbackMgr.getJmxJobCallbackMBean());
-    }
-  }
-
-  public void close() {
-    try {
-      for (final ObjectName name : this.registeredMBeans) {
-        this.mbeanServer.unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
-      }
-    } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
-    }
-  }
-
-  private void registerMbean(final String name, final Object mbean) {
-    final Class<?> mbeanClass = mbean.getClass();
-    final ObjectName mbeanName;
-    try {
-      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
-      this.mbeanServer.registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
-      this.registeredMBeans.add(mbeanName);
-    } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(),
-          e);
-    }
-
-  }
-
-  public List<ObjectName> getMbeanNames() {
-    return this.registeredMBeans;
-  }
-
-  public MBeanInfo getMBeanInfo(final ObjectName name) {
-    try {
-      return this.mbeanServer.getMBeanInfo(name);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
-    try {
-      return this.mbeanServer.getAttribute(name, attribute);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
 
   /**
    * Get the hostname
@@ -546,6 +473,22 @@ public class AzkabanExecutorServer {
     this.server.stop();
     this.server.destroy();
     getFlowRunnerManager().shutdownNow();
-    close();
+    this.mbeanRegistrationManager.closeMBeans();
+  }
+
+  @Override
+  public void configureMBeanServer() {
+    logger.info("Registering MBeans...");
+
+    this.mbeanRegistrationManager.registerMBean("executorJetty", new JmxJettyServer(this.server));
+    this.mbeanRegistrationManager
+        .registerMBean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
+    this.mbeanRegistrationManager.registerMBean("jobJMXMBean", JmxJobMBeanManager.getInstance());
+
+    if (JobCallbackManager.isInitialized()) {
+      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
+      this.mbeanRegistrationManager
+          .registerMBean("jobCallbackJMXMBean", jobCallbackMgr.getJmxJobCallbackMBean());
+    }
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.Constants;
@@ -23,16 +22,13 @@ import azkaban.utils.JSONUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+
 
 public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
 
@@ -72,29 +68,12 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
     final Map<String, Object> ret = new HashMap<>();
 
     if (hasParam(req, JMX_GET_MBEANS)) {
-      ret.put("mbeans", this.server.getMbeanNames());
+      ret.put("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
     } else if (hasParam(req, JMX_GET_ALL_MBEAN_ATTRIBUTES)) {
       if (!hasParam(req, JMX_MBEAN)) {
         ret.put("error", "Parameters 'mbean' must be set");
       } else {
-        final String mbeanName = getParam(req, JMX_MBEAN);
-        try {
-          final ObjectName name = new ObjectName(mbeanName);
-          final MBeanInfo info = this.server.getMBeanInfo(name);
-
-          final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-          final Map<String, Object> attributes = new TreeMap<>();
-
-          for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-            final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-            attributes.put(attrInfo.getName(), obj);
-          }
-
-          ret.put("attributes", attributes);
-        } catch (final Exception e) {
-          logger.error(e);
-          ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-        }
+        ret.putAll(this.server.mbeanRegistrationManager.getMBeanResult(getParam(req, JMX_MBEAN)));
       }
     }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -13,16 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.executor.ExecutorInfo;
 import azkaban.utils.JSONUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -83,24 +80,9 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillRemainingMemoryPercent(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_Grep && exists_Meminfo) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c",
-              "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils.runProcess("/bin/bash", "-c",
+            "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
 
         long totalMemory = 0;
         long totalFreeMemory = 0;
@@ -241,23 +223,9 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillCpuUsage(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_LoadAvg) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c", "/bin/cat /proc/loadavg");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils
+            .runProcess("/bin/bash", "-c", "/bin/cat /proc/loadavg");
 
         // process the output from bash call.
         if (output.size() > 0) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
@@ -13,14 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.Status;
 
+
 public class BlockingStatus {
 
-  private static final long WAIT_TIME = 5 * 60 * 1000;
+  private static final long WAIT_TIME = 300000;  // 5 * 60 * 1000
   private final int execId;
   private final String jobId;
   private Status status;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.ExecutableFlow;
@@ -24,9 +23,10 @@ import azkaban.executor.Status;
 import java.util.ArrayList;
 import java.util.Map;
 
+
 public class RemoteFlowWatcher extends FlowWatcher {
 
-  private final static long CHECK_INTERVAL_MS = 60 * 1000;
+  private final static long CHECK_INTERVAL_MS = 60000; // 60 * 1000
 
   private int execId;
   private ExecutorLoader loader;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -35,6 +34,7 @@ import azkaban.jmx.JmxTriggerManager;
 import azkaban.metrics.MetricsManager;
 import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleManager;
+import azkaban.server.IMBeanRegistrable;
 import azkaban.server.AzkabanServer;
 import azkaban.server.session.SessionCache;
 import azkaban.trigger.TriggerManager;
@@ -48,6 +48,7 @@ import azkaban.trigger.builtin.SlaAlertAction;
 import azkaban.trigger.builtin.SlaChecker;
 import azkaban.user.UserManager;
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.StdOutErrRedirect;
@@ -76,11 +77,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -89,8 +86,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -122,7 +117,7 @@ import org.mortbay.thread.QueuedThreadPool;
  * Jetty truststore jetty.trustpassword - Jetty truststore password
  */
 @Singleton
-public class AzkabanWebServer extends AzkabanServer {
+public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable {
 
   public static final String DEFAULT_CONF_PATH = "conf";
   private static final String AZKABAN_ACCESS_LOGGER_NAME =
@@ -146,11 +141,9 @@ public class AzkabanWebServer extends AzkabanServer {
   private final MetricsManager metricsManager;
   private final Props props;
   private final SessionCache sessionCache;
-  private final List<ObjectName> registeredMBeans = new ArrayList<>();
   private final FlowTriggerScheduler scheduler;
   private final FlowTriggerService flowTriggerService;
   private Map<String, TriggerPlugin> triggerPlugins;
-  private MBeanServer mbeanServer;
 
   @Inject
   public AzkabanWebServer(final Props props,
@@ -198,6 +191,7 @@ public class AzkabanWebServer extends AzkabanServer {
       DateTimeZone.setDefault(DateTimeZone.forID(timezone));
       logger.info("Setting timezone to " + timezone);
     }
+
     configureMBeanServer();
   }
 
@@ -307,40 +301,11 @@ public class AzkabanWebServer extends AzkabanServer {
     final ClassLoader parentLoader = AzkabanWebServer.class.getClassLoader();
     final File[] pluginDirs = viewerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        logger.error("Error viewer plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        logger.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          logger.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        logger.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
@@ -349,78 +314,21 @@ public class AzkabanWebServer extends AzkabanServer {
       final String pluginJobTypes = pluginProps.getString("viewer.jobtypes", null);
       final int pluginOrder = pluginProps.getInt("viewer.order", 0);
       final boolean pluginHidden = pluginProps.getBoolean("viewer.hidden", false);
-      final List<String> extLibClasspath =
+      final List<String> extLibClassPaths =
           pluginProps.getStringList("viewer.external.classpaths",
               (List<String>) null);
 
       final String pluginClass = pluginProps.getString("viewer.servlet.class");
       if (pluginClass == null) {
         logger.error("Viewer class is not set.");
+        continue;
       } else {
         logger.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            logger.error(e);
-          }
-        }
-
-        // Load any external libraries.
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            final File extLibFile = new File(pluginDir, extLib);
-            if (extLibFile.exists()) {
-              if (extLibFile.isDirectory()) {
-                // extLibFile is a directory; load all the files in the
-                // directory.
-                final File[] extLibFiles = extLibFile.listFiles();
-                for (int i = 0; i < extLibFiles.length; ++i) {
-                  try {
-                    final URL url = extLibFiles[i].toURI().toURL();
-                    urls.add(url);
-                  } catch (final MalformedURLException e) {
-                    logger.error(e);
-                  }
-                }
-              } else { // extLibFile is a file
-                try {
-                  final URL url = extLibFile.toURI().toURL();
-                  urls.add(url);
-                } catch (final MalformedURLException e) {
-                  logger.error(e);
-                }
-              }
-            } else {
-              logger.error("External library path "
-                  + extLibFile.getAbsolutePath() + " not found.");
-              continue;
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        logger
-            .error("Library path " + libDir.getAbsolutePath() + " not found.");
-        continue;
-      }
-
-      Class<?> viewerClass = null;
-      try {
-        viewerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        logger.error("Class " + pluginClass + " not found.");
+      Class<?> viewerClass =
+          PluginUtils.getPluginClass(pluginClass, pluginDir, extLibClassPaths, parentLoader);
+      if (viewerClass == null) {
         continue;
       }
 
@@ -682,25 +590,26 @@ public class AzkabanWebServer extends AzkabanServer {
     this.triggerPlugins = triggerPlugins;
   }
 
-  private void configureMBeanServer() {
+  @Override
+  public void configureMBeanServer() {
     logger.info("Registering MBeans...");
-    this.mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
-    registerMbean("jetty", new JmxJettyServer(this.server));
-    registerMbean("triggerManager", new JmxTriggerManager(this.triggerManager));
+    this.mbeanRegistrationManager.registerMBean("jetty", new JmxJettyServer(this.server));
+    this.mbeanRegistrationManager.registerMBean("triggerManager", new JmxTriggerManager(this.triggerManager));
 
     if (this.executorManagerAdapter instanceof ExecutorManager) {
-      registerMbean("executorManager",
+      this.mbeanRegistrationManager.registerMBean("executorManager",
           new JmxExecutorManager((ExecutorManager) this.executorManagerAdapter));
     } else if (this.executorManagerAdapter instanceof ExecutionController) {
-      registerMbean("executionController", new JmxExecutionController((ExecutionController) this
-          .executorManagerAdapter));
+      this.mbeanRegistrationManager.registerMBean("executionController",
+          new JmxExecutionController((ExecutionController) this.executorManagerAdapter));
     }
 
     // Register Log4J loggers as JMX beans so the log level can be
     // updated via JConsole or Java VisualVM
     final HierarchyDynamicMBean log4jMBean = new HierarchyDynamicMBean();
-    registerMbean("log4jmxbean", log4jMBean);
+    this.mbeanRegistrationManager.registerMBean("log4jmxbean", log4jMBean);
+
     final ObjectName accessLogLoggerObjName =
         log4jMBean.addLoggerMBean(AZKABAN_ACCESS_LOGGER_NAME);
 
@@ -715,14 +624,7 @@ public class AzkabanWebServer extends AzkabanServer {
   }
 
   public void close() {
-    try {
-      for (final ObjectName name : this.registeredMBeans) {
-        this.mbeanServer.unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
-      }
-    } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
-    }
+    this.mbeanRegistrationManager.closeMBeans();
     this.scheduleManager.shutdown();
     this.executorManagerAdapter.shutdown();
     try {
@@ -732,41 +634,5 @@ public class AzkabanWebServer extends AzkabanServer {
       logger.error(e);
     }
     this.server.destroy();
-  }
-
-  private void registerMbean(final String name, final Object mbean) {
-    final Class<?> mbeanClass = mbean.getClass();
-    final ObjectName mbeanName;
-    try {
-      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
-      this.mbeanServer.registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
-      this.registeredMBeans.add(mbeanName);
-    } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(),
-          e);
-    }
-  }
-
-  public List<ObjectName> getMbeanNames() {
-    return this.registeredMBeans;
-  }
-
-  public MBeanInfo getMBeanInfo(final ObjectName name) {
-    try {
-      return this.mbeanServer.getMBeanInfo(name);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
-    try {
-      return this.mbeanServer.getAttribute(name, attribute);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
@@ -14,19 +14,17 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.webapp.plugin.TriggerPlugin;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +34,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 import org.mortbay.jetty.servlet.Context;
+
 
 public class TriggerPluginLoader {
 
@@ -56,98 +55,34 @@ public class TriggerPluginLoader {
       return new HashMap<>();
     }
 
-    final Map<String, TriggerPlugin> installedTriggerPlugins =
-        new HashMap<>();
+    final Map<String, TriggerPlugin> installedTriggerPlugins = new HashMap<>();
     final ClassLoader parentLoader = AzkabanWebServer.class.getClassLoader();
     final File[] pluginDirs = triggerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        log.error("Error! Trigger plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        log.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          log.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        log.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
       final String pluginName = pluginProps.getString("trigger.name");
-      final List<String> extLibClasspath =
+      final List<String> extLibClassPaths =
           pluginProps.getStringList("trigger.external.classpaths",
               (List<String>) null);
 
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
         log.error("Trigger class is not set.");
-      } else {
-        log.error("Plugin class " + pluginClass);
-      }
-
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            log.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              log.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        log.error("Library path " + propertiesDir + " not found.");
         continue;
+      } else {
+        log.info("Plugin class " + pluginClass);
       }
 
-      Class<?> triggerClass = null;
-      try {
-        triggerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        log.error("Class " + pluginClass + " not found.");
+      Class<?> triggerClass =
+          PluginUtils.getPluginClass(pluginClass, pluginDir, extLibClassPaths, parentLoader);
+      if (triggerClass == null) {
         continue;
       }
 
@@ -157,9 +92,8 @@ public class TriggerPluginLoader {
 
       Constructor<?> constructor = null;
       try {
-        constructor =
-            triggerClass.getConstructor(String.class, Props.class,
-                Context.class, AzkabanWebServer.class);
+        constructor = triggerClass
+            .getConstructor(String.class, Props.class, Context.class, AzkabanWebServer.class);
       } catch (final NoSuchMethodException e) {
         log.error("Constructor not found in " + pluginClass);
         continue;
@@ -167,9 +101,7 @@ public class TriggerPluginLoader {
 
       Object obj = null;
       try {
-        obj =
-            constructor.newInstance(pluginName, pluginProps, root,
-                azkabanWebServer);
+        obj = constructor.newInstance(pluginName, pluginProps, root, azkabanWebServer);
       } catch (final Exception e) {
         log.error(e);
       }
@@ -191,5 +123,4 @@ public class TriggerPluginLoader {
 
     return installedTriggerPlugins;
   }
-
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -293,7 +292,6 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("timezone", TimeZone.getDefault().getID());
     page.add("currentTime", (new DateTime()).getMillis());
     page.add("size", getDisplayExecutionPageSize());
-
     page.add("System", System.class);
     page.add("TimeUtils", TimeUtils.class);
     page.add("WebUtils", WebUtils.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -488,36 +487,12 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final String projectName, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectName);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectName), user, type, ret);
   }
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void ajaxRestartFailed(final HttpServletRequest req,
@@ -550,8 +525,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
     final long startMs = System.currentTimeMillis();
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -562,17 +536,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     resp.setCharacterEncoding("utf-8");
 
     try {
-      final LogData data =
-          this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
@@ -592,8 +558,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private void ajaxFetchJobLogs(final HttpServletRequest req,
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -607,27 +572,33 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     try {
       final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
       if (node == null) {
-        ret.put("error",
-            "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
+        ret.put("error", "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
         return;
       }
 
       final int attempt = this.getIntParam(req, "attempt", node.getAttempt());
-      final LogData data =
-          this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length,
-              attempt);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length, attempt);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
+  }
+
+  private Map<String, Object> appendLogData(final LogData data, final int defaultOffset) {
+    Map<String, Object> parameters = new HashMap<>();
+
+    if (data == null) {
+      parameters.put("length", 0);
+      parameters.put("offset", defaultOffset);
+      parameters.put("data", "");
+    } else {
+      parameters.put("length", data.getLength());
+      parameters.put("offset", data.getOffset());
+      parameters.put("data", StringEscapeUtils.escapeHtml(data.getData()));
+    }
+
+    return parameters;
   }
 
   private void ajaxFetchJobStats(final HttpServletRequest req,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.executor.ConnectorParams;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
@@ -35,17 +33,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 
+
 /**
  * Limited set of jmx calls for when you cannot attach to the jvm
  */
 public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     ConnectorParams {
 
-  /**
-   *
-   */
   private static final long serialVersionUID = 1L;
-
   private static final Logger logger = Logger.getLogger(JMXHttpServlet.class
       .getName());
 
@@ -94,13 +89,13 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         }
         ret = result;
       } else if (JMX_GET_MBEANS.equals(ajax)) {
-        ret.put("mbeans", this.server.getMbeanNames());
+        ret.put("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
       } else if (JMX_GET_MBEAN_INFO.equals(ajax)) {
         if (hasParam(req, JMX_MBEAN)) {
           final String mbeanName = getParam(req, JMX_MBEAN);
           try {
             final ObjectName name = new ObjectName(mbeanName);
-            final MBeanInfo info = this.server.getMBeanInfo(name);
+            final MBeanInfo info = this.server.mbeanRegistrationManager.getMBeanInfo(name);
             ret.put("attributes", info.getAttributes());
             ret.put("description", info.getDescription());
           } catch (final Exception e) {
@@ -119,7 +114,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
           try {
             final ObjectName name = new ObjectName(mbeanName);
-            final Object obj = this.server.getMBeanAttribute(name, attribute);
+            final Object obj = this.server.mbeanRegistrationManager.getMBeanAttribute(name, attribute);
             ret.put("value", obj);
           } catch (final Exception e) {
             logger.error(e);
@@ -130,24 +125,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         if (!hasParam(req, JMX_MBEAN)) {
           ret.put("error", "Parameters 'mbean' must be set");
         } else {
-          final String mbeanName = getParam(req, JMX_MBEAN);
-          try {
-            final ObjectName name = new ObjectName(mbeanName);
-            final MBeanInfo info = this.server.getMBeanInfo(name);
-
-            final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-            final Map<String, Object> attributes = new TreeMap<>();
-
-            for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-              final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-              attributes.put(attrInfo.getName(), obj);
-            }
-
-            ret.put("attributes", attributes);
-          } catch (final Exception e) {
-            logger.error(e);
-            ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-          }
+          ret.putAll(this.server.mbeanRegistrationManager.getMBeanResult(getParam(req, JMX_MBEAN)));
         }
       } else {
         ret.put("commands", new String[]{
@@ -168,7 +146,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/jmxpage.vm");
 
-    page.add("mbeans", this.server.getMbeanNames());
+    page.add("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
 
     final Map<String, Object> executorMBeans = new HashMap<>();
     for (final String hostPort : this.executorManagerAdapter.getAllActiveExecutorServerHosts()) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.Constants;
@@ -54,11 +53,12 @@ import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
-import org.joda.time.Minutes;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
 
+
 public class ScheduleServlet extends LoginAbstractAzkabanServlet {
+
   public static final String PARAM_SLA_EMAILS = "slaEmails";
   public static final String PARAM_SCHEDULE_ID = "scheduleId";
   public static final String PARAM_SETTINGS = "settings";
@@ -194,7 +194,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
       final Map<String, String> settings = getParamGroup(req, PARAM_SETTINGS);
 
       List<SlaOption> slaOptions = new ArrayList<>();
-       for (final String set : settings.keySet()) {
+      for (final String set : settings.keySet()) {
         final SlaOption slaOption;
         try {
           slaOption = parseSlaSetting(settings.get(set), sched.getFlowName(), slaEmails);
@@ -203,7 +203,6 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
         }
         slaOptions.add(slaOption);
       }
-
 
       if (slaOptions.isEmpty()) {
         throw new ScheduleManagerException(
@@ -274,7 +273,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     }
     return null;
 
-    }
+  }
 
   private Duration parseDuration(final String duration) {
     final int hour = Integer.parseInt(duration.split(":")[0]);
@@ -381,19 +380,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put(PARAM_ERROR, "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put(STATUS_ERROR,
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void handleGetAllSchedules(final HttpServletRequest req,


### PR DESCRIPTION
There are no logic changes besides 2 tiny bugfixes, which I will list as below,

Create AbstractHadoopJavaProcessJob class to share common codes which are used by
HadoopHiveJob, HadoopJavaJob, HadoopPigJob & HadoopSparkJob. 

Create AbstractMBeanRegistrableServer class to share common codes which are used by AzkabanExecServer, AzkabanWebServer.

Clean some non-referenced import files to improve the code quality

Remove duplicate code if it can be replaced by FileIOUtils.getSourcePathFromClass() function

Introduce PropsUtils.loadPluginProps() Utility function for removing duplicate code in the following classes (AlerterHolder, AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader)

Add private constructor for PropsUtils class to match the singleton pattern for Utility Class.

Create new PluginUtils class includes getUrls, getURLClassLoader, getPluginClass Utils which are used by AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader.

Add default parameter for Utils.createPeriodString() function, which make it be reusable in Schedule.class, BasicTimeChecker.class, ScheduleServlet.calss

Introduce Props.getMapByPrefix(final String prefix, boolean ignoreCase) function to simplify the AbstractProcessJob.getEnvironmentVariables() function

Introduce SlaOption.convertToObjects static function which can be shared by ExecuteFlowAction.class and Schedule.class

Move check and delete tokenFile logic into the HadoopJobUtils.cancelHadoopTokens Util since it is duplicated in all callers

Create Utils.runProcess Utils to reduce duplicate code in ServerStatisticsServlet class.

Create FilterProjectByPermission function in LoginAbstractAzkabanServlet for making it be reusable in all extended classes.

BUG:

Remove Logger log in AbstractProcessJob since log object has been existed in the parent AbstractJob class.

In both PluginCheckerAndActionsLoader.load() and TriggerPluginLoader.load() function., error log was fired regardless if(pluginClass == null) is true/false. Fix this bug. log.error when (plugClass == null) and skip the following unnecessary logic. log.info when (plugClass != null) and run the following expected logic.

Will Introduce more test cases to cover the logic soon.