### PR TITLE
Implement ability to check executor's capacity before polling for new Dispatching Logic

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -88,11 +88,26 @@ public class Constants {
   // The flow exec id for a flow trigger instance unable to trigger a flow yet
   public static final int FAILED_EXEC_ID = -2;
 
+  // How often executors will poll new executions in Poll Dispatch model
+  public static final int DEFAULT_AZKABAN_POLLING_INTERVAL_MS = 1000;
+
+  // Executors can use cpu load calculated from this period to take/skip polling turns
+  public static final int DEFAULT_AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC = 60;
+
+
   public static class ConfigurationKeys {
 
     // Configures Azkaban to use new polling model for dispatching
     public static final String AZKABAN_POLL_MODEL = "azkaban.poll.model";
     public static final String AZKABAN_POLLING_INTERVAL_MS = "azkaban.polling.interval.ms";
+    public static final String AZKABAN_POLLING_CRITERIA_FLOW_THREADS_AVAILABLE =
+        "azkaban.polling_criteria.flow_threads_available";
+    public static final String AZKABAN_POLLING_CRITERIA_MIN_FREE_MEMORY_GB =
+        "azkaban.polling_criteria.min_free_memory_gb";
+    public static final String AZKABAN_POLLING_CRITERIA_MAX_CPU_UTILIZATION_PCT =
+        "azkaban.polling_criteria.max_cpu_utilization_pct";
+    public static final String AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC =
+        "azkaban.polling_criteria.cpu_load_period_sec";
 
     // Configures properties for Azkaban executor health check
     public static final String AZKABAN_EXECUTOR_HEALTHCHECK_INTERVAL_MIN = "azkaban.executor.healthcheck.interval.min";

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -16,6 +16,7 @@
  */
 package azkaban;
 
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.db.AzkabanDataSource;
 import azkaban.db.H2FileDataSource;
 import azkaban.db.MySQLDataSource;
@@ -28,6 +29,7 @@ import azkaban.spi.StorageException;
 import azkaban.storage.StorageImplementationType;
 import azkaban.trigger.JdbcTriggerImpl;
 import azkaban.trigger.TriggerLoader;
+import azkaban.utils.OsCpuUtil;
 import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -61,6 +63,15 @@ public class AzkabanCommonModule extends AbstractModule {
     bind(TriggerLoader.class).to(JdbcTriggerImpl.class);
     bind(ProjectLoader.class).to(JdbcProjectImpl.class);
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class);
+    bind(OsCpuUtil.class).toProvider(() -> {
+      final int cpuLoadPeriodSec = this.props
+          .getInt(ConfigurationKeys.AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC,
+              Constants.DEFAULT_AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC);
+      final int pollingIntervalMs = this.props
+          .getInt(ConfigurationKeys.AZKABAN_POLLING_INTERVAL_MS,
+              Constants.DEFAULT_AZKABAN_POLLING_INTERVAL_MS);
+      return new OsCpuUtil(Math.max(1, (cpuLoadPeriodSec * 1000) / pollingIntervalMs));
+    });
   }
 
   public Class<? extends Storage> resolveStorageClassType() {

--- a/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
@@ -76,8 +76,11 @@ public class OsCpuUtil {
     if (this.collectedCpuStats.isEmpty()) {
       return -1;
     }
-    final CpuStats oldestCpuStats = this.collectedCpuStats.pollLast();
     final CpuStats newestCpuStats = getCpuStats();
+    if (newestCpuStats == null) {
+      return -1;
+    }
+    final CpuStats oldestCpuStats = this.collectedCpuStats.pollLast();
     this.collectedCpuStats.push(newestCpuStats);
 
     return calcCpuLoad(oldestCpuStats, newestCpuStats);

--- a/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
@@ -1,0 +1,179 @@
+package azkaban.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utility class for getting CPU usage (in percentage)
+ *
+ * CPU information is obtained from /proc/stat, so only Linux systems will support this class
+ *
+ * Assumes frequent calls at regular intervals to {@link #getCpuLoad() getCpuLoad}. The length of
+ * time over which cpu load is calculated can be adjusted with parameter
+ * {@code numCpuStatsToCollect} in the class constructor and how often {@link #getCpuLoad()
+ * getCpuLoad} is called.
+ * Example: if {@link #getCpuLoad() getCpuLoad} is called every second and {@code
+ * numCpuStatsToCollect} is set to 60 then each call to {@link #getCpuLoad() getCpuLoad} returns
+ * the cpu load over the last minute.
+ */
+public class OsCpuUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(OsCpuUtil.class);
+
+  private static final String CPU_STAT_FILE = "/proc/stat";
+
+  private final Deque<CpuStats> collectedCpuStats;
+
+  @Inject
+  public OsCpuUtil(int numCpuStatsToCollect) {
+    if (numCpuStatsToCollect <= 0) {
+      numCpuStatsToCollect = 1;
+    }
+    this.collectedCpuStats = new ArrayDeque<>(numCpuStatsToCollect);
+
+    final CpuStats cpuStats = getCpuStats();
+    if (cpuStats != null) {
+      for (int i = 0; i < numCpuStatsToCollect; i++) {
+        this.collectedCpuStats.push(cpuStats);
+      }
+    }
+  }
+
+  /**
+   * Collects a new cpu stat data point and calculates cpu load with it and the oldest one
+   * collected which is then deleted.
+   *
+   * @return percentage of CPU usage. -1 if there are no cpu stats.
+   */
+  public double getCpuLoad() {
+    if (this.collectedCpuStats.isEmpty()) {
+      return -1;
+    }
+    final CpuStats oldestCpuStats = this.collectedCpuStats.pollLast();
+    final CpuStats newestCpuStats = getCpuStats();
+    this.collectedCpuStats.push(newestCpuStats);
+
+    return calcCpuLoad(oldestCpuStats, newestCpuStats);
+  }
+
+  private double calcCpuLoad(final CpuStats startCpuStats, final CpuStats endCpuStats) {
+    final long startSysUptime = startCpuStats.getSysUptime();
+    final long startTimeCpuIdle = startCpuStats.getTimeCpuIdle();
+    final long endSysUptime = endCpuStats.getSysUptime();
+    final long endTimeCpuIdle = endCpuStats.getTimeCpuIdle();
+
+    if (endSysUptime == startSysUptime) {
+      logger.error("Failed to calculate cpu load: division by zero");
+      return -1.0;
+    }
+    final double percentageCpuIdle =
+        (100.0 * (endTimeCpuIdle - startTimeCpuIdle)) / (endSysUptime - startSysUptime);
+    return 100.0 - percentageCpuIdle;
+  }
+
+  private CpuStats getCpuStats() {
+    if (!Files.isRegularFile(Paths.get(CPU_STAT_FILE))) {
+      // Mac doesn't use proc pseudo files for example.
+      return null;
+    }
+
+    final String cpuLine = getCpuLineFromStatFile();
+    if (cpuLine == null) {
+      return null;
+    }
+
+    return getCpuStatsFromLine(cpuLine);
+  }
+
+  private String getCpuLineFromStatFile() {
+    BufferedReader br = null;
+    try {
+      br = Files.newBufferedReader(Paths.get(CPU_STAT_FILE), StandardCharsets.UTF_8);
+      String line;
+      while ((line = br.readLine()) != null) {
+        // looking for a line starting with "cpu<space>" which aggregates the values in all of
+        // the other "cpuN" lines.
+        if (line.startsWith("cpu ")) {
+          return line;
+        }
+      }
+    } catch (final IOException e) {
+      final String errMsg = "Failed to read cpu stat file: " + CPU_STAT_FILE;
+      logger.error(errMsg, e);
+    } finally {
+      if (br != null) {
+        try {
+          br.close();
+        } catch (final IOException e) {
+          final String errMsg = "Failed to close cpu stat file: " + CPU_STAT_FILE;
+          logger.error(errMsg, e);
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parses cpu usage information from /proc/stat file.
+   * Example of line expected with the meanings of the values below:
+   * cpu  4705  356  584    3699   23    23     0       0     0          0
+   * ---- user nice system idle iowait  irq  softirq steal guest guest_nice
+   *
+   * Method visible within the package for testing purposes.
+   *
+   * @param line the text containing cpu usage statistics
+   * @return CpuStats object. null if there is an error.
+   */
+  CpuStats getCpuStatsFromLine(final String line) {
+    try {
+      final String[] cpuInfo = line.split("\\s+");
+      final long user = Long.parseLong(cpuInfo[1]);
+      final long nice = Long.parseLong(cpuInfo[2]);
+      final long system = Long.parseLong(cpuInfo[3]);
+      final long idle = Long.parseLong(cpuInfo[4]);
+      final long iowait = Long.parseLong(cpuInfo[5]);
+      final long irq = Long.parseLong(cpuInfo[6]);
+      final long softirq = Long.parseLong(cpuInfo[7]);
+      final long steal = Long.parseLong(cpuInfo[8]);
+
+      // guest and guest_nice are counted on user and nice respectively, so don't add them
+      final long totalCpuTime = user + nice + system + idle + iowait + irq + softirq + steal;
+
+      final long idleCpuTime = idle + iowait;
+
+      return new CpuStats(totalCpuTime, idleCpuTime);
+    } catch (final NumberFormatException | ArrayIndexOutOfBoundsException e) {
+      final String errMsg = "Failed to parse cpu stats from line: " + line;
+      logger.error(errMsg, e);
+    }
+    return null;
+  }
+
+  static class CpuStats {
+
+    private final long sysUptime;
+    private final long timeCpuIdle;
+
+    public CpuStats(final long sysUptime, final long timeCpuIdle) {
+      this.sysUptime = sysUptime;
+      this.timeCpuIdle = timeCpuIdle;
+    }
+
+    public long getSysUptime() {
+      return this.sysUptime;
+    }
+
+    public long getTimeCpuIdle() {
+      return this.timeCpuIdle;
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.utils;
 
 import java.io.BufferedReader;

--- a/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsCpuUtil.java
@@ -31,7 +31,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Utility class for getting CPU usage (in percentage)
  *
- * CPU information is obtained from /proc/stat, so only Linux systems will support this class
+ * CPU information is obtained from /proc/stat, so only Linux systems will support this class.
+ * Calculation procedure is taken from:
+ * https://github.com/Leo-G/DevopsWiki/wiki/How-Linux-CPU-Usage-Time-and-Percentage-is-calculated
  *
  * Assumes frequent calls at regular intervals to {@link #getCpuLoad() getCpuLoad}. The length of
  * time over which cpu load is calculated can be adjusted with parameter

--- a/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,8 +23,10 @@ class OsMemoryUtil {
   // This file is used by Linux. It doesn't exist on Mac for example.
   private static final String MEM_INFO_FILE = "/proc/meminfo";
 
-  private static final ImmutableSet<String> MEM_KEYS = ImmutableSet
+  static final ImmutableSet<String> MEM_KEYS = ImmutableSet
       .of("MemFree", "Buffers", "Cached", "SwapFree");
+
+  static final ImmutableSet<String> PHYSICAL_MEM_KEYS = ImmutableSet.of("MemFree");
 
   /**
    * Includes OS cache and free swap.
@@ -32,6 +35,18 @@ class OsMemoryUtil {
    * this memory check.
    */
   long getOsTotalFreeMemorySize() {
+    return getAggregatedFreeMemorySize(MEM_KEYS);
+  }
+
+  /**
+   * @return the free physical memory size of the OS. 0 if there is an error or the OS doesn't
+   * support this memory check.
+   */
+  long getOsFreePhysicalMemorySize() {
+    return getAggregatedFreeMemorySize(PHYSICAL_MEM_KEYS);
+  }
+
+  private long getAggregatedFreeMemorySize(final Set<String> memKeysToCombine) {
     if (!Files.isRegularFile(Paths.get(MEM_INFO_FILE))) {
       // Mac doesn't support /proc/meminfo for example.
       return 0;
@@ -48,19 +63,20 @@ class OsMemoryUtil {
       logger.error(errMsg, e);
       return 0;
     }
-    return getOsTotalFreeMemorySizeFromStrings(lines);
+    return getOsTotalFreeMemorySizeFromStrings(lines, memKeysToCombine);
   }
 
   /**
    * @param lines text lines from the procinfo file
    * @return the total size of free memory in kB. 0 if there is an error.
    */
-  long getOsTotalFreeMemorySizeFromStrings(final List<String> lines) {
+  long getOsTotalFreeMemorySizeFromStrings(final List<String> lines,
+      final Set<String> memKeysToCombine) {
     long totalFree = 0;
     int count = 0;
 
     for (final String line : lines) {
-      for (final String keyName : MEM_KEYS) {
+      for (final String keyName : memKeysToCombine) {
         if (line.startsWith(keyName)) {
           count++;
           final long size = parseMemoryLine(line);
@@ -72,7 +88,7 @@ class OsMemoryUtil {
       }
     }
 
-    final int length = MEM_KEYS.size();
+    final int length = memKeysToCombine.size();
     if (count != length) {
       final String errMsg = String
           .format("Expect %d keys in the meminfo file. Got %d. content: %s", length, count, lines);

--- a/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
@@ -26,7 +26,8 @@ class OsMemoryUtil {
   static final ImmutableSet<String> MEM_KEYS = ImmutableSet
       .of("MemFree", "Buffers", "Cached", "SwapFree");
 
-  static final ImmutableSet<String> PHYSICAL_MEM_KEYS = ImmutableSet.of("MemFree");
+  static final ImmutableSet<String> MEM_AVAILABLE_KEYS = ImmutableSet.of("MemFree", "Active(file)",
+      "Inactive(file)", "SReclaimable");
 
   /**
    * Includes OS cache and free swap.
@@ -43,7 +44,7 @@ class OsMemoryUtil {
    * support this memory check.
    */
   long getOsFreePhysicalMemorySize() {
-    return getAggregatedFreeMemorySize(PHYSICAL_MEM_KEYS);
+    return getAggregatedFreeMemorySize(MEM_AVAILABLE_KEYS);
   }
 
   private long getAggregatedFreeMemorySize(final Set<String> memKeysToCombine) {

--- a/azkaban-common/src/main/java/azkaban/utils/SystemMemoryInfo.java
+++ b/azkaban-common/src/main/java/azkaban/utils/SystemMemoryInfo.java
@@ -48,4 +48,20 @@ public class SystemMemoryInfo {
     }
     return true;
   }
+
+  /**
+   * @param memKb represents a memory value in kb
+   * @return true if available physical memory is greater than memKb
+   *
+   * Verifies if the currently available physical memory is greater than a given value.
+   */
+  public boolean isFreePhysicalMemoryAbove(final long memKb) {
+    final long freeMemSize = this.util.getOsFreePhysicalMemorySize();
+    if (freeMemSize == 0) {
+      // Fail open.
+      // On the platforms that don't support the mem info file, the returned size will be 0.
+      return true;
+    }
+    return freeMemSize - memKb > 0;
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/utils/OsCpuUtilTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/OsCpuUtilTest.java
@@ -1,0 +1,32 @@
+package azkaban.utils;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import azkaban.utils.OsCpuUtil.CpuStats;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OsCpuUtilTest {
+
+  private final OsCpuUtil osCpuUtil = new OsCpuUtil(1);
+
+  @Test
+  public void testGetCpuStatsFromLine() {
+    final String line = "cpu  1     2 4 8    16    32 64 128 256          512 ";
+    final CpuStats cpuStats = this.osCpuUtil.getCpuStatsFromLine(line);
+    assertThat(cpuStats.getSysUptime()).isEqualTo(255);
+    assertThat(cpuStats.getTimeCpuIdle()).isEqualTo(24);
+  }
+
+  @Test
+  public void testGetCpuStatsFromLineWithInvalidInput() {
+    // line with fewer values than expected
+    String line = "cpu  7     4 3 6    2";
+    Assert.assertNull(this.osCpuUtil.getCpuStatsFromLine(line));
+
+    // line with decimal values
+    line = "cpu  7.1     4.2 3 6    2    2 0 0 0";
+    Assert.assertNull(this.osCpuUtil.getCpuStatsFromLine(line));
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/utils/OsMemoryUtilTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/OsMemoryUtilTest.java
@@ -34,7 +34,7 @@ public class OsMemoryUtilTest {
             "SwapFree:    4 kB",
             "Foo: 10 kB");
 
-    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines);
+    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines, OsMemoryUtil.MEM_KEYS);
     assertEquals(10, size);
   }
 
@@ -42,7 +42,7 @@ public class OsMemoryUtilTest {
   public void getOsTotalFreeMemorySizeMissingEntry() {
     final List<String> lines = Arrays.asList("MemFree:        1 kB", "Foo: 10 kB");
 
-    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines);
+    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines, OsMemoryUtil.MEM_KEYS);
     assertEquals(0, size);
   }
 
@@ -50,7 +50,7 @@ public class OsMemoryUtilTest {
   public void getOsTotalFreeMemorySizeWrongEntry() {
     final List<String> lines = Collections.singletonList("MemFree:        foo kB");
 
-    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines);
+    final long size = this.util.getOsTotalFreeMemorySizeFromStrings(lines, OsMemoryUtil.MEM_KEYS);
     assertEquals(0, size);
   }
 


### PR DESCRIPTION
Continues the work started in PR #2038 by providing executors the ability to check their capacity before taking new executions. Capacity is defined as: 
-availability of flow threads at the time of polling (don't enqueue executions in the executor)
-free physical memory available (in Gigabtyes)
-cpu usage (in percentage)

Each criteria can be enabled or disabled through properties in azkaban.properties file. Executors will only poll a new execution when all the configured criteria are satisfied.

**Configurable properties**:
`azkaban.polling_criteria.flow_threads_available` - possible values true or false. if true executors can poll a new execution only when there are flow threads available.

`azkaban.polling_criteria.min_free_memory_gb` - any value > 0. At least this amount of free physical memory needs to be available to allow polling
`azkaban.polling_criteria.max_cpu_utilization_pct` - 0 < value < 100. Cpu load needs to be less than this value to allow polling
`azkaban.polling_criteria.cpu_load_period_sec` - Period of time over which cpu usage is calculated when cpu utilization criteria is enabled.

In all cases criteria will be considered satisfied and polling allowed if properties are not configured or are configured with invalid values.

Using the new dispatch logic without enabling the "flow threads available" criteria can potentially cause issues, so it should probably be required. The rest of the parameters can be enabled as needed. 

**Potential issues**:
-Executors will poll new executions every time if no criteria is configured. When the maximum number of flow threads configured is reached executions are going to be queued in the executor server. Then, if a queued execution is killed from the UI, that execution will remain in "KILLING" state until it gets a thread to run. This can go from minutes to hours depending on the execution's place in the queue and how long it will take for currently running executions to finish. Meanwhile users can only start new executions of the same flow by specifying the "Run concurrently" option which is not always possible.

-Not all flows take the same amount of time to execute, if executions are allowed to be enqueued in the executor server, long running executions may prevent following executions from starting and cause them to remain enqueued for long periods of time even when other executor servers have the capacity (available flow threads) to start them immediately causing unnecessary delays and an increased chance of missing SLAs.