### PR TITLE
Fix failing autoReload test

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/ParseConfigFile.java
+++ b/azkaban-common/src/main/java/azkaban/user/ParseConfigFile.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.user;
 
 /**

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -89,7 +89,7 @@ public final class UserUtils {
           // There is no entry for this directory, create a watchkey
           WatchKey watchKey = dir.register(watchService,
               new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_MODIFY},
-              SensitivityWatchEventModifier.LOW);
+              SensitivityWatchEventModifier.MEDIUM);
           keys.put(watchKey, dir);
         }
         // Add the config file to dir map
@@ -119,6 +119,9 @@ public final class UserUtils {
         WatchKey watchKey;
         try {
           watchKey = watchService.take();
+          // Wait for a second to ensure there is only one event for a modification.
+          // WatchService otherwise creates two events 1 for content and 1 for modification time.
+          Thread.sleep(1000L);
         } catch (InterruptedException ie) {
           log.warn(ie.getMessage());
           Thread.currentThread().interrupt();

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -78,12 +78,12 @@ public final class UserUtils {
       }
 
       try {
-        Path dir = Paths.get(fileName).getParent();
+        final Path dir = Paths.get(fileName).getParent();
         if (!dirToFilesMap.containsKey(dir)) {
-          // There is not entry for this directory, create a watchkey
+          // There is no entry for this directory, create a watchkey
           WatchKey watchKey = dir.register(watchService,
               new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_MODIFY},
-              SensitivityWatchEventModifier.HIGH);
+              SensitivityWatchEventModifier.LOW);
           keys.put(watchKey, dir);
         }
         // Add the config file to dir map
@@ -108,7 +108,7 @@ public final class UserUtils {
 
     Runnable runnable = () -> {
       // Watchservice is established, now listen for the events till eternity!
-      for (;; ) {
+      for (;;) {
         WatchKey watchKey;
         try {
           watchKey = watchService.take();
@@ -131,7 +131,6 @@ public final class UserUtils {
             // reparse the config file
             log.info("Modification detected, reloading config file " + filename);
             configFileMap.get(filename).parseConfigFile();
-            break;
           }
         }
         watchKey.reset();

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -149,7 +149,8 @@ public final class UserUtils {
             }
             fileTimeMap.put(filename, modifiedTime);
             // reparse the config file
-            log.info("Modification detected, reloading config file " + filename);
+            log.info("Modification detected, reloading config file " + filename + ". The "
+                + "modification time is " + modifiedTime);
             configFileMap.get(filename).parseConfigFile();
           }
         }

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -47,6 +47,7 @@ public final class UserUtils {
   /**
    * Creates a watch thread which listens to specified files' modification and reloads
    * configurations
+   * @param configFileMap : Map of file name with fully qualified path and its corresponding parser.
    */
   static void setupWatch(final Map<String, ParseConfigFile> configFileMap) throws IOException {
     Preconditions.checkNotNull(configFileMap);

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -20,8 +20,11 @@ import azkaban.user.User.UserPermissions;
 import azkaban.utils.Props;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
@@ -116,6 +119,12 @@ public class XmlUserManager implements UserManager {
     try {
       doc = builder.parse(file);
     } catch (final SAXException e) {
+      // Dump out config file contents
+      try {
+        List<String> lines = Files.readAllLines(Paths.get(this.xmlPath));
+      } catch (IOException ioe) {
+        logger.warn("IO Exception while reading config file " + this.xmlPath + ". " + ioe.getMessage());
+      }
       throw new IllegalArgumentException("Exception while parsing " + this.xmlPath
           + ". Invalid XML.", e);
     } catch (final IOException e) {

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -122,6 +122,9 @@ public class XmlUserManager implements UserManager {
       // Dump out config file contents
       try {
         List<String> lines = Files.readAllLines(Paths.get(this.xmlPath));
+        for (String line : lines) {
+          logger.info("Deepak : " + line);
+        }
       } catch (IOException ioe) {
         logger.warn("IO Exception while reading config file " + this.xmlPath + ". " + ioe.getMessage());
       }

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -123,7 +123,7 @@ public class XmlUserManager implements UserManager {
       try {
         List<String> lines = Files.readAllLines(Paths.get(this.xmlPath));
         for (String line : lines) {
-          logger.info("Deepak : " + line);
+          logger.info("XML File : " + line);
         }
       } catch (IOException ioe) {
         logger.warn("IO Exception while reading config file " + this.xmlPath + ". " + ioe.getMessage());


### PR DESCRIPTION
-Lower the sensitivity of watch service to give it ample time to ensure the file is closed before it is parsed.

This maybe causing -1:-1 Premature end of file error
- Added header for ParseConfigFile Interface
- Some minor typo fixes and indentations.