### PR TITLE
Fix dynamic job link url

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -802,7 +802,7 @@ public class ExecutorManager extends EventHandler implements
     try {
       while (!finished) {
         final LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
-        if (data != null) {
+        if (data != null && data.getLength() != 0) {
           applicationId = findApplicationIdFromLog(data.getData());
           if (applicationId != null) {
             return applicationId;


### PR DESCRIPTION
When dynamically generating job link url, we need to fetch application id from the log.
If the log data length is 0, meaning there is no new data, we don't need to search for application id again from the log data. 
This is related to PR #1695 