### PR TITLE
Add APIs for locking a flow

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -88,6 +88,11 @@ public class Constants {
   // The flow exec id for a flow trigger instance unable to trigger a flow yet
   public static final int FAILED_EXEC_ID = -2;
 
+  // Default locked flow error message
+  public static final String DEFAULT_LOCKED_FLOW_ERROR_MESSAGE =
+      "Flow %s in project %s is locked. This is either a repeatedly failing flow, or an ineffcient"
+          + " flow. Please refer to the Dr. Elephant report for this flow for more information.";
+
   public static class ConfigurationKeys {
 
     // Configures Azkaban to use new polling model for dispatching
@@ -244,6 +249,10 @@ public class Constants {
 
     // number of rows to be displayed on the executions page.
     public static final String DISPLAY_EXECUTION_PAGE_SIZE = "azkaban.display.execution_page_size";
+
+    // locked flow error message. Parameters passed in are the flow name and project name.
+    public static final String AZKABAN_LOCKED_FLOW_ERROR_MESSAGE =
+        "azkaban.locked.flow.error.message";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -58,6 +58,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private String executionPath;
   private ExecutionOptions executionOptions;
   private double azkabanFlowVersion;
+  private boolean isLocked;
 
   public ExecutableFlow(final Project project, final Flow flow) {
     this.projectId = project.getId();
@@ -67,6 +68,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.lastModifiedTimestamp = project.getLastModifiedTimestamp();
     this.lastModifiedUser = project.getLastModifiedUser();
     setAzkabanFlowVersion(flow.getAzkabanFlowVersion());
+    setLocked(flow.isLocked());
     this.setFlow(project, flow);
   }
 
@@ -210,6 +212,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public void setAzkabanFlowVersion(final double azkabanFlowVersion) {
     this.azkabanFlowVersion = azkabanFlowVersion;
   }
+
+  public boolean isLocked() { return isLocked; }
+
+  public void setLocked(boolean locked) { isLocked = locked; }
 
   @Override
   public Map<String, Object> toObject() {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -45,6 +45,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String LASTMODIFIEDUSER_PARAM = "lastModifiedUser";
   public static final String SLAOPTIONS_PARAM = "slaOptions";
   public static final String AZKABANFLOWVERSION_PARAM = "azkabanFlowVersion";
+  public static final String IS_LOCKED_PARAM = "isLocked";
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
   private int scheduleId = -1;
@@ -250,6 +251,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
 
+    flowObj.put(IS_LOCKED_PARAM, this.isLocked);
+
     return flowObj;
   }
 
@@ -291,6 +294,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
               .collect(Collectors.toList());
       this.executionOptions.setSlaOptions(slaOptions);
     }
+
+    this.setLocked(flowObj.getBool(IS_LOCKED_PARAM, false));
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -213,9 +213,9 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.azkabanFlowVersion = azkabanFlowVersion;
   }
 
-  public boolean isLocked() { return isLocked; }
+  public boolean isLocked() { return this.isLocked; }
 
-  public void setLocked(boolean locked) { isLocked = locked; }
+  public void setLocked(boolean locked) { this.isLocked = locked; }
 
   @Override
   public Map<String, Object> toObject() {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -577,6 +577,14 @@ public class ExecutionController extends EventHandler implements ExecutorManager
   @Override
   public String submitExecutableFlow(final ExecutableFlow exflow, final String userId)
       throws ExecutorManagerException {
+    if (exflow.isLocked()) {
+      // Skip execution for locked flows.
+      final String message = String.format("Flow %s for project %s is locked.", exflow.getId(),
+          exflow.getProjectName());
+      logger.info(message);
+      return message;
+    }
+
     final String exFlowKey = exflow.getProjectName() + "." + exflow.getId() + ".submitFlow";
     // Use project and flow name to prevent race condition when same flow is submitted by API and
     // schedule at the same time

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -934,6 +934,13 @@ public class ExecutorManager extends EventHandler implements
   @Override
   public String submitExecutableFlow(final ExecutableFlow exflow, final String userId)
       throws ExecutorManagerException {
+    if (exflow.isLocked()) {
+      // Skip execution for locked flows.
+      final String message = String.format("Flow %s for project %s is locked.", exflow.getId(),
+          exflow.getProjectName());
+      logger.info(message);
+      return message;
+    }
 
     final String exFlowKey = exflow.getProjectName() + "." + exflow.getId() + ".submitFlow";
     // using project and flow name to prevent race condition when same flow is submitted by API and schedule at the same time

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -467,7 +467,7 @@ public class Flow {
     this.projectId = projectId;
   }
 
-  public boolean isLocked() { return isLocked; }
+  public boolean isLocked() { return this.isLocked; }
 
-  public void setLocked(boolean locked) { isLocked = locked; }
+  public void setLocked(boolean locked) { this.isLocked = locked; }
 }

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -51,6 +51,7 @@ public class Flow {
   private boolean isEmbeddedFlow = false;
   private double azkabanFlowVersion = Constants.DEFAULT_AZKABAN_FLOW_VERSION;
   private String condition = null;
+  private boolean isLocked = false;
 
   public Flow(final String id) {
     this.id = id;
@@ -64,6 +65,7 @@ public class Flow {
     final Boolean isEmbeddedFlow = (Boolean) flowObject.get("embeddedFlow");
     final Double azkabanFlowVersion = (Double) flowObject.get("azkabanFlowVersion");
     final String condition = (String) flowObject.get("condition");
+    final Boolean isLocked = (Boolean) flowObject.get("isLocked");
 
     final Flow flow = new Flow(id);
     if (layedout != null) {
@@ -80,6 +82,10 @@ public class Flow {
 
     if (condition != null) {
       flow.setCondition(condition);
+    }
+
+    if (isLocked != null) {
+      flow.setLocked(isLocked);
     }
 
     final int projId = (Integer) flowObject.get("project.id");
@@ -347,6 +353,7 @@ public class Flow {
     flowObj.put("embeddedFlow", this.isEmbeddedFlow);
     flowObj.put("azkabanFlowVersion", this.azkabanFlowVersion);
     flowObj.put("condition", this.condition);
+    flowObj.put("isLocked", this.isLocked);
 
     if (this.errors != null) {
       flowObj.put("errors", this.errors);
@@ -460,4 +467,7 @@ public class Flow {
     this.projectId = projectId;
   }
 
+  public boolean isLocked() { return isLocked; }
+
+  public void setLocked(boolean locked) { isLocked = locked; }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
@@ -266,6 +266,12 @@ public class ExecutableFlowTest {
     Assert.assertEquals("innerFlow", jobdFlow.getFlowId());
     Assert.assertEquals("jobd", jobdFlow.getId());
     Assert.assertEquals(4, jobdFlow.getExecutableNodes().size());
+
+    Assert.assertEquals(false, exFlow.isLocked());
+    exFlow.setLocked(true);
+    Assert.assertEquals(true, exFlow.isLocked());
+    exFlow.setLocked(false);
+    Assert.assertEquals(false, exFlow.isLocked());
   }
 
   @Test
@@ -296,6 +302,7 @@ public class ExecutableFlowTest {
     exFlow.resetForRetry();
     exFlow.resetForRetry();
     exFlow.setDelayedExecution(1000);
+    exFlow.setLocked(true);
 
     final ExecutionOptions options = new ExecutionOptions();
     options.setConcurrentOption("blah");

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -212,6 +212,19 @@ public class ExecutionControllerTest {
         this.user.getUserId());
   }
 
+  @Test
+  public void testSetFlowLock() throws Exception {
+    // trying to execute a locked flow should raise an error
+    this.flow1.setLocked(true);
+    String msg = this.controller.submitExecutableFlow(this.flow1, this.user.getUserId());
+    assertThat(msg).isEqualTo("Flow derived-member-data for project flow is locked.");
+
+    // should succeed after unlocking the flow
+    this.flow1.setLocked(false);
+    this.controller.submitExecutableFlow(this.flow1, this.user.getUserId());
+      verify(this.loader).uploadExecutableFlow(this.flow1);
+  }
+
   private void submitFlow(final ExecutableFlow flow, final ExecutionReference ref) throws
       Exception {
     when(this.loader.fetchUnfinishedFlows()).thenReturn(this.unfinishedFlows);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -486,6 +486,21 @@ public class ExecutorManagerTest {
     verify(this.loader, Mockito.times(2)).unassignExecutor(-1);
   }
 
+  @Test
+  public void testSetFlowLock() throws Exception {
+    testSetUpForRunningFlows();
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    flow1.setLocked(true);
+    String msg = this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    assertThat(msg).isEqualTo("Flow derived-member-data for project flow is locked.");
+
+    // unlock the flow
+    flow1.setLocked(false);
+    this.manager.submitExecutableFlow(flow1, this.user.getUserId());
+    verify(this.loader).uploadExecutableFlow(flow1);
+    verify(this.loader).addActiveExecutableReference(any());
+  }
+
   /*
    * TODO: will move below method to setUp() and run before every test for both runningFlows and queuedFlows
    */

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -154,10 +154,12 @@ public class FlowTriggerScheduler {
           final List<? extends Trigger> quartzTriggers = quartzScheduler.getTriggersOfJob(jobKey);
           final boolean isPaused = this.scheduler
               .isJobPaused(FlowTriggerQuartzJob.JOB_NAME, groupName);
+          final Project project = projectManager.getProject(projectId);
+          final Flow flow = project.getFlow(flowId);
           scheduledFlowTrigger = new ScheduledFlowTrigger(projectId,
               this.projectManager.getProject(projectId).getName(),
               flowId, flowTrigger, submitUser, quartzTriggers.isEmpty() ? null
-              : quartzTriggers.get(0), isPaused);
+              : quartzTriggers.get(0), isPaused, flow.isLocked());
         } catch (final Exception ex) {
           logger.error("Unable to get flow trigger by job key {}", jobKey, ex);
           scheduledFlowTrigger = null;
@@ -217,10 +219,11 @@ public class FlowTriggerScheduler {
     private final Trigger quartzTrigger;
     private final String submitUser;
     private final boolean isPaused;
+    private final boolean isLocked;
 
     public ScheduledFlowTrigger(final int projectId, final String projectName, final String flowId,
         final FlowTrigger flowTrigger, final String submitUser,
-        final Trigger quartzTrigger, final boolean isPaused) {
+        final Trigger quartzTrigger, final boolean isPaused, final boolean isLocked) {
       this.projectId = projectId;
       this.projectName = projectName;
       this.flowId = flowId;
@@ -228,6 +231,7 @@ public class FlowTriggerScheduler {
       this.submitUser = submitUser;
       this.quartzTrigger = quartzTrigger;
       this.isPaused = isPaused;
+      this.isLocked = isLocked;
     }
 
     public boolean isPaused() {
@@ -262,5 +266,7 @@ public class FlowTriggerScheduler {
     public String getSubmitUser() {
       return this.submitUser;
     }
+
+    public boolean isLocked() { return this.isLocked; }
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -466,6 +466,10 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectName", project.getName());
     page.add("flowid", flow.getFlowId());
 
+    // check the current flow definition to see if the flow is locked.
+    Flow currentFlow = project.getFlow(flow.getFlowId());
+    page.add("isLocked", currentFlow.isLocked());
+
     page.render();
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -87,6 +87,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   static final String FLOW_IS_LOCKED_PARAM = "isLocked";
   static final String FLOW_ID_PARAM = "flowId";
   static final String FLOW_NAME_PARAM = "flowName";
+  static final String ERROR_PARAM = "error";
   private static final String APPLICATION_ZIP_MIME_TYPE = "application/zip";
   private static final long serialVersionUID = 1;
   private static final Logger logger = Logger
@@ -231,7 +232,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final Project project = this.projectManager.getProject(projectName);
     if (project == null) {
-      ret.put("error", "Project " + projectName + " doesn't exist.");
+      ret.put(ERROR_PARAM, "Project " + projectName + " doesn't exist.");
     } else {
       ret.put("projectId", project.getId());
       final String ajaxName = getParam(req, "ajax");
@@ -320,7 +321,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           ajaxIsFlowLocked(project, ret, req);
         }
       } else {
-        ret.put("error", "Cannot execute command " + ajaxName);
+        ret.put(ERROR_PARAM, "Cannot execute command " + ajaxName);
       }
     }
 
@@ -333,7 +334,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       return true;
     }
 
-    ret.put("error", "Permission denied. Need " + type.toString() + " access.");
+    ret.put(ERROR_PARAM, "Permission denied. Need " + type.toString() + " access.");
     return false;
   }
 
@@ -384,7 +385,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       final Flow flow = project.getFlow(flowName);
       if (flow == null) {
-        ret.put("error", "Flow " + flowName + " not found.");
+        ret.put(ERROR_PARAM, "Flow " + flowName + " not found.");
         return;
       }
 
@@ -393,7 +394,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         ret.put("condition", flow.getCondition());
       }
     } catch (final AccessControlException e) {
-      ret.put("error", e.getMessage());
+      ret.put(ERROR_PARAM, e.getMessage());
     }
   }
 
@@ -407,7 +408,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           this.executorManagerAdapter.getExecutableFlows(project.getId(), flowId, 0, 1,
               Status.SUCCEEDED);
     } catch (final ExecutorManagerException e) {
-      ret.put("error", "Error retrieving executable flows");
+      ret.put(ERROR_PARAM, "Error retrieving executable flows");
       return;
     }
 
@@ -436,7 +437,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           this.executorManagerAdapter.getExecutableFlows(project.getId(), flowId, from,
               length, exFlows);
     } catch (final ExecutorManagerException e) {
-      ret.put("error", "Error retrieving executable flows");
+      ret.put(ERROR_PARAM, "Error retrieving executable flows");
     }
 
     ret.put("flow", flowId);
@@ -587,21 +588,21 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
       // invalid project
       if (project == null) {
-        ret.put("error", "invalid project");
+        ret.put(ERROR_PARAM, "invalid project");
         isOperationSuccessful = false;
       }
 
       // project is already deleted
       if (isOperationSuccessful
           && this.projectManager.isActiveProject(project.getId())) {
-        ret.put("error", "Project " + project.getName()
+        ret.put(ERROR_PARAM, "Project " + project.getName()
             + " should be deleted before purging");
         isOperationSuccessful = false;
       }
 
       // only eligible users can purge a project
       if (isOperationSuccessful && !hasPermission(project, user, Type.ADMIN)) {
-        ret.put("error", "Cannot purge. User '" + user.getUserId()
+        ret.put(ERROR_PARAM, "Cannot purge. User '" + user.getUserId()
             + "' is not an ADMIN.");
         isOperationSuccessful = false;
       }
@@ -610,7 +611,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         this.projectManager.purgeProject(project, user);
       }
     } catch (final Exception e) {
-      ret.put("error", e.getMessage());
+      ret.put(ERROR_PARAM, e.getMessage());
       isOperationSuccessful = false;
     }
 
@@ -686,7 +687,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       this.projectManager.updateProjectDescription(project, description, user);
     } catch (final ProjectManagerException e) {
-      ret.put("error", e.getMessage());
+      ret.put(ERROR_PARAM, e.getMessage());
     }
   }
 
@@ -697,14 +698,14 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final Flow flow = project.getFlow(flowName);
     if (flow == null) {
-      ret.put("error",
+      ret.put(ERROR_PARAM,
           "Flow " + flowName + " not found in project " + project.getName());
       return;
     }
 
     final Node node = flow.getNode(jobName);
     if (node == null) {
-      ret.put("error", "Job " + jobName + " not found in flow " + flowName);
+      ret.put(ERROR_PARAM, "Job " + jobName + " not found in flow " + flowName);
       return;
     }
 
@@ -712,7 +713,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       jobProp = this.projectManager.getProperties(project, flow, jobName, node.getJobSource());
     } catch (final ProjectManagerException e) {
-      ret.put("error", "Failed to retrieve job properties!");
+      ret.put(ERROR_PARAM, "Failed to retrieve job properties!");
       return;
     }
 
@@ -725,7 +726,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       overrideProp = this.projectManager
           .getJobOverrideProperty(project, flow, jobName, node.getJobSource());
     } catch (final ProjectManagerException e) {
-      ret.put("error", "Failed to retrieve job override properties!");
+      ret.put(ERROR_PARAM, "Failed to retrieve job override properties!");
       return;
     }
 
@@ -756,14 +757,14 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final Flow flow = project.getFlow(flowName);
     if (flow == null) {
-      ret.put("error",
+      ret.put(ERROR_PARAM,
           "Flow " + flowName + " not found in project " + project.getName());
       return;
     }
 
     final Node node = flow.getNode(jobName);
     if (node == null) {
-      ret.put("error", "Job " + jobName + " not found in flow " + flowName);
+      ret.put(ERROR_PARAM, "Job " + jobName + " not found in flow " + flowName);
       return;
     }
 
@@ -774,7 +775,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           .setJobOverrideProperty(project, flow, overrideParams, jobName, node.getJobSource(),
               user);
     } catch (final ProjectManagerException e) {
-      ret.put("error", "Failed to upload job override property");
+      ret.put(ERROR_PARAM, "Failed to upload job override property");
     }
 
   }
@@ -806,7 +807,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       final HashMap<String, Object> ret) {
     final Flow flow = project.getFlow(flowId);
     if (flow == null) {
-      ret.put("error",
+      ret.put(ERROR_PARAM,
           "Flow " + flowId + " not found in project " + project.getName());
       return;
     }
@@ -859,7 +860,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final Node node = flow.getNode(nodeId);
 
     if (node == null) {
-      ret.put("error", "Job " + nodeId + " doesn't exist.");
+      ret.put(ERROR_PARAM, "Job " + nodeId + " doesn't exist.");
       return;
     }
 
@@ -871,12 +872,12 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       jobProps = this.projectManager.getProperties(project, flow, nodeId, node.getJobSource());
     } catch (final ProjectManagerException e) {
-      ret.put("error", "Failed to upload job override property for " + nodeId);
+      ret.put(ERROR_PARAM, "Failed to upload job override property for " + nodeId);
       return;
     }
 
     if (jobProps == null) {
-      ret.put("error", "Properties for " + nodeId + " isn't found.");
+      ret.put(ERROR_PARAM, "Properties for " + nodeId + " isn't found.");
       return;
     }
 
@@ -939,10 +940,10 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       try {
         this.projectManager.addProjectProxyUser(project, name, user);
       } catch (final ProjectManagerException e) {
-        ret.put("error", e.getMessage());
+        ret.put(ERROR_PARAM, e.getMessage());
       }
     } else {
-      ret.put("error", "User " + user.getUserId()
+      ret.put(ERROR_PARAM, "User " + user.getUserId()
           + " has no permission to add " + name + " as proxy user.");
       return;
     }
@@ -958,7 +959,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       this.projectManager.removeProjectProxyUser(project, name, user);
     } catch (final ProjectManagerException e) {
-      ret.put("error", e.getMessage());
+      ret.put(ERROR_PARAM, e.getMessage());
     }
   }
 
