### PR TITLE
 [DEDUPE] Refactor and Deduplicate the common codes NEW REVISION

### DIFF
--- a/az-core/src/main/java/azkaban/utils/PluginUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PluginUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.utils;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
+
+
+public class PluginUtils {
+  private static final Logger logger = Logger.getLogger(PluginUtils.class);
+
+  /**
+   * Private constructor.
+   */
+  private PluginUtils() {
+  }
+
+  /**
+   * Convert a list of files to a list of files' URLs
+   * @param files list of file handles
+   * @return an arrayList of the corresponding files' URLs
+   */
+  public static ArrayList<URL> getUrls(File[] files) {
+    final ArrayList<URL> urls = new ArrayList<>();
+    for (File file : files) {
+      try {
+        final URL url = file.toURI().toURL();
+        urls.add(url);
+      } catch (final MalformedURLException e) {
+        logger.error(e);
+      }
+    }
+    return urls;
+  }
+
+  /**
+   * Get URLClassLoader
+   * @param pluginDir
+   * @param extLibClasspath
+   * @param parentLoader
+   * @return
+   */
+  public static URLClassLoader getURLClassLoader(final File pluginDir, List<String> extLibClasspath, ClassLoader parentLoader) {
+    final File libDir = new File(pluginDir, "lib");
+    if (libDir.exists() && libDir.isDirectory()) {
+      final File[] files = libDir.listFiles();
+      final ArrayList<URL> urls = getUrls(files);
+
+      if (extLibClasspath != null) {
+        for (final String extLib : extLibClasspath) {
+          try {
+            final File extLibFile = new File(pluginDir, extLib);
+            if (extLibFile.exists()) {
+              if (extLibFile.isDirectory()) {
+                // extLibFile is a directory; load all the files in the
+                // directory.
+                final File[] extLibFiles = extLibFile.listFiles();
+                urls.addAll(getUrls(extLibFiles));
+              } else {
+                final URL url = extLibFile.toURI().toURL();
+                urls.add(url);
+              }
+            } else {
+              logger.error("External library path " + extLibFile.getAbsolutePath() + " not found.");
+              return null;
+            }
+          } catch (final MalformedURLException e) {
+            logger.error(e);
+          }
+        }
+      }
+      return new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
+    } else {
+      logger.error("Library path " + libDir + " not found.");
+      return null;
+    }
+  }
+
+  public static Class<?> getPluginClass(final URLClassLoader urlClassLoader, String pluginClass) {
+    if (urlClassLoader == null) {
+      return null;
+    }
+
+    try {
+      return urlClassLoader.loadClass(pluginClass);
+    } catch (final ClassNotFoundException e) {
+      logger.error("Class " + pluginClass + " not found.");
+      return null;
+    }
+  }
+}

