### PR TITLE
Preserve JSON encoding in generated output properties

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
@@ -179,7 +179,9 @@ public abstract class AbstractProcessJob extends AbstractJob {
             (Map<String, Object>) JSONUtils.parseJSONFromString(content);
 
         for (final Map.Entry<String, Object> entry : propMap.entrySet()) {
-          outputProps.put(entry.getKey(), entry.getValue().toString());
+          Object val = entry.getValue();
+          String strVal = val instanceof String ? (String) val : JSONUtils.toJSON(val);
+          outputProps.put(entry.getKey(), strVal);
         }
       }
       return outputProps;


### PR DESCRIPTION
Currently, if an output property is JSON, the generated property doesn't preserve the JSON encoding. For example, the following:

`echo '{"param1”:[“a”,”b”]}’ > $JOB_OUTPUT_PROP_FILE`

results in param1 having a value of “[a,b]”, which is not valid JSON; the result of calling toString() on the java List containing the “a” and “b” strings. This prevents subsequent jobs from deserializing JSON.

This pull request preserves JSON output properties without affecting non-JSON string values.