### PR TITLE
Demonstrate XmlUserManager's failure to read a file

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -130,7 +130,11 @@ public final class UserUtils {
             // Match!
             // reparse the config file
             log.info("Modification detected, reloading config file " + filename);
-            configFileMap.get(filename).parseConfigFile();
+            try {
+              configFileMap.get(filename).parseConfigFile();
+            } catch (Exception e) {
+              log.error("Failed parsing config file after update: " + filename, e);
+            }
             break;
           }
         }

--- a/azkaban-common/src/test/java/azkaban/user/XmlUserManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/XmlUserManagerTest.java
@@ -16,7 +16,6 @@
 
 package azkaban.user;
 
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import azkaban.utils.Props;
@@ -34,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -133,12 +131,14 @@ public class XmlUserManagerTest {
         fail("File did not update.");
       }
       // Try for a minute polling every 2 seconds if the config is reloaded
-      Awaitility.await().atMost(60L, TimeUnit.SECONDS).
+      Awaitility.await().atMost(10L, TimeUnit.SECONDS).
           pollInterval(2L, TimeUnit.SECONDS).until(
           () -> {
             User user;
             try {
               user = manager.getUser("user8", "password8");
+              // write again
+              Files.write(filePath, lines);
             } catch (UserManagerException e) {
               System.out.println("user8 has updated password. " + e.getMessage());
               user = null;


### PR DESCRIPTION
Some preliminary work for
https://github.com/azkaban/azkaban/issues/2220

Test output (test succeeds):

```
2019/04/28 10:07:23.782 +0300 INFO [UserUtils] Starting configuration watching thread.
File modification time = 2019-04-28T07:06:41Z
File modification time after write = 2019-04-28T07:07:23Z
2019/04/28 10:07:25.762 +0300 INFO [UserUtils] Modification detected, reloading config file /Users/JuhoAutio/ideaprojects/azkaban-public/azkaban-common/build/resources/test/test-conf/azkaban-users-test1.xml
content = <azkaban-users>
  <user groups="group0" password="password0" roles="role0" username="user0"/>
  <user groups="group1,group2" password="password1" roles="role0,role1" username="user1"/>
  <user groups="group1,group2,group3" password="password2" roles="role0,role1,role2"
    username="user2"/>
  <user groups="group1, group2" password="password3" roles="role1, role2" username="user3"/>
  <user groups="group1 , group2" password="password4" roles="role1 , role2" username="user4"/>
  <user groups="group1 , group2," password="password5" roles="role1 , role2," username="user5"/>
  <user groups="group1 , group2, " password="password6" roles="role3 , role2, " username="user6"/>
  <user groups="group1" password="password7" username="user7"/>
  <user password="passwordModified" roles="role3" username="user8"/>
  <user password="password9" username="user9"/>
</azkaban-users>

[Fatal Error] :-1:-1: Premature end of file.
2019/04/28 10:07:25.775 +0300 ERROR [UserUtils] Failed parsing config file after update: /Users/JuhoAutio/ideaprojects/azkaban-public/azkaban-common/build/resources/test/test-conf/azkaban-users-test1.xml
java.lang.IllegalArgumentException: Exception while parsing /Users/JuhoAutio/ideaprojects/azkaban-public/azkaban-common/build/resources/test/test-conf/azkaban-users-test1.xml. Invalid XML.
	at azkaban.user.XmlUserManager.parseXMLFile(XmlUserManager.java:140)
	at azkaban.user.UserUtils.lambda$setupWatch$0(UserUtils.java:134)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.xml.sax.SAXParseException; Premature end of file.
	at org.apache.xerces.parsers.DOMParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.DocumentBuilderImpl.parse(Unknown Source)
	at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:121)
	at azkaban.user.XmlUserManager.parseXMLFile(XmlUserManager.java:134)
	... 2 more
2019/04/28 10:07:27.758 +0300 INFO [UserUtils] Modification detected, reloading config file /Users/JuhoAutio/ideaprojects/azkaban-public/azkaban-common/build/resources/test/test-conf/azkaban-users-test1.xml
content = <azkaban-users>
  <user groups="group0" password="password0" roles="role0" username="user0"/>
  <user groups="group1,group2" password="password1" roles="role0,role1" username="user1"/>
  <user groups="group1,group2,group3" password="password2" roles="role0,role1,role2"
    username="user2"/>
  <user groups="group1, group2" password="password3" roles="role1, role2" username="user3"/>
  <user groups="group1 , group2" password="password4" roles="role1 , role2" username="user4"/>
  <user groups="group1 , group2," password="password5" roles="role1 , role2," username="user5"/>
  <user groups="group1 , group2, " password="password6" roles="role3 , role2, " username="user6"/>
  <user groups="group1" password="password7" username="user7"/>
  <user password="passwordModified" roles="role3" username="user8"/>
  <user password="password9" username="user9"/>
</azkaban-users>

2019/04/28 10:07:27.763 +0300 INFO [XmlUserManager] Loading user user0
2019/04/28 10:07:27.764 +0300 INFO [XmlUserManager] Loading user user1
2019/04/28 10:07:27.764 +0300 INFO [XmlUserManager] Loading user user2
2019/04/28 10:07:27.765 +0300 INFO [XmlUserManager] Loading user user3
2019/04/28 10:07:27.765 +0300 INFO [XmlUserManager] Loading user user4
2019/04/28 10:07:27.766 +0300 INFO [XmlUserManager] Loading user user5
2019/04/28 10:07:27.766 +0300 INFO [XmlUserManager] Loading user user6
2019/04/28 10:07:27.766 +0300 INFO [XmlUserManager] Loading user user7
2019/04/28 10:07:27.767 +0300 INFO [XmlUserManager] Loading user user8
2019/04/28 10:07:27.767 +0300 INFO [XmlUserManager] Loading user user9
user8 has updated password. Username/Password not found.
Config reloaded successfully.
```
