### PR TITLE
Change data type of project_flows.json from BLOB to LONGBLOB

### DIFF
--- a/azkaban-db/src/main/sql/create.project_flows.sql
+++ b/azkaban-db/src/main/sql/create.project_flows.sql
@@ -4,7 +4,7 @@ CREATE TABLE project_flows (
   flow_id       VARCHAR(128),
   modified_time BIGINT NOT NULL,
   encoding_type TINYINT,
-  json          BLOB,
+  json          LONGBLOB,
   PRIMARY KEY (project_id, version, flow_id)
 );
 

--- a/azkaban-db/src/main/sql/upgrade.3.71.1.to.3.72.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.71.1.to.3.72.sql
@@ -1,0 +1,4 @@
+-- DB Migration from 3.71.1 to 3.72
+
+-- PR #???? changes the type of project_flows.json from BLOB to LONGBLOB
+ALTER TABLE project_flows ALTER COLUMN json LONGBLOB;

--- a/azkaban-db/src/main/sql/upgrade.3.71.1.to.3.72.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.71.1.to.3.72.sql
@@ -1,4 +1,4 @@
 -- DB Migration from 3.71.1 to 3.72
 
--- PR #???? changes the type of project_flows.json from BLOB to LONGBLOB
+-- PR #2192 changes the type of project_flows.json from BLOB to LONGBLOB
 ALTER TABLE project_flows ALTER COLUMN json LONGBLOB;


### PR DESCRIPTION
This allows JSON greater than 64kB to be stored for a flow.