### PR TITLE
Add whitelist for specifying max number of concurrent runs for flows

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -224,6 +224,8 @@ public class Constants {
     public static final String USE_MULTIPLE_EXECUTORS = "azkaban.use.multiple.executors";
     public static final String MAX_CONCURRENT_RUNS_ONEFLOW = "azkaban.max.concurrent.runs.oneflow";
 
+    // list of whitelisted flows, with specific max number of concurrent runs. Format:
+    // <project 1>,<flow 1>,<number>;<project 2>,<flow 2>,<number>
     public static final String CONCURRENT_RUNS_ONEFLOW_WHITELIST =
         "azkaban.concurrent.runs.oneflow.whitelist";
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -88,6 +88,9 @@ public class Constants {
   // The flow exec id for a flow trigger instance unable to trigger a flow yet
   public static final int FAILED_EXEC_ID = -2;
 
+  // Default maximum number of concurrent runs for a single flow
+  public static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
+
   public static class ConfigurationKeys {
 
     // Configures Azkaban to use new polling model for dispatching
@@ -220,6 +223,10 @@ public class Constants {
 
     public static final String USE_MULTIPLE_EXECUTORS = "azkaban.use.multiple.executors";
     public static final String MAX_CONCURRENT_RUNS_ONEFLOW = "azkaban.max.concurrent.runs.oneflow";
+
+    public static final String CONCURRENT_RUNS_ONEFLOW_WHITELIST =
+        "azkaban.concurrent.runs.oneflow.whitelist";
+
     public static final String WEBSERVER_QUEUE_SIZE = "azkaban.webserver.queue.size";
     public static final String ACTIVE_EXECUTOR_REFRESH_IN_MS =
         "azkaban.activeexecutor.refresh.milisecinterval";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -52,12 +52,12 @@ public class ExecutionController extends EventHandler implements ExecutorManager
 
   private static final Logger logger = LoggerFactory.getLogger(ExecutionController.class);
   private static final Duration RECENTLY_FINISHED_LIFETIME = Duration.ofMinutes(10);
-  private static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
   private final ExecutorLoader executorLoader;
   private final ExecutorApiGateway apiGateway;
   private final AlerterHolder alerterHolder;
   private final ExecutorHealthChecker executorHealthChecker;
   private final int maxConcurrentRunsOneFlow;
+  private final Map<Pair<String,String>, Integer> maxConcurrentRunsPerFlowMap;
   private final CommonMetrics commonMetrics;
 
   @Inject
@@ -70,14 +70,8 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     this.apiGateway = apiGateway;
     this.alerterHolder = alerterHolder;
     this.executorHealthChecker = executorHealthChecker;
-    this.maxConcurrentRunsOneFlow = getMaxConcurrentRunsOneFlow(azkProps);
-  }
-
-  private int getMaxConcurrentRunsOneFlow(final Props azkProps) {
-    // The default threshold is set to 30 for now, in case some users are affected. We may
-    // decrease this number in future, to better prevent DDos attacks.
-    return azkProps.getInt(ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW,
-        DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
+    this.maxConcurrentRunsOneFlow = ExecutorUtils.getMaxConcurrentRunsOneFlow(azkProps);
+    this.maxConcurrentRunsPerFlowMap = ExecutorUtils.getMaxConcurentRunsPerFlowMap(azkProps);
   }
 
   @Override
@@ -604,10 +598,12 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       }
 
       if (!running.isEmpty()) {
-        if (running.size() > this.maxConcurrentRunsOneFlow) {
+        int maxConcurrentRuns = ExecutorUtils.getMaxConcurrentRunsForFlow(
+            exflow.getProjectName(), flowId, maxConcurrentRunsOneFlow, maxConcurrentRunsPerFlowMap);
+        if (running.size() > maxConcurrentRuns) {
           this.commonMetrics.markSubmitFlowSkip();
           throw new ExecutorManagerException("Flow " + flowId
-              + " has more than " + this.maxConcurrentRunsOneFlow + " concurrent runs. Skipping",
+              + " has more than " + maxConcurrentRuns + " concurrent runs. Skipping",
               ExecutorManagerException.Reason.SkippedExecution);
         } else if (options.getConcurrentOption().equals(
             ExecutionOptions.CONCURRENT_OPTION_PIPELINE)) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
@@ -1,0 +1,62 @@
+package azkaban.executor;
+
+import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Executor utility functions */
+public class ExecutorUtils {
+
+  /** Private constructor. */
+  private ExecutorUtils() {}
+
+  /** @return the maximum number of concurrent runs for one flow */
+  public static int getMaxConcurrentRunsOneFlow(final Props azkProps) {
+    // The default threshold is set to 30 for now, in case some users are affected. We may
+    // decrease this number in future, to better prevent DDos attacks.
+    return azkProps.getInt(ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW,
+        Constants.DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
+  }
+
+  /** @return a map of (project name, flow name) to max number of concurrent runs for the flow. */
+  public static Map<Pair<String, String>, Integer> getMaxConcurentRunsPerFlowMap(
+      final Props azkProps) {
+    Map<Pair<String, String>, Integer> map = new HashMap<>();
+    String perFlowSettings =azkProps.get(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST);
+    if (perFlowSettings != null) {
+      String[] flowSettings = perFlowSettings.split(";");
+      for (String flowSetting: flowSettings) {
+        String[] setting = flowSetting.split(",");
+        Preconditions.checkState(setting.length == 3,
+            "setting value must be specified as <project name>,<flow name>,<max concurrent runs>");
+        Pair<String, String> key = new Pair(setting[0], setting[1]);
+        Integer maxRuns = Integer.parseInt(setting[2]);
+        map.put(key, maxRuns);
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Get the maximum number of concurrent runs for the specified flow, using the value in
+   * azkaban.concurrent.runs.oneflow.whitelist if explictly specified for the flow, and otherwise
+   * azkaban.max.concurrent.runs.oneflow or the default.
+   *
+   * @param projectName project name
+   * @param flowName flow name
+   * @param defaultMaxConcurrentRuns default max number of concurrent runs for one flow, if not
+   * explcitly specified for the flow.
+   * @param maxConcurrentRunsFlowMap map of (project, flow) to max number of concurrent runs for
+   * flow for which the value is explicitly specified via whitelist.
+   * @return the maximum number of concurrent runs for the flow.
+   */
+  public static int getMaxConcurrentRunsForFlow(String projectName, String flowName,
+      int defaultMaxConcurrentRuns, Map<Pair<String, String>, Integer> maxConcurrentRunsFlowMap) {
+      return maxConcurrentRunsFlowMap.getOrDefault(new Pair(projectName, flowName),
+          defaultMaxConcurrentRuns);
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
@@ -26,10 +26,14 @@ public class ExecutorUtils {
   public static Map<Pair<String, String>, Integer> getMaxConcurentRunsPerFlowMap(
       final Props azkProps) {
     Map<Pair<String, String>, Integer> map = new HashMap<>();
-    String perFlowSettings =azkProps.get(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST);
+    String perFlowSettings = azkProps.get(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST);
     if (perFlowSettings != null) {
+      // settings for flows are delimited by semicolon, so split on semicolon to to get the list
+      // of flows with custom max concurrent runs
       String[] flowSettings = perFlowSettings.split(";");
       for (String flowSetting: flowSettings) {
+        // fields for a flow are delimited by comma, so split on comma to get the list of fields:
+        // project name, flow name, and max number of concurrent runs.
         String[] setting = flowSetting.split(",");
         Preconditions.checkState(setting.length == 3,
             "setting value must be specified as <project name>,<flow name>,<max concurrent runs>");

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorUtils.java
@@ -1,4 +1,18 @@
-package azkaban.executor;
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package azkaban.executor;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.user.User;
@@ -171,12 +172,25 @@ public class ExecutionControllerTest {
 
   @Test
   public void testSubmitFlowsExceedingMaxConcurrentRuns() throws Exception {
+    this.props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST, "exectest1,"
+        + "exec2,3");
     submitFlow(this.flow2, this.ref2);
     submitFlow(this.flow3, this.ref3);
     assertThatThrownBy(() -> this.controller.submitExecutableFlow(this.flow4, this.user.getUserId
         ())).isInstanceOf(ExecutorManagerException.class).hasMessageContaining("Flow " + this
         .flow4.getId() + " has more than 1 concurrent runs. Skipping");
   }
+
+  @Test
+  public void testSubmitFlowsConcurrentWhitelist() throws Exception {
+    this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
+    submitFlow(this.flow2, this.ref2);
+    submitFlow(this.flow3, this.ref3);
+    assertThatThrownBy(() -> this.controller.submitExecutableFlow(this.flow4, this.user.getUserId
+        ())).isInstanceOf(ExecutorManagerException.class).hasMessageContaining("Flow " + this
+        .flow4.getId() + " has more than 1 concurrent runs. Skipping");
+  }
+
 
   @Test
   public void testSubmitFlowsWithSkipOption() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -404,6 +404,34 @@ public class ExecutorManagerTest {
     this.manager.submitExecutableFlow(flow4, this.user.getUserId());
   }
 
+  // Flows can be whitelisted to support a specified max number of concurrent flows.
+  @Test(expected = ExecutorManagerException.class)
+  public void testConcurrentRunWhitelist() throws Exception {
+    testSetUpForRunningFlows();
+    this.props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST, "basicyamlshelltest,"
+        + "bashSleep,4");
+    final ExecutableFlow flow1 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow1.setExecutionId(101);
+    final ExecutableFlow flow2 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow2.setExecutionId(102);
+    final ExecutableFlow flow3 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow3.setExecutionId(103);
+    final ExecutableFlow flow4 = TestUtils
+        .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
+    flow4.setExecutionId(104);
+    this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow1);
+    this.manager.submitExecutableFlow(flow2, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow2);
+    this.manager.submitExecutableFlow(flow3, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow3);
+    this.manager.submitExecutableFlow(flow4, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow4);
+  }
+
   @Ignore
   @Test
   public void testFetchAllActiveFlows() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
@@ -1,10 +1,21 @@
-package azkaban.executor;
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */package azkaban.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
@@ -68,6 +68,5 @@ public class ExecutorUtilsTest {
     // return default value if there are no if the whitelisted flow map is empty
     assertThat(ExecutorUtils.getMaxConcurrentRunsForFlow("project1", "flow1",
         defaultMaxConcurrent, Collections.EMPTY_MAP)).isEqualTo(10);
-
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorUtilsTest.java
@@ -1,0 +1,73 @@
+package azkaban.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.utils.Pair;
+import azkaban.utils.Props;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+/** Tests for {@link ExecutorUtils}. */
+public class ExecutorUtilsTest {
+  @Test
+  public void testGetMaxConcurrentRunsOneFlow() {
+    Props props = new Props();
+    assertThat(ExecutorUtils.getMaxConcurrentRunsOneFlow(props)).isEqualTo(
+        Constants.DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW);
+
+    // set explictly
+    props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 5);
+    assertThat(ExecutorUtils.getMaxConcurrentRunsOneFlow(props)).isEqualTo(
+        5);
+  }
+
+  @Test
+  public void testGetMaxConcurentRunsPerFlowMap() {
+    Props props = new Props();
+
+    // empty map is returned if whitelist is not set
+    assertThat(ExecutorUtils.getMaxConcurentRunsPerFlowMap(props).size()).isEqualTo(0);
+
+    props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST,
+        "project1,flow1,300;project2,flow2,5");
+
+    Map<Pair<String, String>, Integer> map =  ExecutorUtils.getMaxConcurentRunsPerFlowMap(props);
+    assertThat(map.size()).isEqualTo(2);
+    assertThat(map.get(new Pair("project1", "flow1"))).isEqualTo(300);
+    assertThat(map.get(new Pair("project2", "flow2"))).isEqualTo(5);
+
+    // negative test: missing flow
+    props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST,
+        "project1,flow1,300;project2,5");
+    assertThatThrownBy(() -> ExecutorUtils.getMaxConcurentRunsPerFlowMap(props)).isInstanceOf
+        (IllegalStateException.class);
+  }
+
+  @Test
+  public void testGetMaxConcurrentRunsForFlow() {
+    Props props = new Props();
+    props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 10);
+    props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST,
+        "project1,flow1,300;project2,flow2,5");
+    Map<Pair<String, String>, Integer> map =  ExecutorUtils.getMaxConcurentRunsPerFlowMap(props);
+    int defaultMaxConcurrent = ExecutorUtils.getMaxConcurrentRunsOneFlow(props);
+    assertThat(ExecutorUtils.getMaxConcurrentRunsForFlow("project1", "flow1",
+        defaultMaxConcurrent, map)).isEqualTo(300);
+    assertThat(ExecutorUtils.getMaxConcurrentRunsForFlow("project2", "flow2",
+        defaultMaxConcurrent, map)).isEqualTo(5);
+    assertThat(ExecutorUtils.getMaxConcurrentRunsForFlow("project3", "flow3",
+        defaultMaxConcurrent, map)).isEqualTo(10);
+
+    // return default value if there are no if the whitelisted flow map is empty
+    assertThat(ExecutorUtils.getMaxConcurrentRunsForFlow("project1", "flow1",
+        defaultMaxConcurrent, Collections.EMPTY_MAP)).isEqualTo(10);
+
+  }
+}


### PR DESCRIPTION
For some use cases, such as Gobblin as a Service, there is a requirement to be able to run a higher number of concurrent runs for a workflow than the default value of 30. Azkaban configuration parameter azkaban.max.concurrent.runs.oneflow(introduced in https://github.com/azkaban/azkaban/pull/1590) can be set to change the default for an Azkaban cluster, but this will affect all flows running on the cluster. New Azkaban configuration parameter azkaban.concurrent.runs.oneflow.whitelist will allow specific flows to have a higher (or low) max concurrent number of runs. The value lists the project, flow and number for each flow. Flows are semicolon separated, and each field for a flow is comma separated. The value has the format: "<project name 1>,<flow name 1>,<num concurrent>;<project name 2>,<flow name 2>,<num concurrent>..."