@@ -969,20 +970,20 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     if (group) {
       if (project.getGroupPermission(name) != null) {
-        ret.put("error", "Group permission already exists.");
+        ret.put(ERROR_PARAM, "Group permission already exists.");
         return;
       }
       if (!this.userManager.validateGroup(name)) {
-        ret.put("error", "Group is invalid.");
+        ret.put(ERROR_PARAM, "Group is invalid.");
         return;
       }
     } else {
       if (project.getUserPermission(name) != null) {
-        ret.put("error", "User permission already exists.");
+        ret.put(ERROR_PARAM, "User permission already exists.");
         return;
       }
       if (!this.userManager.validateUser(name)) {
-        ret.put("error", "User is invalid.");
+        ret.put(ERROR_PARAM, "User is invalid.");
         return;
       }
     }
@@ -1008,7 +1009,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       this.projectManager.updateProjectPermission(project, name, perm, group, user);
     } catch (final ProjectManagerException e) {
-      ret.put("error", e.getMessage());
+      ret.put(ERROR_PARAM, e.getMessage());
     }
   }
 
@@ -1034,7 +1035,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     if (perm == null) {
-      ret.put("error", "Permissions for " + name + " cannot be found.");
+      ret.put(ERROR_PARAM, "Permissions for " + name + " cannot be found.");
       return;
     }
 