--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -743,18 +742,26 @@ public class Props {
   }
 
   /**
-   * Get a map of all properties by string prefix
+   * Get a flattened map of all properties by given prefix
    *
-   * @param prefix The string prefix
+   * @param prefix the prefix string
+   * @return a flattened map with all properties with the given prefix
    */
   public Map<String, String> getMapByPrefix(final String prefix) {
-    final Map<String, String> values = this._parent == null ? new HashMap<>() :
-        this._parent.getMapByPrefix(prefix);
+    final Map<String, String> values = (this._parent == null)
+        ? new HashMap<>()
+        : this._parent.getMapByPrefix(prefix);
 
     // when there is a conflict, value from the child takes the priority.
+    if (prefix == null) { // when prefix is null, return an empty map
+      return values;
+    }
+
     for (final String key : this.localKeySet()) {
-      if (key.startsWith(prefix)) {
-        values.put(key.substring(prefix.length()), get(key));
+      if (key != null && key.length() >= prefix.length()) {
+        if (key.startsWith(prefix)) {
+          values.put(key.substring(prefix.length()), get(key));
+        }
       }
     }
     return values;

--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import com.google.common.collect.MapDifference;
@@ -36,10 +35,16 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
 public class PropsUtils {
-
   private static final Logger logger = Logger.getLogger(PropsUtils.class);
   private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
       .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
+
+  /**
+   * Private constructor.
+   */
+  private PropsUtils() {
+  }
+
 
   /**
    * Load job schedules from the given directories
@@ -90,6 +95,44 @@ public class PropsUtils {
       return props;
     } catch (final IOException e) {
       throw new RuntimeException("Error loading properties.", e);
+    }
+  }
+
+  /**
+   * Load plugin properties
+   * @param pluginDir  plugin's Base Directory
+   * @return The properties
+   */
+  public static Props loadPluginProps(final File pluginDir) {
+    if (!pluginDir.exists()) {
+      logger.error("Error! Plugin path " + pluginDir.getPath() + " doesn't exist.");
+      return null;
+    }
+
+    if (!pluginDir.isDirectory()) {
+      logger.error("The plugin path " + pluginDir + " is not a directory.");
+      return null;
+    }
+
+    final File propertiesDir = new File(pluginDir, "conf");
+    if (propertiesDir.exists() && propertiesDir.isDirectory()) {
+      final File propertiesFile = new File(propertiesDir, "plugin.properties");
+      final File propertiesOverrideFile =
+          new File(propertiesDir, "override.properties");
+
+      if (propertiesFile.exists()) {
+        if (propertiesOverrideFile.exists()) {
+          return loadProps(null, propertiesFile, propertiesOverrideFile);
+        } else {
+          return loadProps(null, propertiesFile);
+        }
+      } else {
+        logger.error("Plugin conf file " + propertiesFile + " not found.");
+        return null;
+      }
+    } else {
+      logger.error("Plugin conf path " + propertiesDir + " not found.");
+      return null;
     }
   }
 

--- a/az-core/src/main/java/azkaban/utils/TimeUtils.java
+++ b/az-core/src/main/java/azkaban/utils/TimeUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.time.Instant;
@@ -169,7 +168,7 @@ public class TimeUtils {
     String periodStr = "null";
 
     if (period == null) {
-      return "null";
+      return periodStr;
     }
 
     if (period.get(DurationFieldType.years()) > 0) {

--- a/az-core/src/test/java/azkaban/utils/UtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/UtilsTest.java
@@ -20,9 +20,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -56,5 +59,12 @@ public class UtilsTest {
         zipFile.delete();
       }
     }
+  }
+
+  @Test
+  public void testRunProcess() throws IOException, InterruptedException {
+    ArrayList<String> result =
+        Utils.runProcess("/bin/bash", "-c", "ls");
+    Assert.assertNotEquals(result.size(), 0);
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.utils.Props;
+import org.apache.log4j.Logger;
+
+
+/**
+ * Abstract Hadoop Java Process Job for Job PlugIn
+ */
+public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implements IHadoopJob {
+
+  public AbstractHadoopJavaProcessJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
+    super(jobid, sysProps, jobProps, logger);
+    hadoopProxy.init(sysProps, jobProps, logger);
+  }
+
+  @Override
+  public void run() throws Exception {
+    try {
+      super.run();
+    } catch (Throwable t) {
+      t.printStackTrace();
+      getLog().error("caught error running the job", t);
+      throw t;
+    } finally {
+      hadoopProxy.cancelHadoopTokens(getLog());
+    }
+  }
+
+  @Override
+  public void setupHadoopJobProperties() {
+    String[] tagKeys = new String[]{
+        CommonJobProperties.EXEC_ID,
+        CommonJobProperties.FLOW_ID,
+        CommonJobProperties.PROJECT_NAME
+    };
+    getJobProps().put(
+        HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
+        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys)
+    );
+  }
+
+  protected String getJVMProxySecureArgument() {
+    return hadoopProxy.getJVMArgument(getSysProps(), getJobProps(), getLog());
+  }
+
+  @Override
+  public Props appendExtraProps(Props props) {
+    HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
+    return props;
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AzkabanPigListener.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AzkabanPigListener.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.IOException;
@@ -49,6 +48,7 @@ import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 
 public class AzkabanPigListener implements PigProgressNotificationListener {
+
   private static Logger logger = Logger.getLogger(AzkabanPigListener.class);
   private String statsFile;
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -15,17 +15,16 @@
  */
 package azkaban.jobtype;
 
-import azkaban.flow.CommonJobProperties;
-import azkaban.utils.Props;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.utils.Props;
 
 
 /**
@@ -40,6 +39,7 @@ import org.apache.log4j.Logger;
  * constructed.
  */
 public class HadoopConfigurationInjector {
+
   private static Logger _logger = Logger.getLogger(HadoopConfigurationInjector.class);
 
   // File to which the Hadoop configuration to inject will be written.
@@ -50,6 +50,7 @@ public class HadoopConfigurationInjector {
 
   public static final String WORKFLOW_ID_SEPERATOR = "$";
   private static final String WORKFLOW_ID_CONFIG = "yarn.workflow.id";
+
   /*
    * To be called by the forked process to load the generated links and Hadoop
    * configuration properties to automatically inject.
@@ -114,7 +115,7 @@ public class HadoopConfigurationInjector {
   }
 
   private static void addHadoopProperty(Props props, String propertyName) {
-      props.put(INJECT_PREFIX + propertyName, props.get(propertyName));
+    props.put(INJECT_PREFIX + propertyName, props.get(propertyName));
   }
 
   private static void addHadoopWorkflowProperty(Props props, String propertyName) {
@@ -142,7 +143,7 @@ public class HadoopConfigurationInjector {
         CommonJobProperties.SUBMIT_USER
     };
 
-    for(String propertyName : propsToInject) {
+    for (String propertyName : propsToInject) {
       addHadoopProperty(props, propertyName);
     }
     addHadoopWorkflowProperty(props, WORKFLOW_ID_CONFIG);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopHiveJob.java
@@ -13,109 +13,45 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.PrivilegedExceptionAction;
+import azkaban.utils.FileIOUtils;
+import azkaban.utils.Utils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
-
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 
-public class HadoopHiveJob extends JavaProcessJob {
 
-  public static final String HIVE_SCRIPT = "hive.script";
+public class HadoopHiveJob extends AbstractHadoopJavaProcessJob {
+
+  private static final String HIVE_SCRIPT = "hive.script";
   private static final String HIVECONF_PARAM_PREFIX = "hiveconf.";
   private static final String HIVEVAR_PARAM_PREFIX = "hivevar.";
-  public static final String HADOOP_SECURE_HIVE_WRAPPER =
+  private static final String HADOOP_SECURE_HIVE_WRAPPER =
       "azkaban.jobtype.HadoopSecureHiveWrapper";
-
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
 
   private boolean debug = false;
 
-  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log)
-      throws IOException {
+  public HadoopHiveJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-
-    shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
-    obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
-
     debug = getJobProps().getBoolean("debug", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-
-    try {
-      super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job");
-      throw new Exception(t);
-    } finally {
-      if (tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -146,25 +82,7 @@ public class HadoopHiveJob extends JavaProcessJob {
       args += " " + typeSysJVMArgs;
     }
 
-    if (shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
 
     return args;
   }
@@ -210,79 +128,42 @@ public class HadoopHiveJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecureHiveWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
+
     List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(HIVE_SCRIPT);
   }
 
-  protected Map<String, String> getHiveConf() {
+  private Map<String, String> getHiveConf() {
     return getJobProps().getMapByPrefix(HIVECONF_PARAM_PREFIX);
   }
 
-  protected Map<String, String> getHiveVar() {
+  private Map<String, String> getHiveVar() {
     return getJobProps().getMapByPrefix(HIVEVAR_PARAM_PREFIX);
   }
 
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   /**
-   * This cancel method, in addition to the default canceling behavior, also kills the MR jobs launched by Hive
+   * This cancel method, in addition to the default canceling behavior, also kills the MR jobs
+   * launched by Hive
    * on Hadoop
    */
   @Override
@@ -291,9 +172,6 @@ public class HadoopHiveJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the Hive launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
@@ -13,19 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.security.PrivilegedExceptionAction;
+import azkaban.utils.FileIOUtils;
+import azkaban.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import java.util.StringTokenizer;
 
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
 import azkaban.flow.CommonJobProperties;
@@ -33,57 +27,20 @@ import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.Props;
 
-public class HadoopJavaJob extends JavaProcessJob {
 
-  public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String CANCEL_METHOD_PARAM = "method.cancel";
-  public static final String PROGRESS_METHOD_PARAM = "method.progress";
+public class HadoopJavaJob extends AbstractHadoopJavaProcessJob {
 
-  public static final String JOB_CLASS = "job.class";
-  public static final String DEFAULT_CANCEL_METHOD = "cancel";
-  public static final String DEFAULT_RUN_METHOD = "run";
-  public static final String DEFAULT_PROGRESS_METHOD = "getProgress";
-
-  private String _runMethod;
-  private String _cancelMethod;
-  private String _progressMethod;
-
+  private String _runMethod = "";
+  private String _cancelMethod = "";
+  private String _progressMethod = "";
   private Object _javaObject = null;
-
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
   private boolean noUserClasspath = false;
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
 
   public HadoopJavaJob(String jobid, Props sysProps, Props jobProps, Logger log)
       throws RuntimeException {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-    shouldProxy =
-        getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING,
-        Boolean.toString(shouldProxy));
-    obtainTokens =
-        getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-            false);
-    noUserClasspath =
-        getSysProps().getBoolean("azkaban.no.user.classpath", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager =
-            HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        e.printStackTrace();
-        throw new RuntimeException("Failed to get hadoop security manager!"
-            + e.getCause());
-      }
-    }
+    noUserClasspath = getSysProps().getBoolean("azkaban.no.user.classpath", false);
   }
 
   @Override
@@ -121,7 +78,7 @@ public class HadoopJavaJob extends JavaProcessJob {
       classPath = new ArrayList<String>();
     }
 
-    classPath.add(getSourcePathFromClass(HadoopJavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopJavaJobRunnerMain.class));
 
     /**
      * Todo kunkun-tang: The legacy code uses a quite outdated method to resolve
@@ -129,116 +86,36 @@ public class HadoopJavaJob extends JavaProcessJob {
      */
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
     // merging classpaths from plugin.properties
-    mergeClassPaths(classPath,
-        getJobProps().getStringList("jobtype.classpath", null, ","));
+    List<String> jobTypeClassPath = getJobProps().getStringList("jobtype.classpath", null, ",");
+    Utils.mergeTypeClassPaths(classPath, jobTypeClassPath, getSysProps().get("plugin.dir"));
+
     // merging classpaths from private.properties
-    mergeClassPaths(classPath,
-        getSysProps().getStringList("jobtype.classpath", null, ","));
+    List<String> sysTypeClassPath = getSysProps().getStringList("jobtype.classpath", null, ",");
+    Utils.mergeTypeClassPaths(classPath, sysTypeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  private void mergeClassPaths(List<String> classPath,
-      List<String> typeClassPath) {
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
-  }
-
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile =
-          HadoopJobUtils
-              .getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-    try {
-      super.run();
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new Exception(e);
-    } finally {
-      if (tokenFile != null) {
-        try {
-          HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy,
-              tokenFile, getLog());
-        } catch (Throwable t) {
-          t.printStackTrace();
-          getLog().error("Failed to cancel tokens.");
-        }
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -264,10 +141,6 @@ public class HadoopJavaJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps,
-        tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -13,17 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import static azkaban.security.commons.SecurityUtils.MAPREDUCE_JOB_CREDENTIALS_BINARY;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Writer;
@@ -54,6 +50,7 @@ import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 
+
 public class HadoopJavaJobRunnerMain {
 
   public static final String JOB_CLASS = "job.class";
@@ -67,8 +64,8 @@ public class HadoopJavaJobRunnerMain {
 
   public static final String CANCEL_METHOD_PARAM = "method.cancel";
   public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String[] PROPS_CLASSES = new String[] {
-      "azkaban.utils.Props", "azkaban.common.utils.Props" };
+  public static final String[] PROPS_CLASSES = new String[]{
+      "azkaban.utils.Props", "azkaban.common.utils.Props"};
 
   private static final Layout DEFAULT_LAYOUT = new PatternLayout("%p %m\n");
 
@@ -194,17 +191,17 @@ public class HadoopJavaJobRunnerMain {
       try {
         final Method generatedPropertiesMethod =
             _javaObject.getClass().getMethod(GET_GENERATED_PROPERTIES_METHOD,
-                new Class<?>[] {});
+                new Class<?>[]{});
         Object outputGendProps =
-            generatedPropertiesMethod.invoke(_javaObject, new Object[] {});
+            generatedPropertiesMethod.invoke(_javaObject, new Object[]{});
 
         if (outputGendProps != null) {
           final Method toPropertiesMethod =
               outputGendProps.getClass().getMethod("toProperties",
-                  new Class<?>[] {});
+                  new Class<?>[]{});
           Properties properties =
               (Properties) toPropertiesMethod.invoke(outputGendProps,
-                  new Object[] {});
+                  new Object[]{});
 
           Props outputProps = new Props(null, properties);
           outputGeneratedProperties(outputProps);
@@ -247,7 +244,7 @@ public class HadoopJavaJobRunnerMain {
   private void runMethod(Object obj, String runMethod)
       throws IllegalAccessException, InvocationTargetException,
       NoSuchMethodException {
-    obj.getClass().getMethod(runMethod, new Class<?>[] {}).invoke(obj);
+    obj.getClass().getMethod(runMethod, new Class<?>[]{}).invoke(obj);
   }
 
   private void outputGeneratedProperties(Props outputProperties) {
@@ -305,7 +302,7 @@ public class HadoopJavaJobRunnerMain {
       } catch (NoSuchMethodException e) {
       }
 
-      if (method != null)
+      if (method != null) {
         try {
           method.invoke(_javaObject);
         } catch (Exception e) {
@@ -313,7 +310,7 @@ public class HadoopJavaJobRunnerMain {
             _logger.error("Cancel method failed! ", e);
           }
         }
-      else {
+      } else {
         throw new RuntimeException("Job " + _jobName
             + " does not have cancel method " + _cancelMethod);
       }
@@ -369,7 +366,7 @@ public class HadoopJavaJobRunnerMain {
       Constructor<?> propsCon =
           getConstructor(propsClass, propsClass, Properties[].class);
       Object props =
-          propsCon.newInstance(null, new Properties[] { properties });
+          propsCon.newInstance(null, new Properties[]{properties});
 
       Constructor<?> con =
           getConstructor(runningClass, String.class, propsClass);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import com.google.common.base.Joiner;
@@ -22,7 +21,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -51,6 +49,7 @@ import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
 
+
 /**
  * <pre>
  * There are many common methods that's required by the Hadoop*Job.java's. They are all consolidated
@@ -63,52 +62,40 @@ import azkaban.utils.Props;
  *
  * </pre>
  *
- *
  * @see azkaban.jobtype.HadoopSparkJob
  * @see HadoopHiveJob
  * @see HadoopPigJob
  * @see HadoopJavaJob
  */
-
 public class HadoopJobUtils {
-  public static String MATCH_ALL_REGEX = ".*";
 
-  public static String MATCH_NONE_REGEX = ".^";
-
+  public static final String MATCH_ALL_REGEX = ".*";
+  public static final String MATCH_NONE_REGEX = ".^";
   public static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM = "hadoop.security.manager.class";
-
   // the regex to look for while looking for application id's in the hadoop log
   public static final Pattern APPLICATION_ID_PATTERN = Pattern
-          .compile("^(application_\\d+_\\d+).*");
-
+      .compile("^(application_\\d+_\\d+).*");
   // Azkaban built in property name
   public static final String JOBTYPE_GLOBAL_JVM_ARGS = "jobtype.global.jvm.args";
-
   // Azkaban built in property name
   public static final String JOBTYPE_JVM_ARGS = "jobtype.jvm.args";
-
   // Azkaban built in property name
   public static final String JVM_ARGS = "jvm.args";
-
   // MapReduce config for specifying additional namenodes for delegation tokens
   public static final String MAPREDUCE_JOB_OTHER_NAMENODES = "mapreduce.job.hdfs-servers";
-
   // MapReduce config for mapreduce job tags
   public static final String MAPREDUCE_JOB_TAGS = "mapreduce.job.tags";
-
   // Azkaban property for listing additional namenodes for delegation tokens
   private static final String OTHER_NAMENODES_PROPERTY = "other_namenodes";
 
   /**
    * Invalidates a Hadoop authentication token file
-   *
-   * @param hadoopSecurityManager
-   * @param userToProxy
-   * @param tokenFile
-   * @param log
    */
   public static void cancelHadoopTokens(HadoopSecurityManager hadoopSecurityManager,
-          String userToProxy, File tokenFile, Logger log) {
+      String userToProxy, File tokenFile, Logger log) {
+    if (tokenFile == null) {
+      return;
+    }
     try {
       hadoopSecurityManager.cancelTokens(tokenFile, userToProxy, log);
     } catch (HadoopSecurityManagerException e) {
@@ -116,34 +103,34 @@ public class HadoopJobUtils {
     } catch (Exception e) {
       log.error(e.getCause() + e.getMessage());
     }
+    if (tokenFile.exists()) {
+      tokenFile.delete();
+    }
   }
 
   /**
    * Based on the HADOOP_SECURITY_MANAGER_CLASS_PARAM setting in the incoming props, finds the
    * correct HadoopSecurityManager Java class
    *
-   * @param props
-   * @param log
    * @return a HadoopSecurityManager object. Will throw exception if any errors occur (including not
-   *         finding a class)
-   * @throws RuntimeException
-   *           : If any errors happen along the way.
+   * finding a class)
+   * @throws RuntimeException : If any errors happen along the way.
    */
   public static HadoopSecurityManager loadHadoopSecurityManager(Props props, Logger log)
-          throws RuntimeException {
+      throws RuntimeException {
 
     Class<?> hadoopSecurityManagerClass = props.getClass(HADOOP_SECURITY_MANAGER_CLASS_PARAM, true,
-            HadoopJobUtils.class.getClassLoader());
+        HadoopJobUtils.class.getClassLoader());
     log.info("Loading hadoop security manager " + hadoopSecurityManagerClass.getName());
     HadoopSecurityManager hadoopSecurityManager = null;
 
     try {
       Method getInstanceMethod = hadoopSecurityManagerClass.getMethod("getInstance", Props.class);
       hadoopSecurityManager = (HadoopSecurityManager) getInstanceMethod.invoke(
-              hadoopSecurityManagerClass, props);
+          hadoopSecurityManagerClass, props);
     } catch (InvocationTargetException e) {
       String errMsg = "Could not instantiate Hadoop Security Manager "
-              + hadoopSecurityManagerClass.getName() + e.getCause();
+          + hadoopSecurityManagerClass.getName() + e.getCause();
       log.error(errMsg);
       throw new RuntimeException(errMsg, e);
     } catch (Exception e) {
@@ -151,7 +138,6 @@ public class HadoopJobUtils {
     }
 
     return hadoopSecurityManager;
-
   }
 
   /**
@@ -159,6 +145,7 @@ public class HadoopJobUtils {
    * calling job is MapReduce-based and so uses the
    * {@link #MAPREDUCE_JOB_OTHER_NAMENODES} from a {@link Configuration} object
    * to get the list of additional namenodes.
+   *
    * @param props Props to add the new Namenode URIs to.
    * @see #addAdditionalNamenodesToProps(Props, String)
    */
@@ -177,9 +164,10 @@ public class HadoopJobUtils {
    * the {@link #OTHER_NAMENODES_PROPERTY} property, from Props and inserts it
    * back with the addition of the the potentially JobType-specific Namenode URIs
    * from additionalNamenodes. Modifies props in-place.
+   *
    * @param props Props to add the new Namenode URIs to.
    * @param additionalNamenodes Comma-separated list of Namenode URIs from which to fetch
-   *                            delegation tokens.
+   * delegation tokens.
    */
   public static void addAdditionalNamenodesToProps(Props props, String additionalNamenodes) {
     String otherNamenodes = props.get(OTHER_NAMENODES_PROPERTY);
@@ -192,15 +180,9 @@ public class HadoopJobUtils {
 
   /**
    * Fetching token with the Azkaban user
-   *
-   * @param hadoopSecurityManager
-   * @param props
-   * @param log
-   * @return
-   * @throws HadoopSecurityManagerException
    */
   public static File getHadoopTokens(HadoopSecurityManager hadoopSecurityManager, Props props,
-          Logger log) throws HadoopSecurityManagerException {
+      Logger log) throws HadoopSecurityManagerException {
 
     File tokenFile = null;
     try {
@@ -222,18 +204,17 @@ public class HadoopJobUtils {
    *
    * </pre>
    *
-   * @param unresolvedJarSpec
    * @return jar file list, comma separated, all .../* expanded into actual jar names in order
-   *
    */
   public static String resolveWildCardForJarSpec(String workingDirectory, String unresolvedJarSpec,
-          Logger log) {
+      Logger log) {
 
     log.debug("resolveWildCardForJarSpec: unresolved jar specification: " + unresolvedJarSpec);
     log.debug("working directory: " + workingDirectory);
 
-    if (unresolvedJarSpec == null || unresolvedJarSpec.isEmpty())
+    if (unresolvedJarSpec == null || unresolvedJarSpec.isEmpty()) {
       return "";
+    }
 
     StringBuilder resolvedJarSpec = new StringBuilder();
 
@@ -291,12 +272,12 @@ public class HadoopJobUtils {
    * @return the resolved actual jar/py file name to execute
    */
   public static String resolveExecutionJarName(String workingDirectory,
-          String userSpecifiedJarName, Logger log) {
+      String userSpecifiedJarName, Logger log) {
 
     if (log.isDebugEnabled()) {
       String debugMsg = String.format(
-              "Resolving execution jar name: working directory: %s,  user specified name: %s",
-              workingDirectory, userSpecifiedJarName);
+          "Resolving execution jar name: working directory: %s,  user specified name: %s",
+          workingDirectory, userSpecifiedJarName);
       log.debug(debugMsg);
     }
 
@@ -315,26 +296,27 @@ public class HadoopJobUtils {
 
     if (log.isDebugEnabled()) {
       String debugMsg = String.format("Resolving execution jar name: dirname: %s, jar name: %s",
-              dirName, jarPrefix);
+          dirName, jarPrefix);
       log.debug(debugMsg);
     }
 
     File[] potentialExecutionJarList;
     try {
-      potentialExecutionJarList = getFilesInFolderByRegex(new File(dirName), jarPrefix + ".*(jar|py)");
+      potentialExecutionJarList = getFilesInFolderByRegex(new File(dirName),
+          jarPrefix + ".*(jar|py)");
     } catch (FileNotFoundException e) {
       throw new IllegalStateException(
-              "execution jar is suppose to be in this folder, but the folder doesn't exist: "
-                      + dirName);
+          "execution jar is suppose to be in this folder, but the folder doesn't exist: "
+              + dirName);
     }
 
     if (potentialExecutionJarList.length == 0) {
       throw new IllegalStateException("unable to find execution jar for Spark at path: "
-              + userSpecifiedJarPath + "*.(jar|py)");
+          + userSpecifiedJarPath + "*.(jar|py)");
     } else if (potentialExecutionJarList.length > 1) {
       throw new IllegalStateException(
-              "I find more than one matching instance of the execution jar at the path, don't know which one to use: "
-                      + userSpecifiedJarPath + "*.(jar|py)");
+          "I find more than one matching instance of the execution jar at the path, don't know which one to use: "
+              + userSpecifiedJarPath + "*.(jar|py)");
     }
 
     String resolvedJarName = potentialExecutionJarList[0].toString();
@@ -343,13 +325,11 @@ public class HadoopJobUtils {
   }
 
   /**
-   *
    * @return a list of files in the given folder that matches the regex. It may be empty, but will
-   *         never return a null
-   * @throws FileNotFoundException
+   * never return a null
    */
   private static File[] getFilesInFolderByRegex(File folder, final String regex)
-          throws FileNotFoundException {
+      throws FileNotFoundException {
     // sanity check
 
     if (!folder.exists()) {
@@ -358,39 +338,43 @@ public class HadoopJobUtils {
     }
     if (!folder.isDirectory()) {
       throw new IllegalStateException(
-              "execution jar is suppose to be in this folder, but the object present is not a directory: "
-                      + folder);
+          "execution jar is suppose to be in this folder, but the object present is not a directory: "
+              + folder);
     }
 
     File[] matchingFiles = folder.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
-        if (name.matches(regex))
+        if (name.matches(regex)) {
           return true;
-        else
+        } else {
           return false;
+        }
       }
     });
 
     if (matchingFiles == null) {
       throw new IllegalStateException(
-              "the File[] matchingFiles variable is null.  This means an IOException occured while doing listFiles.  Please check disk availability and retry again");
+          "the File[] matchingFiles variable is null.  This means an IOException occured while doing listFiles.  Please check disk availability and retry again");
     }
 
     return matchingFiles;
   }
 
-/**
- * This method is a decorator around the KillAllSpawnedHadoopJobs method.
- * This method takes additional parameters to determine whether KillAllSpawnedHadoopJobs needs to be executed
- * using doAs as a different user
- *
- * @param logFilePath Azkaban log file path
- * @param jobProps Azkaban job props
- * @param tokenFile Pass in the tokenFile if value is known.  It is ok to skip if the token file is in the environmental variable
- * @param log a usable logger
- */
-  public static void proxyUserKillAllSpawnedHadoopJobs(final String logFilePath, Props jobProps, File tokenFile, final Logger log) {
+  /**
+   * This method is a decorator around the KillAllSpawnedHadoopJobs method.
+   * This method takes additional parameters to determine whether KillAllSpawnedHadoopJobs needs to
+   * be executed
+   * using doAs as a different user
+   *
+   * @param logFilePath Azkaban log file path
+   * @param jobProps Azkaban job props
+   * @param tokenFile Pass in the tokenFile if value is known.  It is ok to skip if the token file
+   * is in the environmental variable
+   * @param log a usable logger
+   */
+  public static void proxyUserKillAllSpawnedHadoopJobs(final String logFilePath, Props jobProps,
+      File tokenFile, final Logger log) {
     Properties properties = new Properties();
     properties.putAll(jobProps.getFlattened());
 
@@ -420,8 +404,6 @@ public class HadoopJobUtils {
    *
    * Only works with Hadoop2
    *
-   * @param logFilePath
-   * @param log
    * @return a Set<String>. The set will contain the applicationIds that this job tried to kill.
    */
   public static Set<String> killAllSpawnedHadoopJobs(String logFilePath, Logger log) {
@@ -446,7 +428,6 @@ public class HadoopJobUtils {
    * This can be used in conjunction with the @killJobOnCluster method in this file.
    * </pre>
    *
-   * @param logFilePath
    * @return a Set. May be empty, but will never be null
    */
   public static Set<String> findApplicationIdFromLog(String logFilePath, Logger log) {
@@ -458,10 +439,11 @@ public class HadoopJobUtils {
     }
     if (!logFile.isFile()) {
       throw new IllegalArgumentException("the logFilePath specified  is not a valid file: "
-              + logFilePath);
+          + logFilePath);
     }
     if (!logFile.canRead()) {
-      throw new IllegalArgumentException("unable to read the logFilePath specified: " + logFilePath);
+      throw new IllegalArgumentException(
+          "unable to read the logFilePath specified: " + logFilePath);
     }
 
     BufferedReader br = null;
@@ -475,7 +457,7 @@ public class HadoopJobUtils {
 
       // finds all the application IDs
       while ((line = br.readLine()) != null) {
-        String [] inputs = line.split("\\s");
+        String[] inputs = line.split("\\s");
         if (inputs != null) {
           for (String input : inputs) {
             Matcher m = APPLICATION_ID_PATTERN.matcher(input);
@@ -490,8 +472,9 @@ public class HadoopJobUtils {
       log.error("Error while trying to find applicationId for log", e);
     } finally {
       try {
-        if (br != null)
+        if (br != null) {
           br.close();
+        }
       } catch (Exception e) {
         // do nothing
       }
@@ -507,13 +490,9 @@ public class HadoopJobUtils {
    *   If spark job has started, the cancel will hang until the spark job is complete
    *   If the spark job is complete, it will return immediately, with a job not found on job tracker
    * </pre>
-   *
-   * @param applicationId
-   * @throws IOException
-   * @throws YarnException
    */
   public static void killJobOnCluster(String applicationId, Logger log) throws YarnException,
-          IOException {
+      IOException {
 
     YarnConfiguration yarnConf = new YarnConfiguration();
     YarnClient yarnClient = YarnClient.createYarnClient();
@@ -522,7 +501,7 @@ public class HadoopJobUtils {
 
     String[] split = applicationId.split("_");
     ApplicationId aid = ApplicationId.newInstance(Long.parseLong(split[1]),
-            Integer.parseInt(split[2]));
+        Integer.parseInt(split[2]));
 
     log.info("start klling application: " + aid);
     yarnClient.killApplication(aid);
@@ -535,16 +514,14 @@ public class HadoopJobUtils {
    *  String.format("-D%s=%s", key, value);
    * </pre>
    *
-   * @param props
-   * @param key
    * @return will return String.format("-D%s=%s", key, value). Throws RuntimeException if props not
-   *         present
+   * present
    */
   public static String javaOptStringFromAzkabanProps(Props props, String key) {
     String value = props.get(key);
     if (value == null) {
       throw new RuntimeException(String.format("Cannot find property [%s], in azkaban props: [%s]",
-              key, value));
+          key, value));
     }
     return String.format("-D%s=%s", key, value);
   }
@@ -553,24 +530,20 @@ public class HadoopJobUtils {
    * Filter a collection of String commands to match a whitelist regex and not match a blacklist
    * regex.
    *
-   * @param commands
-   *          Collection of commands to be filtered
-   * @param whitelistRegex
-   *          whitelist regex to work as inclusion criteria
-   * @param blacklistRegex
-   *          blacklist regex to work as exclusion criteria
-   * @param log
-   *          logger to report violation
+   * @param commands Collection of commands to be filtered
+   * @param whitelistRegex whitelist regex to work as inclusion criteria
+   * @param blacklistRegex blacklist regex to work as exclusion criteria
+   * @param log logger to report violation
    * @return filtered list of matching. Empty list if no command match all the criteria.
    */
   public static List<String> filterCommands(Collection<String> commands, String whitelistRegex,
-          String blacklistRegex, Logger log) {
+      String blacklistRegex, Logger log) {
     List<String> filteredCommands = new LinkedList<String>();
     Pattern whitelistPattern = Pattern.compile(whitelistRegex);
     Pattern blacklistPattern = Pattern.compile(blacklistRegex);
     for (String command : commands) {
       if (whitelistPattern.matcher(command).matches()
-              && !blacklistPattern.matcher(command).matches()) {
+          && !blacklistPattern.matcher(command).matches()) {
         filteredCommands.add(command);
       } else {
         log.warn(String.format("Removing restricted command: %s", command));
@@ -585,15 +558,14 @@ public class HadoopJobUtils {
    *  String.format("-D%s=%s", key, value);
    * </pre>
    *
-   * @param conf
-   * @param key
    * @return will return String.format("-D%s=%s", key, value). Throws RuntimeException if props not
-   *         present
+   * present
    */
   public static String javaOptStringFromHadoopConfiguration(Configuration conf, String key) {
     String value = conf.get(key);
     if (value == null) {
-      throw new RuntimeException(String.format("Cannot find property [%s], in Hadoop configuration: [%s]",
+      throw new RuntimeException(
+          String.format("Cannot find property [%s], in Hadoop configuration: [%s]",
               key, value));
     }
     return String.format("-D%s=%s", key, value);
@@ -602,7 +574,8 @@ public class HadoopJobUtils {
   /**
    * Construct a CSV of tags for the Hadoop application.
    *
-   * @param List of keys to construct tags from.
+   * @param props job properties
+   * @param keys list of keys to construct tags from.
    * @return a CSV of tags
    */
   public static String constructHadoopTags(Props props, String[] keys) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -13,30 +13,26 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
 
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 import org.apache.pig.PigRunner;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
+
 
 /*
  * need lib:
@@ -46,99 +42,37 @@ import azkaban.utils.StringUtils;
  * HadoopSecurityManager(corresponding version with hadoop)
  * abandon support for pig 0.8 and prior versions. don't see a use case here.
  */
+public class HadoopPigJob extends AbstractHadoopJavaProcessJob {
 
-public class HadoopPigJob extends JavaProcessJob {
-
-  public static final String PIG_SCRIPT = "pig.script";
-  public static final String UDF_IMPORT = "udf.import.list";
-  public static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
-  public static final String DEFAULT_PIG_ADDITIONAL_JARS =
+  private static final String PIG_SCRIPT = "pig.script";
+  private static final String UDF_IMPORT = "udf.import.list";
+  private static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
+  private static final String DEFAULT_PIG_ADDITIONAL_JARS =
       "default.pig.additional.jars";
-  public static final String PIG_PARAM_PREFIX = "param.";
-  public static final String PIG_PARAM_FILES = "paramfile";
-  public static final String HADOOP_UGI = "hadoop.job.ugi";
-  public static final String DEBUG = "debug";
+  private static final String PIG_PARAM_PREFIX = "param.";
+  private static final String PIG_PARAM_FILES = "paramfile";
+  private static final String HADOOP_UGI = "hadoop.job.ugi";
+  private static final String DEBUG = "debug";
 
-  public static String HADOOP_SECURE_PIG_WRAPPER =
+  private static String HADOOP_SECURE_PIG_WRAPPER =
       "azkaban.jobtype.HadoopSecurePigWrapper";
 
-  private String userToProxy = null;
-  private boolean shouldProxy = false;
-  private boolean obtainTokens = false;
-  File tokenFile = null;
-
   private final boolean userPigJar;
-
-  private HadoopSecurityManager hadoopSecurityManager;
-
   private File pigLogFile = null;
 
-  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger log)
-      throws IOException {
+  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, jobProps, log);
-
-    HADOOP_SECURE_PIG_WRAPPER = HadoopSecurePigWrapper.class.getName();
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-    shouldProxy =
-        getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-    getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING,
-        Boolean.toString(shouldProxy));
-    obtainTokens =
-        getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-            false);
+    HADOOP_SECURE_PIG_WRAPPER = HadoopSecurePigWrapper.class.getName();
     userPigJar = getJobProps().getBoolean("use.user.pig.jar", false);
-
-    if (shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        hadoopSecurityManager =
-            HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
   @Override
   public void run() throws Exception {
-    String[] tagKeys = new String[] { CommonJobProperties.EXEC_ID,
-        CommonJobProperties.FLOW_ID, CommonJobProperties.PROJECT_NAME };
-    getJobProps().put(HadoopConfigurationInjector.INJECT_PREFIX
-        + HadoopJobUtils.MAPREDUCE_JOB_TAGS,
-        HadoopJobUtils.constructHadoopTags(getJobProps(), tagKeys));
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
-
-    if (shouldProxy && obtainTokens) {
-      userToProxy = getJobProps().getString("user.to.proxy");
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      HadoopJobUtils.addAdditionalNamenodesToPropsFromMRJob(props, getLog());
-      tokenFile =
-          HadoopJobUtils
-              .getHadoopTokens(hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          tokenFile.getAbsolutePath());
-    }
-    try {
-      super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job", t);
-      throw new Exception(t);
-    } finally {
-      if (tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy,
-            tokenFile, getLog());
-        if (tokenFile.exists()) {
-          tokenFile.delete();
-        }
-      }
-    }
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    super.run();
   }
 
   @Override
@@ -173,38 +107,20 @@ public class HadoopPigJob extends JavaProcessJob {
       args += " -Dhadoop.job.ugi=" + hadoopUGI;
     }
 
-    if (shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
 
     return args;
   }
 
   @Override
   protected String getMainArguments() {
-    ArrayList<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<>();
     Map<String, String> map = getPigParams();
     if (map != null) {
       for (Map.Entry<String, String> entry : map.entrySet()) {
         list.add("-param "
             + StringUtils.shellQuote(entry.getKey() + "=" + entry.getValue(),
-                StringUtils.SINGLE_QUOTE));
+            StringUtils.SINGLE_QUOTE));
       }
     }
 
@@ -243,79 +159,51 @@ public class HadoopPigJob extends JavaProcessJob {
     List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurePigWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurePigWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
     // assuming pig 0.8 and up
     if (!userPigJar) {
-      classPath.add(getSourcePathFromClass(PigRunner.class));
+      classPath.add(FileIOUtils.getSourcePathFromClass(PigRunner.class));
     }
 
     // merging classpaths from plugin.properties
-    mergeClassPaths(classPath,
-        getJobProps().getStringList("jobtype.classpath", null, ","));
+    Utils.mergeTypeClassPaths(classPath,
+        getJobProps().getStringList("jobtype.classpath", null, ","),
+        getSysProps().get("plugin.dir"));
     // merging classpaths from private.properties
-    mergeClassPaths(classPath,
-        getSysProps().getStringList("jobtype.classpath", null, ","));
+    Utils.mergeTypeClassPaths(classPath,
+        getSysProps().getStringList("jobtype.classpath", null, ","),
+        getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
   }
 
-  private void mergeClassPaths(List<String> classPath,
-      List<String> typeClassPath) {
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
-  }
-
-  protected boolean getDebug() {
+  private boolean getDebug() {
     return getJobProps().getBoolean(DEBUG, false);
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(PIG_SCRIPT);
   }
 
-  protected List<String> getUDFImportList() {
-    List<String> udfImports = new ArrayList<String>();
-    List<String> typeImports =
-        getSysProps().getStringList(UDF_IMPORT, null, ",");
-    List<String> jobImports =
-        getJobProps().getStringList(UDF_IMPORT, null, ",");
-    if (typeImports != null) {
-      udfImports.addAll(typeImports);
-    }
-    if (jobImports != null) {
-      udfImports.addAll(jobImports);
-    }
+  private List<String> getUDFImportList() {
+    List<String> udfImports = new ArrayList<>();
+    //append typeImports
+    Utils.mergeStringList(udfImports, getSysProps().getStringList(UDF_IMPORT, null, ","));
+    //append jobImports
+    Utils.mergeStringList(udfImports, getJobProps().getStringList(UDF_IMPORT, null, ","));
     return udfImports;
   }
 
@@ -325,7 +213,7 @@ public class HadoopPigJob extends JavaProcessJob {
    * TODO kunkun-tang: A refactor is necessary here. Recommend using Java Optional to better handle
    * parsing exceptions.
    */
-  protected List<String> getAdditionalJarsList() {
+  private List<String> getAdditionalJarsList() {
 
     List<String> wholeAdditionalJarsList = new ArrayList<>();
 
@@ -354,36 +242,16 @@ public class HadoopPigJob extends JavaProcessJob {
     return wholeAdditionalJarsList;
   }
 
-  protected String getHadoopUGI() {
+  private String getHadoopUGI() {
     return getJobProps().getString(HADOOP_UGI, null);
   }
 
-  protected Map<String, String> getPigParams() {
+  private Map<String, String> getPigParams() {
     return getJobProps().getMapByPrefix(PIG_PARAM_PREFIX);
   }
 
-  protected List<String> getPigParamFiles() {
+  private List<String> getPigParamFiles() {
     return getJobProps().getStringList(PIG_PARAM_FILES, null, ",");
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   /**
@@ -396,10 +264,6 @@ public class HadoopPigJob extends JavaProcessJob {
 
     info("Cancel called.  Killing the Pig launched MR jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps,
-        tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+
+import java.io.File;
+
+import org.apache.log4j.Logger;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.Props;
+
+
+/**
+ * Hadoop Proxy
+ */
+public class HadoopProxy {
+
+  private HadoopSecurityManager hadoopSecurityManager;
+  private boolean shouldProxy = false;
+  private boolean obtainTokens = false;
+  private String userToProxy = null;
+  private File tokenFile = null;
+
+  public HadoopProxy() {
+  }
+
+  public boolean isProxyEnabled() {
+    return this.shouldProxy && this.obtainTokens;
+  }
+
+  /**
+   * Initialize the Hadoop Proxy Object
+   *
+   * @param sysProps system properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void init(Props sysProps, Props jobProps, final Logger logger) {
+    shouldProxy = sysProps.getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
+    jobProps.put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
+    obtainTokens = sysProps.getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+    if (shouldProxy) {
+      logger.info("Initiating hadoop security manager.");
+      try {
+        hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(sysProps, logger);
+      } catch (RuntimeException e) {
+        e.printStackTrace();
+        throw new RuntimeException("Failed to get hadoop security manager!"
+            + e.getCause());
+      }
+    }
+  }
+
+  /**
+   * Setup Job Properties when the proxy is enabled
+   *
+   * @param props all properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void setupPropsForProxy(Props props, Props jobProps, final Logger logger)
+      throws Exception {
+    if (isProxyEnabled()) {
+      userToProxy = jobProps.getString(HadoopSecurityManager.USER_TO_PROXY);
+      logger.info("Need to proxy. Getting tokens.");
+      // get tokens in to a file, and put the location in props
+      tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, logger);
+      jobProps.put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
+    }
+  }
+
+  /**
+   * Generate JVM Proxy Secure Argument
+   *
+   * @param sysProps system properties
+   * @param jobProps job properties
+   * @param logger logger handler
+   * @return proxy secure JVM argument string
+   */
+  public String getJVMArgument(Props sysProps, Props jobProps, final Logger logger) {
+    String secure = "";
+
+    if (shouldProxy) {
+      logger.info("Setting up secure proxy info for child process");
+      secure = " -D" + HadoopSecurityManager.USER_TO_PROXY
+          + "=" + jobProps.getString(HadoopSecurityManager.USER_TO_PROXY);
+
+      String extraToken = sysProps.getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, "false");
+      if (extraToken != null) {
+        secure += " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "=" + extraToken;
+      }
+      logger.info("Secure settings = " + secure);
+    } else {
+      logger.info("Not setting up secure proxy info for child process");
+    }
+
+    return secure;
+  }
+
+  /**
+   * Cancel Hadoop Tokens
+   *
+   * @param logger logger handler
+   */
+  public void cancelHadoopTokens(final Logger logger) {
+    if (tokenFile == null) {
+      return;
+    }
+    try {
+      hadoopSecurityManager.cancelTokens(tokenFile, userToProxy, logger);
+    } catch (HadoopSecurityManagerException e) {
+      logger.error(e.getCause() + e.getMessage());
+    } catch (Exception e) {
+      logger.error(e.getCause() + e.getMessage());
+    }
+    if (tokenFile.exists()) {
+      tokenFile.delete();
+    }
+  }
+
+  /**
+   * Kill all Spawned Hadoop Jobs
+   *
+   * @param jobProps job properties
+   * @param logger logger handler
+   */
+  public void killAllSpawnedHadoopJobs(Props jobProps, final Logger logger) {
+    if (tokenFile == null) {
+      return; // do null check for tokenFile
+    }
+
+    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
+    logger.info("Log file path is: " + logFilePath);
+
+    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, logger);
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureHiveWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureHiveWrapper.java
@@ -43,6 +43,7 @@ import org.apache.log4j.Logger;
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.utils.Props;
 
+
 public class HadoopSecureHiveWrapper {
 
   private static final String DOUBLE_QUOTE_STRING = Character
@@ -108,7 +109,7 @@ public class HadoopSecureHiveWrapper {
 
     OptionsProcessor op = new OptionsProcessor();
 
-    if (!op.process_stage1(new String[] {})) {
+    if (!op.process_stage1(new String[]{})) {
       throw new IllegalArgumentException("Can't process empty args?!?");
     }
 
@@ -174,8 +175,9 @@ public class HadoopSecureHiveWrapper {
    * Also, surround the files with uri niceities.
    */
   static String expandHiveAuxJarsPath(String original) throws IOException {
-    if (original == null || original.contains(".jar"))
+    if (original == null || original.contains(".jar")) {
       return original;
+    }
 
     File[] files = new File(original).listFiles();
 
@@ -193,8 +195,9 @@ public class HadoopSecureHiveWrapper {
     StringBuffer sb = new StringBuffer();
     for (int i = 0; i < files.length; i++) {
       sb.append("file:///").append(files[i].getCanonicalPath());
-      if (i != files.length - 1)
+      if (i != files.length - 1) {
         sb.append(",");
+      }
     }
 
     return sb.toString();
@@ -205,9 +208,6 @@ public class HadoopSecureHiveWrapper {
    * HiveConf
    *
    * An example: -hiveconf 'zipcode=10', -hiveconf hive.root.logger=INFO,console
-   *
-   * @param hiveConf
-   * @param args
    */
   private static void populateHiveConf(HiveConf hiveConf, String[] args) {
 
@@ -261,7 +261,6 @@ public class HadoopSecureHiveWrapper {
   /**
    * Strip single quote or double quote at either end of the string
    *
-   * @param input
    * @return string with w/o leading or trailing single or double quote
    */
   private static String stripSingleDoubleQuote(String input) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
@@ -27,7 +26,6 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
@@ -36,8 +34,8 @@ import org.apache.pig.tools.pigstats.JobStats;
 import org.apache.pig.tools.pigstats.PigStats;
 import org.apache.pig.tools.pigstats.PigStats.JobGraph;
 
-import azkaban.jobExecutor.ProcessJob;
 import azkaban.utils.Props;
+
 
 public class HadoopSecurePigWrapper {
 
@@ -116,8 +114,6 @@ public class HadoopSecurePigWrapper {
 
   /**
    * Dump Hadoop counters for each of the M/R jobs in the given PigStats.
-   *
-   * @param pigStats
    */
   private static void dumpHadoopCounters(PigStats pigStats) {
     try {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.utils.Props;
@@ -42,6 +41,7 @@ import static azkaban.flow.CommonJobProperties.EXECUTION_LINK;
 import static azkaban.flow.CommonJobProperties.JOB_LINK;
 import static azkaban.flow.CommonJobProperties.WORKFLOW_LINK;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+
 
 /**
  * <pre>
@@ -81,9 +81,6 @@ public class HadoopSecureSparkWrapper {
   /**
    * Entry point: a Java wrapper to the spark-submit command
    * Args is built in HadoopSparkJob.
-   *
-   * @param args
-   * @throws Exception
    */
   public static void main(final String[] args) throws Exception {
 
@@ -108,8 +105,6 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * Actually adjusts cmd args based on execution environment and calls the spark-submit command
-   *
-   * @param args
    */
   private static void runSpark(String[] args) {
 
@@ -157,16 +152,17 @@ public class HadoopSecureSparkWrapper {
     // So if user gives --conf spark.driver.extraJavaOptions=XX, we append the value in --driver-java-options
     for (int i = 0; i < argArray.length; i++) {
       if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName)
-        && argArray[i+1].startsWith(SPARK_CONF_EXTRA_DRIVER_OPTIONS)) {
-        driverJavaOptions.append(" ").append(argArray[++i].substring(SPARK_CONF_EXTRA_DRIVER_OPTIONS.length() + 1));
+          && argArray[i + 1].startsWith(SPARK_CONF_EXTRA_DRIVER_OPTIONS)) {
+        driverJavaOptions.append(" ")
+            .append(argArray[++i].substring(SPARK_CONF_EXTRA_DRIVER_OPTIONS.length() + 1));
       }
     }
 
     // Append addtional driver java opts about azkaban context
-    String[] requiredJavaOpts = { WORKFLOW_LINK, JOB_LINK, EXECUTION_LINK, ATTEMPT_LINK };
+    String[] requiredJavaOpts = {WORKFLOW_LINK, JOB_LINK, EXECUTION_LINK, ATTEMPT_LINK};
     for (int i = 0; i < requiredJavaOpts.length; i++) {
-        driverJavaOptions.append(" ").append(HadoopJobUtils.javaOptStringFromHadoopConfiguration(conf,
-                  requiredJavaOpts[i]));
+      driverJavaOptions.append(" ").append(HadoopJobUtils.javaOptStringFromHadoopConfiguration(conf,
+          requiredJavaOpts[i]));
     }
     // Update driver java opts
     argArray[1] = driverJavaOptions.toString();
@@ -179,7 +175,8 @@ public class HadoopSecureSparkWrapper {
     // feature for Spark. This config inside Spark jobtype is to enforce dynamic allocation feature is used for all
     // Spark applications submitted via Azkaban Spark job type.
     String dynamicAllocProp = System.getenv(HadoopSparkJob.SPARK_DYNAMIC_RES_ENV_VAR);
-    boolean dynamicAllocEnabled = dynamicAllocProp != null && dynamicAllocProp.equals(Boolean.TRUE.toString());
+    boolean dynamicAllocEnabled =
+        dynamicAllocProp != null && dynamicAllocProp.equals(Boolean.TRUE.toString());
     if (dynamicAllocEnabled) {
       for (int i = 0; i < argArray.length; i++) {
         if (argArray[i] == null) {
@@ -190,12 +187,15 @@ public class HadoopSecureSparkWrapper {
         // by setting some conf params to false, we need to ignore these settings to enforce the application
         // uses dynamic allocation for spark
         if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) // --conf
-            && (argArray[i + 1].startsWith(SPARK_CONF_SHUFFLE_SERVICE_ENABLED) // spark.shuffle.service.enabled
-            || argArray[i + 1].startsWith(SPARK_CONF_DYNAMIC_ALLOC_ENABLED)) // spark.dynamicAllocation.enabled
-            ) {
+            && (argArray[i + 1].startsWith(SPARK_CONF_SHUFFLE_SERVICE_ENABLED)
+            // spark.shuffle.service.enabled
+            || argArray[i + 1]
+            .startsWith(SPARK_CONF_DYNAMIC_ALLOC_ENABLED)) // spark.dynamicAllocation.enabled
+        ) {
 
           logger.info(
-              "Azbakan enforces dynamic resource allocation. Ignore user param: " + argArray[i] + " " + argArray[i
+              "Azbakan enforces dynamic resource allocation. Ignore user param: " + argArray[i]
+                  + " " + argArray[i
                   + 1]);
           argArray[i] = null;
           argArray[++i] = null;
@@ -209,14 +209,16 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * This method is used to enforce queue for Spark application. Rules are explained below.
-   * a) If dynamic resource allocation is enabled for selected spark version and application requires large container
-   *    then schedule it into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
-   * b) If dynamic resource allocation is enabled for selected spark version and application requires small container
-   *    then schedule it into Org specific queue.
-   * c) If dynamic resource allocation is disabled for selected spark version then schedule application into default
-   *    queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
-   * @param argArray
-   * @return
+   * a) If dynamic resource allocation is enabled for selected spark version and application
+   * requires large container
+   * then schedule it into default queue by a default conf(spark.yarn.queue) in
+   * spark-defaults.conf.
+   * b) If dynamic resource allocation is enabled for selected spark version and application
+   * requires small container
+   * then schedule it into Org specific queue.
+   * c) If dynamic resource allocation is disabled for selected spark version then schedule
+   * application into default
+   * queue by a default conf(spark.yarn.queue) in spark-defaults.conf.
    */
   protected static String[] handleQueueEnforcement(String[] argArray) {
     SparkConf sparkConf = getSparkProperties();
@@ -228,8 +230,9 @@ public class HadoopSecureSparkWrapper {
       if (isLargeContainerRequired(argArray, conf, sparkConf)) {
         // Case A
         requiredSparkDefaultQueue = true;
-        logger.info("Spark application requires Large containers. Scheduling this application into default queue by a "
-            + "default conf(spark.yarn.queue) in spark-defaults.conf.");
+        logger.info(
+            "Spark application requires Large containers. Scheduling this application into default queue by a "
+                + "default conf(spark.yarn.queue) in spark-defaults.conf.");
       } else {
         // Case B
         logger.info(
@@ -244,13 +247,15 @@ public class HadoopSecureSparkWrapper {
       }
     } else {
       // Case C
-      logger.info("Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
-          + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
+      logger.info(
+          "Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
+              + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
       requiredSparkDefaultQueue = true;
     }
 
     if (queueParameterIndex != -1 && requiredSparkDefaultQueue) {
-      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: " + argArray[queueParameterIndex] + " "
+      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: "
+          + argArray[queueParameterIndex] + " "
           + argArray[queueParameterIndex + 1]);
       argArray[queueParameterIndex] = null;
       argArray[queueParameterIndex + 1] = null;
@@ -261,15 +266,15 @@ public class HadoopSecureSparkWrapper {
   /**
    * This method is used to check whether large container is required for application or not.
    * To decide that, it is using parameters like
-   * User Job parameters/default value for : spark.executor.cores, spark.executor.memory, spark.yarn.executor.memoryOverhead
+   * User Job parameters/default value for : spark.executor.cores, spark.executor.memory,
+   * spark.yarn.executor.memoryOverhead
    * Jobtype Plugin parameters: spark.min.mem.vore.ratio, spark.min.memory-gb.size
-   * If rounded memory / spark.executor.cores >= spark.min.mem.vore.ratio or rounded memory >= spark.min.memory-gb.size
+   * If rounded memory / spark.executor.cores >= spark.min.mem.vore.ratio or rounded memory >=
+   * spark.min.memory-gb.size
    * then large container is required to schedule this application.
-   * @param conf
-   * @param sparkConf
-   * @return
    */
-  private static boolean isLargeContainerRequired(String[] argArray, Configuration conf, SparkConf sparkConf) {
+  private static boolean isLargeContainerRequired(String[] argArray, Configuration conf,
+      SparkConf sparkConf) {
     Map<String, String> executorParameters = getUserSpecifiedExecutorParameters(argArray);
     String executorVcore = executorParameters.get(SPARK_EXECUTOR_CORES);
     String executorMem = executorParameters.get(SPARK_EXECUTOR_MEMORY);
@@ -286,11 +291,14 @@ public class HadoopSecureSparkWrapper {
 
     double roundedMemoryGbSize = getRoundedMemoryGb(executorMem, executorMemOverhead, conf);
 
-    double minRatio = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR));
-    double minMemSize = Double.parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
+    double minRatio = Double
+        .parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR));
+    double minMemSize = Double
+        .parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
 
     logger.info(
-        "RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore + ", MinRatio: " + minRatio
+        "RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore
+            + ", MinRatio: " + minRatio
             + ", MinMemSize: " + minMemSize);
     return roundedMemoryGbSize / (double) Integer.parseInt(executorVcore) >= minRatio
         || roundedMemoryGbSize >= minMemSize;
@@ -305,9 +313,11 @@ public class HadoopSecureSparkWrapper {
     Configuration conf = new Configuration();
     boolean nodeLabelingYarn = conf.getBoolean(YARN_CONF_NODE_LABELING_ENABLED, false);
     String nodeLabelingProp = System.getenv(HadoopSparkJob.SPARK_NODE_LABELING_ENV_VAR);
-    boolean nodeLabelingPolicy = nodeLabelingProp != null && nodeLabelingProp.equals(Boolean.TRUE.toString());
+    boolean nodeLabelingPolicy =
+        nodeLabelingProp != null && nodeLabelingProp.equals(Boolean.TRUE.toString());
     String autoNodeLabelProp = System.getenv(HadoopSparkJob.SPARK_AUTO_NODE_LABELING_ENV_VAR);
-    boolean autoNodeLabeling = autoNodeLabelProp != null && autoNodeLabelProp.equals(Boolean.TRUE.toString());
+    boolean autoNodeLabeling =
+        autoNodeLabelProp != null && autoNodeLabelProp.equals(Boolean.TRUE.toString());
     String desiredNodeLabel = System.getenv(HadoopSparkJob.SPARK_DESIRED_NODE_LABEL_ENV_VAR);
 
     SparkConf sparkConf = getSparkProperties();
@@ -330,12 +340,12 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to ignore user specified node label Parameter. When auto node labeling is enabled,
+   * This method is used to ignore user specified node label Parameter. When auto node labeling is
+   * enabled,
    * job type should ignore user supplied node label expression for Spark executors.
-   * @param argArray
-   * @param autoNodeLabeling
    */
-  private static void ignoreUserSpecifiedNodeLabelParameter(String[] argArray, boolean autoNodeLabeling) {
+  private static void ignoreUserSpecifiedNodeLabelParameter(String[] argArray,
+      boolean autoNodeLabeling) {
     for (int i = 0; i < argArray.length; i++) {
       if (argArray[i] == null) {
         continue;
@@ -346,7 +356,8 @@ public class HadoopSecureSparkWrapper {
         if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
             .startsWith(SPARK_EXECUTOR_NODE_LABEL_EXP)) {
           logger.info(
-              "Azbakan auto-sets node label expression. Ignore user param: " + argArray[i] + " " + argArray[i + 1]);
+              "Azbakan auto-sets node label expression. Ignore user param: " + argArray[i] + " "
+                  + argArray[i + 1]);
           argArray[i] = null;
           argArray[++i] = null;
           continue;
@@ -356,10 +367,9 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to get User specified executor parameters. It is capturing executor-memory, executor-cores and
+   * This method is used to get User specified executor parameters. It is capturing executor-memory,
+   * executor-cores and
    * spark.yarn.executor.memoryOverhead.
-   * @param argArray
-   * @return
    */
   private static Map<String, String> getUserSpecifiedExecutorParameters(String[] argArray) {
     Map<String, String> executorParameters = Maps.newHashMap();
@@ -375,7 +385,8 @@ public class HadoopSecureSparkWrapper {
       }
       if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
           .startsWith(SPARK_EXECUTOR_MEMORY_OVERHEAD)) {
-        executorParameters.put(SPARK_EXECUTOR_MEMORY_OVERHEAD, argArray[i + 1].split("=")[1].trim());
+        executorParameters
+            .put(SPARK_EXECUTOR_MEMORY_OVERHEAD, argArray[i + 1].split("=")[1].trim());
       }
     }
     return executorParameters;
@@ -383,8 +394,6 @@ public class HadoopSecureSparkWrapper {
 
   /**
    * This method is used to retrieve index of queue parameter passed by User.
-   * @param argArray
-   * @return
    */
   private static int getUserSpecifiedQueueParameterIndex(String[] argArray) {
     int queueParameterIndex = -1;
@@ -395,7 +404,8 @@ public class HadoopSecureSparkWrapper {
       // Fetch index of queue parameter passed by User.
       // (--queue test or --conf spark.yarn.queue=test)
       if ((argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
-          .startsWith(SPARK_CONF_QUEUE)) || (argArray[i].equals(SparkJobArg.QUEUE.sparkParamName))) {
+          .startsWith(SPARK_CONF_QUEUE)) || (argArray[i]
+          .equals(SparkJobArg.QUEUE.sparkParamName))) {
         queueParameterIndex = i++;
         break;
       }
@@ -404,8 +414,8 @@ public class HadoopSecureSparkWrapper {
   }
 
   /**
-   * This method is used to get Spark properties which will fetch properties from spark-defaults.conf file.
-   * @return
+   * This method is used to get Spark properties which will fetch properties from
+   * spark-defaults.conf file.
    */
   private static SparkConf getSparkProperties() {
     String sparkPropertyFile = HadoopSecureSparkWrapper.class.getClassLoader()
@@ -424,6 +434,7 @@ public class HadoopSecureSparkWrapper {
    * 3) Use the logic inside YARN to round up the container size according to defined min
    * allocation for memory size.
    * 4) Return the memory GB size.
+   *
    * @param mem requested executor memory size, of the format 2G or 1024M
    * @param memOverhead user defined memory overhead
    * @param config Hadoop Configuration object

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -13,10 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -33,6 +30,7 @@ import org.apache.log4j.Logger;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 
+
 /**
  * <pre>
  * There are many common methods that's required by the HadoopSecure*Wrapper.java's. They are all consolidated
@@ -48,20 +46,19 @@ public class HadoopSecureWrapperUtils {
   /**
    * Perform all the magic required to get the proxyUser in a securitized grid
    *
-   * @param userToProxy
    * @return a UserGroupInformation object for the specified userToProxy, which will also contain
-   *         the logged in user's tokens
-   * @throws IOException
+   * the logged in user's tokens
    */
-  private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy, String filelocation, Logger log
-          ) throws IOException {
+  private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy,
+      String filelocation, Logger log
+  ) throws IOException {
 
     if (!new File(filelocation).exists()) {
       throw new RuntimeException("hadoop token file doesn't exist.");
     }
 
     log.info("Found token file.  Setting " + HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY
-            + " to " + filelocation);
+        + " to " + filelocation);
     System.setProperty(HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY, filelocation);
 
     UserGroupInformation loginUser = null;
@@ -82,13 +79,11 @@ public class HadoopSecureWrapperUtils {
    * Sets up the UserGroupInformation proxyUser object so that calling code can do doAs returns null
    * if the jobProps does not call for a proxyUser
    *
-   * @param jobPropsIn
-   * @param tokenFile
-   *          pass tokenFile if known. Pass null if the tokenFile is in the environmental variable
-   *          already.
-   * @param log
+   * @param jobProps job properties
+   * @param tokenFile pass tokenFile if known. Pass null if the tokenFile is in the environmental
+   * variable already.
    * @return returns null if no need to run as proxyUser, otherwise returns valid proxyUser that can
-   *         doAs
+   * doAs
    */
   public static UserGroupInformation setupProxyUser(Properties jobProps,
       String tokenFile, Logger log) {
@@ -125,15 +120,13 @@ public class HadoopSecureWrapperUtils {
     return proxyUser;
   }
 
-   /**
+  /**
    * Loading the properties file, which is a combination of the jobProps file and sysProps file
    *
    * @return a Property file, which is the combination of the jobProps file and sysProps file
-   * @throws IOException
-   * @throws FileNotFoundException
    */
 
-   @SuppressWarnings("DefaultCharset")
+  @SuppressWarnings("DefaultCharset")
   public static Properties loadAzkabanProps() throws IOException, FileNotFoundException {
     String propsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
     Properties props = new Properties();
@@ -145,7 +138,6 @@ public class HadoopSecureWrapperUtils {
    * Looks for particular properties inside the Properties object passed in, and determines whether
    * proxying should happen or not
    *
-   * @param props
    * @return a boolean value of whether the job should proxy or not
    */
   public static boolean shouldProxy(Properties props) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
@@ -13,133 +13,89 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Pattern;
-
 import org.apache.log4j.Logger;
-
-import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.ProcessJob;
-import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.utils.Props;
+
 
 /**
  * HadoopShell is a Hadoop security enabled "command" jobtype. This jobtype
  * adheres to same format and other details as "command" jobtype.
  *
  * @author gaggarwa
- *
  */
-public class HadoopShell extends ProcessJob {
-	private String userToProxy = null;
-	private boolean shouldProxy = false;
-	private boolean obtainTokens = false;
-	private File tokenFile = null;
-	public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
-	public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
-	public static final String WHITELIST_REGEX = "command.whitelist.regex";
-	public static final String BLACKLIST_REGEX = "command.blacklist.regex";
+public class HadoopShell extends ProcessJob implements IHadoopJob {
 
-	private HadoopSecurityManager hadoopSecurityManager;
+  public static final String HADOOP_OPTS = ENV_PREFIX + "HADOOP_OPTS";
+  public static final String HADOOP_GLOBAL_OPTS = "hadoop.global.opts";
+  public static final String WHITELIST_REGEX = "command.whitelist.regex";
+  public static final String BLACKLIST_REGEX = "command.blacklist.regex";
 
-	public HadoopShell(String jobid, Props sysProps, Props jobProps, Logger log) throws RuntimeException {
-		super(jobid, sysProps, jobProps, log);
+  public HadoopShell(String jobid, Props sysProps, Props jobProps, Logger logger)
+      throws RuntimeException {
+    super(jobid, sysProps, jobProps, logger);
+    hadoopProxy.init(sysProps, jobProps, logger);
+  }
 
-		shouldProxy = getSysProps().getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
-		getJobProps().put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
-		obtainTokens = getSysProps().getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+  @Override
+  public void run() throws Exception {
+    setupHadoopJobProperties();
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
 
-		if (shouldProxy) {
-			getLog().info("Initiating hadoop security manager.");
-			try {
-				hadoopSecurityManager = HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-			} catch (RuntimeException e) {
-				e.printStackTrace();
-				throw new RuntimeException("Failed to get hadoop security manager!" + e.getCause());
-			}
-		}
-	}
+    try {
+      super.run();
+    } catch (Throwable e) {
+      e.printStackTrace();
+      getLog().error("caught error running the job");
+      throw e;
+    } finally {
+      hadoopProxy.cancelHadoopTokens(getLog());
+    }
+  }
 
-	@Override
-	public void run() throws Exception {
-		setupHadoopOpts(getJobProps());
-		HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
-		if (shouldProxy && obtainTokens) {
-			userToProxy = getJobProps().getString("user.to.proxy");
-			getLog().info("Need to proxy. Getting tokens.");
-			Props props = new Props();
-			props.putAll(getJobProps());
-			props.putAll(getSysProps());
+  /**
+   * Append HADOOP_GLOBAL_OPTS with HADOOP_OPTS in the given props
+   **/
+  @Override
+  public void setupHadoopJobProperties() {
+    if (getJobProps().containsKey(HADOOP_GLOBAL_OPTS)) {
+      String hadoopGlobalOps = getJobProps().getString(HADOOP_GLOBAL_OPTS);
+      if (getJobProps().containsKey(HADOOP_OPTS)) {
+        String hadoopOps = getJobProps().getString(HADOOP_OPTS);
+        getJobProps().put(HADOOP_OPTS, String.format("%s %s", hadoopOps, hadoopGlobalOps));
+      } else {
+        getJobProps().put(HADOOP_OPTS, hadoopGlobalOps);
+      }
+    }
+  }
 
-			tokenFile = HadoopJobUtils.getHadoopTokens(hadoopSecurityManager, props, getLog());
-			getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION, tokenFile.getAbsolutePath());
-		}
-		try {
-			super.run();
-		} catch (Exception e) {
-			e.printStackTrace();
-			throw new Exception(e);
-		} finally {
-			if (tokenFile != null) {
-				try {
-					HadoopJobUtils.cancelHadoopTokens(hadoopSecurityManager, userToProxy, tokenFile, getLog());
-				} catch (Throwable t) {
-					t.printStackTrace();
-					getLog().error("Failed to cancel tokens.");
-				}
-				if (tokenFile.exists()) {
-					tokenFile.delete();
-				}
-			}
-		}
-	}
+  @Override
+  protected List<String> getCommandList() {
+    // Use the same parsing login as in default "command job";
+    List<String> commands = super.getCommandList();
 
-	/**
-	 * Append HADOOP_GLOBAL_OPTS with HADOOP_OPTS in the given props
-	 *
-	 * @param props
-	 */
-	private void setupHadoopOpts(Props props) {
-		if (props.containsKey(HADOOP_GLOBAL_OPTS)) {
-			String hadoopGlobalOps = props.getString(HADOOP_GLOBAL_OPTS);
-			if (props.containsKey(HADOOP_OPTS)) {
-				String hadoopOps = props.getString(HADOOP_OPTS);
-				props.put(HADOOP_OPTS, String.format("%s %s", hadoopOps, hadoopGlobalOps));
-			} else {
-				props.put(HADOOP_OPTS, hadoopGlobalOps);
-			}
-		}
-	}
+    return HadoopJobUtils.filterCommands(
+        commands,
+        // ".*" will match everything
+        getSysProps().getString(WHITELIST_REGEX, HadoopJobUtils.MATCH_ALL_REGEX),
+        // ".^" will match nothing
+        getSysProps().getString(BLACKLIST_REGEX, HadoopJobUtils.MATCH_NONE_REGEX),
+        getLog()
+    );
+  }
 
-	@Override
-	protected List<String> getCommandList() {
-		// Use the same parsing login as in default "command job";
-		List<String> commands = super.getCommandList();
-		return HadoopJobUtils.filterCommands(commands, getSysProps().getString(WHITELIST_REGEX, HadoopJobUtils.MATCH_ALL_REGEX), // ".*" will match everything
-				getSysProps().getString(BLACKLIST_REGEX, HadoopJobUtils.MATCH_NONE_REGEX), getLog()); // ".^" will match nothing
-	}
-
-	/**
-	 * This cancel method, in addition to the default canceling behavior, also
-	 * kills the MR jobs launched by this job on Hadoop
-	 */
-	@Override
-	public void cancel() throws InterruptedException {
-		super.cancel();
-
-		info("Cancel called.  Killing the launched Hadoop jobs on the cluster");
-
-		final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-		info("Log file path is: " + logFilePath);
-
-		HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, getLog());
-	}
+  /**
+   * This cancel method, in addition to the default canceling behavior, also
+   * kills the MR jobs launched by this job on Hadoop
+   */
+  @Override
+  public void cancel() throws InterruptedException {
+    super.cancel();
+    info("Cancel called.  Killing the launched Hadoop jobs on the cluster");
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
+  }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSparkJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSparkJob.java
@@ -13,18 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
-
-import static azkaban.security.commons.HadoopSecurityManager.ENABLE_PROXYING;
-import static azkaban.security.commons.HadoopSecurityManager.OBTAIN_BINARY_TOKEN;
-import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -35,10 +32,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
 import org.apache.tools.ant.DirectoryScanner;
+
 
 /**
  * <pre>
@@ -80,7 +77,7 @@ import org.apache.tools.ant.DirectoryScanner;
  *                  should set up dynamic allocation properly and set related conf in spark-default.conf)
  *
  * spark.node.labeling.enforced (set to true if we want to enforce node labeling policy.
-  *                 Enabling node labeling policy for spark job type is different from enabling node
+ *                 Enabling node labeling policy for spark job type is different from enabling node
  *                  labeling feature in YARN. This config inside Spark job type is to enforce node
  *                  labeling is used for all Spark applications submitted via Azkaban Spark job type.
  *                  If set to true, our client wrapper will ignore user specified queue. If this
@@ -92,7 +89,7 @@ import org.apache.tools.ant.DirectoryScanner;
  *
  * @see azkaban.jobtype.HadoopSecureSparkWrapper
  */
-public class HadoopSparkJob extends JavaProcessJob {
+public class HadoopSparkJob extends AbstractHadoopJavaProcessJob {
 
   // SPARK_HOME ENV VAR for HadoopSecureSparkWrapper(Spark Client)
   public static final String SPARK_HOME_ENV_VAR = "SPARK_HOME";
@@ -148,39 +145,14 @@ public class HadoopSparkJob extends JavaProcessJob {
   // Spark configuration property to specify additional Namenodes to fetch tokens for
   private static final String SPARK_CONF_ADDITIONAL_NAMENODES = "spark.yarn.access.namenodes";
 
-  // security variables
-  private String userToProxy = null;
-
-  private boolean shouldProxy = false;
-
-  private boolean obtainTokens = false;
-
-  private File tokenFile = null;
-
-  private HadoopSecurityManager hadoopSecurityManager;
 
   public HadoopSparkJob(final String jobid, final Props sysProps, final Props jobProps,
       final Logger log) {
     super(jobid, sysProps, jobProps, log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
-
-    this.shouldProxy = getSysProps().getBoolean(ENABLE_PROXYING, false);
-    getJobProps().put(ENABLE_PROXYING, Boolean.toString(this.shouldProxy));
-    this.obtainTokens = getSysProps().getBoolean(OBTAIN_BINARY_TOKEN, false);
-
-    if (this.shouldProxy) {
-      getLog().info("Initiating hadoop security manager.");
-      try {
-        this.hadoopSecurityManager =
-            HadoopJobUtils.loadHadoopSecurityManager(getSysProps(), log);
-      } catch (final RuntimeException e) {
-        throw new RuntimeException("Failed to get hadoop security manager!" + e);
-      }
-    }
   }
 
-  static String testableGetMainArguments(final Props jobProps, final String workingDir,
+  private static String testableGetMainArguments(final Props jobProps, final String workingDir,
       final Logger log) {
 
     // if we ever need to recreate a failure scenario in the test case
@@ -291,33 +263,14 @@ public class HadoopSparkJob extends JavaProcessJob {
     }
   }
 
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   /**
    * Add additional namenodes specified in the Spark Configuration
    * ({@link #SPARK_CONF_ADDITIONAL_NAMENODES}) to the Props provided.
+   *
    * @param props Props to add additional namenodes to.
    * @see HadoopJobUtils#addAdditionalNamenodesToProps(Props, String)
    */
-  void addAdditionalNamenodesFromConf(final Props props) {
+  private void addAdditionalNamenodesFromConf(final Props props) {
     final String sparkConfDir = getSparkLibConf()[1];
     final File sparkConfFile = new File(sparkConfDir, "spark-defaults.conf");
     try {
@@ -341,25 +294,21 @@ public class HadoopSparkJob extends JavaProcessJob {
   }
 
   @Override
+  public Props appendExtraProps(Props props) {
+    addAdditionalNamenodesFromConf(props);
+    return props;
+  }
+
+  @Override
   public void run() throws Exception {
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
+    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(), getWorkingDirectory());
+    hadoopProxy.setupPropsForProxy(getAllProps(), getJobProps(), getLog());
+    setupHadoopJobProperties();
+    super.run();
+  }
 
-    if (this.shouldProxy && this.obtainTokens) {
-      this.userToProxy = getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      getLog().info("Need to proxy. Getting tokens.");
-      // get tokens in to a file, and put the location in props
-      final Props props = new Props();
-      props.putAll(getJobProps());
-      props.putAll(getSysProps());
-      addAdditionalNamenodesFromConf(props);
-      this.tokenFile =
-          HadoopJobUtils
-              .getHadoopTokens(this.hadoopSecurityManager, props, getLog());
-      getJobProps().put("env." + HADOOP_TOKEN_FILE_LOCATION,
-          this.tokenFile.getAbsolutePath());
-    }
-
+  @Override
+  public void setupHadoopJobProperties() {
     // If we enable dynamic resource allocation or node labeling in jobtype property,
     // then set proper env var for client wrapper(HadoopSecureSparkWrapper) to modify spark job conf
     // before calling spark-submit to enforce every spark job uses dynamic allocation or node labeling
@@ -374,8 +323,9 @@ public class HadoopSparkJob extends JavaProcessJob {
     if (getSysProps().getBoolean(SPARK_AUTO_NODE_LABELING_JOBTYPE_PROPERTY, Boolean.FALSE)) {
       final String desiredNodeLabel = getSysProps().get(SPARK_DESIRED_NODE_LABEL_JOBTYPE_PROPERTY);
       if (desiredNodeLabel == null) {
-        throw new RuntimeException(SPARK_DESIRED_NODE_LABEL_JOBTYPE_PROPERTY  + " must be configured when " +
-            SPARK_AUTO_NODE_LABELING_JOBTYPE_PROPERTY + " is set to true.");
+        throw new RuntimeException(
+            SPARK_DESIRED_NODE_LABEL_JOBTYPE_PROPERTY + " must be configured when " +
+                SPARK_AUTO_NODE_LABELING_JOBTYPE_PROPERTY + " is set to true.");
       }
       getJobProps().put("env." + SPARK_AUTO_NODE_LABELING_ENV_VAR, Boolean.TRUE.toString());
       getJobProps().put("env." + SPARK_DESIRED_NODE_LABEL_ENV_VAR, desiredNodeLabel);
@@ -390,8 +340,9 @@ public class HadoopSparkJob extends JavaProcessJob {
             SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY + " must be configured.");
       }
       if (!NumberUtils.isNumber(minMemVcoreRatio)) {
-        throw new RuntimeException(SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY + " is configured as " +
-            minMemVcoreRatio + ", but it must be a number.");
+        throw new RuntimeException(
+            SPARK_MIN_MEM_VCORE_RATIO_JOBTYPE_PROPERTY + " is configured as " +
+                minMemVcoreRatio + ", but it must be a number.");
       }
       if (!NumberUtils.isNumber(minMemSize)) {
         throw new RuntimeException(SPARK_MIN_MEM_SIZE_JOBTYPE_PROPERTY + " is configured as " +
@@ -399,21 +350,6 @@ public class HadoopSparkJob extends JavaProcessJob {
       }
       getJobProps().put("env." + SPARK_MIN_MEM_VCORE_RATIO_ENV_VAR, minMemVcoreRatio);
       getJobProps().put("env." + SPARK_MIN_MEM_SIZE_ENV_VAR, minMemSize);
-    }
-    try {
-      super.run();
-    } catch (final Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job");
-      throw new Exception(t);
-    } finally {
-      if (this.tokenFile != null) {
-        HadoopJobUtils.cancelHadoopTokens(this.hadoopSecurityManager, this.userToProxy,
-            this.tokenFile, getLog());
-        if (this.tokenFile.exists()) {
-          this.tokenFile.delete();
-        }
-      }
     }
   }
 
@@ -458,25 +394,8 @@ public class HadoopSparkJob extends JavaProcessJob {
       args += " " + typeSysJVMArgs2;
     }
 
-    if (this.shouldProxy) {
-      info("Setting up secure proxy info for child process");
-      String secure;
-      secure =
-          " -D" + HadoopSecurityManager.USER_TO_PROXY + "="
-              + getJobProps().getString(HadoopSecurityManager.USER_TO_PROXY);
-      final String extraToken =
-          getSysProps().getString(HadoopSecurityManager.OBTAIN_BINARY_TOKEN,
-              "false");
-      if (extraToken != null) {
-        secure +=
-            " -D" + HadoopSecurityManager.OBTAIN_BINARY_TOKEN + "="
-                + extraToken;
-      }
-      info("Secure settings = " + secure);
-      args += secure;
-    } else {
-      info("Not setting up secure proxy info for child process");
-    }
+    args += getJVMProxySecureArgument();
+
     return args;
   }
 
@@ -490,16 +409,15 @@ public class HadoopSparkJob extends JavaProcessJob {
   @Override
   protected List<String> getClassPaths() {
     // The classpath for the process that runs HadoopSecureSparkWrapper
-    final String pluginDir = getSysProps().get("plugin.dir");
     final List<String> classPath = super.getClassPaths();
 
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(HadoopSecureHiveWrapper.class));
-    classPath.add(getSourcePathFromClass(HadoopSecurityManager.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecureHiveWrapper.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(HadoopSecurityManager.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
@@ -507,18 +425,8 @@ public class HadoopSparkJob extends JavaProcessJob {
     final List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
     info("Adding jobtype.classpath: " + typeClassPath);
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      for (final String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-        if (!classPath.contains(jarFile.getAbsolutePath())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     // Decide spark home/conf and append Spark classpath for the client.
     final String[] sparkHomeConf = getSparkLibConf();
@@ -529,30 +437,27 @@ public class HadoopSparkJob extends JavaProcessJob {
     final List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
     info("Adding jobtype.global.classpath: " + typeGlobalClassPath);
-    if (typeGlobalClassPath != null) {
-      for (final String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     info("Final classpath: " + classPath);
     return classPath;
   }
 
   /**
-   * This method is used to retrieve Spark home and conf locations. Below logic is mentioned in detail.
+   * This method is used to retrieve Spark home and conf locations. Below logic is mentioned in
+   * detail.
    * a) If user has specified spark version in job property, e.g. spark-version=1.6.0, then
-   *    i) If spark.{sparkVersion}.home is set in commonprivate.properties/private.properties, then that will be returned.
-   *   ii) If spark.{sparkVersion}.home is not set and spark.home.dir is set then it will retrieve Spark directory inside
-   *       spark.home.dir, matching spark.home.prefix + sparkVersion pattern.
-   * b) If user has not specified spark version in job property, use default spark.home configured in the jobtype
-   *    plugin's config
+   * i) If spark.{sparkVersion}.home is set in commonprivate.properties/private.properties, then
+   * that will be returned.
+   * ii) If spark.{sparkVersion}.home is not set and spark.home.dir is set then it will retrieve
+   * Spark directory inside
+   * spark.home.dir, matching spark.home.prefix + sparkVersion pattern.
+   * b) If user has not specified spark version in job property, use default spark.home configured
+   * in the jobtype
+   * plugin's config
    * c) If spark home is not found by both of the above cases, then throw RuntimeException.
-   * @return
    */
-  protected String[] getSparkLibConf() {
+  private String[] getSparkLibConf() {
     String sparkHome = null;
     String sparkConf = null;
     // If user has specified version in job property. e.g. spark-version=1.6.0
@@ -578,7 +483,7 @@ public class HadoopSparkJob extends JavaProcessJob {
         sparkHome = System.getenv(SPARK_HOME_ENV_VAR);
       }
       sparkConf = (System.getenv(SPARK_CONF_DIR_ENV_VAR) != null) ?
-        System.getenv(SPARK_CONF_DIR_ENV_VAR) : (sparkHome + "/conf");
+          System.getenv(SPARK_CONF_DIR_ENV_VAR) : (sparkHome + "/conf");
       info("Using system default spark: " + sparkHome + " and conf: " + sparkConf);
     }
 
@@ -606,12 +511,16 @@ public class HadoopSparkJob extends JavaProcessJob {
 
   /**
    * This method is used to get spark home from plugin's jobtype config.
-   * If spark.{sparkVersion}.home is set in commonprivate.properties/private.properties, then that will be returned.
-   * If spark.{sparkVersion}.home is not set and spark.base.dir is set then it will retrieve Spark directory inside
-   * spark.base.dir, matching spark.home.prefix + sparkVersion pattern. Regex pattern can be passed as properties for
+   * If spark.{sparkVersion}.home is set in commonprivate.properties/private.properties, then that
+   * will be returned.
+   * If spark.{sparkVersion}.home is not set and spark.base.dir is set then it will retrieve Spark
+   * directory inside
+   * spark.base.dir, matching spark.home.prefix + sparkVersion pattern. Regex pattern can be passed
+   * as properties for
    * version formatting.
-   * @param sparkVersion
-   * @return
+   *
+   * @param sparkVersion the version of spark
+   * @return return the spark home
    */
   private String getSparkHome(final String sparkVersion) {
     String sparkHome = getSysProps().get("spark." + sparkVersion + ".home");
@@ -623,11 +532,12 @@ public class HadoopSparkJob extends JavaProcessJob {
       final String replaceTo = getSysProps().get(SPARK_VERSION_REGEX_TO_REPLACE);
       final String replaceWith =
           getSysProps().get(SPARK_VERSION_REGEX_TO_REPLACE_WITH) != null ? getSysProps()
-          .get(SPARK_VERSION_REGEX_TO_REPLACE_WITH) : "";
+              .get(SPARK_VERSION_REGEX_TO_REPLACE_WITH) : "";
       final String versionPatterToMatch =
-          sparkHomePrefix + ( replaceTo != null ? sparkVersion
+          sparkHomePrefix + (replaceTo != null ? sparkVersion
               .replace(replaceTo, replaceWith) : sparkVersion) + "*";
-      info("Looking for spark at  " + sparkDir + " directory with " + sparkHomePrefix + " prefix for " + sparkVersion
+      info("Looking for spark at  " + sparkDir + " directory with " + sparkHomePrefix
+          + " prefix for " + sparkVersion
           + " version.");
       final DirectoryScanner scanner = new DirectoryScanner();
       scanner.setBasedir(sparkDir);
@@ -640,8 +550,8 @@ public class HadoopSparkJob extends JavaProcessJob {
         final String sparkReferenceDoc = getSysProps().get(SPARK_REFERENCE_DOCUMENT);
         final String exceptionMessage =
             sparkReferenceDoc == null ? "SPARK version specified by User is not available."
-            : "SPARK version specified by User is not available. Available versions are mentioned at: "
-                + sparkReferenceDoc;
+                : "SPARK version specified by User is not available. Available versions are mentioned at: "
+                    + sparkReferenceDoc;
         throw new RuntimeException(exceptionMessage);
       }
     }
@@ -652,6 +562,7 @@ public class HadoopSparkJob extends JavaProcessJob {
    * Given the dir path of Spark Home, return the dir path of Spark lib.
    * It is either sparkHome/lib or sparkHome/jars based on the version of
    * Spark chosen by user.
+   *
    * @param sparkHome dir path of Spark Home
    * @return dir path of Spark lib
    */
@@ -679,12 +590,8 @@ public class HadoopSparkJob extends JavaProcessJob {
   public void cancel() throws InterruptedException {
     super.cancel();
 
-    info("Cancel called.  Killing the Spark job on the cluster");
+    info("Cancel called.  Killing the launched Spark jobs on the cluster");
 
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, this.jobProps,
-        this.tokenFile, getLog());
+    hadoopProxy.killAllSpawnedHadoopJobs(getJobProps(), getLog());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.jobtype;
+
+public interface IHadoopJob {
+
+  /**
+   * Hadoop Proxy Wrapper Object
+   */
+  HadoopProxy hadoopProxy = new HadoopProxy();
+
+  /**
+   * Setup Hadoop-related Job Properties
+   */
+  void setupHadoopJobProperties();
+}

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 LinkedIn Corp.
+ * Copyright 2019 LinkedIn Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
+import azkaban.utils.FileIOUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.util.List;
-import java.util.StringTokenizer;
 
 import org.apache.log4j.Logger;
 
@@ -29,25 +29,23 @@ import azkaban.utils.Props;
 
 public class JavaJob extends JavaProcessJob {
 
-  public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String CANCEL_METHOD_PARAM = "method.cancel";
-  public static final String PROGRESS_METHOD_PARAM = "method.progress";
+  private static final String RUN_METHOD_PARAM = "method.run";
+  private static final String CANCEL_METHOD_PARAM = "method.cancel";
+  private static final String PROGRESS_METHOD_PARAM = "method.progress";
 
-  public static final String JOB_CLASS = "job.class";
-  public static final String DEFAULT_CANCEL_METHOD = "cancel";
-  public static final String DEFAULT_RUN_METHOD = "run";
-  public static final String DEFAULT_PROGRESS_METHOD = "getProgress";
+  private static final String JOB_CLASS = "job.class";
+  private static final String DEFAULT_CANCEL_METHOD = "cancel";
+  private static final String DEFAULT_RUN_METHOD = "run";
+  private static final String DEFAULT_PROGRESS_METHOD = "getProgress";
 
   private String _runMethod;
   private String _cancelMethod;
   private String _progressMethod;
 
   private Object _javaObject = null;
-  private String props;
 
   public JavaJob(String jobid, Props sysProps, Props jobProps, Logger log) {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
-
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
   }
 
@@ -68,18 +66,18 @@ public class JavaJob extends JavaProcessJob {
   protected List<String> getClassPaths() {
     List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
     // To add az-core jar classpath
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
     // To add az-common jar classpath
-    classPath.add(getSourcePathFromClass(JavaProcessJob.class));
-    classPath.add(getSourcePathFromClass(SecurityUtils.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaProcessJob.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(SecurityUtils.class));
 
     classPath.add(HadoopConfigurationInjector.getPath(getJobProps(),
         getWorkingDirectory()));
 
-    String loggerPath = getSourcePathFromClass(Logger.class);
+    String loggerPath = FileIOUtils.getSourcePathFromClass(Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }
@@ -95,51 +93,13 @@ public class JavaJob extends JavaProcessJob {
 
     List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      String pluginDir = getSysProps().get("plugin.dir");
-      for (String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsoluteFile())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
 
     return classPath;
-  }
-
-  private static String getSourcePathFromClass(Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      String name = containedClass.getName();
-      StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   @Override
@@ -152,14 +112,15 @@ public class JavaJob extends JavaProcessJob {
     return "JavaJob{" + "_runMethod='" + _runMethod + '\''
         + ", _cancelMethod='" + _cancelMethod + '\'' + ", _progressMethod='"
         + _progressMethod + '\'' + ", _javaObject=" + _javaObject + ", props="
-        + props + '}';
+        + getAllProps().toString() + '}';
   }
 
 
   @Override
   public void run() throws Exception {
-    HadoopConfigurationInjector.prepareResourcesToInject(getJobProps(),
-        getWorkingDirectory());
+    HadoopConfigurationInjector.prepareResourcesToInject(
+        getJobProps(), getWorkingDirectory()
+    );
     super.run();
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.ProcessJob;
@@ -44,6 +43,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
+
 public class JavaJobRunnerMain {
 
   public static final String JOB_CLASS = "job.class";
@@ -57,9 +57,9 @@ public class JavaJobRunnerMain {
 
   public static final String CANCEL_METHOD_PARAM = "method.cancel";
   public static final String RUN_METHOD_PARAM = "method.run";
-  public static final String[] PROPS_CLASSES = new String[] {
-    "azkaban.utils.Props",
-    "azkaban.common.utils.Props"
+  public static final String[] PROPS_CLASSES = new String[]{
+      "azkaban.utils.Props",
+      "azkaban.common.utils.Props"
   };
 
   private static final Layout DEFAULT_LAYOUT = new PatternLayout("%p %m\n");
@@ -139,16 +139,16 @@ public class JavaJobRunnerMain {
       try {
         final Method generatedPropertiesMethod =
             _javaObject.getClass().getMethod(GET_GENERATED_PROPERTIES_METHOD,
-                new Class<?>[] {});
+                new Class<?>[]{});
         Object outputGendProps =
-            generatedPropertiesMethod.invoke(_javaObject, new Object[] {});
+            generatedPropertiesMethod.invoke(_javaObject, new Object[]{});
         if (outputGendProps != null) {
           final Method toPropertiesMethod =
               outputGendProps.getClass().getMethod("toProperties",
-                  new Class<?>[] {});
+                  new Class<?>[]{});
           Properties properties =
               (Properties) toPropertiesMethod.invoke(outputGendProps,
-                  new Object[] {});
+                  new Object[]{});
 
           Props outputProps = new Props(null, properties);
           outputGeneratedProperties(outputProps);
@@ -190,7 +190,7 @@ public class JavaJobRunnerMain {
   private void runMethod(Object obj, String runMethod)
       throws IllegalAccessException, InvocationTargetException,
       NoSuchMethodException {
-    obj.getClass().getMethod(runMethod, new Class<?>[] {}).invoke(obj);
+    obj.getClass().getMethod(runMethod, new Class<?>[]{}).invoke(obj);
   }
 
   @SuppressWarnings("DefaultCharset")
@@ -311,7 +311,7 @@ public class JavaJobRunnerMain {
       Constructor<?> propsCon =
           getConstructor(propsClass, propsClass, Properties[].class);
       Object props =
-          propsCon.newInstance(null, new Properties[] { properties });
+          propsCon.newInstance(null, new Properties[]{properties});
 
       Constructor<?> con =
           getConstructor(runningClass, String.class, propsClass);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JobDagNode.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JobDagNode.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.util.ArrayList;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class JobDagNode {
+
   protected String name;
 
   protected List<String> parents = new ArrayList<String>();

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/MapReduceJobState.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/MapReduceJobState.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.IOException;
@@ -25,10 +24,12 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.TIPStatus;
 import org.apache.hadoop.mapred.TaskReport;
 
+
 /**
  * Container that holds state of a MapReduce job
  */
 public class MapReduceJobState {
+
   private String jobId;
   private String jobName;
   private String trackingURL;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
@@ -13,60 +13,42 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.SecurityUtils;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Pig Process Job
+ */
 public class PigProcessJob extends JavaProcessJob {
 
-  public static final String PIG_SCRIPT = "pig.script";
-  public static final String UDF_IMPORT = "udf.import.list";
-  public static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
-  public static final String PIG_PARAM_PREFIX = "param.";
-  public static final String PIG_PARAM_FILES = "paramfile";
-  public static final String HADOOP_UGI = "hadoop.job.ugi";
-  public static final String DEBUG = "debug";
-
-  public static final String PIG_JAVA_CLASS = "org.apache.pig.Main";
-  public static final String SECURE_PIG_WRAPPER =
-      "azkaban.jobtype.SecurePigWrapper";
+  private static final String PIG_SCRIPT = "pig.script";
+  private static final String UDF_IMPORT = "udf.import.list";
+  private static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
+  private static final String PIG_PARAM_PREFIX = "param.";
+  private static final String PIG_PARAM_FILES = "paramfile";
+  private static final String HADOOP_UGI = "hadoop.job.ugi";
+  private static final String DEBUG = "debug";
+  private static final String PIG_JAVA_CLASS = "org.apache.pig.Main";
+  private static final String SECURE_PIG_WRAPPER = "azkaban.jobtype.SecurePigWrapper";
 
   public PigProcessJob(final String jobid, final Props sysProps, final Props jobProps,
       final Logger log) {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
-  }
-
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
   }
 
   @Override
@@ -138,7 +120,7 @@ public class PigProcessJob extends JavaProcessJob {
       for (final Map.Entry<String, String> entry : map.entrySet()) {
         list.add("-param "
             + StringUtils.shellQuote(entry.getKey() + "=" + entry.getValue(),
-                StringUtils.SINGLE_QUOTE));
+            StringUtils.SINGLE_QUOTE));
       }
     }
 
@@ -172,87 +154,59 @@ public class PigProcessJob extends JavaProcessJob {
       classPath.add(new File(hadoopHome, "conf").getPath());
     }
 
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
     if (SecurityUtils.shouldProxy(getSysProps().toProperties())) {
-      classPath.add(getSourcePathFromClass(SecurePigWrapper.class));
+      classPath.add(FileIOUtils.getSourcePathFromClass(SecurePigWrapper.class));
     }
 
     final List<String> typeClassPath =
         getSysProps().getStringList("jobtype.classpath", null, ",");
-    if (typeClassPath != null) {
-      // fill in this when load this jobtype
-      final String pluginDir = getSysProps().get("plugin.dir");
-      for (final String jar : typeClassPath) {
-        File jarFile = new File(jar);
-        if (!jarFile.isAbsolute()) {
-          jarFile = new File(pluginDir + File.separatorChar + jar);
-        }
-
-        if (!classPath.contains(jarFile.getAbsoluteFile())) {
-          classPath.add(jarFile.getAbsolutePath());
-        }
-      }
-    }
+    Utils.mergeTypeClassPaths(classPath, typeClassPath, getSysProps().get("plugin.dir"));
 
     final List<String> typeGlobalClassPath =
         getSysProps().getStringList("jobtype.global.classpath", null, ",");
-    if (typeGlobalClassPath != null) {
-      for (final String jar : typeGlobalClassPath) {
-        if (!classPath.contains(jar)) {
-          classPath.add(jar);
-        }
-      }
-    }
+    Utils.mergeStringList(classPath, typeGlobalClassPath);
     return classPath;
   }
 
-  protected boolean getDebug() {
+  private boolean getDebug() {
     return getJobProps().getBoolean(DEBUG, false);
   }
 
-  protected String getScript() {
+  private String getScript() {
     return getJobProps().getString(PIG_SCRIPT);
   }
 
-  protected List<String> getUDFImportList() {
+  private List<String> getUDFImportList() {
     final List<String> udfImports = new ArrayList<>();
-    final List<String> typeImports =
-        getSysProps().getStringList(UDF_IMPORT, null, ",");
-    final List<String> jobImports =
-        getJobProps().getStringList(UDF_IMPORT, null, ",");
-    if (typeImports != null) {
-      udfImports.addAll(typeImports);
-    }
-    if (jobImports != null) {
-      udfImports.addAll(jobImports);
-    }
+    // append typeImports
+    Utils.mergeStringList(udfImports, getSysProps().getStringList(UDF_IMPORT, null, ","));
+    // append jobImports
+    Utils.mergeStringList(udfImports, getJobProps().getStringList(UDF_IMPORT, null, ","));
     return udfImports;
   }
 
-  protected List<String> getAdditionalJarsList() {
+  private List<String> getAdditionalJarsList() {
     final List<String> additionalJars = new ArrayList<>();
-    final List<String> typeJars =
-        getSysProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
-    final List<String> jobJars =
-        getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ",");
-    if (typeJars != null) {
-      additionalJars.addAll(typeJars);
-    }
-    if (jobJars != null) {
-      additionalJars.addAll(jobJars);
-    }
+    // append typeJars
+    Utils.mergeStringList(additionalJars,
+        getSysProps().getStringList(PIG_ADDITIONAL_JARS, null, ","));
+    // append jobJars
+    Utils.mergeStringList(additionalJars,
+        getJobProps().getStringList(PIG_ADDITIONAL_JARS, null, ","));
+
     return additionalJars;
   }
 
-  protected String getHadoopUGI() {
+  private String getHadoopUGI() {
     return getJobProps().getString(HADOOP_UGI, null);
   }
 
-  protected Map<String, String> getPigParams() {
+  private Map<String, String> getPigParams() {
     return getJobProps().getMapByPrefix(PIG_PARAM_PREFIX);
   }
 
-  protected List<String> getPigParamFiles() {
+  private List<String> getPigParamFiles() {
     return getJobProps().getStringList(PIG_PARAM_FILES, null, ",");
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SecurePigWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SecurePigWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import org.apache.hadoop.conf.Configuration;
@@ -33,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Properties;
+
 
 public class SecurePigWrapper {
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SparkJobArg.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/SparkJobArg.java
@@ -1,7 +1,7 @@
 package azkaban.jobtype;
 
-public enum SparkJobArg {
 
+public enum SparkJobArg {
   // standard spark submit arguments, ordered in the spark-submit --help order
   MASTER("master", false), // just to trick the eclipse formatter
   DEPLOY_MODE("deploy-mode", false), //
@@ -55,5 +55,4 @@ public enum SparkJobArg {
   final String sparkParamName;
 
   final boolean needSpecialTreatment;
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import java.io.FileNotFoundException;
@@ -38,12 +37,13 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.log4j.Logger;
 import org.apache.pig.impl.util.ObjectSerializer;
 
+
 public class StatsUtils {
 
   private static Logger logger = Logger.getLogger(StatsUtils.class);
 
   private static final Set<String> JOB_CONF_KEYS = new HashSet<String>(
-      Arrays.asList(new String[] {
+      Arrays.asList(new String[]{
           "mapred.job.map.memory.mb",
           "mapred.job.reduce.memory.mb",
           "mapred.child.java.opts",

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
@@ -50,7 +50,7 @@ public class GobblinHadoopJob extends HadoopJavaJob {
     super(jobid, sysProps, jobProps, log);
     initializePresets();
 
-    jobProps.put(HadoopJavaJob.JOB_CLASS, "gobblin.azkaban.AzkabanJobLauncher");
+    jobProps.put("job.class", "gobblin.azkaban.AzkabanJobLauncher");
     jobProps.put("job.name", jobProps.get(CommonJobProperties.JOB_ID));
     jobProps.put("launcher.type", "MAPREDUCE"); //Azkaban only supports MR mode
     jobProps.put("fs.uri", sysProps.get("fs.uri")); //Azkaban should only support HDFS

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
@@ -14,14 +14,12 @@ import org.apache.log4j.Logger;
 
 
 public class FileUtils {
+
   private static Logger logger = Logger.getLogger(FileUtils.class);
 
   /**
    * Delete file or directory.
    * (Apache FileUtils.deleteDirectory has a bug and is not working.)
-   *
-   * @param file
-   * @throws IOException
    */
   public static void deleteFileOrDirectory(File file) throws IOException {
     if (!file.isDirectory()) {
@@ -70,10 +68,11 @@ public class FileUtils {
         continue;
       }
 
-      FileFilter fileFilter = new AndFileFilter(new WildcardFileFilter(f.getName()), FileFileFilter.FILE);
+      FileFilter fileFilter = new AndFileFilter(new WildcardFileFilter(f.getName()),
+          FileFileFilter.FILE);
       File parent = f.getParentFile() == null ? f : f.getParentFile();
       File[] filteredFiles = parent.listFiles(fileFilter);
-      if(filteredFiles == null) {
+      if (filteredFiles == null) {
         continue;
       }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.javautils;
 
 import java.io.ByteArrayOutputStream;
@@ -33,6 +32,7 @@ import org.apache.log4j.Logger;
 
 import azkaban.utils.Props;
 
+
 public class HadoopUtils {
 
   private static final Logger logger = Logger.getLogger(HadoopUtils.class);
@@ -50,7 +50,7 @@ public class HadoopUtils {
   public static String findContainingJar(String fileName, ClassLoader loader) {
     try {
       for (Enumeration<?> itr = loader.getResources(fileName); itr
-          .hasMoreElements();) {
+          .hasMoreElements(); ) {
         URL url = (URL) itr.nextElement();
         logger.info("findContainingJar finds url:" + url);
         if ("jar".equals(url.getProtocol())) {
@@ -125,8 +125,9 @@ public class HadoopUtils {
 
     // create directory if it does not exist.
     Path parent = path.getParent();
-    if (!fs.exists(parent))
+    if (!fs.exists(parent)) {
       fs.mkdirs(parent);
+    }
 
     // write out properties
     OutputStream output = fs.create(path);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.javautils;
 
 import java.util.Arrays;
@@ -21,18 +20,18 @@ import org.apache.commons.lang.StringUtils;
 
 import azkaban.utils.Props;
 
+
 public class ValidationUtils {
 
   public static void validateNotEmpty(String s, String name) {
-    if(StringUtils.isEmpty(s)) {
+    if (StringUtils.isEmpty(s)) {
       throw new IllegalArgumentException(name + " cannot be empty.");
     }
   }
 
   /**
    * Validates if all of the keys exist of none of them exist
-   * @param props
-   * @param keys
+   *
    * @throws IllegalArgumentException only if some of the keys exist
    */
   public static void validateAllOrNone(Props props, String... keys) {
@@ -40,49 +39,50 @@ public class ValidationUtils {
 
     boolean allExist = true;
     boolean someExist = false;
-    for(String key : keys) {
+    for (String key : keys) {
       Object val = props.get(key);
       allExist &= val != null;
       someExist |= val != null;
     }
 
-    if(someExist && !allExist) {
-      throw new IllegalArgumentException("Either all of properties exist or none of them should exist for " + Arrays.toString(keys));
+    if (someExist && !allExist) {
+      throw new IllegalArgumentException(
+          "Either all of properties exist or none of them should exist for " + Arrays
+              .toString(keys));
     }
   }
 
   /**
    * Validates all keys present in props
-   * @param props
-   * @param keys
-   * @throws UndefinedPropertyException if key does not exist in properties
    */
   public static void validateAllNotEmpty(Props props, String... keys) {
-    for(String key : keys) {
+    for (String key : keys) {
       props.getString(key);
     }
   }
 
   public static void validateAtleastOneNotEmpty(Props props, String... keys) {
     boolean exist = false;
-    for(String key : keys) {
+    for (String key : keys) {
       Object val = props.get(key);
       exist |= val != null;
     }
-    if(!exist) {
-      throw new IllegalArgumentException("At least one of these keys should exist " + Arrays.toString(keys));
+    if (!exist) {
+      throw new IllegalArgumentException(
+          "At least one of these keys should exist " + Arrays.toString(keys));
     }
   }
 
   public static void validateSomeValuesNotEmpty(int notEmptyVals, String... vals) {
     int count = 0;
-    for(String val : vals) {
-      if(!StringUtils.isEmpty(val)) {
+    for (String val : vals) {
+      if (!StringUtils.isEmpty(val)) {
         count++;
       }
     }
     if (count != notEmptyVals) {
-      throw new IllegalArgumentException("Number of not empty vals " + count + " is not desired number " + notEmptyVals);
+      throw new IllegalArgumentException(
+          "Number of not empty vals " + count + " is not desired number " + notEmptyVals);
     }
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
@@ -29,11 +29,15 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
+
 /**
- * Whitelist util. It uses file (new line separated) to construct whitelist and validates if id is whitelisted.
- * Main use case is to control users onboarding on connector job types via their "user.to.proxy" value.
+ * Whitelist util. It uses file (new line separated) to construct whitelist and validates if id is
+ * whitelisted.
+ * Main use case is to control users onboarding on connector job types via their "user.to.proxy"
+ * value.
  */
 public class Whitelist {
+
   public static final String WHITE_LIST_FILE_PATH_KEY = "whitelist.file.path";
 
   private static final String PROXY_USER_KEY = "user.to.proxy";
@@ -43,14 +47,10 @@ public class Whitelist {
 
   /**
    * Creates whitelist instance.
-   *
-   * @param whitelistFilePath
-   * @param fs
-   * @param pollingPeriodSec
    */
   public Whitelist(String whitelistFilePath, FileSystem fs) {
     this.whitelistSet = retrieveWhitelist(fs, new Path(whitelistFilePath));
-    if(logger.isDebugEnabled()) {
+    if (logger.isDebugEnabled()) {
       logger.debug("Whitelist: " + whitelistSet);
     }
   }
@@ -61,7 +61,7 @@ public class Whitelist {
 
   /**
    * Checks if id is in whitelist.
-   * @param id
+   *
    * @throws UnsupportedOperationException if id is not whitelisted
    */
   public void validateWhitelisted(String id) {
@@ -72,9 +72,8 @@ public class Whitelist {
   }
 
   /**
-   * Use proxy user or submit user(if proxy user does not exist) from property and check if it is whitelisted.
-   * @param props
-   * @return
+   * Use proxy user or submit user(if proxy user does not exist) from property and check if it is
+   * whitelisted.
    */
   public void validateWhitelisted(Props props) {
     String id = null;
@@ -83,17 +82,19 @@ public class Whitelist {
       Preconditions.checkArgument(!StringUtils.isEmpty(id), PROXY_USER_KEY + " is required.");
     } else if (props.containsKey(CommonJobProperties.SUBMIT_USER)) {
       id = props.get(CommonJobProperties.SUBMIT_USER);
-      Preconditions.checkArgument(!StringUtils.isEmpty(id), CommonJobProperties.SUBMIT_USER + " is required.");
+      Preconditions.checkArgument(!StringUtils.isEmpty(id),
+          CommonJobProperties.SUBMIT_USER + " is required.");
     } else {
-      throw new IllegalArgumentException("Property neither has " + PROXY_USER_KEY + " nor " + CommonJobProperties.SUBMIT_USER);
+      throw new IllegalArgumentException(
+          "Property neither has " + PROXY_USER_KEY + " nor " + CommonJobProperties.SUBMIT_USER);
     }
     validateWhitelisted(id);
   }
 
   /**
-   * Updates whitelist if there's any change. If it needs to update whitelist, it enforces writelock to make sure
+   * Updates whitelist if there's any change. If it needs to update whitelist, it enforces writelock
+   * to make sure
    * there's an exclusive access on shared variables.
-   *
    */
   @VisibleForTesting
   Set<String> retrieveWhitelist(FileSystem fs, Path path) {

--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.jobsummary;
 
 import azkaban.executor.ExecutableFlow;
@@ -23,7 +22,6 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.server.session.Session;
-import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Props;
@@ -40,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+
 
 public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
   private static final String PROXY_USER_SESSION_KEY =
@@ -69,18 +68,6 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
             "web");
     this.webResourcesPath.mkdirs();
     setResourceDirectory(this.webResourcesPath);
-  }
-
-  private Project getProjectByPermission(final int projectId, final User user,
-      final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-    if (project == null) {
-      return null;
-    }
-    if (!hasPermission(project, user, type)) {
-      return null;
-    }
-    return project;
   }
 
   @Override
@@ -138,7 +125,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
     }
 
     final int projectId = flow.getProjectId();
-    final Project project = getProjectByPermission(projectId, user, Type.READ);
+    final Project project = filterProjectByPermission(this.projectManager.getProject(projectId), user, Type.READ);
     if (project == null) {
       page.render();
       return;

--- a/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ConnectorParams.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 public interface ConnectorParams {
@@ -106,6 +105,4 @@ public interface ConnectorParams {
   public static final String STATS_MAP_REPORTINGINTERVAL = "interval";
   public static final String STATS_MAP_CLEANINGINTERVAL = "interval";
   public static final String STATS_MAP_EMITTERNUMINSTANCES = "numInstances";
-
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractJob.java
@@ -13,12 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.Props;
 import org.apache.log4j.Logger;
 
+
+/**
+ * Base Job
+ */
 public abstract class AbstractJob implements Job {
 
   public static final String JOB_TYPE = "type";
@@ -56,6 +59,19 @@ public abstract class AbstractJob implements Job {
     throw new RuntimeException("Job " + this._id + " does not support cancellation!");
   }
 
+  @Override
+  public Props getJobGeneratedProperties() {
+    return new Props();
+  }
+
+  @Override
+  public abstract void run() throws Exception;
+
+  @Override
+  public boolean isCanceled() {
+    return false;
+  }
+
   public Logger getLog() {
     return this._log;
   }
@@ -91,18 +107,4 @@ public abstract class AbstractJob implements Job {
   public void error(final String message, final Throwable t) {
     this._log.error(message, t);
   }
-
-  @Override
-  public Props getJobGeneratedProperties() {
-    return new Props();
-  }
-
-  @Override
-  public abstract void run() throws Exception;
-
-  @Override
-  public boolean isCanceled() {
-    return false;
-  }
-
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_GROUP_NAME;
@@ -62,10 +61,10 @@ public class ProcessJob extends AbstractProcessJob {
   private static final String CREATE_FILE = "touch";
   private static final int SUCCESSFUL_EXECUTION = 0;
   private static final String TEMP_FILE_NAME = "user_can_write";
+
   private final CommonMetrics commonMetrics;
   private volatile AzkabanProcess process;
   private volatile boolean killed = false;
-
   // For testing only. True if the job process exits successfully.
   private volatile boolean success;
 

--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import azkaban.executor.ExecutionOptions;
@@ -25,6 +24,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class Schedule {
 

--- a/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.server;
 
 import static azkaban.Constants.DEFAULT_PORT_NUMBER;
@@ -152,5 +151,4 @@ public abstract class AzkabanServer {
   public abstract VelocityEngine getVelocityEngine();
 
   public abstract UserManager getUserManager();
-
 }

--- a/azkaban-common/src/main/java/azkaban/server/IMBeanRegistration.java
+++ b/azkaban-common/src/main/java/azkaban/server/IMBeanRegistration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+/**
+ * Interface for MBean Registration
+ */
+public interface IMBeanRegistration {
+
+  MBeanRegistrationManager mbeanRegistrationManager = new MBeanRegistrationManager();
+
+  /**
+   * Function to configure MBean Server
+   */
+  void configureMBeanServer();
+}

--- a/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
+++ b/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.log4j.Logger;
+
+
+/**
+ * A class to manager MBean Registration tasks
+ */
+public class MBeanRegistrationManager {
+  private static final Logger logger = Logger.getLogger(MBeanRegistrationManager.class);
+
+  private List<ObjectName> registeredMBeans = new ArrayList<>();
+  private MBeanServer mbeanServer = null;
+
+  public void registerMBean(final String name, final Object mbean) {
+    final Class<?> mbeanClass = mbean.getClass();
+    final ObjectName mbeanName;
+    try {
+      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
+      getMbeanServer().registerMBean(mbean, mbeanName);
+      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
+      this.registeredMBeans.add(mbeanName);
+    } catch (final Exception e) {
+      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(), e);
+    }
+  }
+
+  /**
+   * Get Platform MBeanServer Instance
+   * @return platform MBeanServer Instance
+   */
+  public MBeanServer getMbeanServer() {
+    return (mbeanServer == null)
+        ? ManagementFactory.getPlatformMBeanServer()
+        : mbeanServer;
+  }
+
+  /**
+   * Close all registered MBeans
+   */
+  public void closeMBeans() {
+    try {
+      for (final ObjectName name : registeredMBeans) {
+        getMbeanServer().unregisterMBean(name);
+        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
+      }
+    } catch (final Exception e) {
+      logger.error("Failed to cleanup MBeanServer", e);
+    }
+  }
+
+  /**
+   * Get MBean Names
+   * @return list of MBean Names
+   */
+  public List<ObjectName> getMBeanNames() {
+    return registeredMBeans;
+  }
+
+  /**
+   * Get MBeanInfo
+   * @param name mbean Name
+   * @return MBeanInfo
+   */
+  public MBeanInfo getMBeanInfo(final ObjectName name) {
+    try {
+      return getMbeanServer().getMBeanInfo(name);
+    } catch (final Exception e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  /**
+   * Get MBean Attribute
+   * @param name mbean name
+   * @param attribute attribute name
+   * @return object of MBean Attribute
+   */
+  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
+    try {
+      return getMbeanServer().getAttribute(name, attribute);
+    } catch (final Exception e) {
+      logger.error(e);
+      return null;
+    }
+  }
+
+  /**
+   * Get MBean Result
+   * @param mbeanName mbeanName
+   * @return Map of MBean
+   */
+  public Map<String, Object> getMBeanResult(final String mbeanName) {
+    final Map<String, Object> ret = new HashMap<>();
+    try {
+      final ObjectName name = new ObjectName(mbeanName);
+      final MBeanInfo info = getMBeanInfo(name);
+
+      final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
+      final Map<String, Object> attributes = new TreeMap<>();
+
+      for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
+        final Object obj = getMBeanAttribute(name, attrInfo.getName());
+        attributes.put(attrInfo.getName(), obj);
+      }
+
+      ret.put("attributes", attributes);
+    } catch (final Exception e) {
+      logger.error(e);
+      ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
+    }
+
+    return ret;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -13,18 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.sla;
 
 import azkaban.executor.ExecutableFlow;
 import azkaban.sla.SlaType.ComponentType;
-import azkaban.utils.Utils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,6 +132,17 @@ public class SlaOption {
 
     this.emails = ImmutableList.copyOf((List<String>)slaOption.getInfo().get(SlaOptionDeprecated
         .INFO_EMAIL_LIST));
+  }
+
+  public static List<Object> convertToObjects(List<SlaOption> slaOptions) {
+    if (slaOptions != null) {
+      final List<Object> slaOptionsObject = new ArrayList<>();
+      for (final SlaOption sla : slaOptions) {
+        slaOptionsObject.add(sla.toObject());
+      }
+      return slaOptionsObject;
+    }
+    return null;
   }
 
   private Duration parseDuration(final String durationStr) {

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.trigger.ConditionChecker;
@@ -27,6 +26,7 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.quartz.CronExpression;
+
 
 public class BasicTimeChecker implements ConditionChecker {
 
@@ -215,5 +215,4 @@ public class BasicTimeChecker implements ConditionChecker {
   @Override
   public void setContext(final Map<String, Object> context) {
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.executor.ExecutableFlow;
@@ -31,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
+
 
 public class ExecuteFlowAction implements TriggerAction {
 
@@ -175,11 +175,8 @@ public class ExecuteFlowAction implements TriggerAction {
     if (this.executionOptions != null) {
       jsonObj.put("executionOptions", this.executionOptions.toObject());
     }
-    if (this.executionOptions.getSlaOptions() != null) {
-      final List<Object> slaOptionsObj = new ArrayList<>();
-      for (final SlaOption sla : this.executionOptions.getSlaOptions()) {
-        slaOptionsObj.add(sla.toObject());
-      }
+    List<Object> slaOptionsObj = SlaOption.convertToObjects(this.executionOptions.getSlaOptions());
+    if (slaOptionsObj != null) {
       jsonObj.put("slaOptions", slaOptionsObj);
     }
     return jsonObj;
@@ -229,5 +226,4 @@ public class ExecuteFlowAction implements TriggerAction {
   public String getId() {
     return this.actionId;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.BufferedInputStream;
@@ -26,10 +25,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,9 +124,9 @@ public class FileIOUtils {
   }
 
   public static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
+    final String containedClassPath = containedClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+
+    File file = new File(containedClassPath);
 
     if (!file.isDirectory() && file.getName().endsWith(".class")) {
       final String name = containedClass.getName();
@@ -134,8 +137,7 @@ public class FileIOUtils {
       }
       return file.getPath();
     } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
+      return containedClassPath;
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import java.io.File;
 import java.util.List;
@@ -43,33 +44,14 @@ public class JavaJob extends JavaProcessJob {
     super(jobid, sysProps, new Props(sysProps, jobProps), log);
   }
 
-  private static String getSourcePathFromClass(final Class<?> containedClass) {
-    File file =
-        new File(containedClass.getProtectionDomain().getCodeSource()
-            .getLocation().getPath());
-
-    if (!file.isDirectory() && file.getName().endsWith(".class")) {
-      final String name = containedClass.getName();
-      final StringTokenizer tokenizer = new StringTokenizer(name, ".");
-      while (tokenizer.hasMoreTokens()) {
-        tokenizer.nextElement();
-        file = file.getParentFile();
-      }
-      return file.getPath();
-    } else {
-      return containedClass.getProtectionDomain().getCodeSource().getLocation()
-          .getPath();
-    }
-  }
-
   @Override
   protected List<String> getClassPaths() {
     final List<String> classPath = super.getClassPaths();
 
-    classPath.add(getSourcePathFromClass(JavaJobRunnerMain.class));
-    classPath.add(getSourcePathFromClass(Props.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(JavaJobRunnerMain.class));
+    classPath.add(FileIOUtils.getSourcePathFromClass(Props.class));
 
-    final String loggerPath = getSourcePathFromClass(org.apache.log4j.Logger.class);
+    final String loggerPath = FileIOUtils.getSourcePathFromClass(org.apache.log4j.Logger.class);
     if (!classPath.contains(loggerPath)) {
       classPath.add(loggerPath);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static azkaban.Constants.ConfigurationKeys;
@@ -43,6 +42,7 @@ import azkaban.metric.MetricException;
 import azkaban.metric.MetricReportManager;
 import azkaban.metric.inmemoryemitter.InMemoryMetricEmitter;
 import azkaban.metrics.MetricsManager;
+import azkaban.server.IMBeanRegistration;
 import azkaban.server.AzkabanServer;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
@@ -54,7 +54,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -63,15 +62,10 @@ import java.security.Permission;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.TimeZone;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
@@ -79,8 +73,9 @@ import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 
+
 @Singleton
-public class AzkabanExecutorServer {
+public class AzkabanExecutorServer implements IMBeanRegistration {
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
@@ -96,9 +91,6 @@ public class AzkabanExecutorServer {
   private final Props props;
   private final Server server;
   private final Context root;
-
-  private final ArrayList<ObjectName> registeredMBeans = new ArrayList<>();
-  private MBeanServer mbeanServer;
 
   @Inject
   public AzkabanExecutorServer(final Props props,
@@ -397,70 +389,6 @@ public class AzkabanExecutorServer {
     return this.runnerManager;
   }
 
-  private void configureMBeanServer() {
-    logger.info("Registering MBeans...");
-    this.mbeanServer = ManagementFactory.getPlatformMBeanServer();
-
-    registerMbean("executorJetty", new JmxJettyServer(this.server));
-    registerMbean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
-    registerMbean("jobJMXMBean", JmxJobMBeanManager.getInstance());
-
-    if (JobCallbackManager.isInitialized()) {
-      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
-      registerMbean("jobCallbackJMXMBean",
-          jobCallbackMgr.getJmxJobCallbackMBean());
-    }
-  }
-
-  public void close() {
-    try {
-      for (final ObjectName name : this.registeredMBeans) {
-        this.mbeanServer.unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
-      }
-    } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
-    }
-  }
-
-  private void registerMbean(final String name, final Object mbean) {
-    final Class<?> mbeanClass = mbean.getClass();
-    final ObjectName mbeanName;
-    try {
-      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
-      this.mbeanServer.registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
-      this.registeredMBeans.add(mbeanName);
-    } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(),
-          e);
-    }
-
-  }
-
-  public List<ObjectName> getMbeanNames() {
-    return this.registeredMBeans;
-  }
-
-  public MBeanInfo getMBeanInfo(final ObjectName name) {
-    try {
-      return this.mbeanServer.getMBeanInfo(name);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
-    try {
-      return this.mbeanServer.getAttribute(name, attribute);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-
   /**
    * Get the hostname
    *
@@ -546,6 +474,20 @@ public class AzkabanExecutorServer {
     this.server.stop();
     this.server.destroy();
     getFlowRunnerManager().shutdownNow();
-    close();
+    this.mbeanRegistrationManager.closeMBeans();
+  }
+
+  @Override
+  public void configureMBeanServer() {
+    logger.info("Registering MBeans...");
+
+    this.mbeanRegistrationManager.registerMBean("executorJetty", new JmxJettyServer(this.server));
+    this.mbeanRegistrationManager.registerMBean("flowRunnerManager", new JmxFlowRunnerManager(this.runnerManager));
+    this.mbeanRegistrationManager.registerMBean("jobJMXMBean", JmxJobMBeanManager.getInstance());
+
+    if (JobCallbackManager.isInitialized()) {
+      final JobCallbackManager jobCallbackMgr = JobCallbackManager.getInstance();
+      this.mbeanRegistrationManager.registerMBean("jobCallbackJMXMBean", jobCallbackMgr.getJmxJobCallbackMBean());
+    }
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.Constants;
@@ -23,16 +22,13 @@ import azkaban.utils.JSONUtils;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+
 
 public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
 
@@ -72,29 +68,12 @@ public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
     final Map<String, Object> ret = new HashMap<>();
 
     if (hasParam(req, JMX_GET_MBEANS)) {
-      ret.put("mbeans", this.server.getMbeanNames());
+      ret.put("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
     } else if (hasParam(req, JMX_GET_ALL_MBEAN_ATTRIBUTES)) {
       if (!hasParam(req, JMX_MBEAN)) {
         ret.put("error", "Parameters 'mbean' must be set");
       } else {
-        final String mbeanName = getParam(req, JMX_MBEAN);
-        try {
-          final ObjectName name = new ObjectName(mbeanName);
-          final MBeanInfo info = this.server.getMBeanInfo(name);
-
-          final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-          final Map<String, Object> attributes = new TreeMap<>();
-
-          for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-            final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-            attributes.put(attrInfo.getName(), obj);
-          }
-
-          ret.put("attributes", attributes);
-        } catch (final Exception e) {
-          logger.error(e);
-          ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-        }
+        ret.putAll(this.server.mbeanRegistrationManager.getMBeanResult(getParam(req, JMX_MBEAN)));
       }
     }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -13,16 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.executor.ExecutorInfo;
 import azkaban.utils.JSONUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -83,24 +80,9 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillRemainingMemoryPercent(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_Grep && exists_Meminfo) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c",
-              "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils.runProcess("/bin/bash", "-c",
+            "/bin/cat /proc/meminfo | grep -E \"^MemTotal:|^MemFree:|^Buffers:|^Cached:|^SwapCached:\"");
 
         long totalMemory = 0;
         long totalFreeMemory = 0;
@@ -241,23 +223,8 @@ public class ServerStatisticsServlet extends HttpServlet {
    */
   protected void fillCpuUsage(final ExecutorInfo stats) {
     if (exists_Bash && exists_Cat && exists_LoadAvg) {
-      final java.lang.ProcessBuilder processBuilder =
-          new java.lang.ProcessBuilder("/bin/bash", "-c", "/bin/cat /proc/loadavg");
       try {
-        final ArrayList<String> output = new ArrayList<>();
-        final Process process = processBuilder.start();
-        process.waitFor();
-        final InputStream inputStream = process.getInputStream();
-        try {
-          final java.io.BufferedReader reader = new java.io.BufferedReader(
-              new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-          String line = null;
-          while ((line = reader.readLine()) != null) {
-            output.add(line);
-          }
-        } finally {
-          inputStream.close();
-        }
+        final ArrayList<String> output = Utils.runProcess("/bin/bash", "-c", "/bin/cat /proc/loadavg");
 
         // process the output from bash call.
         if (output.size() > 0) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/BlockingStatus.java
@@ -13,14 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.Status;
 
+
 public class BlockingStatus {
 
-  private static final long WAIT_TIME = 5 * 60 * 1000;
+  private static final long WAIT_TIME = 300000;  // 5 * 60 * 1000
   private final int execId;
   private final String jobId;
   private Status status;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/RemoteFlowWatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.ExecutableFlow;
@@ -24,9 +23,10 @@ import azkaban.executor.Status;
 import java.util.ArrayList;
 import java.util.Map;
 
+
 public class RemoteFlowWatcher extends FlowWatcher {
 
-  private final static long CHECK_INTERVAL_MS = 60 * 1000;
+  private final static long CHECK_INTERVAL_MS = 60000; // 60 * 1000
 
   private int execId;
   private ExecutorLoader loader;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -35,6 +34,7 @@ import azkaban.jmx.JmxTriggerManager;
 import azkaban.metrics.MetricsManager;
 import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleManager;
+import azkaban.server.IMBeanRegistration;
 import azkaban.server.AzkabanServer;
 import azkaban.server.session.SessionCache;
 import azkaban.trigger.TriggerManager;
@@ -48,6 +48,7 @@ import azkaban.trigger.builtin.SlaAlertAction;
 import azkaban.trigger.builtin.SlaChecker;
 import azkaban.user.UserManager;
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.StdOutErrRedirect;
@@ -76,10 +77,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
@@ -89,8 +87,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -122,7 +118,7 @@ import org.mortbay.thread.QueuedThreadPool;
  * Jetty truststore jetty.trustpassword - Jetty truststore password
  */
 @Singleton
-public class AzkabanWebServer extends AzkabanServer {
+public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistration {
 
   public static final String DEFAULT_CONF_PATH = "conf";
   private static final String AZKABAN_ACCESS_LOGGER_NAME =
@@ -146,11 +142,9 @@ public class AzkabanWebServer extends AzkabanServer {
   private final MetricsManager metricsManager;
   private final Props props;
   private final SessionCache sessionCache;
-  private final List<ObjectName> registeredMBeans = new ArrayList<>();
   private final FlowTriggerScheduler scheduler;
   private final FlowTriggerService flowTriggerService;
   private Map<String, TriggerPlugin> triggerPlugins;
-  private MBeanServer mbeanServer;
 
   @Inject
   public AzkabanWebServer(final Props props,
@@ -198,6 +192,7 @@ public class AzkabanWebServer extends AzkabanServer {
       DateTimeZone.setDefault(DateTimeZone.forID(timezone));
       logger.info("Setting timezone to " + timezone);
     }
+
     configureMBeanServer();
   }
 
@@ -307,40 +302,11 @@ public class AzkabanWebServer extends AzkabanServer {
     final ClassLoader parentLoader = AzkabanWebServer.class.getClassLoader();
     final File[] pluginDirs = viewerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        logger.error("Error viewer plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        logger.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          logger.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        logger.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
@@ -356,71 +322,18 @@ public class AzkabanWebServer extends AzkabanServer {
       final String pluginClass = pluginProps.getString("viewer.servlet.class");
       if (pluginClass == null) {
         logger.error("Viewer class is not set.");
+        continue;
       } else {
         logger.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            logger.error(e);
-          }
-        }
-
-        // Load any external libraries.
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            final File extLibFile = new File(pluginDir, extLib);
-            if (extLibFile.exists()) {
-              if (extLibFile.isDirectory()) {
-                // extLibFile is a directory; load all the files in the
-                // directory.
-                final File[] extLibFiles = extLibFile.listFiles();
-                for (int i = 0; i < extLibFiles.length; ++i) {
-                  try {
-                    final URL url = extLibFiles[i].toURI().toURL();
-                    urls.add(url);
-                  } catch (final MalformedURLException e) {
-                    logger.error(e);
-                  }
-                }
-              } else { // extLibFile is a file
-                try {
-                  final URL url = extLibFile.toURI().toURL();
-                  urls.add(url);
-                } catch (final MalformedURLException e) {
-                  logger.error(e);
-                }
-              }
-            } else {
-              logger.error("External library path "
-                  + extLibFile.getAbsolutePath() + " not found.");
-              continue;
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        logger
-            .error("Library path " + libDir.getAbsolutePath() + " not found.");
+      URLClassLoader urlClassLoader = PluginUtils.getURLClassLoader(pluginDir, extLibClasspath, parentLoader);
+      if (urlClassLoader == null) {
         continue;
       }
 
-      Class<?> viewerClass = null;
-      try {
-        viewerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        logger.error("Class " + pluginClass + " not found.");
+      Class<?> viewerClass = PluginUtils.getPluginClass(urlClassLoader, pluginClass);
+      if (viewerClass == null) {
         continue;
       }
 
@@ -684,25 +597,26 @@ public class AzkabanWebServer extends AzkabanServer {
     this.triggerPlugins = triggerPlugins;
   }
 
-  private void configureMBeanServer() {
+  @Override
+  public void configureMBeanServer() {
     logger.info("Registering MBeans...");
-    this.mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
-    registerMbean("jetty", new JmxJettyServer(this.server));
-    registerMbean("triggerManager", new JmxTriggerManager(this.triggerManager));
+    this.mbeanRegistrationManager.registerMBean("jetty", new JmxJettyServer(this.server));
+    this.mbeanRegistrationManager.registerMBean("triggerManager", new JmxTriggerManager(this.triggerManager));
 
     if (this.executorManagerAdapter instanceof ExecutorManager) {
-      registerMbean("executorManager",
+      this.mbeanRegistrationManager.registerMBean("executorManager",
           new JmxExecutorManager((ExecutorManager) this.executorManagerAdapter));
     } else if (this.executorManagerAdapter instanceof ExecutionController) {
-      registerMbean("executionController", new JmxExecutionController((ExecutionController) this
-          .executorManagerAdapter));
+      this.mbeanRegistrationManager.registerMBean("executionController",
+          new JmxExecutionController((ExecutionController) this.executorManagerAdapter));
     }
 
     // Register Log4J loggers as JMX beans so the log level can be
     // updated via JConsole or Java VisualVM
     final HierarchyDynamicMBean log4jMBean = new HierarchyDynamicMBean();
-    registerMbean("log4jmxbean", log4jMBean);
+    this.mbeanRegistrationManager.registerMBean("log4jmxbean", log4jMBean);
+
     final ObjectName accessLogLoggerObjName =
         log4jMBean.addLoggerMBean(AZKABAN_ACCESS_LOGGER_NAME);
 
@@ -717,14 +631,7 @@ public class AzkabanWebServer extends AzkabanServer {
   }
 
   public void close() {
-    try {
-      for (final ObjectName name : this.registeredMBeans) {
-        this.mbeanServer.unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
-      }
-    } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
-    }
+    this.mbeanRegistrationManager.closeMBeans();
     this.scheduleManager.shutdown();
     this.executorManagerAdapter.shutdown();
     try {
@@ -734,41 +641,5 @@ public class AzkabanWebServer extends AzkabanServer {
       logger.error(e);
     }
     this.server.destroy();
-  }
-
-  private void registerMbean(final String name, final Object mbean) {
-    final Class<?> mbeanClass = mbean.getClass();
-    final ObjectName mbeanName;
-    try {
-      mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
-      this.mbeanServer.registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
-      this.registeredMBeans.add(mbeanName);
-    } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(),
-          e);
-    }
-  }
-
-  public List<ObjectName> getMbeanNames() {
-    return this.registeredMBeans;
-  }
-
-  public MBeanInfo getMBeanInfo(final ObjectName name) {
-    try {
-      return this.mbeanServer.getMBeanInfo(name);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
-  }
-
-  public Object getMBeanAttribute(final ObjectName name, final String attribute) {
-    try {
-      return this.mbeanServer.getAttribute(name, attribute);
-    } catch (final Exception e) {
-      logger.error(e);
-      return null;
-    }
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
@@ -14,20 +14,19 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.Utils;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+
 
 public class PluginCheckerAndActionsLoader {
 
@@ -44,40 +43,11 @@ public class PluginCheckerAndActionsLoader {
     final ClassLoader parentLoader = getClass().getClassLoader();
     final File[] pluginDirs = triggerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        log.error("Error! Trigger plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        log.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          log.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        log.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
@@ -88,48 +58,18 @@ public class PluginCheckerAndActionsLoader {
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
         log.error("Trigger class is not set.");
+        continue;
       } else {
-        log.error("Plugin class " + pluginClass);
+        log.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            log.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              log.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        log.error("Library path " + propertiesDir + " not found.");
+      URLClassLoader urlClassLoader = PluginUtils.getURLClassLoader(pluginDir, extLibClasspath, parentLoader);
+      if (urlClassLoader == null) {
         continue;
       }
 
-      Class<?> triggerClass = null;
-      try {
-        triggerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        log.error("Class " + pluginClass + " not found.");
+      Class<?> triggerClass = PluginUtils.getPluginClass(urlClassLoader, pluginClass);
+      if (triggerClass == null) {
         continue;
       }
 
@@ -152,8 +92,6 @@ public class PluginCheckerAndActionsLoader {
         log.error("Unable to initiate action types for " + pluginClass);
         continue;
       }
-
     }
   }
-
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
@@ -14,19 +14,17 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
 
 import azkaban.utils.FileIOUtils;
+import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.webapp.plugin.TriggerPlugin;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +34,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 import org.mortbay.jetty.servlet.Context;
+
 
 public class TriggerPluginLoader {
 
@@ -56,45 +55,15 @@ public class TriggerPluginLoader {
       return new HashMap<>();
     }
 
-    final Map<String, TriggerPlugin> installedTriggerPlugins =
-        new HashMap<>();
+    final Map<String, TriggerPlugin> installedTriggerPlugins = new HashMap<>();
     final ClassLoader parentLoader = AzkabanWebServer.class.getClassLoader();
     final File[] pluginDirs = triggerPluginPath.listFiles();
     final ArrayList<String> jarPaths = new ArrayList<>();
+
     for (final File pluginDir : pluginDirs) {
-      if (!pluginDir.exists()) {
-        log.error("Error! Trigger plugin path " + pluginDir.getPath()
-            + " doesn't exist.");
-        continue;
-      }
-
-      if (!pluginDir.isDirectory()) {
-        log.error("The plugin path " + pluginDir + " is not a directory.");
-        continue;
-      }
-
-      // Load the conf directory
-      final File propertiesDir = new File(pluginDir, "conf");
-      Props pluginProps = null;
-      if (propertiesDir.exists() && propertiesDir.isDirectory()) {
-        final File propertiesFile = new File(propertiesDir, "plugin.properties");
-        final File propertiesOverrideFile =
-            new File(propertiesDir, "override.properties");
-
-        if (propertiesFile.exists()) {
-          if (propertiesOverrideFile.exists()) {
-            pluginProps =
-                PropsUtils.loadProps(null, propertiesFile,
-                    propertiesOverrideFile);
-          } else {
-            pluginProps = PropsUtils.loadProps(null, propertiesFile);
-          }
-        } else {
-          log.error("Plugin conf file " + propertiesFile + " not found.");
-          continue;
-        }
-      } else {
-        log.error("Plugin conf path " + propertiesDir + " not found.");
+      // load plugin properties
+      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+      if (pluginProps == null) {
         continue;
       }
 
@@ -106,48 +75,18 @@ public class TriggerPluginLoader {
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
         log.error("Trigger class is not set.");
+        continue;
       } else {
-        log.error("Plugin class " + pluginClass);
+        log.info("Plugin class " + pluginClass);
       }
 
-      URLClassLoader urlClassLoader = null;
-      final File libDir = new File(pluginDir, "lib");
-      if (libDir.exists() && libDir.isDirectory()) {
-        final File[] files = libDir.listFiles();
-
-        final ArrayList<URL> urls = new ArrayList<>();
-        for (int i = 0; i < files.length; ++i) {
-          try {
-            final URL url = files[i].toURI().toURL();
-            urls.add(url);
-          } catch (final MalformedURLException e) {
-            log.error(e);
-          }
-        }
-        if (extLibClasspath != null) {
-          for (final String extLib : extLibClasspath) {
-            try {
-              final File file = new File(pluginDir, extLib);
-              final URL url = file.toURI().toURL();
-              urls.add(url);
-            } catch (final MalformedURLException e) {
-              log.error(e);
-            }
-          }
-        }
-
-        urlClassLoader =
-            new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
-      } else {
-        log.error("Library path " + propertiesDir + " not found.");
+      URLClassLoader urlClassLoader = PluginUtils.getURLClassLoader(pluginDir, extLibClasspath, parentLoader);
+      if (urlClassLoader == null) {
         continue;
       }
 
-      Class<?> triggerClass = null;
-      try {
-        triggerClass = urlClassLoader.loadClass(pluginClass);
-      } catch (final ClassNotFoundException e) {
-        log.error("Class " + pluginClass + " not found.");
+      Class<?> triggerClass = PluginUtils.getPluginClass(urlClassLoader, pluginClass);
+      if (triggerClass == null) {
         continue;
       }
 
@@ -157,9 +96,7 @@ public class TriggerPluginLoader {
 
       Constructor<?> constructor = null;
       try {
-        constructor =
-            triggerClass.getConstructor(String.class, Props.class,
-                Context.class, AzkabanWebServer.class);
+        constructor = triggerClass.getConstructor(String.class, Props.class, Context.class, AzkabanWebServer.class);
       } catch (final NoSuchMethodException e) {
         log.error("Constructor not found in " + pluginClass);
         continue;
@@ -167,9 +104,7 @@ public class TriggerPluginLoader {
 
       Object obj = null;
       try {
-        obj =
-            constructor.newInstance(pluginName, pluginProps, root,
-                azkabanWebServer);
+        obj = constructor.newInstance(pluginName, pluginProps, root, azkabanWebServer);
       } catch (final Exception e) {
         log.error(e);
       }
@@ -191,5 +126,4 @@ public class TriggerPluginLoader {
 
     return installedTriggerPlugins;
   }
-
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -293,7 +292,6 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("timezone", TimeZone.getDefault().getID());
     page.add("currentTime", (new DateTime()).getMillis());
     page.add("size", getDisplayExecutionPageSize());
-
     page.add("System", System.class);
     page.add("TimeUtils", TimeUtils.class);
     page.add("WebUtils", WebUtils.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -488,36 +487,12 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final String projectName, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectName);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectName), user, type, ret);
   }
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put("error", "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put("error",
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void ajaxRestartFailed(final HttpServletRequest req,
@@ -550,8 +525,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
     final long startMs = System.currentTimeMillis();
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -562,17 +536,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     resp.setCharacterEncoding("utf-8");
 
     try {
-      final LogData data =
-          this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutableFlowLog(exFlow, offset, length);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
@@ -592,8 +558,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private void ajaxFetchJobLogs(final HttpServletRequest req,
       final HttpServletResponse resp, final HashMap<String, Object> ret, final User user,
       final ExecutableFlow exFlow) throws ServletException {
-    final Project project =
-        getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
+    final Project project = getProjectAjaxByPermission(ret, exFlow.getProjectId(), user, Type.READ);
     if (project == null) {
       return;
     }
@@ -607,27 +572,33 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     try {
       final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
       if (node == null) {
-        ret.put("error",
-            "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
+        ret.put("error", "Job " + jobId + " doesn't exist in " + exFlow.getExecutionId());
         return;
       }
 
       final int attempt = this.getIntParam(req, "attempt", node.getAttempt());
-      final LogData data =
-          this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length,
-              attempt);
-      if (data == null) {
-        ret.put("length", 0);
-        ret.put("offset", offset);
-        ret.put("data", "");
-      } else {
-        ret.put("length", data.getLength());
-        ret.put("offset", data.getOffset());
-        ret.put("data", StringEscapeUtils.escapeHtml(data.getData()));
-      }
+      final LogData data = this.executorManagerAdapter.getExecutionJobLog(exFlow, jobId, offset, length, attempt);
+      ret.putAll(appendLogData(data, offset));
+
     } catch (final ExecutorManagerException e) {
       throw new ServletException(e);
     }
+  }
+
+  private Map<String, Object> appendLogData(final LogData data, final int defaultOffset) {
+    Map<String, Object> parameters = new HashMap<>();
+
+    if (data == null) {
+      parameters.put("length", 0);
+      parameters.put("offset", defaultOffset);
+      parameters.put("data", "");
+    } else {
+      parameters.put("length", data.getLength());
+      parameters.put("offset", data.getOffset());
+      parameters.put("data", StringEscapeUtils.escapeHtml(data.getData()));
+    }
+
+    return parameters;
   }
 
   private void ajaxFetchJobStats(final HttpServletRequest req,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.executor.ConnectorParams;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 import javax.servlet.ServletConfig;
@@ -35,17 +33,14 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
 
+
 /**
  * Limited set of jmx calls for when you cannot attach to the jvm
  */
 public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     ConnectorParams {
 
-  /**
-   *
-   */
   private static final long serialVersionUID = 1L;
-
   private static final Logger logger = Logger.getLogger(JMXHttpServlet.class
       .getName());
 
@@ -94,13 +89,13 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         }
         ret = result;
       } else if (JMX_GET_MBEANS.equals(ajax)) {
-        ret.put("mbeans", this.server.getMbeanNames());
+        ret.put("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
       } else if (JMX_GET_MBEAN_INFO.equals(ajax)) {
         if (hasParam(req, JMX_MBEAN)) {
           final String mbeanName = getParam(req, JMX_MBEAN);
           try {
             final ObjectName name = new ObjectName(mbeanName);
-            final MBeanInfo info = this.server.getMBeanInfo(name);
+            final MBeanInfo info = this.server.mbeanRegistrationManager.getMBeanInfo(name);
             ret.put("attributes", info.getAttributes());
             ret.put("description", info.getDescription());
           } catch (final Exception e) {
@@ -119,7 +114,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
           try {
             final ObjectName name = new ObjectName(mbeanName);
-            final Object obj = this.server.getMBeanAttribute(name, attribute);
+            final Object obj = this.server.mbeanRegistrationManager.getMBeanAttribute(name, attribute);
             ret.put("value", obj);
           } catch (final Exception e) {
             logger.error(e);
@@ -130,24 +125,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         if (!hasParam(req, JMX_MBEAN)) {
           ret.put("error", "Parameters 'mbean' must be set");
         } else {
-          final String mbeanName = getParam(req, JMX_MBEAN);
-          try {
-            final ObjectName name = new ObjectName(mbeanName);
-            final MBeanInfo info = this.server.getMBeanInfo(name);
-
-            final MBeanAttributeInfo[] mbeanAttrs = info.getAttributes();
-            final Map<String, Object> attributes = new TreeMap<>();
-
-            for (final MBeanAttributeInfo attrInfo : mbeanAttrs) {
-              final Object obj = this.server.getMBeanAttribute(name, attrInfo.getName());
-              attributes.put(attrInfo.getName(), obj);
-            }
-
-            ret.put("attributes", attributes);
-          } catch (final Exception e) {
-            logger.error(e);
-            ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
-          }
+          ret.putAll(this.server.mbeanRegistrationManager.getMBeanResult(getParam(req, JMX_MBEAN)));
         }
       } else {
         ret.put("commands", new String[]{
@@ -168,7 +146,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/jmxpage.vm");
 
-    page.add("mbeans", this.server.getMbeanNames());
+    page.add("mbeans", this.server.mbeanRegistrationManager.getMBeanNames());
 
     final Map<String, Object> executorMBeans = new HashMap<>();
     for (final String hostPort : this.executorManagerAdapter.getAllActiveExecutorServerHosts()) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -46,11 +45,11 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+
 /**
  * Abstract Servlet that handles auto login when the session hasn't been verified.
  */
-public abstract class LoginAbstractAzkabanServlet extends
-    AbstractAzkabanServlet {
+public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
 
@@ -394,6 +393,42 @@ public abstract class LoginAbstractAzkabanServlet extends
     }
 
     return false;
+  }
+
+  /**
+   * Filter the project by the Permission
+   */
+  protected Project filterProjectByPermission(final Project project, final User user,
+      final Permission.Type type) {
+    return filterProjectByPermission(project, user, type, null);
+  }
+
+  /**
+   * Filter the project by the Permission
+   *
+   * @param project project
+   * @param user user
+   * @param type permission type
+   * @param ret return Map Object to store error information
+   * @return project itself or null
+   */
+  protected Project filterProjectByPermission(final Project project, final User user,
+      final Permission.Type type, final Map<String, Object> ret) {
+    if (project == null) {
+      if (ret != null) {
+        ret.put("error", "Project 'null' not found.");
+      }
+    } else if (!hasPermission(project, user, type)) {
+      if (ret != null) {
+        ret.put("error",
+            "User '" + user.getUserId() + "' doesn't have " + type.name()
+                + " permissions on " + project.getName());
+      }
+    } else {
+      return project;
+    }
+
+    return null;
   }
 
   protected void handleAjaxLoginAction(final HttpServletRequest req,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -58,6 +58,7 @@ import org.joda.time.Minutes;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
 
+
 public class ScheduleServlet extends LoginAbstractAzkabanServlet {
   public static final String PARAM_SLA_EMAILS = "slaEmails";
   public static final String PARAM_SCHEDULE_ID = "scheduleId";
@@ -381,19 +382,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
   protected Project getProjectAjaxByPermission(final Map<String, Object> ret,
       final int projectId, final User user, final Permission.Type type) {
-    final Project project = this.projectManager.getProject(projectId);
-
-    if (project == null) {
-      ret.put(PARAM_ERROR, "Project '" + project + "' not found.");
-    } else if (!hasPermission(project, user, type)) {
-      ret.put(STATUS_ERROR,
-          "User '" + user.getUserId() + "' doesn't have " + type.name()
-              + " permissions on " + project.getName());
-    } else {
-      return project;
-    }
-
-    return null;
+    return filterProjectByPermission(this.projectManager.getProject(projectId), user, type, ret);
   }
 
   private void handleGetAllSchedules(final HttpServletRequest req,


### PR DESCRIPTION
    There are no logic changes besides 2 tiny bugfixes, which I will list as below,

    Create AbstractHadoopJavaProcessJob class to share common codes which are used by
    HadoopHiveJob, HadoopJavaJob, HadoopPigJob & HadoopSparkJob.
    Create AbstractMBeanRegistrableServer class to share common codes which are used by AzkabanExecServer, AzkabanWebServer.
    Clean some non-referenced import files to improve the code quality
    Remove duplicate code if it can be replaced by FileIOUtils.getSourcePathFromClass() function
    Introduce PropsUtils.loadPluginProps() Utility function for removing duplicate code in the following classes (AlerterHolder, AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader)
    Add private constructor for PropsUtils class to match the singleton pattern for Utility Class.
    Create new PluginUtils class includes getUrls, getURLClassLoader, getPluginClass Utils which are used by AzkabanWebServer, PluginCheckerAndActionsLoader, TriggerPluginLoader.
    Add default parameter for Utils.createPeriodString() function, which make it be reusable in Schedule.class, BasicTimeChecker.class, ScheduleServlet.calss
    Remove unnecessary ENV. prefix checking in AbstractProcessJob.getEnvironmentVariables() function
    Introduce SlaOption.convertToObjects static function which can be shared by ExecuteFlowAction.class and Schedule.class
    Move check and delete tokenFile logic into the HadoopJobUtils.cancelHadoopTokens Util since it is duplicated in all callers
    Create Utils.runProcess Utils to reduce duplicate code in ServerStatisticsServlet class.
    Create FilterProjectByPermission function in LoginAbstractAzkabanServlet for making it be reusable in all extended classes.
    BUG:

    Remove Logger log in AbstractProcessJob since log object has been existed in the parent AbstractJob class.
    2 In both PluginCheckerAndActionsLoader.load() and TriggerPluginLoader.load() function., error log was fired regardless if(pluginClass == null) is true/false. Fix this bug. log.error when (plugClass == null) and skip the following unnecessary logic. log.info when (plugClass != null) and run the following expected logic
    Will Introduce more test cases to cover the logic soon.