### PR TITLE
Remove redundant UNIQUE INDEX declarations in CREATE TABLE statements

### DIFF
--- a/azkaban-db/src/main/sql/create.executors.sql
+++ b/azkaban-db/src/main/sql/create.executors.sql
@@ -3,8 +3,7 @@ CREATE TABLE executors (
   host   VARCHAR(64) NOT NULL,
   port   INT         NOT NULL,
   active BOOLEAN                          DEFAULT FALSE,
-  UNIQUE (host, port),
-  UNIQUE INDEX executor_id (id)
+  UNIQUE (host, port)
 );
 
 CREATE INDEX executor_connection

--- a/azkaban-db/src/main/sql/create.projects.sql
+++ b/azkaban-db/src/main/sql/create.projects.sql
@@ -8,8 +8,7 @@ CREATE TABLE projects (
   last_modified_by VARCHAR(64) NOT NULL,
   description      VARCHAR(2048),
   enc_type         TINYINT,
-  settings_blob    LONGBLOB,
-  UNIQUE INDEX project_id (id)
+  settings_blob    LONGBLOB
 );
 
 CREATE INDEX project_name


### PR DESCRIPTION
The UNIQUE INDEX declarations coincide with the PRIMARY KEY, which is
already constrained to be unique.