@@ -1057,13 +1058,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         this.projectManager
             .updateProjectPermission(project, name, perm, group, user);
       } catch (final ProjectManagerException e) {
-        ret.put("error", e.getMessage());
+        ret.put(ERROR_PARAM, e.getMessage());
       }
     } else {
       try {
         this.projectManager.removeProjectPermission(project, name, group, user);
       } catch (final ProjectManagerException e) {
-        ret.put("error", e.getMessage());
+        ret.put(ERROR_PARAM, e.getMessage());
       }
     }
   }
@@ -1126,7 +1127,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final String flowName = getParam(req, FLOW_NAME_PARAM);
     final Flow flow = project.getFlow(flowName);
     if (flow == null) {
-      ret.put("error",
+      ret.put(ERROR_PARAM,
           "Flow " + flowName + " not found in project " + project.getName());
       return;
     }
@@ -1157,7 +1158,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           }
         }
       } catch (Exception e) {
-        ret.put("error", e);
+        ret.put(ERROR_PARAM, e);
       }
     }
 
@@ -1182,7 +1183,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final Flow flow = project.getFlow(flowName);
     if (flow == null) {
-      ret.put("error",
+      ret.put(ERROR_PARAM,
           "Flow " + flowName + " not found in project " + project.getName());
       return;
     }
@@ -1717,7 +1718,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           "User " + user.getUserId()
               + " doesn't have permission to create projects.";
       logger.info(message);
-      status = "error";
+      status = ERROR_PARAM;
     } else {
       try {
         this.projectManager.createProject(projectName, projectDescription, user);
@@ -1728,7 +1729,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         params.put("path", redirect);
       } catch (final ProjectManagerException e) {
         message = e.getMessage();
-        status = "error";
+        status = ERROR_PARAM;
       }
     }
     final String response = AbstractAzkabanServlet
@@ -1744,7 +1745,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
   private void registerError(final Map<String, String> ret, final String error,
       final HttpServletResponse resp, final int returnCode) {
-    ret.put("error", error);
+    ret.put(ERROR_PARAM, error);
     resp.setStatus(returnCode);
   }
 
@@ -1937,8 +1938,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final String projectName = (String) multipart.get("project");
     ajaxHandleUpload(req, resp, ret, multipart, session);
 
-    if (ret.containsKey("error")) {
-      setErrorMessageInCookie(resp, ret.get("error"));
+    if (ret.containsKey(ERROR_PARAM)) {
+      setErrorMessageInCookie(resp, ret.get(ERROR_PARAM));
     }
 
     if (ret.containsKey("warn")) {
@@ -1969,16 +1970,16 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         if (this.projectManager.loadProjectWhiteList()) {
           ret.put("success", "Project whitelist re-loaded!");
         } else {
-          ret.put("error", "azkaban.properties doesn't contain property "
+          ret.put(ERROR_PARAM, "azkaban.properties doesn't contain property "
               + ProjectWhitelist.XML_FILE_PARAM);
         }
       } catch (final Exception e) {
-        ret.put("error",
+        ret.put(ERROR_PARAM,
             "Exception occurred while trying to re-load project whitelist: "
                 + e);
       }
     } else {
-      ret.put("error", "Provided session doesn't have admin privilege.");
+      ret.put(ERROR_PARAM, "Provided session doesn't have admin privilege.");
     }
 
     this.writeJSON(resp, ret);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -599,6 +599,12 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
+    if (flow.isLocked()) {
+      ret.put(PARAM_STATUS, STATUS_ERROR);
+      ret.put(PARAM_MESSAGE, "Flow " + flowName + " in project " + projectName + " is locked.");
+      return;
+    }
+
     final boolean hasFlowTrigger;
     try {
       hasFlowTrigger = this.projectManager.hasFlowTrigger(project, flow);

--- a/azkaban-web-server/src/main/less/project.less
+++ b/azkaban-web-server/src/main/less/project.less
@@ -77,6 +77,10 @@
     color: #9a9a9a;
     margin-right: 5px;
   }
+
+  .btn.disabled {
+    pointer-events: initial;
+  }
 }
 
 .expanded-flow-job-list {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -139,7 +139,8 @@
         <button type="button" id="retrybtn" class="btn btn-success btn-sm">Retry Failed</button>
       </li>
       <li class="nav-button pull-right">
-        <button type="button" id="executebtn" class="btn btn-success btn-sm">Prepare Execution
+        #set($isDisabled = "#if(${isLocked})disabled#end")
+        <button type="button" id="executebtn" class="btn btn-success btn-sm ${isDisabled}">Prepare Execution
         </button>
       </li>
     </ul>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -85,7 +85,6 @@
     #parse ("azkaban/webapp/servlet/velocity/errormsg.vm")
   #else
 
-
   ## Page header.
 
   <div class="az-page-header page-header-bare">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -85,6 +85,7 @@
     #parse ("azkaban/webapp/servlet/velocity/errormsg.vm")
   #else
 
+
   ## Page header.
 
   <div class="az-page-header page-header-bare">
@@ -97,7 +98,8 @@
         </div>
         <div class="header-control">
           <div class="pull-right header-form">
-            <button type="button" class="btn btn-sm btn-success" id="executebtn">
+            #set($isDisabled = "#if(${isLocked})disabled#end")
+            <button type="button" class="btn btn-sm btn-success ${isDisabled}" id="executebtn">
               Schedule / Execute Flow
             </button>
           </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -47,14 +47,14 @@
 
     var projectId = ${project.id};
     var projectName = "${project.name}";
-    var flowId = "${flowid}";
+    var flowId = "${flowId}";
     var execId = null;
     var pageSize = "${size}";
 
     var flowPageSettings = {
       projectId: ${project.id},
       projectName: "${project.name}",
-      flowId: "${flowid}",
+      flowId: "${flowId}",
       pageSize: ${size},
 
       executionUrl: contextURL + "/executor",
@@ -91,8 +91,8 @@
     <div class="container-full">
       <div class="row">
         <div class="header-title">
-          <h1><a href="${context}/manager?project=${project.name}&flow=${flowid}">Flow
-            <small>$flowid</small>
+          <h1><a href="${context}/manager?project=${project.name}&flow=${flowId}">Flow
+            <small>$flowId</small>
           </a></h1>
         </div>
         <div class="header-control">
@@ -112,7 +112,7 @@
         <li><a
             href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
         </a></li>
-        <li class="active"><strong>Flow</strong> $flowid</li>
+        <li class="active"><strong>Flow</strong> $flowId</li>
       </ol>
     </div>
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -182,7 +182,8 @@
                     Pause
                   </button>
                 #else
-                  <button type="button" id="resumebtn" class="btn btn-info btn-sm"
+                  #set($isDisabled = "#if(${trigger.isLocked()})disabled#end")
+                  <button type="button" id="resumebtn" class="btn btn-info btn-sm  ${isDisabled}"
                           onclick="resumeTrigger('${trigger.getProjectId()}', '${trigger.getFlowId()}')">
                     Resume
                   </button>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -24,7 +24,7 @@
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/project.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=<timestamp>"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
@@ -72,7 +72,10 @@
                 <div class="panel-heading flow-expander" id="${flow.id}">
                   #if (${exec})
                     <div class="pull-right">
-                      <button type="button" class="btn btn-xs btn-success execute-flow"
+                      #set($isDisabled = "#if(${flow.isLocked()})disabled#end")
+                      <button type="button"
+                              title=""
+                              class="btn btn-xs btn-success execute-flow ${isDisabled}"
                               flowId="${flow.id}">Execute Flow
                       </button>
                       <a href="${context}/manager?project=${project.name}&flow=${flow.id}#executions"

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -24,7 +24,7 @@
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=<timestamp>"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=<1556216524794>" rel="stylesheet">
+<link href="/css/azkaban.css?v=1556216524794" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=<timestamp>" rel="stylesheet">
+<link href="/css/azkaban.css?v=<1556216524794>" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css" rel="stylesheet">
+<link href="/css/azkaban.css?v=<timestamp>" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};

--- a/azkaban-web-server/src/web/js/azkaban/view/project.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project.js
@@ -70,6 +70,7 @@ azkaban.FlowTableView = Backbone.View.extend({
       };
       var successHandler = function (data) {
         console.log("Success");
+        console.log("data", data);
         target.loaded = true;
         target.loading = false;
         createJobListFunction(data, targetTBody);
@@ -107,29 +108,29 @@ azkaban.FlowTableView = Backbone.View.extend({
         var hoverMenuDiv = document.createElement('div');
         $(hoverMenuDiv).addClass('pull-right');
         $(hoverMenuDiv).addClass('job-buttons');
+       if (!data.isLocked) {
+          var divRunJob = document.createElement('button');
+          $(divRunJob).attr('type', 'button');
+          $(divRunJob).addClass("btn");
+          $(divRunJob).addClass("btn-success");
+          $(divRunJob).addClass("btn-xs");
+          $(divRunJob).addClass("runJob");
+          $(divRunJob).text("Run Job");
+          divRunJob.jobName = name;
+          divRunJob.flowId = flowId;
+          $(hoverMenuDiv).append(divRunJob);
 
-        var divRunJob = document.createElement('button');
-        $(divRunJob).attr('type', 'button');
-        $(divRunJob).addClass("btn");
-        $(divRunJob).addClass("btn-success");
-        $(divRunJob).addClass("btn-xs");
-        $(divRunJob).addClass("runJob");
-        $(divRunJob).text("Run Job");
-        divRunJob.jobName = name;
-        divRunJob.flowId = flowId;
-        $(hoverMenuDiv).append(divRunJob);
-
-        var divRunWithDep = document.createElement("button");
-        $(divRunWithDep).attr('type', 'button');
-        $(divRunWithDep).addClass("btn");
-        $(divRunWithDep).addClass("btn-success");
-        $(divRunWithDep).addClass("btn-xs");
-        $(divRunWithDep).addClass("runWithDep");
-        $(divRunWithDep).text("Run With Dependencies");
-        divRunWithDep.jobName = name;
-        divRunWithDep.flowId = flowId;
-        $(hoverMenuDiv).append(divRunWithDep);
-
+          var divRunWithDep = document.createElement("button");
+          $(divRunWithDep).attr('type', 'button');
+          $(divRunWithDep).addClass("btn");
+          $(divRunWithDep).addClass("btn-success");
+          $(divRunWithDep).addClass("btn-xs");
+          $(divRunWithDep).addClass("runWithDep");
+          $(divRunWithDep).text("Run With Dependencies");
+          divRunWithDep.jobName = name;
+          divRunWithDep.flowId = flowId;
+          $(hoverMenuDiv).append(divRunWithDep);
+        }
         $(li).append(hoverMenuDiv);
       }
 
@@ -224,6 +225,12 @@ azkaban.FlowTableView = Backbone.View.extend({
   executeFlow: function (evt) {
     console.log("Execute Flow");
     var flowId = $(evt.currentTarget).attr('flowid');
+
+    var isFlowLocked = $(evt.currentTarget).hasClass("disabled");
+    if (isFlowLocked) {
+      evt.stopPropagation();
+      return;
+    }
 
     var executingData = {
       project: projectName,


### PR DESCRIPTION
-  **manager?ajax=setFlowLock** will lock or unlock a flow. 
`curl -X POST --data "session.id=<session id>&ajax=setFlowLock&isLocked=true&project=<project name>&flowName=<flow name>" http://<web server>/manager
{
  "isLocked" : true,
  "project" : "<project name>",
  "projectId" : 2,
  "flowId" : "<flow name"`
-  **manager?ajax=isFlowLocked** will return if a flow is locked or unlocked.
`curl -k --get --data "session.id=<session id>&ajax=isFlowLocked&project=<project name>&flowName=<flow name>" http://<web server>/manager
{
  "isLocked" : true,
  "project" : "<project name",
  "projectId" : 2,
  "flowId" : "flow name"`
A locked flow cannot be executed or scheduled. The caller of the API must have ADMIN privileges to lock the flow. The lock will persist across project uploads.

Flow page for a locked flow:
![Screen Shot 2019-04-29 at 5 07 57 PM](https://user-images.githubusercontent.com/26153035/56979071-c4257400-6b2d-11e9-9f80-3992dd741fa5.png)

Project page with a locked flow:
![Screen Shot 2019-04-29 at 5 08 15 PM](https://user-images.githubusercontent.com/26153035/56979072-c4be0a80-6b2d-11e9-84c5-ab593356b220.png)

Flow trigger page showing a locked flow:
![Screen Shot 2019-04-29 at 5 08 33 PM](https://user-images.githubusercontent.com/26153035/56979074-c4be0a80-6b2d-11e9-964d-8c2a79566864.png)


