### PR TITLE
[CLEANUP] Replace all log4j to slf4j

### DIFF
--- a/az-core/src/main/java/azkaban/AzkabanCoreModule.java
+++ b/az-core/src/main/java/azkaban/AzkabanCoreModule.java
@@ -20,8 +20,6 @@ import azkaban.utils.Props;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,7 +27,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AzkabanCoreModule extends AbstractModule {
 
-  private static final Logger log = LoggerFactory.getLogger(AzkabanCoreModule.class);
   private final Props props;
 
   public AzkabanCoreModule(final Props props) {

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban;
 
 import java.time.Duration;
+
 
 /**
  * Constants used in configuration files or shared among classes.

--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class MetricsManager {
 
-  private static final Logger log = LoggerFactory.getLogger(MetricsManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsManager.class);
   private final MetricRegistry registry;
 
   @Inject
@@ -110,20 +110,20 @@ public class MetricsManager {
     final String metricsServerURL = props.get(METRICS_SERVER_URL);
     if (metricsReporterClassName != null && metricsServerURL != null) {
       try {
-        log.info("metricsReporterClassName: " + metricsReporterClassName);
+        LOG.info("metricsReporterClassName: " + metricsReporterClassName);
         final Class metricsClass = Class.forName(metricsReporterClassName);
 
         final Constructor[] constructors = metricsClass.getConstructors();
         constructors[0].newInstance(reporterName, this.registry, metricsServerURL);
 
       } catch (final Exception e) {
-        log.error("Encountered error while loading and instantiating "
+        LOG.error("Encountered error while loading and instantiating "
             + metricsReporterClassName, e);
         throw new IllegalStateException("Encountered error while loading and instantiating "
             + metricsReporterClassName, e);
       }
     } else {
-      log.error(String.format("No value for property: %s or %s was found",
+      LOG.error(String.format("No value for property: %s or %s was found",
           CUSTOM_METRICS_REPORTER_CLASS_NAME, METRICS_SERVER_URL));
     }
   }

--- a/az-core/src/main/java/azkaban/utils/ExecutorServiceUtils.java
+++ b/az-core/src/main/java/azkaban/utils/ExecutorServiceUtils.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecutorServiceUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(ExecutorServiceUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceUtils.class);
   private static final TimeUnit MILLI_SECONDS_TIME_UNIT = TimeUnit.MILLISECONDS;
 
   /**
@@ -52,7 +52,7 @@ public class ExecutorServiceUtils {
       service.shutdownNow(); // Cancel currently executing tasks
       // Wait a while for tasks to respond to being cancelled
       if (!service.awaitTermination(timeout_in_unit_of_miliseconds, MILLI_SECONDS_TIME_UNIT)) {
-        logger.error("The executor service did not terminate.");
+        LOG.error("The executor service did not terminate.");
       }
     }
   }

--- a/az-core/src/main/java/azkaban/utils/PluginUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PluginUtils.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class PluginUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(PluginUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PluginUtils.class);
   private static String LIBRARY_FOLDER_NAME = "lib";
 
   /**
@@ -49,7 +49,7 @@ public class PluginUtils {
         final URL url = file.toURI().toURL();
         urls.add(url);
       } catch (final MalformedURLException e) {
-        logger.error("File is not convertible to URL.", e);
+        LOG.error("File is not convertible to URL.", e);
       }
     }
     return urls;
@@ -81,13 +81,13 @@ public class PluginUtils {
                 urls.add(url);
               }
             } else {
-              logger.error(
+              LOG.error(
                   "External library path not found. path = " + extLibFile.getAbsolutePath()
               );
               continue;
             }
           } catch (final MalformedURLException e) {
-            logger.error(
+            LOG.error(
                 "Invalid External library path. path = " + extLibClassPath + " dir = " + pluginDir,
                 e
             );
@@ -96,7 +96,7 @@ public class PluginUtils {
       }
       return new URLClassLoader(urls.toArray(new URL[urls.size()]), parentLoader);
     } else {
-      logger.error("Library path not found. path = " + libDir);
+      LOG.error("Library path not found. path = " + libDir);
       return null;
     }
   }
@@ -135,7 +135,7 @@ public class PluginUtils {
     try {
       return urlClassLoader.loadClass(pluginClass);
     } catch (final ClassNotFoundException e) {
-      logger.error("Class not found. class = " + pluginClass);
+      LOG.error("Class not found. class = " + pluginClass);
       return null;
     }
   }

--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -15,7 +15,6 @@
  */
 package azkaban.utils;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import java.io.File;
@@ -33,7 +32,8 @@ import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.MapContext;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -41,7 +41,7 @@ import org.apache.log4j.Logger;
  */
 public class PropsUtils {
 
-  private static final Logger logger = Logger.getLogger(PropsUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PropsUtils.class);
   private static final Pattern VARIABLE_REPLACEMENT_PATTERN = Pattern
       .compile("\\$\\{([a-zA-Z_.0-9]+)\\}");
 
@@ -119,12 +119,12 @@ public class PropsUtils {
    */
   public static Props loadPluginProps(final File pluginDir) {
     if (!pluginDir.exists()) {
-      logger.error("Error! Plugin path " + pluginDir.getPath() + " doesn't exist.");
+      LOG.error("Error! Plugin path " + pluginDir.getPath() + " doesn't exist.");
       return null;
     }
 
     if (!pluginDir.isDirectory()) {
-      logger.error("The plugin path " + pluginDir + " is not a directory.");
+      LOG.error("The plugin path " + pluginDir + " is not a directory.");
       return null;
     }
 
@@ -141,11 +141,11 @@ public class PropsUtils {
           return loadProps(null, propertiesFile);
         }
       } else {
-        logger.error("Plugin conf file " + propertiesFile + " not found.");
+        LOG.error("Plugin conf file " + propertiesFile + " not found.");
         return null;
       }
     } else {
-      logger.error("Plugin conf path " + propertiesDir + " not found.");
+      LOG.error("Plugin conf path " + propertiesDir + " not found.");
       return null;
     }
   }
@@ -224,7 +224,7 @@ public class PropsUtils {
     for (final String key : props.getKeySet()) {
       String value = props.get(key);
       if (value == null) {
-        logger.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
+        LOG.warn("Null value in props for key '" + key + "'. Replacing with empty string.");
         value = "";
       }
 

--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -40,9 +40,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -50,8 +50,8 @@ import org.quartz.CronExpression;
  */
 public class Utils {
 
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(PluginUtils.class);
   private static final Random RANDOM = new Random();
-  private static final Logger logger = Logger.getLogger(Utils.class);
 
   /**
    * Private constructor.
@@ -386,7 +386,7 @@ public class Utils {
         ce.setTimeZone(TimeZone.getTimeZone(timezone.getID()));
         return ce;
       } catch (final ParseException pe) {
-        logger.error("this cron expression {" + cronExpression + "} can not be parsed. "
+        LOG.error("this cron expression {" + cronExpression + "} can not be parsed. "
             + "Please Check Quartz Cron Syntax.");
       }
       return null;

--- a/az-crypto/src/main/java/azkaban/crypto/Crypto.java
+++ b/az-crypto/src/main/java/azkaban/crypto/Crypto.java
@@ -15,12 +15,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+
 
 /**
  * Crypto class that actually delegates to version specific implementation of ICrypto interface. In

--- a/az-crypto/src/main/java/azkaban/crypto/CryptoV1.java
+++ b/az-crypto/src/main/java/azkaban/crypto/CryptoV1.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import org.apache.log4j.Logger;
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 
@@ -25,8 +24,6 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
  * that haven't installed (or cannot install) JCE unlimited strength.
  */
 public class CryptoV1 implements ICrypto {
-
-  private static final Logger logger = Logger.getLogger(CryptoV1.class);
 
   private static final String CIPHERED_TEXT_KEY = "val";
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/az-crypto/src/main/java/azkaban/crypto/CryptoV1_1.java
+++ b/az-crypto/src/main/java/azkaban/crypto/CryptoV1_1.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.security.Provider;
-import org.apache.log4j.Logger;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
@@ -25,8 +24,6 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
  * Uses AES algorithm to encrypt and decrypt.
  */
 public class CryptoV1_1 implements ICrypto {
-
-  private static final Logger logger = Logger.getLogger(CryptoV1_1.class);
 
   private static final String CIPHERED_TEXT_KEY = "val";
   private static final String CRYPTO_ALGO = "PBEWITHSHA256AND128BITAES-CBC-BC";

--- a/az-crypto/src/main/java/azkaban/crypto/EncryptionCLI.java
+++ b/az-crypto/src/main/java/azkaban/crypto/EncryptionCLI.java
@@ -19,6 +19,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+
 /**
  * Command line interface for user to encrypt plain text with passphrase.
  */

--- a/az-crypto/src/main/java/azkaban/crypto/ICrypto.java
+++ b/az-crypto/src/main/java/azkaban/crypto/ICrypto.java
@@ -16,7 +16,7 @@ package azkaban.crypto;
  */
 public interface ICrypto {
 
-  static final String VERSION_IDENTIFIER = "ver";
+  String VERSION_IDENTIFIER = "ver";
 
   /**
    * Encrypts plain text using pass phrase and crypto version.
@@ -26,7 +26,7 @@ public interface ICrypto {
    * @param cryptoVersion Version of this encryption.
    * @return A ciphered text, Base64 encoded.
    */
-  public String encrypt(String plaintext, String passphrase, Version cryptoVersion);
+  String encrypt(String plaintext, String passphrase, Version cryptoVersion);
 
   /**
    * Decrypts ciphered text.
@@ -35,5 +35,5 @@ public interface ICrypto {
    * @param passphrase Passphrase that was used as a key to encrypt the ciphered text
    * @return plain text String
    */
-  public String decrypt(String cipheredText, String passphrase);
+  String decrypt(String cipheredText, String passphrase);
 }

--- a/az-crypto/src/main/java/azkaban/crypto/Version.java
+++ b/az-crypto/src/main/java/azkaban/crypto/Version.java
@@ -35,7 +35,7 @@ public enum Version {
 
   private final String _ver;
 
-  private Version(final String ver) {
+  Version(final String ver) {
     this._ver = ver;
   }
 

--- a/az-exec-util/src/main/c/execute-as-user.c
+++ b/az-exec-util/src/main/c/execute-as-user.c
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 #include <dirent.h>
 #include <fcntl.h>
 #include <fts.h>
@@ -44,7 +43,6 @@ int INVALID_INPUT = 30;
  *  ./hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/native/container-executor/impl/container-executor.c
  *
  */
-
 int change_user(char *username, uid_t user, gid_t group) {
     if (user == getuid() && user == geteuid() &&
             group == getgid() && group == getegid()) {
@@ -126,5 +124,4 @@ int main(int argc, char **argv){
     else{
         return 0;
     }
-
 }

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyCheck.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyCheck.java
@@ -13,11 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
-public interface DependencyCheck {
 
+/**
+ * Defines dependency instance
+ */
+public interface DependencyCheck {
 
   /**
    * Non-blocking run of dependency check

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceCallback.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceCallback.java
@@ -13,9 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
+
+/**
+ * Defines a set of callback functions for the dependency instance
+ */
 public interface DependencyInstanceCallback {
 
   /**

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceConfig.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceConfig.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
+
 /**
- * Defines the dependency instance level configuration.
+ * Defines the instance level configuration for the dependency instance.
  */
 public interface DependencyInstanceConfig {
 

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceContext.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceContext.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
+
 
 /**
  * Implementing class should hold context information for a running dependency

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceRuntimeProps.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyInstanceRuntimeProps.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
+
 /**
- * Defines the dependency instance runtime props.
+ * Defines runtime props for the dependency instance
  */
 public interface DependencyInstanceRuntimeProps {
 

--- a/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyPluginConfig.java
+++ b/az-flow-trigger-dependency-plugin/src/main/java/azkaban/flowtrigger/DependencyPluginConfig.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
+
 /**
- * Defines the dependency plugin level configuration
+ * Defines the plugin level configuration for the dependency instance
  */
 public interface DependencyPluginConfig {
 

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/Constants.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/Constants.java
@@ -13,22 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka;
 
+
 public class Constants {
+
   public static class DependencyPluginConfigKey {
+
     //Define where the Kafka brocker is located.
     public static final String KAKFA_BROKER_URL = "kafka.broker.url";
   }
-  
+
   /**
-   *  Required properties for dependencies
+   * Required properties for dependencies
    */
   public static class DependencyInstanceConfigKey {
+
     public static final String NAME = "name";
     public static final String TOPIC = "topic";
     public static final String MATCH = "match";
   }
-
 }

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaDepInstanceCollection.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaDepInstanceCollection.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka;
 
 import com.google.common.base.Joiner;

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaDependencyInstanceContext.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaDependencyInstanceContext.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka;
 
 import azkaban.flowtrigger.DependencyInstanceCallback;
@@ -23,11 +22,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import trigger.kafka.Constants.DependencyInstanceConfigKey;
 
+
 /**
  * KafkaDependencyInstanceContext maintains attributes of a running instance of kafka dependency.
  */
 public class KafkaDependencyInstanceContext implements DependencyInstanceContext {
-  private final static Logger log = LoggerFactory.getLogger(KafkaDependencyInstanceContext.class);
+
+  private final static Logger LOG = LoggerFactory.getLogger(KafkaDependencyInstanceContext.class);
   private final KafkaDependencyCheck depCheck;
   private final DependencyInstanceCallback callback;
   private final String topicName;
@@ -45,7 +46,7 @@ public class KafkaDependencyInstanceContext implements DependencyInstanceContext
 
   @Override
   public void cancel() {
-    log.info(String.format("Canceling dependency %s", this));
+    LOG.info(String.format("Canceling dependency %s", this));
     this.depCheck.remove(this);
     this.callback.onCancel(this);
   }

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaEventMonitor.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/KafkaEventMonitor.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka;
 
 import azkaban.flowtrigger.DependencyPluginConfig;
@@ -38,11 +37,13 @@ import trigger.kafka.Constants.DependencyPluginConfigKey;
 
 
 /**
- * KafkaEventMonitor implements logic for kafka consumer and maintains the KafkaDepInstanceCollection for dependencies.
+ * KafkaEventMonitor implements logic for kafka consumer and maintains the
+ * KafkaDepInstanceCollection for dependencies.
  */
 @SuppressWarnings("FutureReturnValueIgnored")
 public class KafkaEventMonitor implements Runnable {
-  private final static Logger log = LoggerFactory.getLogger(KafkaEventMonitor.class);
+
+  private final static Logger LOG = LoggerFactory.getLogger(KafkaEventMonitor.class);
   private static final String GROUP_ID =
       "group_" + KafkaEventMonitor.class.getSimpleName() + System.currentTimeMillis();
   private final KafkaDepInstanceCollection depInstances;
@@ -109,7 +110,7 @@ public class KafkaEventMonitor implements Runnable {
               this.triggerDependencies(matchedList, record);
             }
           } catch (final Exception ex) {
-            log.error("failure when parsing record " + recordToProcess, ex);
+            LOG.error("failure when parsing record " + recordToProcess, ex);
           }
         }
         if (!this.subscribedTopics.isEmpty()) {
@@ -117,11 +118,11 @@ public class KafkaEventMonitor implements Runnable {
         }
       }
     } catch (final Exception ex) {
-      log.error("failure when consuming kafka events", ex);
+      LOG.error("failure when consuming kafka events", ex);
     } finally {
       // Failed to send SSL Close message.
       this.consumer.close();
-      log.info("kafka consumer closed...");
+      LOG.info("kafka consumer closed...");
     }
   }
 
@@ -130,7 +131,7 @@ public class KafkaEventMonitor implements Runnable {
    */
   @VisibleForTesting
   synchronized void consumerSubscriptionRebalance() {
-    log.debug("Subscribed Topics " + this.consumer.subscription());
+    LOG.debug("Subscribed Topics " + this.consumer.subscription());
     if (!this.subscribedTopics.isEmpty()) {
       final Iterator<String> iter = this.subscribedTopics.iterator();
       final List<String> topics = new ArrayList<>();
@@ -146,7 +147,8 @@ public class KafkaEventMonitor implements Runnable {
   /**
    * If the matcher returns true, remove the dependency from collection.
    */
-  private void triggerDependencies(final Set<String> matchedList, final ConsumerRecord<String, String> record) {
+  private void triggerDependencies(final Set<String> matchedList,
+      final ConsumerRecord<String, String> record) {
     final List<KafkaDependencyInstanceContext> deleteList = new LinkedList<>();
     for (final String it : matchedList) {
       final List<KafkaDependencyInstanceContext> possibleAvailableDeps =

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/RegexKafkaDependencyMatcher.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/RegexKafkaDependencyMatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka;
 
 import java.util.regex.Pattern;
@@ -24,7 +23,9 @@ import trigger.kafka.matcher.DependencyMatcher;
  * A RegexKafkaDependencyMatcher implements the regex match for whole kafka payload.
  */
 public class RegexKafkaDependencyMatcher implements DependencyMatcher<String> {
-  private Pattern pattern ;
+
+  private Pattern pattern;
+
   RegexKafkaDependencyMatcher(Pattern _pattern) {
     this.pattern = _pattern;
   }

--- a/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/matcher/DependencyMatcher.java
+++ b/az-flow-trigger-dependency-type/kafka-event-trigger/src/main/java/trigger/kafka/matcher/DependencyMatcher.java
@@ -13,16 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package trigger.kafka.matcher;
 
+
 /**
- *  A generic interface that allows user to define their own matching method. 
+ * A generic interface that allows user to define their own matching method.
  */
 public interface DependencyMatcher<T> {
+
   /**
    * Determine whether the dependency condition is match with the Kafka event.
    */
-   boolean isMatch(T payload);
-
+  boolean isMatch(T payload);
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopConfigurationInjector.java
@@ -15,14 +15,15 @@
  */
 package azkaban.jobtype;
 
+import azkaban.flow.CommonJobProperties;
+import azkaban.utils.Props;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.log4j.Logger;
-import azkaban.flow.CommonJobProperties;
-import azkaban.utils.Props;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -38,7 +39,7 @@ import azkaban.utils.Props;
  */
 public class HadoopConfigurationInjector {
 
-  private static Logger _logger = Logger.getLogger(HadoopConfigurationInjector.class);
+  private static Logger LOG = LoggerFactory.getLogger(HadoopConfigurationInjector.class);
   // File to which the Hadoop configuration to inject will be written.
   private static final String INJECT_FILE = "hadoop-inject.xml";
   // Prefix for properties to be automatically injected into the Hadoop conf.
@@ -105,7 +106,7 @@ public class HadoopConfigurationInjector {
       conf.writeXml(xmlOut);
       xmlOut.close();
     } catch (Throwable e) {
-      _logger.error("Encountered error while preparing the Hadoop configuration resource file", e);
+      LOG.error("Encountered error while preparing the Hadoop configuration resource file", e);
     }
   }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -18,6 +18,10 @@ package azkaban.jobtype;
 import static azkaban.security.commons.SecurityUtils.MAPREDUCE_JOB_CREDENTIALS_BINARY;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
+import azkaban.jobExecutor.ProcessJob;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.JSONUtils;
+import azkaban.utils.Props;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -43,10 +47,6 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
-import azkaban.jobExecutor.ProcessJob;
-import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.utils.JSONUtils;
-import azkaban.utils.Props;
 
 
 public class HadoopJavaJobRunnerMain {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -15,6 +15,9 @@
  */
 package azkaban.jobtype;
 
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.Props;
 import com.google.common.base.Joiner;
 import java.io.BufferedReader;
 import java.io.File;
@@ -42,9 +45,6 @@ import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.log4j.Logger;
-import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.security.commons.HadoopSecurityManagerException;
-import azkaban.utils.Props;
 
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -15,6 +15,13 @@
  */
 package azkaban.jobtype;
 
+import azkaban.flow.CommonJobProperties;
+import azkaban.jobExecutor.JavaProcessJob;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.FileIOUtils;
+import azkaban.utils.Props;
+import azkaban.utils.StringUtils;
+import azkaban.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -23,13 +30,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
 import org.apache.pig.PigRunner;
-import azkaban.flow.CommonJobProperties;
-import azkaban.jobExecutor.JavaProcessJob;
-import azkaban.security.commons.HadoopSecurityManager;
-import azkaban.utils.FileIOUtils;
-import azkaban.utils.Props;
-import azkaban.utils.StringUtils;
-import azkaban.utils.Utils;
 
 
 /*
@@ -58,8 +58,8 @@ public class HadoopPigJob extends AbstractHadoopJavaProcessJob {
   private final boolean userPigJar;
   private File pigLogFile = null;
 
-  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger log) {
-    super(jobid, sysProps, jobProps, log);
+  public HadoopPigJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
+    super(jobid, sysProps, jobProps, logger);
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
     HADOOP_SECURE_PIG_WRAPPER = HadoopSecurePigWrapper.class.getName();
     userPigJar = getJobProps().getBoolean("use.user.pig.jar", false);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -17,12 +17,12 @@ package azkaban.jobtype;
 
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
-import java.io.File;
-import org.apache.log4j.Logger;
 import azkaban.flow.CommonJobProperties;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
+import java.io.File;
+import org.apache.log4j.Logger;
 
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecurePigWrapper.java
@@ -17,6 +17,7 @@ package azkaban.jobtype;
 
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
+import azkaban.utils.Props;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -32,22 +33,15 @@ import org.apache.pig.PigRunner;
 import org.apache.pig.tools.pigstats.JobStats;
 import org.apache.pig.tools.pigstats.PigStats;
 import org.apache.pig.tools.pigstats.PigStats.JobGraph;
-import azkaban.utils.Props;
 
 
 public class HadoopSecurePigWrapper {
 
+  private static final Logger LOG = Logger.getRootLogger();
   private static final String PIG_DUMP_HADOOP_COUNTER_PROPERTY = "pig.dump.hadoopCounter";
 
   private static File pigLogFile;
-
   private static Props props;
-
-  private static final Logger logger;
-
-  static {
-    logger = Logger.getRootLogger();
-  }
 
   public static void main(final String[] args) throws Exception {
     Properties jobProps = HadoopSecureWrapperUtils.loadAzkabanProps();
@@ -61,7 +55,7 @@ public class HadoopSecurePigWrapper {
     if (HadoopSecureWrapperUtils.shouldProxy(jobProps)) {
       String tokenFile = System.getenv(HADOOP_TOKEN_FILE_LOCATION);
       UserGroupInformation proxyUser =
-          HadoopSecureWrapperUtils.setupProxyUser(jobProps, tokenFile, logger);
+          HadoopSecureWrapperUtils.setupProxyUser(jobProps, tokenFile, LOG);
       proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
         @Override
         public Void run() throws Exception {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureSparkWrapper.java
@@ -56,9 +56,7 @@ import org.apache.spark.util.Utils;
  */
 public class HadoopSecureSparkWrapper {
 
-  private static final Logger logger = Logger.getRootLogger();
-  private static final String EMPTY_STRING = "";
-
+  private static final Logger LOG = Logger.getRootLogger();
   //SPARK CONF PARAM
   private static final String SPARK_CONF_EXTRA_DRIVER_OPTIONS = "spark.driver.extraJavaOptions";
   private static final String SPARK_CONF_NUM_EXECUTORS = "spark.executor.instances";
@@ -71,7 +69,6 @@ public class HadoopSecureSparkWrapper {
   private static final String SPARK_EXECUTOR_DEFAULT_MEMORY = "1024M";
   private static final String SPARK_EXECUTOR_CORES = "spark.executor.cores";
   private static final String SPARK_EXECUTOR_DEFAULT_CORES = "1";
-
   //YARN CONF PARAM
   private static final String YARN_CONF_NODE_LABELING_ENABLED = "yarn.node-labels.enabled";
   public static final String DEFAULT_QUEUE = "default";
@@ -88,7 +85,7 @@ public class HadoopSecureSparkWrapper {
     if (HadoopSecureWrapperUtils.shouldProxy(jobProps)) {
       String tokenFile = System.getenv(HADOOP_TOKEN_FILE_LOCATION);
       UserGroupInformation proxyUser =
-          HadoopSecureWrapperUtils.setupProxyUser(jobProps, tokenFile, logger);
+          HadoopSecureWrapperUtils.setupProxyUser(jobProps, tokenFile, LOG);
       proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
         @Override
         public Void run() throws Exception {
@@ -122,7 +119,7 @@ public class HadoopSecureSparkWrapper {
 
     // Sample: [--driver-java-options, , --master, yarn-cluster, --class, myclass,
     // --conf, queue=default, --executor-memory, 1g, --num-executors, 15, my.jar, myparams]
-    logger.info("Args before adjusting driver java opts: " + Arrays.toString(newArgs));
+    LOG.info("Args before adjusting driver java opts: " + Arrays.toString(newArgs));
 
     // Adjust driver java opts param
     handleDriverJavaOpts(newArgs);
@@ -135,7 +132,7 @@ public class HadoopSecureSparkWrapper {
 
     // Realign params after adjustment
     newArgs = removeNullsFromArgArray(newArgs);
-    logger.info("Args after adjusting driver java opts: " + Arrays.toString(newArgs));
+    LOG.info("Args after adjusting driver java opts: " + Arrays.toString(newArgs));
 
     org.apache.spark.deploy.SparkSubmit$.MODULE$.main(newArgs);
   }
@@ -191,7 +188,7 @@ public class HadoopSecureSparkWrapper {
             .startsWith(SPARK_CONF_DYNAMIC_ALLOC_ENABLED)) // spark.dynamicAllocation.enabled
         ) {
 
-          logger.info(
+          LOG.info(
               "Azbakan enforces dynamic resource allocation. Ignore user param: " + argArray[i]
                   + " " + argArray[i
                   + 1]);
@@ -228,12 +225,12 @@ public class HadoopSecureSparkWrapper {
       if (isLargeContainerRequired(argArray, conf, sparkConf)) {
         // Case A
         requiredSparkDefaultQueue = true;
-        logger.info(
+        LOG.info(
             "Spark application requires Large containers. Scheduling this application into default queue by a "
                 + "default conf(spark.yarn.queue) in spark-defaults.conf.");
       } else {
         // Case B
-        logger.info(
+        LOG.info(
             "Dynamic allocation is enabled for selected spark version and application requires small container. "
                 + "Hence, scheduling this application into Org specific queue");
         if (queueParameterIndex == -1) {
@@ -245,14 +242,14 @@ public class HadoopSecureSparkWrapper {
       }
     } else {
       // Case C
-      logger.info(
+      LOG.info(
           "Spark version, selected for this application, doesn't support dynamic allocation. Scheduling this "
               + "application into default queue by a default conf(spark.yarn.queue) in spark-defaults.conf.");
       requiredSparkDefaultQueue = true;
     }
 
     if (queueParameterIndex != -1 && requiredSparkDefaultQueue) {
-      logger.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: "
+      LOG.info("Azbakan enforces spark.yarn.queue queue. Ignore user param: "
           + argArray[queueParameterIndex] + " "
           + argArray[queueParameterIndex + 1]);
       argArray[queueParameterIndex] = null;
@@ -294,7 +291,7 @@ public class HadoopSecureSparkWrapper {
     double minMemSize = Double
         .parseDouble(System.getenv(HadoopSparkJob.SPARK_MIN_MEM_SIZE_ENV_VAR));
 
-    logger.info(
+    LOG.info(
         "RoundedMemoryGbSize: " + roundedMemoryGbSize + ", ExecutorVcore: " + executorVcore
             + ", MinRatio: " + minRatio
             + ", MinMemSize: " + minMemSize);
@@ -353,7 +350,7 @@ public class HadoopSecureSparkWrapper {
         // the user application.
         if (argArray[i].equals(SparkJobArg.SPARK_CONF_PREFIX.sparkParamName) && argArray[i + 1]
             .startsWith(SPARK_EXECUTOR_NODE_LABEL_EXP)) {
-          logger.info(
+          LOG.info(
               "Azbakan auto-sets node label expression. Ignore user param: " + argArray[i] + " "
                   + argArray[i + 1]);
           argArray[i] = null;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -15,6 +15,8 @@
  */
 package azkaban.jobtype;
 
+import azkaban.jobExecutor.ProcessJob;
+import azkaban.security.commons.HadoopSecurityManager;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -24,8 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.log4j.Logger;
-import azkaban.jobExecutor.ProcessJob;
-import azkaban.security.commons.HadoopSecurityManager;
 
 
 /**
@@ -47,21 +47,21 @@ public class HadoopSecureWrapperUtils {
    * the logged in user's tokens
    */
   private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy,
-      String fileLocation, Logger log
+      String fileLocation, Logger logger
   ) throws IOException {
 
     if (!new File(fileLocation).exists()) {
       throw new RuntimeException("hadoop token file doesn't exist.");
     }
 
-    log.info("Found token file.  Setting " + HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY
+    logger.info("Found token file.  Setting " + HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY
         + " to " + fileLocation);
     System.setProperty(HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY, fileLocation);
 
     UserGroupInformation loginUser = null;
 
     loginUser = UserGroupInformation.getLoginUser();
-    log.info("Current logged in user is " + loginUser.getUserName());
+    logger.info("Current logged in user is " + loginUser.getUserName());
 
     UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(userToProxy, loginUser);
 
@@ -84,11 +84,11 @@ public class HadoopSecureWrapperUtils {
    * doAs
    */
   public static UserGroupInformation setupProxyUser(Properties jobProps,
-      String tokenFile, Logger log) {
+      String tokenFile, Logger logger) {
     UserGroupInformation proxyUser = null;
 
     if (!HadoopSecureWrapperUtils.shouldProxy(jobProps)) {
-      log.info("submitting job as original submitter, not proxying");
+      logger.info("submitting job as original submitter, not proxying");
       return proxyUser;
     }
 
@@ -104,14 +104,14 @@ public class HadoopSecureWrapperUtils {
       if (securityEnabled) {
         proxyUser =
             HadoopSecureWrapperUtils.createSecurityEnabledProxyUser(
-                userToProxy, tokenFile, log);
-        log.info("security enabled, proxying as user " + userToProxy);
+                userToProxy, tokenFile, logger);
+        logger.info("security enabled, proxying as user " + userToProxy);
       } else {
         proxyUser = UserGroupInformation.createRemoteUser(userToProxy);
-        log.info("security not enabled, proxying as user " + userToProxy);
+        logger.info("security not enabled, proxying as user " + userToProxy);
       }
     } catch (IOException e) {
-      log.error("HadoopSecureWrapperUtils.setupProxyUser threw an IOException",
+      logger.error("HadoopSecureWrapperUtils.setupProxyUser threw an IOException",
           e);
     }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
@@ -15,10 +15,10 @@
  */
 package azkaban.jobtype;
 
-import java.util.List;
-import org.apache.log4j.Logger;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.utils.Props;
+import java.util.List;
+import org.apache.log4j.Logger;
 
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSparkJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSparkJob.java
@@ -147,17 +147,17 @@ public class HadoopSparkJob extends AbstractHadoopJavaProcessJob {
 
 
   public HadoopSparkJob(final String jobid, final Props sysProps, final Props jobProps,
-      final Logger log) {
-    super(jobid, sysProps, jobProps, log);
+      final Logger logger) {
+    super(jobid, sysProps, jobProps, logger);
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
   }
 
   private static String testableGetMainArguments(final Props jobProps, final String workingDir,
-      final Logger log) {
+      final Logger logger) {
 
     // if we ever need to recreate a failure scenario in the test case
-    log.debug(jobProps);
-    log.debug(workingDir);
+    logger.debug(jobProps.toString());
+    logger.debug(workingDir);
 
     final List<String> argList = new ArrayList<>();
 
@@ -182,7 +182,7 @@ public class HadoopSparkJob extends AbstractHadoopJavaProcessJob {
       if (!sparkJobArg.needSpecialTreatment) {
         handleStandardArgument(jobProps, argList, sparkJobArg);
       } else if (sparkJobArg.equals(SparkJobArg.SPARK_JARS)) {
-        sparkJarsHelper(jobProps, workingDir, log, argList);
+        sparkJarsHelper(jobProps, workingDir, logger, argList);
       } else if (sparkJobArg.equals(SparkJobArg.SPARK_CONF_PREFIX)) {
         sparkConfPrefixHelper(jobProps, argList);
       } else if (sparkJobArg.equals(SparkJobArg.DRIVER_JAVA_OPTIONS)) {
@@ -190,7 +190,7 @@ public class HadoopSparkJob extends AbstractHadoopJavaProcessJob {
       } else if (sparkJobArg.equals(SparkJobArg.SPARK_FLAG_PREFIX)) {
         sparkFlagPrefixHelper(jobProps, argList);
       } else if (sparkJobArg.equals(SparkJobArg.EXECUTION_JAR)) {
-        executionJarHelper(jobProps, workingDir, log, argList);
+        executionJarHelper(jobProps, workingDir, logger, argList);
       } else if (sparkJobArg.equals(SparkJobArg.PARAMS)) {
         paramsHelper(jobProps, argList);
       } else if (sparkJobArg.equals(SparkJobArg.SPARK_VERSION)) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/IHadoopJob.java
@@ -15,6 +15,7 @@
  */
 package azkaban.jobtype;
 
+
 public interface IHadoopJob {
 
   /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJob.java
@@ -46,8 +46,8 @@ public class JavaJob extends JavaProcessJob {
 
   private Object _javaObject = null;
 
-  public JavaJob(String jobid, Props sysProps, Props jobProps, Logger log) {
-    super(jobid, sysProps, new Props(sysProps, jobProps), log);
+  public JavaJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
+    super(jobid, sysProps, new Props(sysProps, jobProps), logger);
     getJobProps().put(CommonJobProperties.JOB_ID, jobid);
   }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/PigProcessJob.java
@@ -47,8 +47,8 @@ public class PigProcessJob extends JavaProcessJob {
   private static final String SECURE_PIG_WRAPPER = "azkaban.jobtype.SecurePigWrapper";
 
   public PigProcessJob(final String jobId, final Props sysProps, final Props jobProps,
-      final Logger log) {
-    super(jobId, sysProps, new Props(sysProps, jobProps), log);
+      final Logger logger) {
+    super(jobId, sysProps, new Props(sysProps, jobProps), logger);
   }
 
   @Override

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/StatsUtils.java
@@ -33,13 +33,14 @@ import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.Counters.Counter;
 import org.apache.hadoop.mapred.Counters.Group;
 import org.apache.hadoop.mapred.RunningJob;
-import org.apache.log4j.Logger;
 import org.apache.pig.impl.util.ObjectSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class StatsUtils {
 
-  private static Logger logger = Logger.getLogger(StatsUtils.class);
+  private static Logger LOG = LoggerFactory.getLogger(StatsUtils.class);
 
   private static final Set<String> JOB_CONF_KEYS = new HashSet<String>(
       Arrays.asList(new String[]{
@@ -70,9 +71,9 @@ public class StatsUtils {
       conf.addResource(in);
       return getJobConf(conf);
     } catch (FileNotFoundException e) {
-      logger.warn("Job conf not found.");
+      LOG.warn("Job conf not found.");
     } catch (IOException e) {
-      logger.warn("Error while retrieving job conf: " + e.getMessage());
+      LOG.warn("Error while retrieving job conf: " + e.getMessage());
     }
     return null;
   }
@@ -95,7 +96,7 @@ public class StatsUtils {
         }
       }
     } catch (IOException e) {
-      logger.warn("Error while reading job conf: " + e.getMessage());
+      LOG.warn("Error while reading job conf: " + e.getMessage());
     }
     return jobConfProperties;
   }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinConstants.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinConstants.java
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.connectors.gobblin;
 
 /**
@@ -19,10 +18,10 @@ package azkaban.jobtype.connectors.gobblin;
  */
 public interface GobblinConstants {
 
-  public static final String GOBBLIN_PRESET_DIR_KEY = "gobblin.config.preset.dir"; //Directory where preset file lies.
-  public static final String GOBBLIN_PRESET_KEY = "gobblin.config_preset"; //Name of Gobblin preset
-  public static final String GOBBLIN_WORK_DIRECTORY_KEY = "gobblin.work_dir"; //Gobblin needs working directory. This will be a HDFS directory.
-  public static final String GOBBLIN_PROPERTIES_HELPER_ENABLED_KEY = "gobblin.properties_helper_enabled"; //Validates Gobblin job properties if enabled.
-  public static final String GOBBLIN_HDFS_JOB_JARS_KEY = "job.hdfs.jars";
-  public static final String GOBBLIN_JOB_JARS_KEY = "job.jars";
+  String GOBBLIN_PRESET_DIR_KEY = "gobblin.config.preset.dir"; //Directory where preset file lies.
+  String GOBBLIN_PRESET_KEY = "gobblin.config_preset"; //Name of Gobblin preset
+  String GOBBLIN_WORK_DIRECTORY_KEY = "gobblin.work_dir"; //Gobblin needs working directory. This will be a HDFS directory.
+  String GOBBLIN_PROPERTIES_HELPER_ENABLED_KEY = "gobblin.properties_helper_enabled"; //Validates Gobblin job properties if enabled.
+  String GOBBLIN_HDFS_JOB_JARS_KEY = "job.hdfs.jars";
+  String GOBBLIN_JOB_JARS_KEY = "job.jars";
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinHadoopJob.java
@@ -13,6 +13,15 @@
  */
 package azkaban.jobtype.connectors.gobblin;
 
+import azkaban.flow.CommonJobProperties;
+import azkaban.jobtype.HadoopJavaJob;
+import azkaban.jobtype.connectors.gobblin.helper.HdfsToMySqlValidator;
+import azkaban.jobtype.connectors.gobblin.helper.IPropertiesValidator;
+import azkaban.jobtype.connectors.gobblin.helper.MySqlToHdfsValidator;
+import azkaban.utils.Props;
+import com.google.common.collect.Maps;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,15 +32,6 @@ import java.util.Objects;
 import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import com.google.common.collect.Maps;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Predicate;
-import azkaban.flow.CommonJobProperties;
-import azkaban.jobtype.HadoopJavaJob;
-import azkaban.jobtype.connectors.gobblin.helper.HdfsToMySqlValidator;
-import azkaban.jobtype.connectors.gobblin.helper.IPropertiesValidator;
-import azkaban.jobtype.connectors.gobblin.helper.MySqlToHdfsValidator;
-import azkaban.utils.Props;
 
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinPresets.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/GobblinPresets.java
@@ -11,24 +11,25 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.connectors.gobblin;
 
 import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 
 /**
- * An enum for GobblinPresets. Gobblin has more than hundred properties and GobblinPresets represents set of default properties.
- * Using GobblinPresets, user can reduce number of input parameters which consequently increase usability.
+ * An enum for GobblinPresets.
+ * Gobblin has more than hundred properties and GobblinPresets represents set of default properties.
+ * Using GobblinPresets, user can reduce number of input parameters which consequently increase
+ * usability.
  */
 public enum GobblinPresets {
   MYSQL_TO_HDFS("mysqlToHdfs"),
   HDFS_TO_MYSQL("hdfsToMysql");
 
   private static final Map<String, GobblinPresets> NAME_TO_PRESET;
+
   static {
     Map<String, GobblinPresets> tmp = Maps.newHashMap();
     for (GobblinPresets preset : GobblinPresets.values()) {
@@ -39,14 +40,15 @@ public enum GobblinPresets {
 
   private final String name;
 
-  private GobblinPresets(String name) {
+  GobblinPresets(String name) {
     this.name = name;
   }
 
   public static GobblinPresets fromName(String name) {
     GobblinPresets preset = NAME_TO_PRESET.get(name);
     if (preset == null) {
-      throw new IllegalArgumentException(name + " is unrecognized. Known presets: " + NAME_TO_PRESET.keySet());
+      throw new IllegalArgumentException(
+          name + " is unrecognized. Known presets: " + NAME_TO_PRESET.keySet());
     }
     return preset;
   }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/helper/IPropertiesValidator.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/helper/IPropertiesValidator.java
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.connectors.gobblin.helper;
 
 import azkaban.utils.Props;
@@ -25,8 +24,6 @@ public interface IPropertiesValidator {
   /**
    * Validates props.
    * @param props
-   * @throws UndefinedPropertyException if required property is missing
-   * @throws IllegalArgumentException if property is set incorrectly
    */
-  public void validate(Props props);
+  void validate(Props props);
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/helper/MySqlToHdfsValidator.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/connectors/gobblin/helper/MySqlToHdfsValidator.java
@@ -11,7 +11,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.connectors.gobblin.helper;
 
 import azkaban.jobtype.connectors.gobblin.GobblinConstants;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/examples/java/WordCount.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/examples/java/WordCount.java
@@ -13,13 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.examples.java;
 
+import azkaban.jobtype.javautils.AbstractHadoopJob;
+import azkaban.utils.Props;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.StringTokenizer;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
@@ -35,33 +35,32 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.FileOutputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import azkaban.jobtype.javautils.AbstractHadoopJob;
-import azkaban.utils.Props;
 
 public class WordCount extends AbstractHadoopJob {
 
-  private static final Logger logger = Logger.getLogger(WordCount.class);
+  private final static Logger LOG = LoggerFactory.getLogger(WordCount.class);
 
   private final String inputPath;
   private final String outputPath;
-  private boolean forceOutputOverrite;
+  private boolean forceOutputOverwrite;
 
   public WordCount(String name, Props props) {
     super(name, props);
     this.inputPath = props.getString("input.path");
     this.outputPath = props.getString("output.path");
-    this.forceOutputOverrite =
+    this.forceOutputOverwrite =
         props.getBoolean("force.output.overwrite", false);
   }
 
   public static class Map extends MapReduceBase implements
       Mapper<LongWritable, Text, Text, IntWritable> {
 
-    static enum Counters {
+    enum Counters {
       INPUT_WORDS
-    };
+    }
 
     private final static IntWritable one = new IntWritable(1);
     private Text word = new Text();
@@ -103,7 +102,7 @@ public class WordCount extends AbstractHadoopJob {
 
   @Override
   public void run() throws Exception {
-    logger.info(String.format("Starting %s", getClass().getSimpleName()));
+    LOG.info(String.format("Starting %s", getClass().getSimpleName()));
 
     // hadoop conf should be on the classpath
     JobConf jobconf = getJobConf();
@@ -121,7 +120,7 @@ public class WordCount extends AbstractHadoopJob {
     FileInputFormat.addInputPath(jobconf, new Path(inputPath));
     FileOutputFormat.setOutputPath(jobconf, new Path(outputPath));
 
-    if (forceOutputOverrite) {
+    if (forceOutputOverwrite) {
       FileSystem fs =
           FileOutputFormat.getOutputPath(jobconf).getFileSystem(jobconf);
       fs.delete(FileOutputFormat.getOutputPath(jobconf), true);
@@ -129,5 +128,4 @@ public class WordCount extends AbstractHadoopJob {
 
     super.run();
   }
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveMetaStoreBrowserException.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveMetaStoreBrowserException.java
@@ -13,13 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
+
 
 /**
  * Thrown when unexpected Hive metastore browsing problems come up
  */
 public class HiveMetaStoreBrowserException extends Exception {
+
   private static final long serialVersionUID = 1L;
 
   public HiveMetaStoreBrowserException(String msg) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveModule.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveModule.java
@@ -13,23 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
+
 /**
  * Guice-like module for creating a Hive instance. Easily turned back into a
  * full Guice module when we have need of it.
  */
 class HiveModule {
+
   /**
    * Return a Driver that's connected to the real, honest-to-goodness Hive
    *
-   * @TODO: Better error checking
    * @return Driver that's connected to Hive
+   * @TODO: Better error checking
    */
   Driver provideHiveDriver() {
     HiveConf hiveConf = provideHiveConf();

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryException.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryException.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
+
 public class HiveQueryException extends Exception {
+
   private static final long serialVersionUID = 1L;
   private final String query;
   private final int code;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutionException.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutionException.java
@@ -13,13 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
+
 
 /**
  * Thrown when a query sent for execution ends unsuccessfully.
  */
 public class HiveQueryExecutionException extends Exception {
+
   private static final long serialVersionUID = 1L;
 
   /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutor.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutor.java
@@ -13,44 +13,38 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
 import java.io.InputStream;
 import java.io.PrintStream;
 
+
 /**
  * Utility to execute queries against a Hive database.
  */
 public interface HiveQueryExecutor {
+
   /**
    * Execute the specified quer(y|ies).
    *
    * @param q Query to be executed. Queries may include \n and mutliple,
-   *          ;-delimited statements. The entire string is passed to Hive.
-   *
+   * ;-delimited statements. The entire string is passed to Hive.
    * @throws HiveQueryExecutionException if Hive cannont execute a query.
    */
-  public void executeQuery(String q) throws HiveQueryExecutionException;
+  void executeQuery(String q) throws HiveQueryExecutionException;
 
   /**
    * Redirect the query execution's stdout
-   *
-   * @param out
    */
-  public void setOut(PrintStream out);
+  void setOut(PrintStream out);
 
   /**
    * Redirect the query execution's stdin
-   *
-   * @param in
    */
-  public void setIn(InputStream in);
+  void setIn(InputStream in);
 
   /**
    * Redirect the query execution's stderr
-   *
-   * @param err
    */
-  public void setErr(PrintStream err);
+  void setErr(PrintStream err);
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutorModule.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveQueryExecutorModule.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
 import org.apache.hadoop.hive.cli.CliSessionState;
@@ -25,11 +24,13 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEHISTORYFILELOC;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.SCRATCHDIR;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
+
 /**
  * Guice-like module for creating a Hive instance. Easily turned back into a
  * full Guice module when we have need of it.
  */
 class HiveQueryExecutorModule {
+
   private HiveConf hiveConf = null;
   private CliSessionState ss = null;
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/HiveUtils.java
@@ -13,14 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.hadoop.hive.cli.CliDriver;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Grab bag of utilities for working with Hive. End users should obtain
@@ -28,7 +28,7 @@ import org.apache.log4j.Logger;
  */
 public class HiveUtils {
   private final static Logger LOG =
-      Logger.getLogger("com.linkedin.hive.HiveUtils");
+      LoggerFactory.getLogger("com.linkedin.hive.HiveUtils");
 
   private HiveUtils() {
   }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/RealHiveQueryExecutor.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/RealHiveQueryExecutor.java
@@ -13,9 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
 
+import java.io.InputStream;
+import java.io.PrintStream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.cli.CliDriver;
 import org.apache.hadoop.hive.cli.CliSessionState;
@@ -23,17 +24,16 @@ import org.apache.hadoop.hive.cli.OptionsProcessor;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.shims.ShimLoader;
-import org.apache.log4j.Logger;
-
-import java.io.InputStream;
-import java.io.PrintStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEAUXJARS;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY;
 
+
 class RealHiveQueryExecutor implements HiveQueryExecutor {
-  private final static Logger LOG = Logger
-      .getLogger("com.linkedin.hive.HiveQueryExecutor");
+
+  private final static Logger LOG = LoggerFactory.getLogger("com.linkedin.hive.HiveQueryExecutor");
   private final CliDriver cli;
   private final CliSessionState ss;
 
@@ -57,7 +57,7 @@ class RealHiveQueryExecutor implements HiveQueryExecutor {
 
     OptionsProcessor op = new OptionsProcessor();
 
-    if (!op.process_stage1(new String[] {})) {
+    if (!op.process_stage1(new String[]{})) {
       throw new IllegalArgumentException("Can't process empty args?!?");
     }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/ResultSchema.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/ResultSchema.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils;
+
 
 /**
  * Simple class to represent the resulting schema of a Hive query, which may or
@@ -23,6 +23,7 @@ package azkaban.jobtype.hiveutils;
  * particular version of Hive or its classes.
  */
 public class ResultSchema {
+
   final String name;
   final String type;
   final String comment;
@@ -44,5 +45,4 @@ public class ResultSchema {
   public String getType() {
     return type;
   }
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveAction.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveAction.java
@@ -13,9 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban;
 
+
+/**
+ * Defines Hive Action Interface
+ */
 public interface HiveAction {
-  public void execute() throws HiveViaAzkabanException;
+
+  void execute() throws HiveViaAzkabanException;
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveViaAzkaban.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveViaAzkaban.java
@@ -13,16 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban;
-
-import java.util.Properties;
 
 import azkaban.jobtype.hiveutils.HiveQueryExecutor;
 import azkaban.jobtype.hiveutils.HiveUtils;
 import azkaban.jobtype.hiveutils.azkaban.hive.actions.DropAllPartitionsAddLatest;
 import azkaban.jobtype.hiveutils.azkaban.hive.actions.ExecuteHiveQuery;
 import azkaban.jobtype.hiveutils.azkaban.hive.actions.UpdateTableLocationToLatest;
+import java.util.Properties;
+
 
 /**
  * Simple Java driver class to execute a Hive query provided via the Properties
@@ -31,6 +30,7 @@ import azkaban.jobtype.hiveutils.azkaban.hive.actions.UpdateTableLocationToLates
  * will be joined and fed to to Hive as one big query
  */
 public class HiveViaAzkaban {
+
   final private static String AZK_HIVE_ACTION = "azk.hive.action";
   public static final String EXECUTE_QUERY = "execute.query";
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveViaAzkabanException.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/HiveViaAzkabanException.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban;
 
+
 public class HiveViaAzkabanException extends Exception {
+
   private static final long serialVersionUID = 1L;
 
   public HiveViaAzkabanException(String s) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/Utils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/Utils.java
@@ -13,24 +13,31 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban;
 
 import java.util.Collection;
 import java.util.Properties;
 
+
 public class Utils {
+
+  private Utils() {
+
+  }
+
   public static String joinNewlines(Collection<String> strings) {
-    if (strings == null || strings.size() == 0)
+    if (strings == null || strings.size() == 0) {
       return null;
+    }
 
     StringBuilder sb = new StringBuilder();
 
     for (String s : strings) {
       String trimmed = s.trim();
       sb.append(trimmed);
-      if (!trimmed.endsWith("\n"))
+      if (!trimmed.endsWith("\n")) {
         sb.append("\n");
+      }
     }
 
     return sb.toString();
@@ -47,6 +54,5 @@ public class Utils {
     }
     // TODO: Add a log entry here for the value
     return value;
-
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/AddExternalPartitionHQL.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/AddExternalPartitionHQL.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
 class AddExternalPartitionHQL implements HQL {
+
   // ALTER TABLE table_name ADD PARTITION (partCol = 'value1') location 'loc1';
   private final String table;
   private final String partition;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/AlterTableLocationQL.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/AlterTableLocationQL.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
 class AlterTableLocationQL implements HQL {
+
   private final String table;
   private final String newLocation;
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/Constants.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/Constants.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
 class Constants {
+
   static final String DROP_ALL_PARTITIONS_AND_ADD_LATEST =
       "drop.all.partitions.and.add.newest";
   static final String UPDATE_TABLE_LOCATION_TO_LATEST =

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/DropAllPartitionsAddLatest.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/DropAllPartitionsAddLatest.java
@@ -13,12 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.log4j.Logger;
+import static azkaban.jobtype.hiveutils.azkaban.Utils.verifyProperty;
+import static azkaban.jobtype.hiveutils.azkaban.hive.actions.Constants.DROP_ALL_PARTITIONS_AND_ADD_LATEST;
 
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.jobtype.hiveutils.HiveQueryExecutor;
@@ -26,14 +24,15 @@ import azkaban.jobtype.hiveutils.azkaban.HiveAction;
 import azkaban.jobtype.hiveutils.azkaban.HiveViaAzkabanException;
 import azkaban.jobtype.hiveutils.util.AzkHiveAction;
 import azkaban.jobtype.hiveutils.util.AzkabanJobPropertyDescription;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static azkaban.jobtype.hiveutils.azkaban.Utils.verifyProperty;
-import static azkaban.jobtype.hiveutils.azkaban.hive.actions.Constants.DROP_ALL_PARTITIONS_AND_ADD_LATEST;
 
 /**
  * Drop all the existing partitions in specified table and then add the
@@ -60,9 +59,9 @@ import static azkaban.jobtype.hiveutils.azkaban.hive.actions.Constants.DROP_ALL_
  */
 @AzkHiveAction(DROP_ALL_PARTITIONS_AND_ADD_LATEST)
 public class DropAllPartitionsAddLatest implements HiveAction {
-  private final static Logger LOG =
-      Logger
-          .getLogger("com.linkedin.hive.azkaban.hive.actions.DropAllPartitionsAddLatest");
+
+  private final static Logger logger =
+      LoggerFactory.getLogger("com.linkedin.hive.azkaban.hive.actions.DropAllPartitionsAddLatest");
 
   public static final String DROP_AND_ADD = DROP_ALL_PARTITIONS_AND_ADD_LATEST;
 
@@ -106,7 +105,7 @@ public class DropAllPartitionsAddLatest implements HiveAction {
       FileSystem fs = FileSystem.get(conf);
 
       for (String table : tables) {
-        LOG.info("Determining HQL commands for table " + table);
+        logger.info("Determining HQL commands for table " + table);
         hql.addAll(addAndDrop(fs, tableLocations, table));
       }
       fs.close();
@@ -146,7 +145,7 @@ public class DropAllPartitionsAddLatest implements HiveAction {
 
     String toAdd = directories.remove(directories.size() - 1);
 
-    LOG.info("For table " + table + ", going to add " + toAdd
+    logger.info("For table " + table + ", going to add " + toAdd
         + " and attempt to drop " + directories.size() + " others");
     for (String directory : directories) {
       toDropAndAdd.add(new DropPartitionHQL(table, partition, directory, true));
@@ -156,5 +155,4 @@ public class DropAllPartitionsAddLatest implements HiveAction {
         toAdd, true));
     return toDropAndAdd;
   }
-
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/DropPartitionHQL.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/DropPartitionHQL.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
+
 class DropPartitionHQL implements HQL {
+
   private final String table;
   private final String partition;
   private final String value;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/ExecuteHiveQuery.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/ExecuteHiveQuery.java
@@ -13,12 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
-
-import java.io.FileInputStream;
-import java.nio.charset.StandardCharsets;
-import org.apache.log4j.Logger;
 
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.jobtype.hiveutils.HiveQueryExecutor;
@@ -26,21 +21,25 @@ import azkaban.jobtype.hiveutils.azkaban.Utils;
 import azkaban.jobtype.hiveutils.azkaban.HiveAction;
 import azkaban.jobtype.hiveutils.azkaban.HiveViaAzkabanException;
 import azkaban.jobtype.hiveutils.util.AzkabanJobPropertyDescription;
-
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Execute the provided Hive query. Queries can be specified to Azkaban either
  * directly or as a pointer to a file provided with workflow.
  */
 public class ExecuteHiveQuery implements HiveAction {
-  private final static Logger LOG = Logger
+
+  private final static Logger LOG = LoggerFactory
       .getLogger("com.linkedin.hive.azkaban.hive.actions.ExecuteHiveQuery");
   @AzkabanJobPropertyDescription("Verbatim query to execute. Can also specify hive.query.nn where nn is a series of padded numbers, which will be executed in order")
   public static final String HIVE_QUERY = "hive.query";
@@ -68,8 +67,9 @@ public class ExecuteHiveQuery implements HiveAction {
       throws HiveViaAzkabanException {
     String file = properties.getProperty(HIVE_QUERY_FILE);
 
-    if (file == null)
+    if (file == null) {
       return null;
+    }
 
     LOG.info("Attempting to read query from file: " + file);
 
@@ -90,13 +90,14 @@ public class ExecuteHiveQuery implements HiveAction {
     } catch (IOException e) {
       throw new HiveViaAzkabanException(e);
     } finally {
-      if (br != null)
+      if (br != null) {
         try {
           br.close();
         } catch (IOException e) {
           // TODO: Just throw IOException and catch-wrap in the constructor...
           throw new HiveViaAzkabanException(e);
         }
+      }
     }
 
     return contents.toString();
@@ -107,8 +108,9 @@ public class ExecuteHiveQuery implements HiveAction {
       throws HiveViaAzkabanException {
     String url = properties.getProperty(HIVE_QUERY_URL);
 
-    if (url == null)
+    if (url == null) {
       return null;
+    }
 
     LOG.info("Attempting to retrieve query from URL: " + url);
 
@@ -128,13 +130,14 @@ public class ExecuteHiveQuery implements HiveAction {
     } catch (IOException e) {
       throw new HiveViaAzkabanException(e);
     } finally {
-      if (br != null)
+      if (br != null) {
         try {
           br.close();
         } catch (IOException e) {
           // TODO: Just throw IOException and catch-wrap in the constructor...
           throw new HiveViaAzkabanException(e);
         }
+      }
     }
 
     return contents.toString();
@@ -144,21 +147,24 @@ public class ExecuteHiveQuery implements HiveAction {
       String queryFromFile, String queryFromURL) throws HiveViaAzkabanException {
     int specifiedValues = 0;
 
-    for (String s : new String[] { singleLine, multiLine, queryFromFile,
-        queryFromURL }) {
-      if (s != null)
+    for (String s : new String[]{singleLine, multiLine, queryFromFile,
+        queryFromURL}) {
+      if (s != null) {
         specifiedValues++;
+      }
     }
 
-    if (specifiedValues == 0)
+    if (specifiedValues == 0) {
       throw new HiveViaAzkabanException("Must specify " + HIVE_QUERY + " xor "
           + HIVE_QUERY + ".nn xor " + HIVE_QUERY_FILE + " xor "
           + HIVE_QUERY_URL + " in properties. Exiting.");
+    }
 
-    if (specifiedValues != 1)
+    if (specifiedValues != 1) {
       throw new HiveViaAzkabanException("Must specify only " + HIVE_QUERY
           + " or " + HIVE_QUERY + ".nn or " + HIVE_QUERY_FILE + " or "
           + HIVE_QUERY_URL + " in properties, not more than one. Exiting.");
+    }
 
     if (singleLine != null) {
       LOG.info("Returning " + HIVE_QUERY + " = " + singleLine);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/HQL.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/HQL.java
@@ -13,9 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
+
 interface HQL {
+
   String toHQL();
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/UpdateTableLocationToLatest.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/UpdateTableLocationToLatest.java
@@ -13,12 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.log4j.Logger;
+import static azkaban.jobtype.hiveutils.azkaban.Utils.verifyProperty;
 
 import azkaban.jobtype.hiveutils.HiveQueryExecutionException;
 import azkaban.jobtype.hiveutils.HiveQueryExecutor;
@@ -26,30 +23,32 @@ import azkaban.jobtype.hiveutils.azkaban.HiveAction;
 import azkaban.jobtype.hiveutils.azkaban.HiveViaAzkabanException;
 import azkaban.jobtype.hiveutils.util.AzkHiveAction;
 import azkaban.jobtype.hiveutils.util.AzkabanJobPropertyDescription;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static azkaban.jobtype.hiveutils.azkaban.Utils.verifyProperty;
 
 /**
  * Alter the specified table's location to the 'latest' directory found in
  * specified base directory, where latest is defined as greate lexically.</p>
  *
  * For example, if we have a base dir foo with directories:</p>
- *   /foo/2012-01-01</p>
- *       /2012-01-02</p>
- *       /2012-01-03</p>
+ * /foo/2012-01-01</p>
+ * /2012-01-02</p>
+ * /2012-01-03</p>
  * and we specify table as 'bar', this action will execute
  * ALTER TABLE bar SET LOCATION '/foo/2012-01-03';</p>
  * </p>
  */
 @AzkHiveAction(Constants.UPDATE_TABLE_LOCATION_TO_LATEST)
 public class UpdateTableLocationToLatest implements HiveAction {
-  private final static Logger LOG = Logger
-      .getLogger(UpdateTableLocationToLatest.class);
+
+  private final static Logger LOG = LoggerFactory.getLogger(UpdateTableLocationToLatest.class);
 
   public static final String UPDATE_TABLE_LOCATION_TO_LATEST =
       Constants.UPDATE_TABLE_LOCATION_TO_LATEST;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/Utils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/Utils.java
@@ -13,23 +13,27 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
+import azkaban.jobtype.hiveutils.azkaban.HiveViaAzkabanException;
+import java.io.IOException;
+import java.util.ArrayList;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import azkaban.jobtype.hiveutils.azkaban.HiveViaAzkabanException;
-
-import java.io.IOException;
-import java.util.ArrayList;
 
 class Utils {
-  private final static Logger LOG = Logger.getLogger(Utils.class);
 
-  static ArrayList<String> fetchDirectories(FileSystem fs, String location,
+  private final static Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+  private Utils() {
+
+  }
+
+  public static ArrayList<String> fetchDirectories(FileSystem fs, String location,
       boolean returnFullPath) throws IOException, HiveViaAzkabanException {
     LOG.info("Fetching directories in " + location);
     Path p = new Path(location);
@@ -42,10 +46,12 @@ class Utils {
 
     ArrayList<String> files = new ArrayList<String>(statuses.length);
     for (FileStatus status : statuses) {
-      if (!status.isDir())
+      if (!status.isDirectory()) {
         continue;
-      if (status.getPath().getName().startsWith("."))
+      }
+      if (status.getPath().getName().startsWith(".")) {
         continue;
+      }
 
       files.add(returnFullPath ? status.getPath().toString() : status.getPath()
           .getName());

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/useDatabaseHQL.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/azkaban/hive/actions/useDatabaseHQL.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.azkaban.hive.actions;
 
+
 class UseDatabaseHQL implements HQL {
+
   private final String database;
 
   UseDatabaseHQL(String database) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/AzkHiveAction.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/AzkHiveAction.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.util;
 
 import java.lang.annotation.Documented;
+
 
 @Documented
 public @interface AzkHiveAction {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/AzkabanJobPropertyDescription.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/AzkabanJobPropertyDescription.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.util;
 
 import java.lang.annotation.Documented;
+
 
 /**
  * Description of parameter passed to this class via the Azkaban property to

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/IntendedAudience.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/hiveutils/util/IntendedAudience.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.hiveutils.util;
 
 import java.lang.annotation.Documented;
+
 
 /**
  * Who in LinkedIn this class is aimed at. If specified, other users may have

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/FileUtils.java
@@ -23,7 +23,8 @@ import java.util.List;
 import org.apache.commons.io.filefilter.AndFileFilter;
 import org.apache.commons.io.filefilter.FileFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -31,7 +32,7 @@ import org.apache.log4j.Logger;
  */
 public class FileUtils {
 
-  private static Logger logger = Logger.getLogger(FileUtils.class);
+  private static Logger LOG = LoggerFactory.getLogger(FileUtils.class);
 
   /**
    * Delete file or directory.
@@ -67,7 +68,7 @@ public class FileUtils {
       deleteFileOrDirectory(file);
       return true;
     } catch (Exception e) {
-      logger.warn("Failed to delete file. file = " + file.getAbsolutePath(), e);
+      LOG.warn("Failed to delete file. file = " + file.getAbsolutePath(), e);
       return false;
     }
   }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/HadoopUtils.java
@@ -15,6 +15,7 @@
  */
 package azkaban.jobtype.javautils;
 
+import azkaban.utils.Props;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,8 +28,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.log4j.Logger;
-import azkaban.utils.Props;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -36,7 +37,7 @@ import azkaban.utils.Props;
  */
 public class HadoopUtils {
 
-  private static final Logger logger = Logger.getLogger(HadoopUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopUtils.class);
 
   public static void setClassLoaderAndJar(JobConf conf, Class<?> jobClass) {
     conf.setClassLoader(Thread.currentThread().getContextClassLoader());
@@ -53,7 +54,7 @@ public class HadoopUtils {
       for (Enumeration<?> itr = loader.getResources(fileName); itr
           .hasMoreElements(); ) {
         URL url = (URL) itr.nextElement();
-        logger.info("findContainingJar finds url:" + url);
+        LOG.info("findContainingJar finds url:" + url);
         if ("jar".equals(url.getProtocol())) {
           String toReturn = url.getPath();
           if (toReturn.startsWith("file:")) {
@@ -90,7 +91,7 @@ public class HadoopUtils {
     if (fs.exists(path)) {
       for (FileStatus status : fs.listStatus(path)) {
         if (!shouldPathBeIgnored(status.getPath())) {
-          if (status.isDir()) {
+          if (status.isDirectory()) {
             addAllSubPaths(conf, status.getPath());
           } else {
             FileInputFormat.addInputPath(conf, status.getPath());

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/ValidationUtils.java
@@ -13,10 +13,10 @@
  */
 package azkaban.jobtype.javautils;
 
+import azkaban.utils.Props;
 import java.util.Arrays;
 import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
-import azkaban.utils.Props;
 
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/javautils/Whitelist.java
@@ -11,6 +11,11 @@
  */
 package azkaban.jobtype.javautils;
 
+import azkaban.flow.CommonJobProperties;
+import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -19,12 +24,8 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
-import azkaban.flow.CommonJobProperties;
-import azkaban.utils.Props;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -37,7 +38,7 @@ public class Whitelist {
 
   public static final String WHITE_LIST_FILE_PATH_KEY = "whitelist.file.path";
   private static final String PROXY_USER_KEY = "user.to.proxy";
-  private static Logger logger = Logger.getLogger(Whitelist.class);
+  private static Logger LOG = LoggerFactory.getLogger(Whitelist.class);
 
   private final Set<String> whitelistSet;
 
@@ -46,8 +47,8 @@ public class Whitelist {
    */
   public Whitelist(String whitelistFilePath, FileSystem fs) {
     this.whitelistSet = retrieveWhitelist(fs, new Path(whitelistFilePath));
-    if (logger.isDebugEnabled()) {
-      logger.debug("Whitelist: " + whitelistSet);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Whitelist: " + whitelistSet);
     }
   }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigIoStats.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigIoStats.java
@@ -13,16 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.pig;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.pig.tools.pigstats.InputStats;
 import org.apache.pig.tools.pigstats.OutputStats;
 
+
 public class PigIoStats {
+
   private long bytes;
   private long records;
   private String location;

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigJobDagNode.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigJobDagNode.java
@@ -13,27 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.pig;
 
+import azkaban.jobtype.JobDagNode;
+import azkaban.jobtype.MapReduceJobState;
+import azkaban.jobtype.StatsUtils;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import azkaban.jobtype.JobDagNode;
-import azkaban.jobtype.MapReduceJobState;
-import azkaban.jobtype.StatsUtils;
-
 import org.apache.pig.tools.pigstats.JobStats;
 
-public class PigJobDagNode extends JobDagNode {
-  private String jobId;
 
+public class PigJobDagNode extends JobDagNode {
+
+  private String jobId;
   private List<String> features;
   private List<String> aliases;
-
   private PigJobStats jobStats;
 
   public PigJobDagNode(String name, String[] aliases, String[] features) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigJobStats.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/pig/PigJobStats.java
@@ -13,46 +13,38 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype.pig;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.pig.tools.pigstats.JobStats;
 import org.apache.pig.tools.pigstats.InputStats;
 import org.apache.pig.tools.pigstats.OutputStats;
 
+
 public class PigJobStats {
+
   private int numberMaps;
   private int numberReduces;
-
   private long minMapTime;
   private long maxMapTime;
   private long avgMapTime;
-
   private long minReduceTime;
   private long maxReduceTime;
   private long avgReduceTime;
-
   private long bytesWritten;
   private long hdfsBytesWritten;
-
   private long mapInputRecords;
   private long mapOutputRecords;
   private long reduceInputRecords;
   private long reduceOutputRecords;
-
   private long proactiveSpillCountObjects;
   private long proactiveSpillCountRecs;
-
   private long recordsWritten;
   private long smmSpillCount;
-
   private String errorMessage;
-
   private List<PigIoStats> inputStats;
   private List<PigIoStats> outputStats;
 

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsExecutionJar.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.HashSet;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -13,6 +12,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+
 
 // TODO kunkun-tang: This test class needs more refactors.
 @Ignore

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsFilterCommands.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsFilterCommands.java
@@ -4,12 +4,11 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
-
 import junit.framework.Assert;
+
 
 /**
  * Test class for filterCommands method in HadoopJobUtils

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsFindApplicationIdFromLog.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsFindApplicationIdFromLog.java
@@ -5,11 +5,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Set;
-
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 
 @SuppressWarnings("DefaultCharset")
 public class TestHadoopJobUtilsFindApplicationIdFromLog {

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsResolveJarSpec.java
@@ -2,14 +2,12 @@ package azkaban.jobtype;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import azkaban.utils.Props;
 
 // TODO kunkun-tang: This test class needs more refactors.
 public class TestHadoopJobUtilsResolveJarSpec {

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import java.util.EnumSet;
@@ -21,7 +20,6 @@ import java.util.Set;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
@@ -31,12 +29,13 @@ import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
-import org.apache.log4j.Logger;
-
+import org.apache.hadoop.security.AccessControlException;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * This class implements a viewer of avro files
@@ -45,7 +44,7 @@ import org.codehaus.jackson.JsonGenerator;
  */
 public class AvroFileViewer extends HdfsFileViewer {
 
-  private static Logger logger = Logger.getLogger(AvroFileViewer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AvroFileViewer.class);
   // Will spend 5 seconds trying to pull data and then stop.
   private static long STOP_TIME = 2000l;
 
@@ -59,8 +58,8 @@ public class AvroFileViewer extends HdfsFileViewer {
   @Override
   public Set<Capability> getCapabilities(FileSystem fs, Path path)
       throws AccessControlException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("path:" + path.toUri().getPath());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("path:" + path.toUri().getPath());
     }
 
     DataFileStream<Object> avroDataStream = null;
@@ -72,9 +71,9 @@ public class AvroFileViewer extends HdfsFileViewer {
     } catch (AccessControlException e) {
       throw e;
     } catch (IOException e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(path.toUri().getPath() + " is not an avro file.");
-        logger.debug("Error in getting avro schema: ", e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(path.toUri().getPath() + " is not an avro file.");
+        LOG.debug("Error in getting avro schema: ", e);
       }
       return EnumSet.noneOf(Capability.class);
     } finally {
@@ -83,15 +82,15 @@ public class AvroFileViewer extends HdfsFileViewer {
           avroDataStream.close();
         }
       } catch (IOException e) {
-        logger.error(e);
+        LOG.error("Close Avro Data Stream Failure", e);
       }
     }
   }
 
   @Override
   public String getSchema(FileSystem fs, Path path) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("path:" + path.toUri().getPath());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("path:" + path.toUri().getPath());
     }
 
     DataFileStream<Object> avroDataStream = null;
@@ -100,9 +99,9 @@ public class AvroFileViewer extends HdfsFileViewer {
       Schema schema = avroDataStream.getSchema();
       return schema.toString(true);
     } catch (IOException e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug(path.toUri().getPath() + " is not an avro file.");
-        logger.debug("Error in getting avro schema: ", e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(path.toUri().getPath() + " is not an avro file.");
+        LOG.debug("Error in getting avro schema: ", e);
       }
       return null;
     } finally {
@@ -111,15 +110,15 @@ public class AvroFileViewer extends HdfsFileViewer {
           avroDataStream.close();
         }
       } catch (IOException e) {
-        logger.error(e);
+        LOG.error("Close Avro Data Stream Failure", e);
       }
     }
   }
 
   private DataFileStream<Object> getAvroDataStream(FileSystem fs, Path path)
       throws IOException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("path:" + path.toUri().getPath());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("path:" + path.toUri().getPath());
     }
 
     GenericDatumReader<Object> avroReader = new GenericDatumReader<Object>();
@@ -151,8 +150,8 @@ public class AvroFileViewer extends HdfsFileViewer {
   public void displayFile(FileSystem fs, Path path, OutputStream outputStream,
       int startLine, int endLine) throws IOException {
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("display avro file:" + path.toUri().getPath());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("display avro file:" + path.toUri().getPath());
     }
 
     DataFileStream<Object> avroDatastream = null;
@@ -192,5 +191,4 @@ public class AvroFileViewer extends HdfsFileViewer {
       avroDatastream.close();
     }
   }
-
 }

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AzkabanSequenceFileReader.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AzkabanSequenceFileReader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import azkaban.security.commons.HadoopSecurityManager;
@@ -47,7 +46,9 @@ import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Our forked version of hadoop sequence file.
@@ -56,8 +57,7 @@ import org.apache.log4j.Logger;
  */
 @SuppressWarnings("deprecation")
 public class AzkabanSequenceFileReader {
-  private final static Logger LOG = Logger
-      .getLogger(HadoopSecurityManager.class);
+  private final static Logger LOG = LoggerFactory.getLogger(AzkabanSequenceFileReader.class);
   private static final byte BLOCK_COMPRESS_VERSION = (byte) 4;
   private static final byte CUSTOM_COMPRESS_VERSION = (byte) 5;
   private static final byte VERSION_WITH_METADATA = (byte) 6;

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/BsonFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/BsonFileViewer.java
@@ -13,24 +13,20 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
+import com.mongodb.util.JSON;
 import java.util.EnumSet;
 import java.util.Set;
 import java.io.IOException;
 import java.io.OutputStream;
-
-import org.apache.hadoop.fs.permission.AccessControlException;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.bson.BSONObject;
 import org.bson.BasicBSONCallback;
 import org.bson.BasicBSONDecoder;
 
-import com.mongodb.util.JSON;
 
 /**
  * File viewer for Mongo bson files.
@@ -53,8 +49,7 @@ public final class BsonFileViewer extends HdfsFileViewer {
   }
 
   @Override
-  public Set<Capability> getCapabilities(FileSystem fs, Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) {
     if (path.getName().endsWith(".bson")) {
       return EnumSet.of(Capability.READ);
     }

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/Capability.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/Capability.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
+
 
 public enum Capability {
   READ,

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ContentType.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ContentType.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
+
 
 public enum ContentType {
   TEXT,

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsFileViewer.java
@@ -13,23 +13,22 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import java.util.EnumSet;
 import java.util.Set;
 import java.io.IOException;
 import java.io.OutputStream;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
+import org.apache.hadoop.security.AccessControlException;
+
 
 public abstract class HdfsFileViewer {
+
   public abstract String getName();
 
-  public Set<Capability> getCapabilities(FileSystem fs, Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) throws AccessControlException {
     return EnumSet.noneOf(Capability.class);
   }
 

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HtmlFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HtmlFileViewer.java
@@ -28,7 +28,6 @@
  * (e.g. jquery script hosted on google.com can be fetched, but jquery script
  * stored on local hdfs cannot)
  */
-
 package azkaban.viewer.hdfs;
 
 import java.io.IOException;
@@ -38,16 +37,18 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class HtmlFileViewer extends HdfsFileViewer {
 
+  private static final Logger LOG = LoggerFactory.getLogger(HtmlFileViewer.class);
   // only display the first 25M chars. it is used to prevent
   // showing/downloading gb of data
   private static final int BUFFER_LIMIT = 25000000;
   private static final String VIEWER_NAME = "Html";
-  private static final Logger logger = Logger.getLogger(HtmlFileViewer.class);
+
   private final Set<String> acceptedSuffix = new HashSet<>();
 
   public HtmlFileViewer() {
@@ -62,8 +63,7 @@ public class HtmlFileViewer extends HdfsFileViewer {
 
 
   @Override
-  public Set<Capability> getCapabilities(final FileSystem fs, final Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(final FileSystem fs, final Path path) {
     final String fileName = path.getName();
     final int pos = fileName.lastIndexOf('.');
     if (pos < 0) {
@@ -82,12 +82,15 @@ public class HtmlFileViewer extends HdfsFileViewer {
   public void displayFile(final FileSystem fs, final Path path, final OutputStream outputStream,
       final int startLine, final int endLine) throws IOException {
 
-    if (logger.isDebugEnabled())
-      logger.debug("read in uncompressed html file");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("read in uncompressed html file");
+    }
 
     // BUFFER_LIMIT is the only thing we care about, line limit is redundant and actually not
     // very useful for html files. Thus using Integer.MAX_VALUE to effectively remove the endLine limit.
-    TextFileViewer.displayFileContent(fs, path, outputStream, startLine, Integer.MAX_VALUE, BUFFER_LIMIT);
+    TextFileViewer.displayFileContent(
+        fs, path, outputStream, startLine, Integer.MAX_VALUE, BUFFER_LIMIT
+    );
   }
 
   @Override

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ImageFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ImageFileViewer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import java.io.BufferedInputStream;
@@ -25,11 +24,12 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.Arrays;
 import java.util.HashSet;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
-import org.apache.log4j.Logger;
+import org.apache.hadoop.security.AccessControlException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Reads a image file if the file size is not larger than
@@ -39,7 +39,7 @@ import org.apache.log4j.Logger;
  */
 public class ImageFileViewer extends HdfsFileViewer {
 
-  private static Logger logger = Logger.getLogger(ImageFileViewer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ImageFileViewer.class);
   private static final long MAX_IMAGE_FILE_SIZE = 10485760L;
   private static final String VIEWER_NAME = "Image";
 
@@ -47,7 +47,7 @@ public class ImageFileViewer extends HdfsFileViewer {
 
   public ImageFileViewer() {
     final String[] imageSuffix = {
-      ".jpg", ".jpeg", ".tif", ".tiff", ".png", ".gif", ".bmp", ".svg"
+        ".jpg", ".jpeg", ".tif", ".tiff", ".png", ".gif", ".bmp", ".svg"
     };
     acceptedSuffix = new HashSet<String>(Arrays.asList(imageSuffix));
   }
@@ -58,8 +58,7 @@ public class ImageFileViewer extends HdfsFileViewer {
   }
 
   @Override
-  public Set<Capability> getCapabilities(FileSystem fs, Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) throws AccessControlException {
     String fileName = path.getName();
     int pos = fileName.lastIndexOf('.');
     if (pos < 0) {
@@ -90,8 +89,8 @@ public class ImageFileViewer extends HdfsFileViewer {
   public void displayFile(FileSystem fs, Path path, OutputStream outputStream,
       int startLine, int endLine) throws IOException {
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("read in image file");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("read in image file");
     }
 
     InputStream inputStream = null;

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ORCFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ORCFileViewer.java
@@ -1,21 +1,21 @@
 package azkaban.viewer.hdfs;
 
+import azkaban.viewer.hdfs.utils.SerDeUtilsWrapper;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Set;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
 import org.apache.hadoop.hive.ql.io.orc.Reader;
 import org.apache.hadoop.hive.ql.io.orc.RecordReader;
-import org.apache.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import azkaban.viewer.hdfs.utils.SerDeUtilsWrapper;
 
 /**
  * This class implements a viewer for ORC files
@@ -23,132 +23,126 @@ import azkaban.viewer.hdfs.utils.SerDeUtilsWrapper;
  * @author gaggarwa
  */
 public class ORCFileViewer extends HdfsFileViewer {
-    private static Logger logger = Logger.getLogger(ORCFileViewer.class);
-    // Will spend 5 seconds trying to pull data and then stop.
-    private final static long STOP_TIME = 5000l;
-    private final static int JSON_INDENT = 2;
 
-    private static final String VIEWER_NAME = "ORC";
+  private static final Logger LOG = LoggerFactory.getLogger(ORCFileViewer.class);
+  // Will spend 5 seconds trying to pull data and then stop.
+  private final static long STOP_TIME = 5000l;
+  private final static int JSON_INDENT = 2;
+  private static final String VIEWER_NAME = "ORC";
 
-    @Override
-    public String getName() {
-        return VIEWER_NAME;
+  @Override
+  public String getName() {
+    return VIEWER_NAME;
+  }
+
+  /**
+   * Get ORCFileViewer functionalities. Currently schema and read are
+   * supported. {@inheritDoc}
+   *
+   * @see HdfsFileViewer#getCapabilities(org.apache.hadoop.fs.FileSystem,
+   * org.apache.hadoop.fs.Path)
+   */
+  @Override
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("orc file path: " + path.toUri().getPath());
     }
 
-    /**
-     * Get ORCFileViewer functionalities. Currently schema and read are
-     * supported. {@inheritDoc}
-     *
-     * @see HdfsFileViewer#getCapabilities(org.apache.hadoop.fs.FileSystem,
-     *      org.apache.hadoop.fs.Path)
-     */
-    @Override
-    public Set<Capability> getCapabilities(FileSystem fs, Path path) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("orc file path: " + path.toUri().getPath());
-        }
-
-        Reader orcReader = null;
-        RecordReader recordReader = null;
+    Reader orcReader = null;
+    RecordReader recordReader = null;
+    try {
+      // no need to close orcreader
+      orcReader = OrcFile.createReader(fs, path);
+      recordReader = orcReader.rows(null);
+    } catch (Exception e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(path.toUri().getPath() + " is not a ORC file.");
+        LOG.debug("Error in opening ORC file: " + e.getLocalizedMessage());
+      }
+      return EnumSet.noneOf(Capability.class);
+    } finally {
+      if (recordReader != null) {
         try {
-            // no need to close orcreader
-            orcReader = OrcFile.createReader(fs, path);
-            recordReader = orcReader.rows(null);
-        } catch (Exception e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(path.toUri().getPath() + " is not a ORC file.");
-                logger.debug("Error in opening ORC file: "
-                    + e.getLocalizedMessage());
-            }
-            return EnumSet.noneOf(Capability.class);
-        } finally {
-            if (recordReader != null) {
-                try {
-                    recordReader.close();
-                } catch (IOException e) {
-                    logger.error(e);
-                }
-            }
-        }
-        return EnumSet.of(Capability.READ, Capability.SCHEMA);
-    }
-
-    /**
-     * Reads orc file and write to outputstream in json format {@inheritDoc}
-     *
-     * @throws IOException
-     * @throws
-     *
-     * @see HdfsFileViewer#displayFile(org.apache.hadoop.fs.FileSystem,
-     *      org.apache.hadoop.fs.Path, OutputStream, int, int)
-     */
-    @Override
-    public void displayFile(FileSystem fs, Path path, OutputStream outStream,
-        int startLine, int endLine) throws IOException {
-        if (logger.isDebugEnabled()) {
-            logger.debug("displaying orc file:" + path.toUri().getPath());
-        }
-        StringBuilder ret = new StringBuilder();
-        Reader orcreader = null;
-        RecordReader reader = null;
-        Object row = null;
-        try {
-            int lineNum = 1;
-
-            orcreader = OrcFile.createReader(fs, path);
-            reader = orcreader.rows(null);
-            long endTime = System.currentTimeMillis() + STOP_TIME;
-            while (reader.hasNext() && lineNum <= endLine
-                && System.currentTimeMillis() <= endTime) {
-                row = reader.next(row);
-                if (lineNum >= startLine) {
-                    ret.append(String.format("Record %d:\n", lineNum));
-                    String jsonString =
-                        SerDeUtilsWrapper.getJSON(row,
-                            orcreader.getObjectInspector());
-                    try {
-                        JSONObject jsonobj = new JSONObject(jsonString);
-                        ret.append(jsonobj.toString(JSON_INDENT));
-                    } catch (JSONException e) {
-                        logger.error("Failed to parse json as JSONObject", e);
-                        // default to unformatted json string
-                        ret.append(jsonString);
-                    }
-                    ret.append("\n\n");
-                }
-                lineNum++;
-            }
-            outStream.write(ret.toString().getBytes(StandardCharsets.UTF_8));
+          recordReader.close();
         } catch (IOException e) {
-            outStream.write(("Error in display orc file: " + e
-                .getLocalizedMessage()).getBytes("UTF-8"));
-            throw e;
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
+          LOG.error("Close Record Reader Failure", e);
         }
+      }
+    }
+    return EnumSet.of(Capability.READ, Capability.SCHEMA);
+  }
+
+  /**
+   * Reads orc file and write to outputstream in json format {@inheritDoc}
+   *
+   * @see HdfsFileViewer#displayFile(org.apache.hadoop.fs.FileSystem,
+   * org.apache.hadoop.fs.Path, OutputStream, int, int)
+   */
+  @Override
+  public void displayFile(FileSystem fs, Path path, OutputStream outStream,
+      int startLine, int endLine) throws IOException {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("displaying orc file:" + path.toUri().getPath());
+    }
+    StringBuilder ret = new StringBuilder();
+    Reader orcreader = null;
+    RecordReader reader = null;
+    Object row = null;
+    try {
+      int lineNum = 1;
+
+      orcreader = OrcFile.createReader(fs, path);
+      reader = orcreader.rows(null);
+      long endTime = System.currentTimeMillis() + STOP_TIME;
+      while (reader.hasNext() && lineNum <= endLine
+          && System.currentTimeMillis() <= endTime) {
+        row = reader.next(row);
+        if (lineNum >= startLine) {
+          ret.append(String.format("Record %d:\n", lineNum));
+          String jsonString =
+              SerDeUtilsWrapper.getJSON(row,
+                  orcreader.getObjectInspector());
+          try {
+            JSONObject jsonobj = new JSONObject(jsonString);
+            ret.append(jsonobj.toString(JSON_INDENT));
+          } catch (JSONException e) {
+            LOG.error("Failed to parse json as JSONObject", e);
+            // default to unformatted json string
+            ret.append(jsonString);
+          }
+          ret.append("\n\n");
+        }
+        lineNum++;
+      }
+      outStream.write(ret.toString().getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      outStream.write(("Error in display orc file: " + e
+          .getLocalizedMessage()).getBytes("UTF-8"));
+      throw e;
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+
+  /**
+   * Get schema in same syntax as in hadoop --orcdump {@inheritDoc}
+   *
+   * @see HdfsFileViewer#getSchema(org.apache.hadoop.fs.FileSystem,
+   * org.apache.hadoop.fs.Path)
+   */
+  @Override
+  public String getSchema(FileSystem fs, Path path) {
+    String schema = null;
+    try {
+      Reader orcReader = OrcFile.createReader(fs, path);
+      schema = orcReader.getObjectInspector().getTypeName();
+    } catch (IOException e) {
+      LOG.warn("Cannot get schema for file: " + path.toUri().getPath());
+      return null;
     }
 
-    /**
-     * Get schema in same syntax as in hadoop --orcdump {@inheritDoc}
-     *
-     * @see HdfsFileViewer#getSchema(org.apache.hadoop.fs.FileSystem,
-     *      org.apache.hadoop.fs.Path)
-     */
-    @Override
-    public String getSchema(FileSystem fs, Path path) {
-        String schema = null;
-        try {
-            Reader orcReader = OrcFile.createReader(fs, path);
-            schema = orcReader.getObjectInspector().getTypeName();
-        } catch (IOException e) {
-            logger
-                .warn("Cannot get schema for file: " + path.toUri().getPath());
-            return null;
-        }
-
-        return schema;
-    }
-
+    return schema;
+  }
 }

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/SequenceFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/SequenceFileViewer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import java.io.IOException;
@@ -24,7 +23,8 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
+import org.apache.hadoop.security.AccessControlException;
+
 
 public abstract class SequenceFileViewer extends HdfsFileViewer {
 

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/TextFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/TextFileViewer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.hdfs;
 
 import java.io.BufferedReader;
@@ -25,31 +24,21 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.HashSet;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class TextFileViewer extends HdfsFileViewer {
 
-  private static Logger logger = Logger.getLogger(TextFileViewer.class);
-  private HashSet<String> acceptedSuffix = new HashSet<String>();
-
+  private static final Logger LOG = LoggerFactory.getLogger(TextFileViewer.class);
   // only display the first 1M chars. it is used to prevent
   // showing/downloading gb of data
   private static final int BUFFER_LIMIT = 1000000;
   private static final String VIEWER_NAME = "Text";
 
   public TextFileViewer() {
-    acceptedSuffix.add(".txt");
-    acceptedSuffix.add(".csv");
-    acceptedSuffix.add(".props");
-    acceptedSuffix.add(".xml");
-    acceptedSuffix.add(".html");
-    acceptedSuffix.add(".json");
-    acceptedSuffix.add(".log");
   }
 
   @Override
@@ -58,8 +47,7 @@ public class TextFileViewer extends HdfsFileViewer {
   }
 
   @Override
-  public Set<Capability> getCapabilities(FileSystem fs, Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) {
     return EnumSet.of(Capability.READ);
   }
 
@@ -67,8 +55,9 @@ public class TextFileViewer extends HdfsFileViewer {
   public void displayFile(FileSystem fs, Path path, OutputStream outputStream,
       int startLine, int endLine) throws IOException {
 
-    if (logger.isDebugEnabled())
-      logger.debug("read in uncompressed text file");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("read in uncompressed text file");
+    }
 
     displayFileContent(fs, path, outputStream, startLine, endLine, BUFFER_LIMIT);
   }
@@ -90,13 +79,15 @@ public class TextFileViewer extends HdfsFileViewer {
       int bufferSize = 0;
       for (int i = startLine; i < endLine; i++) {
         String line = reader.readLine();
-        if (line == null)
+        if (line == null) {
           break;
+        }
 
         // break if reach the buffer limit
         bufferSize += line.length();
-        if (bufferSize >= bufferLimit)
+        if (bufferSize >= bufferLimit) {
           break;
+        }
 
         output.write(line);
         output.write("\n");

--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -36,12 +36,13 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
 
-  private static final Logger logger = Logger.getLogger(JobSummaryServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JobSummaryServlet.class);
 
   private final Props props;
   private final File webResourcesPath;

--- a/az-reportal/src/main/java/azkaban/reportal/util/Reportal.java
+++ b/az-reportal/src/main/java/azkaban/reportal/util/Reportal.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.reportal.util;
 
 import azkaban.executor.ExecutionOptions;
@@ -39,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Days;
@@ -50,9 +48,13 @@ import org.joda.time.ReadablePeriod;
 import org.joda.time.Weeks;
 import org.joda.time.Years;
 import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Reportal {
 
+  private static final Logger LOG = LoggerFactory.getLogger(Reportal.class);
   public static final String REPORTAL_CONFIG_PREFIX = "reportal.config.";
   public static final String REPORTAL_CONFIG_PREFIX_REGEX =
       "^reportal[.]config[.].+";
@@ -62,7 +64,6 @@ public class Reportal {
       "\\s*,\\s*|\\s*;\\s*|\\s+";
   // One Schedule's default End Time: 01/01/2050, 00:00:00, UTC
   private static final long DEFAULT_SCHEDULE_END_EPOCH_TIME = 2524608000000L;
-  private static final Logger logger = Logger.getLogger(Reportal.class);
   public static Getter<Boolean> boolGetter = new Getter<>(false,
       Boolean.class);
   public static Getter<Integer> intGetter = new Getter<>(0,
@@ -284,7 +285,7 @@ public class Reportal {
       final long endScheduleTime = report.endSchedule == null ?
           DEFAULT_SCHEDULE_END_EPOCH_TIME : parseDateToEpoch(report.endSchedule);
 
-      logger.info("This report scheudle end time is " + endScheduleTime);
+      LOG.info("This report scheudle end time is " + endScheduleTime);
 
       scheduleManager.scheduleFlow(-1, this.project.getId(), this.project.getName(),
           flow.getId(), "ready", firstSchedTime.getMillis(), endScheduleTime,

--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.viewer.reportal;
 
 import azkaban.executor.ExecutableFlow;
@@ -49,9 +48,13 @@ import java.util.Scanner;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class ReportalMailCreator implements MailCreator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReportalMailCreator.class);
   public static final String REPORTAL_MAIL_CREATOR = "ReportalMailCreator";
   public static final int NUM_PREVIEW_ROWS = 50;
   //Attachment that equal or larger than 10MB will be skipped in the email
@@ -62,8 +65,6 @@ public class ReportalMailCreator implements MailCreator {
   public static String outputFileSystem = "";
   public static String reportalStorageUser = "";
   public static File reportalMailTempDirectory;
-
-  private static final Logger logger = Logger.getLogger(ReportalMailCreator.class);
 
   static {
     DefaultMailCreator.registerCreator(REPORTAL_MAIL_CREATOR,
@@ -84,7 +85,8 @@ public class ReportalMailCreator implements MailCreator {
 
   @Override
   public boolean createErrorEmail(ExecutableFlow flow, List<ExecutableFlow>
-      pastExecutions, EmailMessage message, String azkabanName, String scheme, String clientHostname,
+      pastExecutions, EmailMessage message, String azkabanName, String scheme,
+      String clientHostname,
       String clientPortNumber, String... reasons) {
 
     ExecutionOptions option = flow.getExecutionOptions();
@@ -138,7 +140,7 @@ public class ReportalMailCreator implements MailCreator {
       try {
         return createMessage(project, flow, message, urlPrefix, printData);
       } catch (Exception e) {
-        logger.error("Message creation failed for " + flow.getId(), e);
+        LOG.error("Message creation failed for " + flow.getId(), e);
       }
     }
 
@@ -156,9 +158,11 @@ public class ReportalMailCreator implements MailCreator {
     message.println("<html>");
     message.println("<head></head>");
     message
-        .println("<body style='font-family: verdana; color: #000000; background-color: #cccccc; padding: 20px;'>");
+        .println(
+            "<body style='font-family: verdana; color: #000000; background-color: #cccccc; padding: 20px;'>");
     message
-        .println("<div style='background-color: #ffffff; border: 1px solid #aaaaaa; padding: 20px;-webkit-border-radius: 15px; -moz-border-radius: 15px; border-radius: 15px;'>");
+        .println(
+            "<div style='background-color: #ffffff; border: 1px solid #aaaaaa; padding: 20px;-webkit-border-radius: 15px; -moz-border-radius: 15px; border-radius: 15px;'>");
     // Title
     message.println("<b>" + project.getMetadata().get("title") + "</b>");
     message
@@ -192,7 +196,8 @@ public class ReportalMailCreator implements MailCreator {
     while (flowParameters.containsKey("reportal.variable." + i + ".from")) {
       if (i == 0) {
         message
-            .println("<div style='margin-top: 10px; margin-bottom: 10px; border-bottom: 1px solid #ccc; padding-bottom: 5px; font-weight: bold;'>");
+            .println(
+                "<div style='margin-top: 10px; margin-bottom: 10px; border-bottom: 1px solid #ccc; padding-bottom: 5px; font-weight: bold;'>");
         message.println("Variables");
         message.println("</div>");
         message
@@ -282,7 +287,7 @@ public class ReportalMailCreator implements MailCreator {
       try {
         streamProvider.cleanUp();
       } catch (IOException e) {
-        logger.error("Stream provider cleanup failed for " + flow.getId(), e);
+        LOG.error("Stream provider cleanup failed for " + flow.getId(), e);
       }
 
       boolean emptyResults = true;
@@ -298,7 +303,8 @@ public class ReportalMailCreator implements MailCreator {
         job.getAttempt();
 
         message
-            .println("<div style='margin-top: 10px; margin-bottom: 10px; border-bottom: 1px solid #ccc; padding-bottom: 5px; font-weight: bold;'>");
+            .println(
+                "<div style='margin-top: 10px; margin-bottom: 10px; border-bottom: 1px solid #ccc; padding-bottom: 5px; font-weight: bold;'>");
         message.println(file);
         message.println("</div>");
         message.println("<div>");
@@ -349,9 +355,9 @@ public class ReportalMailCreator implements MailCreator {
 
       if (totalFileSize < MAX_ATTACHMENT_SIZE) {
         for (i = 0; i < fileList.length; i++) {
-            String file = fileList[i];
-            File tempOutputFile = new File(tempFolder, file);
-            message.addAttachment(file, tempOutputFile);
+          String file = fileList[i];
+          File tempOutputFile = new File(tempFolder, file);
+          message.addAttachment(file, tempOutputFile);
         }
       }
 
@@ -367,10 +373,11 @@ public class ReportalMailCreator implements MailCreator {
     }
 
     message.println("</div>");
-    if (totalFileSize >= MAX_ATTACHMENT_SIZE){
-      message.println("<tr>The total size of the reports (" + totalFileSize/1024/1024 + "MB) is bigger than the allowed maximum size of " +
-              MAX_ATTACHMENT_SIZE/1024/1024 + "MB. " +
-                  "It is too big to be attached in this message. Please use the link above titled Result Data to download the reports</tr>");
+    if (totalFileSize >= MAX_ATTACHMENT_SIZE) {
+      message.println("<tr>The total size of the reports (" + totalFileSize / 1024 / 1024
+          + "MB) is bigger than the allowed maximum size of " +
+          MAX_ATTACHMENT_SIZE / 1024 / 1024 + "MB. " +
+          "It is too big to be attached in this message. Please use the link above titled Result Data to download the reports</tr>");
     }
     message.println("</body>").println("</html>");
 

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -34,8 +34,6 @@ import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import org.apache.commons.dbutils.QueryRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -44,8 +42,6 @@ import org.slf4j.LoggerFactory;
  * move towards more modular structuring of Guice components.
  */
 public class AzkabanCommonModule extends AbstractModule {
-
-  private static final Logger log = LoggerFactory.getLogger(AzkabanCommonModule.class);
 
   private final Props props;
   private final AzkabanCommonModuleConfig config;

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModuleConfig.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_STORAGE_HDFS_ROOT_URI;
@@ -26,12 +25,9 @@ import azkaban.storage.StorageImplementationType;
 import azkaban.utils.Props;
 import javax.inject.Inject;
 import java.net.URI;
-import org.apache.log4j.Logger;
 
 
 public class AzkabanCommonModuleConfig {
-
-  private static final Logger log = Logger.getLogger(AzkabanCommonModuleConfig.class);
 
   private final Props props;
   private final URI hdfsRootUri;

--- a/azkaban-common/src/main/java/azkaban/HadoopModule.java
+++ b/azkaban-common/src/main/java/azkaban/HadoopModule.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HadoopModule extends AbstractModule{
 
-  private static final Logger log = LoggerFactory.getLogger(HadoopModule.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopModule.class);
   private final Props props;
 
   HadoopModule(final Props props) {
@@ -73,7 +73,7 @@ public class HadoopModule extends AbstractModule{
       auth.authorize();
       return FileSystem.get(hadoopConf);
     } catch (final IOException e) {
-      log.error("Unable to initialize HDFS", e);
+      LOG.error("Unable to initialize HDFS", e);
       throw new AzkabanException(e);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.database;
 
 import azkaban.database.DataSourceUtils.PropertyType;
@@ -37,7 +36,9 @@ import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * @deprecated in favor of {@link azkaban.db.DatabaseSetup}.
@@ -45,13 +46,12 @@ import org.apache.log4j.Logger;
 @Deprecated
 public class AzkabanDatabaseSetup {
 
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanDatabaseSetup.class);
   public static final String DATABASE_CHECK_VERSION = "database.check.version";
   public static final String DATABASE_AUTO_UPDATE_TABLES =
       "database.auto.update.tables";
   public static final String DATABASE_SQL_SCRIPT_DIR =
       "database.sql.scripts.dir";
-  private static final Logger logger = Logger
-      .getLogger(AzkabanDatabaseSetup.class);
   private static final String DEFAULT_SCRIPT_PATH = "sql";
   private static final String CREATE_SCRIPT_PREFIX = "create.";
   private static final String UPDATE_SCRIPT_PREFIX = "update.";
@@ -120,26 +120,26 @@ public class AzkabanDatabaseSetup {
 
   public void printUpgradePlan() {
     if (!this.tables.isEmpty()) {
-      logger.info("The following are installed tables");
+      LOG.info("The following are installed tables");
       for (final Map.Entry<String, String> installedTable : this.tables.entrySet()) {
-        logger.info(" " + installedTable.getKey() + " version:"
+        LOG.info(" " + installedTable.getKey() + " version:"
             + installedTable.getValue());
       }
     } else {
-      logger.info("No installed tables found.");
+      LOG.info("No installed tables found.");
     }
 
     if (!this.missingTables.isEmpty()) {
-      logger.info("The following are missing tables that need to be installed");
+      LOG.info("The following are missing tables that need to be installed");
       for (final String table : this.missingTables) {
-        logger.info(" " + table);
+        LOG.info(" " + table);
       }
     } else {
-      logger.info("There are no missing tables.");
+      LOG.info("There are no missing tables.");
     }
 
     if (!this.upgradeList.isEmpty()) {
-      logger.info("The following tables need to be updated.");
+      LOG.info("The following tables need to be updated.");
       for (final Map.Entry<String, List<String>> upgradeTable : this.upgradeList
           .entrySet()) {
         String tableInfo = " " + upgradeTable.getKey() + " versions:";
@@ -147,10 +147,10 @@ public class AzkabanDatabaseSetup {
           tableInfo += upVersion + ",";
         }
 
-        logger.info(tableInfo);
+        LOG.info(tableInfo);
       }
     } else {
-      logger.info("No tables need to be updated.");
+      LOG.info("No tables need to be updated.");
     }
   }
 
@@ -158,7 +158,7 @@ public class AzkabanDatabaseSetup {
       throws SQLException, IOException {
     // We call this because it has an unitialize check.
     if (!needsUpdating()) {
-      logger.info("Nothing to be done.");
+      LOG.info("Nothing to be done.");
       return;
     }
 
@@ -182,7 +182,7 @@ public class AzkabanDatabaseSetup {
   }
 
   private void loadTableVersion() throws SQLException {
-    logger.info("Searching for table versions in the properties table");
+    LOG.info("Searching for table versions in the properties table");
     if (this.tables.containsKey("properties")) {
       // Load version from settings
       final QueryRunner runner = new QueryRunner(this.dataSource);
@@ -201,12 +201,12 @@ public class AzkabanDatabaseSetup {
         }
       }
     } else {
-      logger.info("Properties table doesn't exist.");
+      LOG.info("Properties table doesn't exist.");
     }
   }
 
   private void loadInstalledTables() throws SQLException {
-    logger.info("Searching for installed tables");
+    LOG.info("Searching for installed tables");
     Connection conn = null;
     try {
       conn = this.dataSource.getConnection();
@@ -357,10 +357,10 @@ public class AzkabanDatabaseSetup {
     String scriptName = "";
     if (update) {
       scriptName = "update." + table + "." + version;
-      logger.info("Update table " + table + " to version " + version);
+      LOG.info("Update table " + table + " to version " + version);
     } else {
       scriptName = "create." + table;
-      logger.info("Creating new table " + table + " version " + version);
+      LOG.info("Creating new table " + table + " version " + version);
     }
 
     final String dbSpecificScript = scriptName + "." + dbType + ".sql";

--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseUpdater.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.database;
 
 import azkaban.server.AzkabanServer;
@@ -24,12 +23,13 @@ import java.util.Arrays;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class AzkabanDatabaseUpdater {
 
-  private static final Logger logger = Logger
-      .getLogger(AzkabanDatabaseUpdater.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanDatabaseUpdater.class);
 
   public static void main(final String[] args) throws Exception {
     final OptionParser parser = new OptionParser();
@@ -47,8 +47,8 @@ public class AzkabanDatabaseUpdater {
     final Props props = AzkabanServer.loadProps(args, parser);
 
     if (props == null) {
-      logger.error("Properties not found. Need it to connect to the db.");
-      logger.error("Exiting...");
+      LOG.error("Properties not found. Need it to connect to the db.");
+      LOG.error("Exiting...");
       return;
     }
 
@@ -57,7 +57,7 @@ public class AzkabanDatabaseUpdater {
     if (options.has(updateOption)) {
       updateDB = true;
     } else {
-      logger.info("Running DatabaseUpdater in test mode");
+      LOG.info("Running DatabaseUpdater in test mode");
     }
 
     String scriptDir = "sql";
@@ -70,26 +70,26 @@ public class AzkabanDatabaseUpdater {
 
   public static void runDatabaseUpdater(final Props props, final String sqlDir,
       final boolean updateDB) throws IOException, SQLException {
-    logger.info("Use scripting directory " + sqlDir);
+    LOG.info("Use scripting directory " + sqlDir);
 
     if (updateDB) {
-      logger.info("Will auto update any changes.");
+      LOG.info("Will auto update any changes.");
     } else {
-      logger.info("Running DatabaseUpdater in test mode. Use -u to update");
+      LOG.info("Running DatabaseUpdater in test mode. Use -u to update");
     }
 
     final AzkabanDatabaseSetup setup = new AzkabanDatabaseSetup(props);
     setup.loadTableInfo();
     if (!setup.needsUpdating()) {
-      logger.info("Everything looks up to date.");
+      LOG.info("Everything looks up to date.");
       return;
     }
 
-    logger.info("Need to update the db.");
+    LOG.info("Need to update the db.");
     setup.printUpgradePlan();
 
     if (updateDB) {
-      logger.info("Updating DB");
+      LOG.info("Updating DB");
       setup.updateDatabase(true, true);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -13,17 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.database;
 
 import azkaban.utils.Props;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class DataSourceUtils {
 
-  private static final Logger logger = Logger.getLogger(DataSourceUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DataSourceUtils.class);
 
   /**
    * Hidden datasource
@@ -52,7 +53,7 @@ public class DataSourceUtils {
     } else if (databaseType.equals("h2")) {
       final String path = props.getString("h2.path");
       final Path h2DbPath = Paths.get(path).toAbsolutePath();
-      logger.info("h2 DB path: " + h2DbPath);
+      LOG.info("h2 DB path: " + h2DbPath);
       dataSource = getH2DataSource(h2DbPath);
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ActiveExecutors.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ActiveExecutors.java
@@ -13,14 +13,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Loads & provides executors.
@@ -28,7 +29,7 @@ import org.apache.log4j.Logger;
 @Singleton
 public class ActiveExecutors {
 
-  private static final Logger logger = Logger.getLogger(ExecutorManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorManager.class);
 
   private volatile ImmutableSet<Executor> activeExecutors;
   private final ExecutorLoader executorLoader;
@@ -48,7 +49,7 @@ public class ActiveExecutors {
     final ImmutableSet<Executor> newExecutors = loadExecutors();
     if (newExecutors.isEmpty()) {
       final String error = "No active executors found";
-      logger.error(error);
+      LOG.error(error);
       throw new ExecutorManagerException(error);
     } else {
       this.activeExecutors = newExecutors;
@@ -65,8 +66,7 @@ public class ActiveExecutors {
   }
 
   private ImmutableSet<Executor> loadExecutors() throws ExecutorManagerException {
-    logger.info("Initializing executors from database.");
+    LOG.info("Initializing executors from database.");
     return ImmutableSet.copyOf(this.executorLoader.fetchActiveExecutors());
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
@@ -30,13 +30,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class AlerterHolder {
 
-  private static final Logger logger = Logger.getLogger(AlerterHolder.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AlerterHolder.class);
   private Map<String, Alerter> alerters;
 
   @Inject
@@ -44,7 +45,7 @@ public class AlerterHolder {
     try {
       this.alerters = loadAlerters(props, mailAlerter);
     } catch (final Exception ex) {
-      logger.error(ex);
+      LOG.error("Load Alerters Failure", ex);
       this.alerters = new HashMap<>();
     }
   }
@@ -84,10 +85,10 @@ public class AlerterHolder {
 
       final String pluginClass = pluginProps.getString("alerter.class");
       if (pluginClass == null) {
-        logger.error("Alerter class is not set.");
+        LOG.error("Alerter class is not set.");
         continue;
       } else {
-        logger.info("Plugin class " + pluginClass);
+        LOG.info("Plugin class " + pluginClass);
       }
 
       Class<?> alerterClass =
@@ -98,14 +99,14 @@ public class AlerterHolder {
       }
 
       final String source = FileIOUtils.getSourcePathFromClass(alerterClass);
-      logger.info("Source jar " + source);
+      LOG.info("Source jar " + source);
       jarPaths.add("jar:file:" + source);
 
       Constructor<?> constructor = null;
       try {
         constructor = alerterClass.getConstructor(Props.class);
       } catch (final NoSuchMethodException e) {
-        logger.error("Constructor not found in " + pluginClass);
+        LOG.error("Constructor not found in " + pluginClass);
         continue;
       }
 
@@ -113,11 +114,11 @@ public class AlerterHolder {
       try {
         obj = constructor.newInstance(pluginProps);
       } catch (final Exception e) {
-        logger.error(e);
+        LOG.error("Create Alerter Instance Failure", e);
       }
 
       if (!(obj instanceof Alerter)) {
-        logger.error("The object is not an Alerter");
+        LOG.error("The object is not an Alerter");
         continue;
       }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -32,12 +32,12 @@ import org.slf4j.LoggerFactory;
 
 public class ExecutableFlowBase extends ExecutableNode {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutableFlowBase.class);
   public static final String FLOW_ID_PARAM = "flowId";
   public static final String NODES_PARAM = "nodes";
   public static final String PROPERTIES_PARAM = "properties";
   public static final String SOURCE_PARAM = "source";
   public static final String INHERITED_PARAM = "inherited";
-  private static final Logger logger = LoggerFactory.getLogger(ExecutableFlowBase.class);
 
   private final HashMap<String, ExecutableNode> executableNodes =
       new HashMap<>();
@@ -137,7 +137,7 @@ public class ExecutableFlowBase extends ExecutableNode {
       final ExecutableNode targetNode = this.executableNodes.get(edge.getTargetId());
 
       if (sourceNode == null) {
-        logger.info("Source node " + edge.getSourceId() + " doesn't exist");
+        LOG.info("Source node " + edge.getSourceId() + " doesn't exist");
       }
       sourceNode.addOutNode(edge.getTargetId());
       targetNode.addInNode(edge.getSourceId());

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowPriorityComparator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowPriorityComparator.java
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import azkaban.utils.Pair;
 import java.util.Comparator;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Comparator implicitly used in priority queue for QueuedExecutions.
@@ -26,8 +27,7 @@ import org.apache.log4j.Logger;
 public final class ExecutableFlowPriorityComparator implements
     Comparator<Pair<ExecutionReference, ExecutableFlow>> {
 
-  private static final Logger logger = Logger
-      .getLogger(ExecutableFlowPriorityComparator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutableFlowPriorityComparator.class);
 
   /**
    * <pre>
@@ -86,7 +86,7 @@ public final class ExecutableFlowPriorityComparator implements
                 ExecutionOptions.FLOW_PRIORITY));
       } catch (final NumberFormatException ex) {
         priority = ExecutionOptions.DEFAULT_FLOW_PRIORITY;
-        logger.error(
+        LOG.error(
             "Failed to parse flow priority for exec_id = "
                 + exflow.getExecutionId(), ex);
       }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class ExecutionController extends EventHandler implements ExecutorManagerAdapter {
 
-  private static final Logger logger = LoggerFactory.getLogger(ExecutionController.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionController.class);
   private static final Duration RECENTLY_FINISHED_LIFETIME = Duration.ofMinutes(10);
   private final ExecutorLoader executorLoader;
   private final ExecutorApiGateway apiGateway;
@@ -115,7 +115,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       executors = this.executorLoader.fetchActiveExecutors();
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get all active executors.", e);
+      LOG.error("Failed to get all active executors.", e);
     }
     return executors;
   }
@@ -133,7 +133,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
         ports.add(executor.getHost() + ":" + executor.getPort());
       }
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get primary server hosts.", e);
+      LOG.error("Failed to get primary server hosts.", e);
     }
     return ports;
   }
@@ -152,7 +152,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
         }
       }
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get all active executor server hosts.", e);
+      LOG.error("Failed to get all active executor server hosts.", e);
     }
     return ports;
   }
@@ -170,7 +170,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       executionIds.addAll(getRunningFlowsHelper(projectId, flowId,
           this.executorLoader.fetchUnfinishedFlows().values()));
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get running flows for project " + projectId + ", flow "
+      LOG.error("Failed to get running flows for project " + projectId + ", flow "
           + flowId, e);
     }
     return executionIds;
@@ -196,7 +196,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       getActiveFlowsWithExecutorHelper(flows, this.executorLoader.fetchUnfinishedFlows().values());
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get active flows with executor.", e);
+      LOG.error("Failed to get active flows with executor.", e);
     }
     return flows;
   }
@@ -223,7 +223,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
           this.executorLoader.fetchUnfinishedFlows().values());
 
     } catch (final ExecutorManagerException e) {
-      logger.error(
+      LOG.error(
           "Failed to check if the flow is running for project " + projectId + ", flow " + flowId,
           e);
     }
@@ -260,7 +260,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       getFlowsHelper(flows, this.executorLoader.fetchUnfinishedFlows().values());
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get running flows.", e);
+      LOG.error("Failed to get running flows.", e);
     }
     return flows;
   }
@@ -281,7 +281,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       getExecutionIdsHelper(allIds, this.executorLoader.fetchUnfinishedFlows().values());
     } catch (final ExecutorManagerException e) {
-      this.logger.error("Failed to get running flow ids.", e);
+      this.LOG.error("Failed to get running flow ids.", e);
     }
     return allIds;
   }
@@ -294,7 +294,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows());
     } catch (final ExecutorManagerException e) {
-      this.logger.error("Failed to get queued flow ids.", e);
+      this.LOG.error("Failed to get queued flow ids.", e);
     }
     return allIds;
   }
@@ -315,7 +315,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       size = this.executorLoader.fetchQueuedFlows().size();
     } catch (final ExecutorManagerException e) {
-      this.logger.error("Failed to get queued flow size.", e);
+      this.LOG.error("Failed to get queued flow size.", e);
     }
     return size;
   }
@@ -327,7 +327,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       flows = this.executorLoader.fetchRecentlyFinishedFlows(
           RECENTLY_FINISHED_LIFETIME);
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to fetch recently finished flows.", e);
+      LOG.error("Failed to fetch recently finished flows.", e);
     }
     return flows;
   }
@@ -490,14 +490,14 @@ public class ExecutionController extends EventHandler implements ExecutorManager
             return applicationId;
           }
           offset = data.getOffset() + data.getLength();
-          this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
+          LOG.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
               + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
         } else {
           finished = true;
         }
       }
     } catch (final ExecutorManagerException e) {
-      this.logger.error("Failed to get application ID for execution " + exFlow.getExecutionId() +
+      LOG.error("Failed to get application ID for execution " + exFlow.getExecutionId() +
           ", job " + jobId + ", attempt " + attempt + ", data offset " + offset, e);
     }
     return null;
@@ -625,7 +625,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       // Skip execution for locked flows.
       final String message = String.format("Flow %s for project %s is locked.", exflow.getId(),
           exflow.getProjectName());
-      logger.info(message);
+      LOG.info(message);
       return message;
     }
 
@@ -635,7 +635,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     // causing two same flow submission entering this piece.
     synchronized (exFlowKey.intern()) {
       final String flowId = exflow.getFlowId();
-      logger.info("Submitting execution flow " + flowId + " by " + userId);
+      LOG.info("Submitting execution flow " + flowId + " by " + userId);
 
       String message = "";
 
@@ -761,5 +761,4 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     return this.executorLoader.fetchFlowHistory(projectId, flowId, from, length,
         status);
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecutionControllerUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       ExecutionControllerUtils.class);
   private static final String SPARK_JOB_TYPE = "spark";
   private static final String APPLICATION_ID = "${application.id}";
@@ -92,7 +92,7 @@ public class ExecutionControllerUtils {
     } catch (final ExecutorManagerException e) {
       // If failed due to azkaban internal error, do not alert user.
       alertUser = false;
-      logger.error("Failed to finalize flow " + flow.getExecutionId() + ", do not alert user.", e);
+      LOG.error("Failed to finalize flow " + flow.getExecutionId() + ", do not alert user.", e);
     }
 
     if (alertUser) {
@@ -116,7 +116,7 @@ public class ExecutionControllerUtils {
         try {
           mailAlerter.alertOnError(flow, extraReasons);
         } catch (final Exception e) {
-          logger.error("Failed to alert on error for execution " + flow.getExecutionId(), e);
+          LOG.error("Failed to alert on error for execution " + flow.getExecutionId(), e);
         }
       }
       if (options.getFlowParameters().containsKey("alert.type")) {
@@ -126,11 +126,11 @@ public class ExecutionControllerUtils {
           try {
             alerter.alertOnError(flow, extraReasons);
           } catch (final Exception e) {
-            logger.error("Failed to alert on error by " + alertType + " for execution " + flow
+            LOG.error("Failed to alert on error by " + alertType + " for execution " + flow
                 .getExecutionId(), e);
           }
         } else {
-          logger.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
+          LOG.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
         }
       }
     } else {
@@ -138,7 +138,7 @@ public class ExecutionControllerUtils {
         try {
           mailAlerter.alertOnSuccess(flow);
         } catch (final Exception e) {
-          logger.error("Failed to alert on success for execution " + flow.getExecutionId(), e);
+          LOG.error("Failed to alert on success for execution " + flow.getExecutionId(), e);
         }
       }
       if (options.getFlowParameters().containsKey("alert.type")) {
@@ -148,11 +148,11 @@ public class ExecutionControllerUtils {
           try {
             alerter.alertOnSuccess(flow);
           } catch (final Exception e) {
-            logger.error("Failed to alert on success by " + alertType + " for execution " + flow
+            LOG.error("Failed to alert on success by " + alertType + " for execution " + flow
                 .getExecutionId(), e);
           }
         } else {
-          logger.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
+          LOG.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
         }
       }
     }
@@ -168,12 +168,12 @@ public class ExecutionControllerUtils {
       final AlerterHolder alerterHolder) {
     final ExecutionOptions options = flow.getExecutionOptions();
     if (options.getNotifyOnFirstFailure()) {
-      logger.info("Alert on first error of execution " + flow.getExecutionId());
+      LOG.info("Alert on first error of execution " + flow.getExecutionId());
       final Alerter mailAlerter = alerterHolder.get("email");
       try {
         mailAlerter.alertOnFirstError(flow);
       } catch (final Exception e) {
-        logger.error("Failed to send first error email." + e.getMessage(), e);
+        LOG.error("Failed to send first error email." + e.getMessage(), e);
       }
 
       if (options.getFlowParameters().containsKey("alert.type")) {
@@ -183,10 +183,10 @@ public class ExecutionControllerUtils {
           try {
             alerter.alertOnFirstError(flow);
           } catch (final Exception e) {
-            logger.error("Failed to alert by " + alertType, e);
+            LOG.error("Failed to alert by " + alertType, e);
           }
         } else {
-          logger.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
+          LOG.error("Alerter type " + alertType + " doesn't exist. Failed to alert.");
         }
       }
     }
@@ -302,7 +302,7 @@ public class ExecutionControllerUtils {
         while ((inputLine = in.readLine()) != null) {
           if (FAILED_TO_READ_APPLICATION_PATTERN.matcher(inputLine).find()
               || INVALID_APPLICATION_ID_PATTERN.matcher(inputLine).find()) {
-            logger.info(
+            LOG.info(
                 "RM job link is invalid or has expired for application_" + applicationId);
             isRMJobLinkValid = false;
             break;
@@ -310,7 +310,7 @@ public class ExecutionControllerUtils {
         }
       }
     } catch (final Exception e) {
-      logger.error("Failed to get job link for application_" + applicationId, e);
+      LOG.error("Failed to get job link for application_" + applicationId, e);
       return null;
     }
 
@@ -329,7 +329,7 @@ public class ExecutionControllerUtils {
       }
     }
 
-    logger.info(
+    LOG.info(
         "Job link url is " + jobLinkUrl + " for execution " + exFlow.getExecutionId() + ", job "
             + jobId);
     return jobLinkUrl;
@@ -347,7 +347,7 @@ public class ExecutionControllerUtils {
     if (matcher.find()) {
       appId = matcher.group().substring(12);
     }
-    logger.info("Application ID is " + appId);
+    LOG.info("Application ID is " + appId);
     return appId;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
@@ -13,19 +13,20 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Handles removing of running executions (after they have been deemed to be be done or orphaned).
  */
 public class ExecutionFinalizer {
 
-  private static final Logger logger = Logger.getLogger(ExecutionFinalizer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionFinalizer.class);
 
   private final ExecutorLoader executorLoader;
   private final ExecutorManagerUpdaterStage updaterStage;
@@ -87,7 +88,7 @@ public class ExecutionFinalizer {
       this.runningExecutions.get().remove(execId);
     } catch (final ExecutorManagerException e) {
       alertUser = false; // failed due to azkaban internal error, not to alert user
-      logger.error(e);
+      LOG.error("Error on Finalize Flow", e);
     }
 
     // TODO append to the flow log that we marked this flow as failed + the extraReasons

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -33,12 +33,14 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @Singleton
 public class ExecutionFlowDao {
 
-  private static final Logger logger = Logger.getLogger(ExecutionFlowDao.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionFlowDao.class);
   private final DatabaseOperator dbOperator;
 
   @Inject
@@ -79,7 +81,7 @@ public class ExecutionFlowDao {
 
     try {
       final long id = this.dbOperator.transaction(insertAndGetLastID);
-      logger.info("Flow given " + flow.getFlowId() + " given id " + id);
+      LOG.info("Flow given " + flow.getFlowId() + " given id " + id);
       flow.setExecutionId((int) id);
       updateExecutableFlow(flow);
     } catch (final SQLException e) {
@@ -443,7 +445,7 @@ public class ExecutionFlowDao {
         final byte[] data = rs.getBytes(3);
 
         if (data == null) {
-          ExecutionFlowDao.logger.error("Found a flow with empty data blob exec_id: " + id);
+          ExecutionFlowDao.LOG.error("Found a flow with empty data blob exec_id: " + id);
         } else {
           final EncodingType encType = EncodingType.fromInteger(encodingType);
           try {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionJobDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionJobDao.java
@@ -34,12 +34,14 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @Singleton
 public class ExecutionJobDao {
 
-  private static final Logger logger = Logger.getLogger(ExecutorDao.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutorDao.class);
   private final DatabaseOperator dbOperator;
 
   @Inject
@@ -66,7 +68,7 @@ public class ExecutionJobDao {
 
     final ExecutableFlow flow = node.getExecutableFlow();
     final String flowId = node.getParentFlow().getFlowPath();
-    logger.info("Uploading flowId " + flowId);
+    LOG.info("Uploading flowId " + flowId);
     try {
       this.dbOperator.update(INSERT_EXECUTION_NODE, flow.getExecutionId(),
           flow.getProjectId(), flow.getVersion(), flowId, node.getId(),

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import azkaban.db.EncodingType;
@@ -37,14 +36,15 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class ExecutionLogsDao {
 
-  private static final Logger logger = Logger.getLogger(ExecutionLogsDao.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecutionLogsDao.class);
   private final DatabaseOperator dbOperator;
   private final EncodingType defaultEncodingType = EncodingType.GZIP;
 
@@ -77,7 +77,7 @@ public class ExecutionLogsDao {
     try {
       this.dbOperator.transaction(transaction);
     } catch (final SQLException e) {
-      logger.error("uploadLogFile failed.", e);
+      LOG.error("uploadLogFile failed.", e);
       throw new ExecutorManagerException("uploadLogFile failed.", e);
     }
   }
@@ -127,10 +127,10 @@ public class ExecutionLogsDao {
             + pos, encType, buffer, pos);
       }
     } catch (final SQLException e) {
-      logger.error("Error writing log part.", e);
+      LOG.error("Error writing log part.", e);
       throw new SQLException("Error writing log part", e);
     } catch (final IOException e) {
-      logger.error("Error chunking.", e);
+      LOG.error("Error chunking.", e);
       throw new SQLException("Error chunking", e);
     }
   }
@@ -142,7 +142,7 @@ public class ExecutionLogsDao {
     try {
       return this.dbOperator.update(DELETE_BY_TIME, millis);
     } catch (final SQLException e) {
-      logger.error("delete execution logs failed", e);
+      LOG.error("delete execution logs failed", e);
       throw new ExecutorManagerException(
           "Error deleting old execution_logs before " + millis, e);
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiClient.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiClient.java
@@ -46,7 +46,7 @@ public class ExecutorApiClient extends RestfulApiClient<String> {
 
     if (statusLine.getStatusCode() >= 300) {
 
-      logger.error(String.format("unable to parse response as the response status is %s",
+      LOG.error(String.format("unable to parse response as the response status is %s",
           statusLine.getStatusCode()));
 
       throw new HttpResponseException(statusLine.getStatusCode(), responseBody);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorDao.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import azkaban.db.DatabaseOperator;
@@ -25,12 +24,11 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
-import org.apache.log4j.Logger;
+
 
 @Singleton
 public class ExecutorDao {
 
-  private static final Logger logger = Logger.getLogger(ExecutorDao.class);
   private final DatabaseOperator dbOperator;
 
   @Inject

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -32,12 +32,14 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @Singleton
 public class FetchActiveFlowDao {
 
-  private static final Logger logger = Logger.getLogger(FetchActiveFlowDao.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FetchActiveFlowDao.class);
 
   private final DatabaseOperator dbOperator;
 
@@ -53,7 +55,7 @@ public class FetchActiveFlowDao {
     final byte[] data = rs.getBytes("flow_data");
 
     if (data == null) {
-      logger.warn("Execution id " + id + " has flow_data = null. To clean up, update status to "
+      LOG.warn("Execution id " + id + " has flow_data = null. To clean up, update status to "
           + "FAILED manually, eg. "
           + "SET status = " + Status.FAILED.getNumVal() + " WHERE id = " + id);
     } else {
@@ -77,7 +79,7 @@ public class FetchActiveFlowDao {
     final int port = rs.getInt("port");
     final Executor executor;
     if (host == null) {
-      logger.warn("Executor id " + executorId + " (on execution " +
+      LOG.warn("Executor id " + executorId + " (on execution " +
           exFlow.getExecutionId() + ") wasn't found");
       executor = null;
     } else {

--- a/azkaban-common/src/main/java/azkaban/executor/NumExecutionsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/NumExecutionsDao.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import azkaban.db.DatabaseOperator;
@@ -22,12 +21,11 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbutils.ResultSetHandler;
-import org.apache.log4j.Logger;
+
 
 @Singleton
 public class NumExecutionsDao {
 
-  private static final Logger logger = Logger.getLogger(NumExecutionsDao.class);
   private final DatabaseOperator dbOperator;
 
   @Inject

--- a/azkaban-common/src/main/java/azkaban/executor/QueuedExecutions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/QueuedExecutions.java
@@ -6,7 +6,9 @@ import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.PriorityBlockingQueue;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * <pre>
@@ -16,7 +18,7 @@ import org.apache.log4j.Logger;
  */
 public class QueuedExecutions {
 
-  private static final Logger logger = Logger.getLogger(QueuedExecutions.class);
+  private static final Logger LOG = LoggerFactory.getLogger(QueuedExecutions.class);
   final long capacity;
 
   /* map to easily access queued flows */
@@ -84,7 +86,7 @@ public class QueuedExecutions {
       this.queuedFlowList.put(pair);
     } catch (final InterruptedException e) {
       final String errMsg = "Failed to insert flow " + exflow.getExecutionId();
-      logger.error(errMsg, e);
+      LOG.error(errMsg, e);
       throw new ExecutorManagerException(errMsg);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdaterThread.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdaterThread.java
@@ -13,18 +13,19 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import javax.inject.Inject;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Updates running executions periodically.
  */
 public class RunningExecutionsUpdaterThread extends Thread {
 
-  private static final Logger logger = Logger.getLogger(RunningExecutionsUpdaterThread.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RunningExecutionsUpdaterThread.class);
 
   volatile int waitTimeIdleMs = 2000;
   volatile int waitTimeMs = 500;
@@ -57,7 +58,7 @@ public class RunningExecutionsUpdaterThread extends Thread {
         // being started.
         waitForNewExecutions();
       } catch (final Exception e) {
-        logger.error("Unexpected exception in updating executions", e);
+        LOG.error("Unexpected exception in updating executions", e);
       }
     }
   }
@@ -82,5 +83,4 @@ public class RunningExecutionsUpdaterThread extends Thread {
   public long getLastThreadCheckTime() {
     return this.lastThreadCheckTime;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/executor/selector/CandidateFilter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/CandidateFilter.java
@@ -13,13 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,7 +29,7 @@ import org.apache.log4j.Logger;
  */
 public abstract class CandidateFilter<T, V> {
 
-  protected static Logger logger = Logger.getLogger(CandidateFilter.class);
+  protected static Logger LOG = LoggerFactory.getLogger(CandidateFilter.class);
 
   // internal repository of the registered filters .
   private final Map<String, FactorFilter<T, V>> factorFilterList =
@@ -45,7 +45,7 @@ public abstract class CandidateFilter<T, V> {
   /**
    * function to register a factorFilter to the internal Map for future reference.
    *
-   * @param factorfilter : the Filter object to be registered.
+   * @param filter : the Filter object to be registered.
    */
   protected void registerFactorFilter(final FactorFilter<T, V> filter) {
     if (null == filter) {
@@ -55,7 +55,7 @@ public abstract class CandidateFilter<T, V> {
 
     // add or replace the filter.
     this.factorFilterList.put(filter.getFactorName(), filter);
-    logger.debug(String.format("Factor filter added for '%s'.",
+    LOG.debug(String.format("Factor filter added for '%s'.",
         filter.getFactorName()));
   }
 
@@ -70,7 +70,7 @@ public abstract class CandidateFilter<T, V> {
    * filtered.
    */
   public boolean filterTarget(final T filteringTarget, final V referencingObject) {
-    logger.debug(String.format("start filtering '%s' with factor filter for '%s'",
+    LOG.debug(String.format("start filtering '%s' with factor filter for '%s'",
         filteringTarget == null ? "(null)" : filteringTarget.toString(),
         this.getName()));
 
@@ -78,13 +78,13 @@ public abstract class CandidateFilter<T, V> {
     boolean result = true;
     for (final FactorFilter<T, V> filter : filterList) {
       result &= filter.filterTarget(filteringTarget, referencingObject);
-      logger.debug(String.format("[Factor: %s] filter result : %s ",
+      LOG.debug(String.format("[Factor: %s] filter result : %s ",
           filter.getFactorName(), result));
       if (!result) {
         break;
       }
     }
-    logger.debug(String.format("Final filtering result : %s ", result));
+    LOG.debug(String.format("Final filtering result : %s ", result));
     return result;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/selector/CandidateSelector.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/CandidateSelector.java
@@ -13,13 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Implementation of the CandidateSelector.
@@ -29,7 +30,7 @@ import org.apache.log4j.Logger;
  */
 public class CandidateSelector<K extends Comparable<K>, V> implements Selector<K, V> {
 
-  private static final Logger logger = Logger.getLogger(CandidateComparator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CandidateComparator.class);
 
   private final CandidateFilter<K, V> filter;
   private final CandidateComparator<K> comparator;
@@ -52,12 +53,12 @@ public class CandidateSelector<K extends Comparable<K>, V> implements Selector<K
 
     // shortcut if the candidateList is empty.
     if (null == candidateList || candidateList.size() == 0) {
-      logger.error("failed to getNext candidate as the passed candidateList is null or empty.");
+      LOG.error("failed to getNext candidate as the passed candidateList is null or empty.");
       return null;
     }
 
-    logger.debug("start candidate selection logic.");
-    logger.debug(String.format("candidate count before filtering: %s", candidateList.size()));
+    LOG.debug("start candidate selection logic.");
+    LOG.debug(String.format("candidate count before filtering: %s", candidateList.size()));
 
     // to keep the input untouched, we will form up a new list based off the filtering result.
     Collection<K> filteredList = new ArrayList<>();
@@ -70,23 +71,23 @@ public class CandidateSelector<K extends Comparable<K>, V> implements Selector<K
       }
     } else {
       filteredList = candidateList;
-      logger.debug("skipping the candidate filtering as the filter object is not specifed.");
+      LOG.debug("skipping the candidate filtering as the filter object is not specifed.");
     }
 
-    logger.debug(String.format("candidate count after filtering: %s", filteredList.size()));
+    LOG.debug(String.format("candidate count after filtering: %s", filteredList.size()));
     if (filteredList.size() == 0) {
-      logger.debug("failed to select candidate as the filtered candidate list is empty.");
+      LOG.debug("failed to select candidate as the filtered candidate list is empty.");
       return null;
     }
 
     if (null == this.comparator) {
-      logger.debug(
+      LOG.debug(
           "candidate comparator is not specified, default hash code comparator class will be used.");
     }
 
     // final work - find the best candidate from the filtered list.
     final K executor = Collections.max(filteredList, this.comparator);
-    logger.debug(String.format("candidate selected %s",
+    LOG.debug(String.format("candidate selected %s",
         null == executor ? "(null)" : executor.toString()));
     return executor;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorComparator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorComparator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
 import azkaban.executor.Executor;
@@ -106,8 +105,8 @@ public class ExecutorComparator extends CandidateComparator<Executor> {
    * shortcuts if   the statistics object is missing from one or both sides of the executors.
    * </pre>
    *
-   * @param stat1 the first statistics  object to be checked .
-   * @param stat2 the second statistics object to be checked.
+   * @param statisticsObj1 the first statistics  object to be checked .
+   * @param statisticsObj2 the second statistics object to be checked.
    * @param caller the name of the calling function, for logging purpose.
    * @return true if the passed statistics are NOT both valid, a shortcut can be made (caller can
    * consume the result), false otherwise.
@@ -116,14 +115,14 @@ public class ExecutorComparator extends CandidateComparator<Executor> {
       final ExecutorInfo statisticsObj2, final String caller) {
     // both doesn't expose the info
     if (null == statisticsObj1 && null == statisticsObj2) {
-      logger.debug(String.format("%s : neither of the executors exposed statistics info.",
+      LOG.debug(String.format("%s : neither of the executors exposed statistics info.",
           caller));
       return true;
     }
 
     //right side doesn't expose the info.
     if (null == statisticsObj2) {
-      logger.debug(String.format(
+      LOG.debug(String.format(
           "%s : choosing left side and the right side executor doesn't expose statistics info",
           caller));
       return true;
@@ -131,7 +130,7 @@ public class ExecutorComparator extends CandidateComparator<Executor> {
 
     //left side doesn't expose the info.
     if (null == statisticsObj1) {
-      logger.debug(String.format(
+      LOG.debug(String.format(
           "%s : choosing right side and the left side executor doesn't expose statistics info",
           caller));
       return true;

--- a/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorFilter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/ExecutorFilter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
 import azkaban.executor.ExecutableFlow;
@@ -23,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
 
 /**
  * De-normalized version of the candidateFilter, which also contains the implementation of the
@@ -58,7 +58,7 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
   public ExecutorFilter(final Collection<String> filterList) {
     // shortcut if the filter list is invalid. A little bit ugly to have to throw in constructor.
     if (null == filterList || filterList.size() == 0) {
-      logger.error(
+      LOG.error(
           "failed to initialize executor filter as the passed filter list is invalid or empty.");
       throw new IllegalArgumentException("filterList");
     }
@@ -68,7 +68,7 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
       if (filterRepository.containsKey(filterName)) {
         this.registerFactorFilter(filterRepository.get(filterName));
       } else {
-        logger.error(String.format("failed to initialize executor filter " +
+        LOG.error(String.format("failed to initialize executor filter " +
                 "as the filter implementation for requested factor '%s' doesn't exist.",
             filterName));
         throw new IllegalArgumentException("filterList");
@@ -100,14 +100,14 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
     return FactorFilter
         .create(STATICREMAININGFLOWSIZE_FILTER_NAME, (filteringTarget, referencingObject) -> {
           if (null == filteringTarget) {
-            logger.debug(String.format("%s : filtering out the target as it is null.",
+            LOG.debug(String.format("%s : filtering out the target as it is null.",
                 STATICREMAININGFLOWSIZE_FILTER_NAME));
             return false;
           }
 
           final ExecutorInfo stats = filteringTarget.getExecutorInfo();
           if (null == stats) {
-            logger.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
+            LOG.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
                 STATICREMAININGFLOWSIZE_FILTER_NAME,
                 filteringTarget.toString()));
             return false;
@@ -134,14 +134,14 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
           public boolean filterTarget(final Executor filteringTarget,
               final ExecutableFlow referencingObject) {
             if (null == filteringTarget) {
-              logger.debug(String.format("%s : filtering out the target as it is null.",
+              LOG.debug(String.format("%s : filtering out the target as it is null.",
                   MINIMUMFREEMEMORY_FILTER_NAME));
               return false;
             }
 
             final ExecutorInfo stats = filteringTarget.getExecutorInfo();
             if (null == stats) {
-              logger.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
+              LOG.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
                   MINIMUMFREEMEMORY_FILTER_NAME,
                   filteringTarget.toString()));
               return false;
@@ -169,14 +169,14 @@ public final class ExecutorFilter extends CandidateFilter<Executor, ExecutableFl
           public boolean filterTarget(final Executor filteringTarget,
               final ExecutableFlow referencingObject) {
             if (null == filteringTarget) {
-              logger.debug(String
+              LOG.debug(String
                   .format("%s : filtering out the target as it is null.", CPUSTATUS_FILTER_NAME));
               return false;
             }
 
             final ExecutorInfo stats = filteringTarget.getExecutorInfo();
             if (null == stats) {
-              logger.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
+              LOG.debug(String.format("%s : filtering out %s as it's stats is unavailable.",
                   CPUSTATUS_FILTER_NAME,
                   filteringTarget.toString()));
               return false;

--- a/azkaban-common/src/main/java/azkaban/executor/selector/FactorComparator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/FactorComparator.java
@@ -13,11 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
 import java.util.Comparator;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * wrapper class for a factor comparator .
@@ -26,7 +27,7 @@ import org.apache.log4j.Logger;
  */
 public final class FactorComparator<T> {
 
-  private static final Logger logger = Logger.getLogger(CandidateComparator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CandidateComparator.class);
 
   private final String factorName;
   private final Comparator<T> comparator;
@@ -55,7 +56,7 @@ public final class FactorComparator<T> {
       final Comparator<T> comparator) {
 
     if (null == factorName || factorName.length() == 0 || weight < 0 || null == comparator) {
-      logger.error(
+      LOG.error(
           "failed to create instance of FactorComparator, at least one of the input paramters are invalid");
       return null;
     }

--- a/azkaban-common/src/main/java/azkaban/executor/selector/FactorFilter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/selector/FactorFilter.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor.selector;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * wrapper class for a factor Filter .
@@ -26,7 +27,7 @@ import org.apache.log4j.Logger;
  */
 public final class FactorFilter<T, V> {
 
-  private static final Logger logger = Logger.getLogger(FactorFilter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FactorFilter.class);
 
   private final String factorName;
   private final Filter<T, V> filter;
@@ -51,7 +52,7 @@ public final class FactorFilter<T, V> {
       final Filter<T, V> filter) {
 
     if (null == factorName || factorName.length() == 0 || null == filter) {
-      logger.error(
+      LOG.error(
           "failed to create instance of FactorFilter, at least one of the input paramters are invalid");
       return null;
     }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.server.AzkabanServer;
@@ -25,6 +24,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+
 
 public class JavaProcessJob extends ProcessJob {
 

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcess.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcess.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor.utils.process;
 
 import azkaban.utils.LogGobbler;
@@ -30,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+
 
 /**
  * An improved version of java.lang.Process.

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcessBuilder.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/utils/process/AzkabanProcessBuilder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor.utils.process;
 
 import com.google.common.base.Joiner;
@@ -23,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
+
 
 /**
  * Helper code for building a process

--- a/azkaban-common/src/main/java/azkaban/jobcallback/JobCallbackValidator.java
+++ b/azkaban-common/src/main/java/azkaban/jobcallback/JobCallbackValidator.java
@@ -12,7 +12,9 @@ import static azkaban.jobcallback.JobCallbackConstants.STATUS_TOKEN;
 
 import azkaban.utils.Props;
 import java.util.Collection;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Responsible for validating the job callback related properties at project upload time
@@ -21,8 +23,7 @@ import org.apache.log4j.Logger;
  */
 public class JobCallbackValidator {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackValidator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JobCallbackValidator.class);
 
   /**
    * Make sure all the job callback related properties are valid
@@ -47,8 +48,8 @@ public class JobCallbackValidator {
               maxPostBodyLength);
     }
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("Found " + totalCallbackCount + " job callbacks for job "
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Found " + totalCallbackCount + " job callbacks for job "
           + jobName);
     }
     return totalCallbackCount;

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManagerException.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManagerException.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
+
 
 public class JobTypeManagerException extends RuntimeException {
 

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypePluginSet.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypePluginSet.java
@@ -20,6 +20,7 @@ import azkaban.utils.Props;
 import java.util.HashMap;
 import java.util.Map;
 
+
 /**
  * Container for job type plugins
  *

--- a/azkaban-common/src/main/java/azkaban/metric/AbstractMetric.java
+++ b/azkaban-common/src/main/java/azkaban/metric/AbstractMetric.java
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.metric;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Abstract class for Metric
@@ -25,7 +26,7 @@ import org.apache.log4j.Logger;
  */
 public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable {
 
-  protected static final Logger logger = Logger.getLogger(MetricReportManager.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(AbstractMetric.class);
   protected String name;
   protected T value;
   protected String type;
@@ -103,11 +104,11 @@ public abstract class AbstractMetric<T> implements IMetric<T>, Cloneable {
    */
   @Override
   public void notifyManager() {
-    logger.debug(String.format("Notifying Manager for %s", this.getClass().getName()));
+    LOG.debug(String.format("Notifying Manager for %s", this.getClass().getName()));
     try {
       this.metricManager.reportMetric(this);
     } catch (final Throwable ex) {
-      logger.error(
+      LOG.error(
           String.format("Metric Manager is not set for %s metric", this.getClass().getName()), ex);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/metric/TimeBasedReportingMetric.java
+++ b/azkaban-common/src/main/java/azkaban/metric/TimeBasedReportingMetric.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.metric;
 
 import java.util.Timer;
 import java.util.TimerTask;
+
 
 /**
  * Metrics tracked after every interval using timer
@@ -76,7 +76,7 @@ public abstract class TimeBasedReportingMetric<T> extends AbstractMetric<T> {
     if (!isValidInterval(interval)) {
       throw new MetricException("Invalid interval: Cannot update timer");
     }
-    logger.debug(String
+    LOG.debug(String
         .format("Updating tracking interval to %d milisecond for %s metric", interval, getName()));
     this.timer.cancel();
     this.timer = new Timer();
@@ -96,5 +96,4 @@ public abstract class TimeBasedReportingMetric<T> extends AbstractMetric<T> {
    * This method is responsible for making any post processing after tracking
    */
   protected abstract void postTrackingEventMethod();
-
 }

--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 class AzkabanProjectLoader {
 
-  private static final Logger log = LoggerFactory.getLogger(AzkabanProjectLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanProjectLoader.class);
   private static final String DIRECTORY_FLOW_REPORT_KEY = "Directory Flow";
 
   private final Props props;
@@ -80,19 +80,19 @@ class AzkabanProjectLoader {
     this.tempDir = new File(props.getString(ConfigurationKeys.PROJECT_TEMP_DIR, "temp"));
     this.executorLoader = executorLoader;
     if (!this.tempDir.exists()) {
-      log.info("Creating temp dir: " + this.tempDir.getAbsolutePath());
+      LOG.info("Creating temp dir: " + this.tempDir.getAbsolutePath());
       this.tempDir.mkdirs();
     } else {
-      log.info("Using temp dir: " + this.tempDir.getAbsolutePath());
+      LOG.info("Using temp dir: " + this.tempDir.getAbsolutePath());
     }
     this.projectVersionRetention = props.getInt(ConfigurationKeys.PROJECT_VERSION_RETENTION, 3);
-    log.info("Project version retention is set to " + this.projectVersionRetention);
+    LOG.info("Project version retention is set to " + this.projectVersionRetention);
   }
 
   public Map<String, ValidationReport> uploadProject(final Project project,
       final File archive, final String fileType, final User uploader, final Props additionalProps)
       throws ProjectManagerException, ExecutorManagerException {
-    log.info("Uploading files to " + project.getName());
+    LOG.info("Uploading files to " + project.getName());
     final Map<String, ValidationReport> reports;
 
     // Since props is an instance variable of ProjectManager, and each
@@ -173,7 +173,7 @@ class AzkabanProjectLoader {
     // config file and creating validator objects for each upload, this does
     // not add too much additional overhead.
     final ValidatorManager validatorManager = new XmlValidatorManager(prop);
-    log.info("Validating project " + archive.getName()
+    LOG.info("Validating project " + archive.getName()
         + " using the registered validators "
         + validatorManager.getValidatorsInfo().toString());
     return validatorManager.validate(project, file);
@@ -188,7 +188,7 @@ class AzkabanProjectLoader {
       }
     }
     if (status == ValidationStatus.ERROR) {
-      log.error("Error found in uploading to " + project.getName());
+      LOG.error("Error found in uploading to " + project.getName());
       return false;
     }
     return true;
@@ -206,19 +206,19 @@ class AzkabanProjectLoader {
 
       this.storageManager.uploadProject(project, newProjectVersion, archive, uploader);
 
-      log.info("Uploading flow to db for project " + archive.getName());
+      LOG.info("Uploading flow to db for project " + archive.getName());
       this.projectLoader.uploadFlows(project, newProjectVersion, flows.values());
-      log.info("Changing project versions for project " + archive.getName());
+      LOG.info("Changing project versions for project " + archive.getName());
       this.projectLoader.changeProjectVersion(project, newProjectVersion,
           uploader.getUserId());
       project.setFlows(flows);
 
       if (loader instanceof DirectoryFlowLoader) {
         final DirectoryFlowLoader directoryFlowLoader = (DirectoryFlowLoader) loader;
-        log.info("Uploading Job properties");
+        LOG.info("Uploading Job properties");
         this.projectLoader.uploadProjectProperties(project, new ArrayList<>(
             directoryFlowLoader.getJobPropsMap().values()));
-        log.info("Uploading Props properties");
+        LOG.info("Uploading Props properties");
         this.projectLoader.uploadProjectProperties(project, directoryFlowLoader.getPropsList());
 
       } else if (loader instanceof DirectoryYamlFlowLoader) {
@@ -247,7 +247,7 @@ class AzkabanProjectLoader {
 
   private void cleanUpProjectOldInstallations(final Project project)
       throws ProjectManagerException, ExecutorManagerException {
-    log.info("Cleaning up old install files older than "
+    LOG.info("Cleaning up old install files older than "
         + (project.getVersion() - this.projectVersionRetention));
     final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = this.executorLoader
         .fetchUnfinishedFlowsMetadata();

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -46,7 +46,7 @@ public class DirectoryFlowLoader implements FlowLoader {
   private static final String PROPERTY_SUFFIX = ".properties";
   private static final String JOB_SUFFIX = ".job";
 
-  private static final Logger logger = LoggerFactory.getLogger(DirectoryFlowLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DirectoryFlowLoader.class);
   private final Props props;
   private final Set<String> errors = new HashSet<>();
   private final Map<String, Flow> flowMap = new HashMap<>();
@@ -162,7 +162,7 @@ public class DirectoryFlowLoader implements FlowLoader {
             + e.getMessage());
       }
 
-      this.logger.info("Adding " + relative);
+      this.LOG.info("Adding " + relative);
       this.propsList.add(parent);
     }
 
@@ -253,7 +253,7 @@ public class DirectoryFlowLoader implements FlowLoader {
       final Props props = this.jobPropsMap.get(node.getId());
 
       if (props == null) {
-        this.logger.error("Job props not found!! For some reason.");
+        LOG.error("Job props not found!! For some reason.");
         continue;
       }
 

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -13,7 +13,6 @@
 * License for the specific language governing permissions and limitations under
 * the License.
 */
-
 package azkaban.project;
 
 import azkaban.Constants;
@@ -40,18 +39,19 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Loads yaml files to flows from project directory.
  */
 public class DirectoryYamlFlowLoader implements FlowLoader {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DirectoryYamlFlowLoader.class);
   // Pattern to match job variables in condition expressions: ${jobName:variable}
   public static final Pattern CONDITION_VARIABLE_REPLACEMENT_PATTERN = Pattern
       .compile("\\$\\{([^:{}]+):([^:{}]+)\\}");
   // Pattern to match conditionOnJobStatus macros, e.g. one_success, all_done
   public static final Pattern CONDITION_ON_JOB_STATUS_PATTERN =
       Pattern.compile("(?i)\\b(" + StringUtils.join(ConditionOnJobStatus.values(), "|") + ")\\b");
-  private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoader.class);
   // Pattern to match a number or a string, e.g. 1234, "hello", 'foo'
   private static final Pattern DIGIT_STRING_PATTERN = Pattern.compile("\\d+|'.*'|\".*\"");
   // Valid operators in condition expressions: &&, ||, ==, !=, >, >=, <, <=
@@ -249,7 +249,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     for (int i = 0; i < operands.length; i++) {
       final Matcher matcher = CONDITION_ON_JOB_STATUS_PATTERN.matcher(operands[i]);
       if (matcher.matches()) {
-        this.logger.info("Operand " + operands[i] + " is a condition on job status.");
+        LOG.info("Operand " + operands[i] + " is a condition on job status.");
         if (foundConditionOnJobStatus) {
           this.errors.add("Invalid condition for " + node.getId()
               + ": cannot combine more than one conditionOnJobStatus macros.");

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
@@ -48,7 +48,7 @@ import org.yaml.snakeyaml.Yaml;
  */
 public class FlowLoaderUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(FlowLoaderUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FlowLoaderUtils.class);
   private static final String XMS = "Xms";
   private static final String XMX = "Xmx";
   /**
@@ -88,10 +88,10 @@ public class FlowLoaderUtils {
       if (overridePropsInNodeBean(nodeBean, pathList, 0, prop)) {
         return nodeBean;
       } else {
-        logger.error("Error setting props for " + path);
+        LOG.error("Error setting props for " + path);
       }
     } catch (final Exception e) {
-      logger.error("Failed to set props, error loading flow YAML file " + flowFile);
+      LOG.error("Failed to set props, error loading flow YAML file " + flowFile);
     }
     return null;
   }
@@ -144,11 +144,11 @@ public class FlowLoaderUtils {
         if (!propsList.isEmpty()) {
           return propsList.get(0);
         } else {
-          logger.error("Error getting props for " + path);
+          LOG.error("Error getting props for " + path);
         }
       }
     } catch (final Exception e) {
-      logger.error("Failed to get props, error loading flow YAML file. ", e);
+      LOG.error("Failed to get props, error loading flow YAML file. ", e);
     }
     return null;
   }
@@ -184,7 +184,7 @@ public class FlowLoaderUtils {
       final NodeBean nodeBean = loader.load(flowFile);
       return loader.toFlowTrigger(nodeBean.getTrigger());
     } catch (final Exception e) {
-      logger.error("Failed to get flow trigger, error loading flow YAML file. ", e);
+      LOG.error("Failed to get flow trigger, error loading flow YAML file. ", e);
     }
     return null;
   }
@@ -290,7 +290,7 @@ public class FlowLoaderUtils {
         FileUtils.deleteDirectory(dir);
       }
     } catch (final IOException e) {
-      logger.error("Failed to delete the directory", e);
+      LOG.error("Failed to delete the directory", e);
       dir.deleteOnExit();
     }
   }

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.project;
 
 import static java.util.Objects.requireNonNull;
@@ -45,13 +44,14 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class ProjectManager {
 
-  private static final Logger logger = Logger.getLogger(ProjectManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ProjectManager.class);
   private final AzkabanProjectLoader azkabanProjectLoader;
   private final ProjectLoader projectLoader;
   private final Props props;
@@ -105,7 +105,7 @@ public class ProjectManager {
         final FlowTrigger flowTrigger = FlowLoaderUtils.getFlowTriggerFromYamlFile(flowFile);
         return flowTrigger != null;
       } catch (final Exception ex) {
-        logger.error("error in getting flow file", ex);
+        LOG.error("error in getting flow file", ex);
         throw ex;
       } finally {
         FlowLoaderUtils.cleanUpDir(tempDir);
@@ -180,7 +180,7 @@ public class ProjectManager {
     try {
       pattern = Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
     } catch (final PatternSyntaxException e) {
-      logger.error("Bad regex pattern " + regexPattern);
+      LOG.error("Bad regex pattern " + regexPattern);
       return array;
     }
 
@@ -208,7 +208,7 @@ public class ProjectManager {
     try {
       pattern = Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
     } catch (final PatternSyntaxException e) {
-      logger.error("Bad regex pattern " + regexPattern);
+      LOG.error("Bad regex pattern " + regexPattern);
       return allProjects;
     }
     for (final Project project : getProjects()) {
@@ -235,12 +235,12 @@ public class ProjectManager {
       try {
         fetchedProject = this.projectLoader.fetchProjectByName(name);
         if (fetchedProject != null) {
-          logger.info("Project " + name + " not found in cache, fetched from DB.");
+          LOG.info("Project " + name + " not found in cache, fetched from DB.");
         } else {
-          logger.info("No active project with name " + name + " exists in cache or DB.");
+          LOG.info("No active project with name " + name + " exists in cache or DB.");
         }
       } catch (final ProjectManagerException e) {
-        logger.error("Could not load project from store.", e);
+        LOG.error("Could not load project from store.", e);
       }
     }
     return fetchedProject;
@@ -255,7 +255,7 @@ public class ProjectManager {
       try {
         fetchedProject = this.projectLoader.fetchProjectById(id);
       } catch (final ProjectManagerException e) {
-        logger.error("Could not load project from store.", e);
+        LOG.error("Could not load project from store.", e);
       }
     }
     return fetchedProject;
@@ -280,7 +280,7 @@ public class ProjectManager {
         throw new ProjectManagerException("Project already exists.");
       }
 
-      logger.info("Trying to create " + projectName + " by user "
+      LOG.info("Trying to create " + projectName + " by user "
           + creator.getUserId());
       newProject = this.projectLoader.createNewProject(projectName, description, creator);
       this.projectsByName.put(newProject.getName(), newProject);
@@ -358,7 +358,7 @@ public class ProjectManager {
           jobName == null ? flow.getId() : flow.getId() + Constants.PATH_DELIMITER + jobName;
       props = FlowLoaderUtils.getPropsFromYamlFile(path, flowFile);
     } catch (final Exception e) {
-      this.logger.error("Failed to get props from flow file. " + e);
+      LOG.error("Failed to get props from flow file. " + e);
     } finally {
       FlowLoaderUtils.cleanUpDir(tempDir);
     }
@@ -406,7 +406,7 @@ public class ProjectManager {
         this.projectLoader
             .uploadFlowFile(flow.getProjectId(), flow.getVersion(), flowFile, flowVersion + 1);
       } catch (final Exception e) {
-        this.logger.error("Failed to set job override property. " + e);
+        LOG.error("Failed to set job override property. " + e);
       } finally {
         FlowLoaderUtils.cleanUpDir(tempDir);
       }
@@ -435,7 +435,7 @@ public class ProjectManager {
 
   public void addProjectProxyUser(final Project project, final String proxyName,
       final User modifier) throws ProjectManagerException {
-    logger.info("User " + modifier.getUserId() + " adding proxy user "
+    LOG.info("User " + modifier.getUserId() + " adding proxy user "
         + proxyName + " to project " + project.getName());
     project.addProxyUser(proxyName);
 
@@ -447,7 +447,7 @@ public class ProjectManager {
 
   public void removeProjectProxyUser(final Project project, final String proxyName,
       final User modifier) throws ProjectManagerException {
-    logger.info("User " + modifier.getUserId() + " removing proxy user "
+    LOG.info("User " + modifier.getUserId() + " removing proxy user "
         + proxyName + " from project " + project.getName());
     project.removeProxyUser(proxyName);
 
@@ -460,7 +460,7 @@ public class ProjectManager {
   public void updateProjectPermission(final Project project, final String name,
       final Permission perm, final boolean group, final User modifier)
       throws ProjectManagerException {
-    logger.info("User " + modifier.getUserId()
+    LOG.info("User " + modifier.getUserId()
         + " updating permissions for project " + project.getName() + " for "
         + name + " " + perm.toString());
     this.projectLoader.updatePermission(project, name, perm, group);
@@ -477,7 +477,7 @@ public class ProjectManager {
 
   public void removeProjectPermission(final Project project, final String name,
       final boolean group, final User modifier) throws ProjectManagerException {
-    logger.info("User " + modifier.getUserId()
+    LOG.info("User " + modifier.getUserId()
         + " removing permissions for project " + project.getName() + " for "
         + name);
     this.projectLoader.removePermission(project, name, group);

--- a/azkaban-common/src/main/java/azkaban/project/validator/ValidatorManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/validator/ValidatorManager.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.log4j.Logger;
 
+
 /**
  * ValidatorManager is responsible for loading the list of validators specified in the Azkaban
  * validator configuration file. Once these validators are loaded, the ValidatorManager will use the

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import java.util.List;
+
 
 public interface ScheduleLoader {
 

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import azkaban.executor.ExecutionOptions;
@@ -26,11 +25,13 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * The ScheduleManager stores and executes the schedule. It uses a single thread instead and waits
@@ -42,7 +43,7 @@ import org.joda.time.format.DateTimeFormatter;
 public class ScheduleManager implements TriggerAgent {
 
   public static final String SIMPLE_TIME_TRIGGER = "SimpleTimeTrigger";
-  private static final Logger logger = Logger.getLogger(ScheduleManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ScheduleManager.class);
   private final DateTimeFormatter _dateFormat = DateTimeFormat
       .forPattern("MM-dd-yyyy HH:mm:ss:SSS");
   private final ScheduleLoader loader;
@@ -138,7 +139,7 @@ public class ScheduleManager implements TriggerAgent {
     try {
       this.loader.removeSchedule(sched);
     } catch (final ScheduleManagerException e) {
-      logger.error(e);
+      LOG.error("Remove Schedule Failure", e);
     }
   }
 
@@ -159,8 +160,7 @@ public class ScheduleManager implements TriggerAgent {
     final Schedule sched = new Schedule(scheduleId, projectId, projectName, flowName, status,
         firstSchedTime, endSchedTime, timezone, period, lastModifyTime, nextExecTime,
         submitTime, submitUser, execOptions, null);
-    logger
-        .info("Scheduling flow '" + sched.getScheduleName() + "' for "
+    LOG.info("Scheduling flow '" + sched.getScheduleName() + "' for "
             + this._dateFormat.print(firstSchedTime) + " with a period of " + (period == null
             ? "(non-recurring)"
             : period));
@@ -187,8 +187,7 @@ public class ScheduleManager implements TriggerAgent {
         new Schedule(scheduleId, projectId, projectName, flowName, status,
             firstSchedTime, endSchedTime, timezone, null, lastModifyTime, nextExecTime,
             submitTime, submitUser, execOptions, cronExpression);
-    logger
-        .info("Scheduling flow '" + sched.getScheduleName() + "' for "
+    LOG.info("Scheduling flow '" + sched.getScheduleName() + "' for "
             + this._dateFormat.print(firstSchedTime) + " cron Expression = " + cronExpression);
 
     insertSchedule(sched);
@@ -219,11 +218,10 @@ public class ScheduleManager implements TriggerAgent {
           internalSchedule(s);
         }
       } catch (final ScheduleManagerException e) {
-        logger.error(e);
+        LOG.error("Insert Schedule Failure", e);
       }
     } else {
-      logger
-          .error("The provided schedule is non-recurring and the scheduled time already passed. "
+      LOG.error("The provided schedule is non-recurring and the scheduled time already passed. "
               + s.getScheduleName());
     }
   }

--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import azkaban.Constants;
@@ -31,12 +30,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class TriggerBasedScheduleLoader implements ScheduleLoader {
 
-  private static final Logger logger = Logger
-      .getLogger(TriggerBasedScheduleLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerBasedScheduleLoader.class);
 
   private final TriggerManagerAdapter triggerManager;
 
@@ -160,7 +160,7 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
           act.getExecutionOptions(),
           triggerTimeChecker.getCronExpression());
     } else {
-      logger.error("Failed to parse schedule from trigger!");
+      LOG.error("Failed to parse schedule from trigger!");
       throw new ScheduleManagerException(
           "Failed to parse schedule from trigger!");
     }
@@ -215,10 +215,10 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
       this.lastUpdateTime = Math.max(this.lastUpdateTime, t.getLastModifyTime());
       final Schedule s = triggerToSchedule(t);
       schedules.add(s);
-      logger.info("loaded schedule for "
-          + s.getProjectName() + " (project_ID: " + s.getProjectId() + ")");
+      LOG.info(
+          "loaded schedule for " + s.getProjectName() + " (project_ID: " + s.getProjectId() + ")"
+      );
     }
     return schedules;
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
+++ b/azkaban-common/src/main/java/azkaban/server/AzkabanServer.java
@@ -29,13 +29,14 @@ import java.util.Arrays;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
-import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public abstract class AzkabanServer {
 
-  private static final Logger logger = Logger.getLogger(AzkabanServer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanServer.class);
   private static Props azkabanProperties = null;
 
   public static Props loadProps(final String[] args) {
@@ -60,18 +61,17 @@ public abstract class AzkabanServer {
 
     if (options.has(configDirectory)) {
       final String path = options.valueOf(configDirectory);
-      logger.info("Loading azkaban settings file from " + path);
+      LOG.info("Loading azkaban settings file from " + path);
       final File dir = new File(path);
       if (!dir.exists()) {
-        logger.error("Conf directory " + path + " doesn't exist.");
+        LOG.error("Conf directory " + path + " doesn't exist.");
       } else if (!dir.isDirectory()) {
-        logger.error("Conf directory " + path + " isn't a directory.");
+        LOG.error("Conf directory " + path + " isn't a directory.");
       } else {
         azkabanSettings = loadAzkabanConfigurationFromDirectory(dir);
       }
     } else {
-      logger
-          .info("Conf parameter not set, attempting to get value from AZKABAN_HOME env.");
+      LOG.info("Conf parameter not set, attempting to get value from AZKABAN_HOME env.");
       azkabanSettings = loadConfigurationFromAzkabanHome();
     }
 
@@ -102,18 +102,18 @@ public abstract class AzkabanServer {
     try {
       // This is purely optional
       if (azkabanPrivatePropsFile.exists() && azkabanPrivatePropsFile.isFile()) {
-        logger.info("Loading azkaban private properties file");
+        LOG.info("Loading azkaban private properties file");
         props = new Props(null, azkabanPrivatePropsFile);
       }
 
       if (azkabanPropsFile.exists() && azkabanPropsFile.isFile()) {
-        logger.info("Loading azkaban properties file");
+        LOG.info("Loading azkaban properties file");
         props = new Props(props, azkabanPropsFile);
       }
     } catch (final FileNotFoundException e) {
-      logger.error("File not found. Could not load azkaban config file", e);
+      LOG.error("File not found. Could not load azkaban config file", e);
     } catch (final IOException e) {
-      logger.error("File found, but error reading. Could not load azkaban config file", e);
+      LOG.error("File found, but error reading. Could not load azkaban config file", e);
     }
     return props;
   }
@@ -127,17 +127,17 @@ public abstract class AzkabanServer {
     final String azkabanHome = System.getenv("AZKABAN_HOME");
 
     if (azkabanHome == null) {
-      logger.error("AZKABAN_HOME not set. Will try default.");
+      LOG.error("AZKABAN_HOME not set. Will try default.");
       return null;
     }
     if (!new File(azkabanHome).isDirectory() || !new File(azkabanHome).canRead()) {
-      logger.error(azkabanHome + " is not a readable directory.");
+      LOG.error(azkabanHome + " is not a readable directory.");
       return null;
     }
 
     final File confPath = new File(azkabanHome, Constants.DEFAULT_CONF_PATH);
     if (!confPath.exists() || !confPath.isDirectory() || !confPath.canRead()) {
-      logger.error(azkabanHome + " does not contain a readable conf directory.");
+      LOG.error(azkabanHome + " does not contain a readable conf directory.");
       return null;
     }
 

--- a/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
+++ b/azkaban-common/src/main/java/azkaban/server/MBeanRegistrationManager.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * A class to manager MBean Registration tasks
  */
 public class MBeanRegistrationManager {
-  private static final Logger logger = LoggerFactory.getLogger(MBeanRegistrationManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MBeanRegistrationManager.class);
 
   private List<ObjectName> registeredMBeans = new ArrayList<>();
   private MBeanServer mbeanServer = null;
@@ -44,10 +44,10 @@ public class MBeanRegistrationManager {
     try {
       mbeanName = new ObjectName(mbeanClass.getName() + ":name=" + name);
       getMbeanServer().registerMBean(mbean, mbeanName);
-      logger.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
+      LOG.info("Bean " + mbeanClass.getCanonicalName() + " registered.");
       this.registeredMBeans.add(mbeanName);
     } catch (final Exception e) {
-      logger.error("Error registering mbean " + mbeanClass.getCanonicalName(), e);
+      LOG.error("Error registering mbean " + mbeanClass.getCanonicalName(), e);
     }
   }
 
@@ -68,10 +68,10 @@ public class MBeanRegistrationManager {
     try {
       for (final ObjectName name : registeredMBeans) {
         getMbeanServer().unregisterMBean(name);
-        logger.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
+        LOG.info("Jmx MBean " + name.getCanonicalName() + " unregistered.");
       }
     } catch (final Exception e) {
-      logger.error("Failed to cleanup MBeanServer", e);
+      LOG.error("Failed to cleanup MBeanServer", e);
     }
   }
 
@@ -92,7 +92,7 @@ public class MBeanRegistrationManager {
     try {
       return getMbeanServer().getMBeanInfo(name);
     } catch (final Exception e) {
-      logger.error("Load MBean Information Failure", e);
+      LOG.error("Load MBean Information Failure", e);
       return null;
     }
   }
@@ -107,7 +107,7 @@ public class MBeanRegistrationManager {
     try {
       return getMbeanServer().getAttribute(name, attribute);
     } catch (final Exception e) {
-      logger.error(
+      LOG.error(
           "Retrieve MBeanServer attribute Failure. "
               + "ObjectName = " + name.toString() + ", "
               + "attribute = " + attribute,
@@ -137,7 +137,7 @@ public class MBeanRegistrationManager {
 
       ret.put("attributes", attributes);
     } catch (final Exception e) {
-      logger.error("Invalid MBean Name. name = " + mbeanName, e);
+      LOG.error("Invalid MBean Name. name = " + mbeanName, e);
       ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
     }
 

--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -33,13 +32,14 @@ import java.net.URI;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class HdfsStorage implements Storage {
 
-  private static final Logger log = Logger.getLogger(HdfsStorage.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsStorage.class);
   private static final String HDFS_SCHEME = "hdfs";
 
   private final HdfsAuth hdfsAuth;
@@ -70,21 +70,20 @@ public class HdfsStorage implements Storage {
         String.valueOf(metadata.getProjectId()));
     try {
       if (this.hdfs.mkdirs(projectsPath)) {
-        log.info("Created project dir: " + projectsPath);
+        LOG.info("Created project dir: " + projectsPath);
       }
       final Path targetPath = createTargetPath(metadata, projectsPath);
       if (this.hdfs.exists(targetPath)) {
-        log.info(
-            String.format("Duplicate Found: meta: %s path: %s", metadata, targetPath));
+        LOG.info(String.format("Duplicate Found: meta: %s path: %s", metadata, targetPath));
         return getRelativePath(targetPath);
       }
 
       // Copy file to HDFS
-      log.info(String.format("Creating project artifact: meta: %s path: %s", metadata, targetPath));
+      LOG.info(String.format("Creating project artifact: meta: %s path: %s", metadata, targetPath));
       this.hdfs.copyFromLocalFile(new Path(localFile.getAbsolutePath()), targetPath);
       return getRelativePath(targetPath);
     } catch (final IOException e) {
-      log.error("error in put(): Metadata: " + metadata);
+      LOG.error("error in put(): Metadata: " + metadata);
       throw new StorageException(e);
     }
   }
@@ -107,7 +106,7 @@ public class HdfsStorage implements Storage {
     try {
       return this.hdfs.delete(path, false);
     } catch (final IOException e) {
-      log.error("HDFS delete failed on " + path, e);
+      LOG.error("HDFS delete failed on " + path, e);
       return false;
     }
   }

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -32,13 +31,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class LocalStorage implements Storage {
 
-  private static final Logger log = Logger.getLogger(LocalStorage.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStorage.class);
 
   final File rootDirectory;
 
@@ -52,7 +52,7 @@ public class LocalStorage implements Storage {
     final File baseDirectory = new File(baseDirectoryPath);
     if (!baseDirectory.exists()) {
       baseDirectory.mkdir();
-      log.info("Creating dir: " + baseDirectory.getAbsolutePath());
+      LOG.info("Creating dir: " + baseDirectory.getAbsolutePath());
     }
     return baseDirectory;
   }
@@ -81,7 +81,7 @@ public class LocalStorage implements Storage {
   public String put(final StorageMetadata metadata, final File localFile) {
     final File projectDir = new File(this.rootDirectory, String.valueOf(metadata.getProjectId()));
     if (projectDir.mkdir()) {
-      log.info("Created project dir: " + projectDir.getAbsolutePath());
+      LOG.info("Created project dir: " + projectDir.getAbsolutePath());
     }
 
     final File targetFile = new File(projectDir, String.format("%s-%s.zip",
@@ -89,7 +89,7 @@ public class LocalStorage implements Storage {
         new String(Hex.encodeHex(metadata.getHash()))));
 
     if (targetFile.exists()) {
-      log.info(String.format("Duplicate found: meta: %s, targetFile: %s, ", metadata,
+      LOG.info(String.format("Duplicate found: meta: %s, targetFile: %s, ", metadata,
           targetFile.getAbsolutePath()));
       return getRelativePath(targetFile);
     }
@@ -98,7 +98,7 @@ public class LocalStorage implements Storage {
     try {
       FileUtils.copyFile(localFile, targetFile);
     } catch (final IOException e) {
-      log.error("LocalStorage error in put(): meta: " + metadata);
+      LOG.error("LocalStorage error in put(): meta: " + metadata);
       throw new StorageException(e);
     }
     return getRelativePath(targetFile);
@@ -113,9 +113,9 @@ public class LocalStorage implements Storage {
     final File file = getFile(key);
     final boolean result = file.exists() && file.delete();
     if (result) {
-      log.warn("Deleted file: " + file.getAbsolutePath());
+      LOG.warn("Deleted file: " + file.getAbsolutePath());
     } else {
-      log.warn("Unable to delete file: " + file.getAbsolutePath());
+      LOG.warn("Unable to delete file: " + file.getAbsolutePath());
     }
     return result;
   }

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -39,7 +38,8 @@ import java.util.Arrays;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -49,7 +49,7 @@ import org.apache.log4j.Logger;
 @Singleton
 public class StorageManager {
 
-  private static final Logger log = Logger.getLogger(StorageManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StorageManager.class);
 
   private final StorageCleaner storageCleaner;
   private final Storage storage;
@@ -99,7 +99,7 @@ public class StorageManager {
         version,
         uploader.getUserId(),
         md5);
-    log.info(String.format("Adding archive to storage. Meta:%s File: %s[%d bytes]",
+    LOG.info(String.format("Adding archive to storage. Meta:%s File: %s[%d bytes]",
         metadata, localFile.getName(), localFile.length()));
 
     /* upload to storage */
@@ -116,7 +116,7 @@ public class StorageManager {
           requireNonNull(md5),
           requireNonNull(resourceId)
       );
-      log.info(String.format("Added project metadata to DB. Meta:%s File: %s[%d bytes] URI: %s",
+      LOG.info(String.format("Added project metadata to DB. Meta:%s File: %s[%d bytes] URI: %s",
           metadata, localFile.getName(), localFile.length(), resourceId));
     }
   }
@@ -128,7 +128,7 @@ public class StorageManager {
     try {
       this.storageCleaner.cleanupProjectArtifacts(projectId);
     } catch (final Exception e) {
-      log.error("Error occured during cleanup. Ignoring and continuing...", e);
+      LOG.error("Error occured during cleanup. Ignoring and continuing...", e);
     }
   }
 
@@ -150,7 +150,7 @@ public class StorageManager {
    * @return Handler object containing hooks to fetched project file
    */
   public ProjectFileHandler getProjectFile(final int projectId, final int version) {
-    log.info(
+    LOG.info(
         String.format("Fetching project file. project ID: %d version: %d", projectId, version));
     // TODO spyne: remove huge hack ! There should not be any special handling for Database Storage.
     if (this.storage instanceof DatabaseStorage) {

--- a/azkaban-common/src/main/java/azkaban/trigger/ActionTypeLoader.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/ActionTypeLoader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger;
 
 import azkaban.utils.Props;
@@ -21,13 +20,15 @@ import azkaban.utils.Utils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class ActionTypeLoader {
 
   public static final String DEFAULT_TRIGGER_ACTION_PLUGIN_DIR =
       "plugins/triggeractions";
-  private static final Logger logger = Logger.getLogger(ActionTypeLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ActionTypeLoader.class);
   protected static Map<String, Class<? extends TriggerAction>> actionToClass =
       new HashMap<>();
 
@@ -35,7 +36,7 @@ public class ActionTypeLoader {
       final Map<String, Class<? extends TriggerAction>> builtinActions) {
     actionToClass.putAll(builtinActions);
     for (final String type : builtinActions.keySet()) {
-      logger.info("Loaded " + type + " action.");
+      LOG.info("Loaded " + type + " action.");
     }
   }
 
@@ -44,7 +45,7 @@ public class ActionTypeLoader {
 
   public synchronized void registerActionType(final String type,
       final Class<? extends TriggerAction> actionClass) {
-    logger.info("Registering action " + type);
+    LOG.info("Registering action " + type);
     if (!actionToClass.containsKey(type)) {
       actionToClass.put(type, actionClass);
     }

--- a/azkaban-common/src/main/java/azkaban/trigger/CheckerTypeLoader.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/CheckerTypeLoader.java
@@ -13,20 +13,21 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger;
 
 import azkaban.utils.Props;
 import azkaban.utils.Utils;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class CheckerTypeLoader {
 
   public static final String DEFAULT_CONDITION_CHECKER_PLUGIN_DIR =
       "plugins/conditioncheckers";
-  private static final Logger logger = Logger.getLogger(CheckerTypeLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CheckerTypeLoader.class);
   protected static Map<String, Class<? extends ConditionChecker>> checkerToClass =
       new HashMap<>();
 
@@ -34,7 +35,7 @@ public class CheckerTypeLoader {
       final Map<String, Class<? extends ConditionChecker>> builtinCheckers) {
     checkerToClass.putAll(checkerToClass);
     for (final String type : builtinCheckers.keySet()) {
-      logger.info("Loaded " + type + " checker.");
+      LOG.info("Loaded " + type + " checker.");
     }
   }
 
@@ -43,7 +44,7 @@ public class CheckerTypeLoader {
 
   public synchronized void registerCheckerType(final String type,
       final Class<? extends ConditionChecker> checkerClass) {
-    logger.info("Registering checker " + type);
+    LOG.info("Registering checker " + type);
     if (!checkerToClass.containsKey(type)) {
       checkerToClass.put(type, checkerClass);
     }

--- a/azkaban-common/src/main/java/azkaban/trigger/Condition.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Condition.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger;
 
 import java.util.ArrayList;
@@ -23,12 +22,14 @@ import java.util.Map;
 import org.apache.commons.jexl2.Expression;
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.MapContext;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Condition {
 
-  private static final Logger logger = Logger.getLogger(Condition.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Condition.class);
 
   private static final JexlEngine jexl = new JexlEngine();
   private static CheckerTypeLoader checkerLoader = null;
@@ -83,7 +84,7 @@ public class Condition {
 
     } catch (final Exception e) {
       e.printStackTrace();
-      logger.error("Failed to recreate condition from json.", e);
+      LOG.error("Failed to recreate condition from json.", e);
       throw new Exception("Failed to recreate condition from json.", e);
     }
 
@@ -119,7 +120,7 @@ public class Condition {
       checker.reset();
     }
     updateNextCheckTime();
-    logger.info("Done resetting checkers. The next check time will be "
+    LOG.info("Done resetting checkers. The next check time will be "
         + new DateTime(this.nextCheckTime));
   }
 
@@ -132,8 +133,8 @@ public class Condition {
   }
 
   public boolean isMet() {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Testing condition " + this.expression);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Testing condition " + this.expression);
     }
     return this.expression.evaluate(this.context).equals(Boolean.TRUE);
   }

--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger;
 
 import static java.util.Objects.requireNonNull;
@@ -23,13 +22,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class Trigger {
 
-  private static final Logger logger = Logger.getLogger(Trigger.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Trigger.class);
   private static ActionTypeLoader actionTypeLoader;
   private final long submitTime;
   private final String submitUser;
@@ -94,7 +94,7 @@ public class Trigger {
 
     Trigger trigger = null;
     try {
-      logger.info("Decoding for " + JSONUtils.toJSON(obj));
+      LOG.info("Decoding for " + JSONUtils.toJSON(obj));
       final Condition triggerCond = Condition.fromJson(jsonObj.get("triggerCondition"));
       final Condition expireCond = Condition.fromJson(jsonObj.get("expireCondition"));
       final List<TriggerAction> actions = new ArrayList<>();
@@ -168,7 +168,7 @@ public class Trigger {
       trigger.setStatus(status);
     } catch (final Exception e) {
       e.printStackTrace();
-      logger.error("Failed to decode the trigger.", e);
+      LOG.error("Failed to decode the trigger.", e);
       throw new Exception("Failed to decode the trigger.", e);
     }
 

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerAction.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger;
 
 import java.util.Map;
+
 
 public interface TriggerAction {
 
@@ -33,5 +33,4 @@ public interface TriggerAction {
   void setContext(Map<String, Object> context);
 
   String getDescription();
-
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -29,19 +29,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ExecuteFlowAction implements TriggerAction {
 
   public static final String type = "ExecuteFlowAction";
-
   public static final String EXEC_ID = "ExecuteFlowAction.execid";
+
+  private static Logger LOG = LoggerFactory.getLogger(ExecuteFlowAction.class);
 
   private static ExecutorManagerAdapter executorManagerAdapter;
   private static TriggerManager triggerManager;
   private static ProjectManager projectManager;
-  private static Logger logger = Logger.getLogger(ExecuteFlowAction.class);
   private final String actionId;
   private final String projectName;
   private int projectId;
@@ -59,9 +60,9 @@ public class ExecuteFlowAction implements TriggerAction {
     this.executionOptions = executionOptions;
   }
 
-  public static void setLogger(final Logger logger) {
-    ExecuteFlowAction.logger = logger;
-  }
+//  public static void setLogger(final Logger logger) {
+//    ExecuteFlowAction.logger = logger;
+//  }
 
   public static ExecutorManagerAdapter getExecutorManager() {
     return executorManagerAdapter;
@@ -207,9 +208,9 @@ public class ExecuteFlowAction implements TriggerAction {
 
     exflow.setExecutionOptions(this.executionOptions);
 
-    logger.info("Invoking flow " + project.getName() + "." + this.flowName);
+    LOG.info("Invoking flow " + project.getName() + "." + this.flowName);
     executorManagerAdapter.submitExecutableFlow(exflow, this.submitUser);
-    logger.info("Invoked flow " + project.getName() + "." + this.flowName);
+    LOG.info("Invoked flow " + project.getName() + "." + this.flowName);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.ServiceProvider;
@@ -26,13 +25,15 @@ import azkaban.trigger.TriggerAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class SlaAlertAction implements TriggerAction {
 
   public static final String type = "AlertAction";
 
-  private static final Logger logger = Logger.getLogger(SlaAlertAction.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SlaAlertAction.class);
 
   private final String actionId;
   private final SlaOption slaOption;
@@ -101,7 +102,7 @@ public class SlaAlertAction implements TriggerAction {
 
   @Override
   public void doAction() throws Exception {
-    logger.info("Alerting on sla failure.");
+    LOG.info("Alerting on sla failure.");
     if (slaOption.hasAlert()) {
       final Alerter alerter = this.alerters.get(SlaOption.ALERT_TYPE_EMAIL);
       if (alerter != null) {
@@ -110,10 +111,10 @@ public class SlaAlertAction implements TriggerAction {
           alerter.alertOnSla(this.slaOption, slaOption.createSlaMessage(flow));
         } catch (final Exception e) {
           e.printStackTrace();
-          logger.error("Failed to alert by " + SlaOption.ALERT_TYPE_EMAIL);
+          LOG.error("Failed to alert by " + SlaOption.ALERT_TYPE_EMAIL);
         }
       } else {
-        logger.error("Alerter type " + SlaOption.ALERT_TYPE_EMAIL
+        LOG.error("Alerter type " + SlaOption.ALERT_TYPE_EMAIL
             + " doesn't exist. Failed to alert.");
       }
     }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaChecker.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.trigger.builtin;
 
 import azkaban.ServiceProvider;
@@ -27,16 +26,19 @@ import azkaban.sla.SlaType.ComponentType;
 import azkaban.sla.SlaType;
 import azkaban.sla.SlaType.StatusType;
 import azkaban.trigger.ConditionChecker;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class SlaChecker implements ConditionChecker {
 
   public static final String type = "SlaChecker";
-  private static final Logger logger = Logger.getLogger(SlaChecker.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlaChecker.class);
+
   private final String id;
   private final SlaOption slaOption;
   private final int execId;
@@ -145,12 +147,12 @@ public class SlaChecker implements ConditionChecker {
   // return true to trigger sla action
   @Override
   public Object eval() {
-    logger.info("Checking sla for execution " + this.execId);
+    LOG.info("Checking sla for execution " + this.execId);
     final ExecutableFlow flow;
     try {
       flow = this.executorLoader.fetchExecutableFlow(this.execId);
     } catch (final ExecutorManagerException e) {
-      logger.error("Can't get executable flow.", e);
+      LOG.error("Can't get executable flow.", e);
       e.printStackTrace();
       // something wrong, send out alerts
       return true;
@@ -163,7 +165,7 @@ public class SlaChecker implements ConditionChecker {
     try {
       flow = this.executorLoader.fetchExecutableFlow(this.execId);
     } catch (final ExecutorManagerException e) {
-      logger.error("Can't get executable flow.", e);
+      LOG.error("Can't get executable flow.", e);
       // something wrong, send out alerts
       return true;
     }
@@ -175,7 +177,7 @@ public class SlaChecker implements ConditionChecker {
     try {
       flow = this.executorLoader.fetchExecutableFlow(this.execId);
     } catch (final ExecutorManagerException e) {
-      logger.error("Can't get executable flow.", e);
+      LOG.error("Can't get executable flow.", e);
       // something wrong, send out alerts
       return true;
     }

--- a/azkaban-common/src/main/java/azkaban/user/UserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/user/UserUtils.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public final class UserUtils {
 
-  private static final Logger log = LoggerFactory.getLogger(UserUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UserUtils.class);
 
   private UserUtils() {
 
@@ -55,7 +55,7 @@ public final class UserUtils {
     try {
       watchService = FileSystems.getDefault().newWatchService();
     } catch (final IOException e) {
-      log.warn(" Failed to create WatchService ", e);
+      LOG.warn(" Failed to create WatchService ", e);
       throw e;
     }
 
@@ -73,7 +73,7 @@ public final class UserUtils {
 
       final File file = new File(fileName);
       if (!file.exists()) {
-        log.warn("Failed to setup watch service, user provided file " + fileName + " does not "
+        LOG.warn("Failed to setup watch service, user provided file " + fileName + " does not "
             + "exist.");
         continue;
       }
@@ -91,17 +91,17 @@ public final class UserUtils {
         dirToFilesMap.put(dir, fileName);
       } catch (final IOException e) {
         // Ignore the IOException
-        log.warn("IOException while setting up watch on conf " + fileName + ". ", e);
+        LOG.warn("IOException while setting up watch on conf " + fileName + ". ", e);
       }
     }
 
     // Return if WatchService is not initialized
     if (keys.size() == 0) {
-      log.warn("Watchservice was not setup for any config file(s).");
+      LOG.warn("Watchservice was not setup for any config file(s).");
       try {
         watchService.close();
       } catch (final IOException e) {
-        log.warn("IOException while closing watchService. ", e);
+        LOG.warn("IOException while closing watchService. ", e);
       }
       return;
     }
@@ -123,7 +123,7 @@ public final class UserUtils {
           // in the watch service.
           Thread.sleep(1000L);
         } catch (final InterruptedException ie) {
-          log.warn(ie.toString());
+          LOG.warn(ie.toString());
           Thread.currentThread().interrupt();
           return;
         }
@@ -140,12 +140,12 @@ public final class UserUtils {
           }
           // Match!
           // Reparse the config file
-          log.info("Modification detected, reloading config file " + filename + ".");
+          LOG.info("Modification detected, reloading config file " + filename + ".");
           try {
             configFileMap.get(filename).parseConfigFile();
           } catch (final Exception e) {
             // If there is any exception while parsing the config file, log it and move on
-            log.warn("Reload failed for config file " + filename + " due to ", e);
+            LOG.warn("Reload failed for config file " + filename + " due to ", e);
           }
         }
         watchKey.reset();
@@ -153,7 +153,7 @@ public final class UserUtils {
     };
 
     final Thread thread = new Thread(runnable);
-    log.info("Starting configuration watching thread.");
+    LOG.info("Starting configuration watching thread.");
     thread.start();
   }
 }

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -44,6 +44,8 @@ import org.xml.sax.SAXException;
  */
 public class XmlUserManager implements UserManager {
 
+  private static final Logger LOG = LoggerFactory.getLogger(XmlUserManager.class);
+
   public static final String XML_FILE_PARAM = "user.manager.xml.file";
   public static final String AZKABAN_USERS_TAG = "azkaban-users";
   public static final String USER_TAG = "user";
@@ -58,7 +60,6 @@ public class XmlUserManager implements UserManager {
   public static final String PROXY_ATTR = "proxy";
   public static final String GROUPS_ATTR = "groups";
   public static final String GROUPNAME_ATTR = "name";
-  private static final Logger logger = LoggerFactory.getLogger(XmlUserManager.class);
   private final String xmlPath;
 
   private HashMap<String, User> users;
@@ -82,7 +83,7 @@ public class XmlUserManager implements UserManager {
     try {
       UserUtils.setupWatch(parseConfigFileMap);
     } catch (final IOException e) {
-      logger.warn(" Failed to create WatchService " + e.getMessage());
+      LOG.warn(" Failed to create WatchService " + e.getMessage());
     }
   }
 
@@ -175,7 +176,7 @@ public class XmlUserManager implements UserManager {
     // Add the user to the node
     final User user = new User(userNameAttr.getNodeValue());
     users.put(username, user);
-    logger.info("Loading user " + user.getUserId());
+    LOG.info("Loading user " + user.getUserId());
 
     final Node roles = userAttrMap.getNamedItem(ROLES_ATTR);
     if (roles != null) {
@@ -240,7 +241,7 @@ public class XmlUserManager implements UserManager {
         final Permission.Type type = Permission.Type.valueOf(permString);
         perm.addPermission(type);
       } catch (final IllegalArgumentException e) {
-        logger.error("Error adding type " + permString
+        LOG.error("Error adding type " + permString
             + ". Permission doesn't exist.", e);
       }
     }
@@ -329,7 +330,7 @@ public class XmlUserManager implements UserManager {
     }
 
     groupRoles.put(groupName, roleSet);
-    logger.info("Group roles " + groupName + " added.");
+    LOG.info("Group roles " + groupName + " added.");
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/utils/AuthenticationUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/AuthenticationUtils.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AuthenticationUtils {
 
-  private static final Logger logger = LoggerFactory.getLogger(AuthenticationUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AuthenticationUtils.class);
 
   public static HttpURLConnection loginAuthenticatedURL(final URL url, final String keytabPrincipal,
       final String keytabPath) throws Exception {
@@ -45,7 +45,7 @@ public class AuthenticationUtils {
     conf.setClassLoader(ucl);
     UserGroupInformation.setConfiguration(conf);
 
-    logger.info(
+    LOG.info(
         "Logging in URL: " + url.toString() + " using Principal: " + keytabPrincipal + ", Keytab: "
             + keytabPath);
 

--- a/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
+++ b/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.File;
@@ -32,15 +31,17 @@ import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMultipart;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class EmailMessage {
 
+  private static final Logger LOG = LoggerFactory.getLogger(EmailMessage.class);
   private static final int MAX_EMAIL_RETRY_COUNT = 5;
   private static int _mailTimeout = 10000;
   private static int _connectionTimeout = 10000;
   private static long _totalAttachmentMaxSizeInByte = 1024 * 1024 * 1024; // 1
-  private final Logger logger = Logger.getLogger(EmailMessage.class);
   private final List<String> _toAddress = new ArrayList<>();
   private final int _mailPort;
   private final ArrayList<BodyPart> _attachments = new ArrayList<>();
@@ -230,7 +231,7 @@ public class EmailMessage {
         connectToSMTPServer(s);
         return;
       } catch (final Exception e) {
-        this.logger.error("Connecting to SMTP server failed, attempt: " + attempt, e);
+        LOG.error("Connecting to SMTP server failed, attempt: " + attempt, e);
       }
     }
     s.close();
@@ -246,7 +247,7 @@ public class EmailMessage {
         s.sendMessage(message, message.getRecipients(Message.RecipientType.TO));
         return;
       } catch (final Exception e) {
-        this.logger.error("Sending email messages failed, attempt: " + attempt, e);
+        LOG.error("Sending email messages failed, attempt: " + attempt, e);
       }
     }
     s.close();

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import static java.util.Objects.requireNonNull;
@@ -41,14 +40,16 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.mail.internet.AddressException;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @Singleton
 public class Emailer extends AbstractMailer implements Alerter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(Emailer.class);
   private static final String HTTPS = "https";
   private static final String HTTP = "http";
-  private static final Logger logger = Logger.getLogger(Emailer.class);
   private final CommonMetrics commonMetrics;
   private final String scheme;
   private final String clientHostname;
@@ -109,7 +110,7 @@ public class Emailer extends AbstractMailer implements Alerter {
         "SLA violation for " + getJobOrFlowName(slaOption) + " on " + getAzkabanName();
     final List<String> emailList =
         (List<String>) slaOption.getEmails();
-    logger.info("Sending SLA email " + slaMessage);
+    LOG.info("Sending SLA email " + slaMessage);
     sendEmail(emailList, subject, slaMessage);
   }
 
@@ -135,7 +136,7 @@ public class Emailer extends AbstractMailer implements Alerter {
         last72hoursExecutions = this.executorLoader.fetchFlowHistory(flow.getProjectId(), flow
             .getFlowId(), startTime);
       } catch (final ExecutorManagerException e) {
-        logger.error("unable to fetch past executions", e);
+        LOG.error("unable to fetch past executions", e);
       }
     }
 
@@ -209,7 +210,7 @@ public class Emailer extends AbstractMailer implements Alerter {
 
   private MailCreator getMailCreator(final String name) {
     final MailCreator mailCreator = DefaultMailCreator.getCreator(name);
-    logger.debug("ExecutorMailer using mail creator:" + mailCreator.getClass().getCanonicalName());
+    LOG.debug("ExecutorMailer using mail creator:" + mailCreator.getClass().getCanonicalName());
     return mailCreator;
   }
 
@@ -218,10 +219,10 @@ public class Emailer extends AbstractMailer implements Alerter {
     if (mailCreated) {
       try {
         message.sendEmail();
-        logger.info("Sent " + operation);
+        LOG.info("Sent " + operation);
         this.commonMetrics.markSendEmailSuccess();
       } catch (final Exception e) {
-        logger.error("Failed to send " + operation, e);
+        LOG.error("Failed to send " + operation, e);
         if (!(e instanceof AddressException)) {
           this.commonMetrics.markSendEmailFail();
         }

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUser.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUser.java
@@ -19,7 +19,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * This is a wrapper over the binary executable execute-as-user. It provides a simple API to run
@@ -27,8 +29,8 @@ import org.apache.log4j.Logger;
  */
 public class ExecuteAsUser {
 
-  private final static Logger log = Logger.getLogger(ExecuteAsUser.class);
-  private final static String EXECUTE_AS_USER = "execute-as-user";
+  private static final Logger LOG = LoggerFactory.getLogger(ExecuteAsUser.class);
+  private static final String EXECUTE_AS_USER = "execute-as-user";
 
   private final File binaryExecutable;
 
@@ -57,7 +59,7 @@ public class ExecuteAsUser {
    * @return The return value of the shell command
    */
   public int execute(final String user, final List<String> command) throws IOException {
-    log.info("Command: " + command);
+    LOG.info("Command: " + command);
     final Process process = new ProcessBuilder()
         .command(constructExecuteAsCommand(user, command))
         .inheritIO()
@@ -67,7 +69,7 @@ public class ExecuteAsUser {
     try {
       exitCode = process.waitFor();
     } catch (final InterruptedException e) {
-      log.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       exitCode = 1;
     }
     return exitCode;

--- a/azkaban-common/src/main/java/azkaban/utils/ExternalLinkUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExternalLinkUtils.java
@@ -13,18 +13,23 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import azkaban.Constants;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class ExternalLinkUtils {
 
-  private static final Logger logger = Logger.getLogger(ExternalLinkUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExternalLinkUtils.class);
+
+  private ExternalLinkUtils() {
+
+  }
 
   public static String getExternalAnalyzerOnReq(final Props azkProps,
       final HttpServletRequest req) {
@@ -56,7 +61,7 @@ public class ExternalLinkUtils {
       final Props jobProps) {
     String urlTemplate = getURLForTopic(topic, azkProps);
     if (urlTemplate.isEmpty()) {
-      logger.error("No URL specified for topic " + topic);
+      LOG.error("No URL specified for topic " + topic);
       return "";
     }
     final String job = encodeToUTF8(jobId);
@@ -64,7 +69,7 @@ public class ExternalLinkUtils {
         jobProps.getString(Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID));
 
     urlTemplate = urlTemplate.replace("${jobid}", job).replace("${execid}", execid);
-    logger.info("Creating link: " + urlTemplate);
+    LOG.info("Creating link: " + urlTemplate);
     return urlTemplate;
   }
 
@@ -72,7 +77,7 @@ public class ExternalLinkUtils {
       final HttpServletRequest req) {
     String urlTemplate = getURLForTopic(topic, azkProps);
     if (urlTemplate.isEmpty()) {
-      logger.error("No URL specified for topic " + topic);
+      LOG.error("No URL specified for topic " + topic);
       return "";
     }
     String flowExecutionURL = "";
@@ -82,7 +87,7 @@ public class ExternalLinkUtils {
     flowExecutionURL = encodeToUTF8(flowExecutionURL);
 
     urlTemplate = urlTemplate.replace("${url}", flowExecutionURL);
-    logger.info("Creating link: " + urlTemplate);
+    LOG.info("Creating link: " + urlTemplate);
     return urlTemplate;
   }
 
@@ -96,7 +101,7 @@ public class ExternalLinkUtils {
     try {
       return URLEncoder.encode(url, "UTF-8").replaceAll("\\+", "%20");
     } catch (final UnsupportedEncodingException e) {
-      logger.error("Specified encoding is not supported", e);
+      LOG.error("Specified encoding is not supported", e);
     }
     return "";
   }

--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FileIOUtils {
 
-  private static final Logger log = LoggerFactory.getLogger(FileIOUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FileIOUtils.class);
 
   /**
    * Check if a directory is writable
@@ -87,7 +87,7 @@ public class FileIOUtils {
       try {
         FileUtils.deleteDirectory(dir);
       } catch (final IOException e) {
-        log.error("error when deleting dir {}", dir, e);
+        LOG.error("error when deleting dir {}", dir, e);
       }
     }
   }
@@ -105,7 +105,7 @@ public class FileIOUtils {
         .newBufferedWriter(filePath, StandardCharsets.UTF_8)) {
       writer.write(String.valueOf(num));
     } catch (final IOException e) {
-      log.error("Failed to write the number {} to the file {}", num, filePath, e);
+      LOG.error("Failed to write the number {} to the file {}", num, filePath, e);
       throw e;
     }
   }
@@ -153,7 +153,7 @@ public class FileIOUtils {
   public static Props loadOutputFileProps(final File file) {
     InputStream reader = null;
     try {
-      log.info("output properties file=" + file.getAbsolutePath());
+      LOG.info("output properties file=" + file.getAbsolutePath());
       reader = new BufferedInputStream(new FileInputStream(file));
       final Props outputProps = new Props();
       final String content = Streams.asString(reader).trim();
@@ -168,12 +168,12 @@ public class FileIOUtils {
       }
       return outputProps;
     } catch (final FileNotFoundException e) {
-      log.info(
+      LOG.info(
           String.format("File[%s] wasn't found, returning empty props.", file)
       );
       return new Props();
     } catch (final Exception e) {
-      log.error(
+      LOG.error(
           "Exception thrown when trying to load output file props.  Returning empty Props instead of failing. Is this really the best thing to do?",
           e);
       return new Props();

--- a/azkaban-common/src/main/java/azkaban/utils/LogGobbler.java
+++ b/azkaban-common/src/main/java/azkaban/utils/LogGobbler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import com.google.common.base.Joiner;
@@ -22,6 +21,7 @@ import java.io.IOException;
 import java.io.Reader;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+
 
 public class LogGobbler extends Thread {
 
@@ -84,5 +84,4 @@ public class LogGobbler extends Thread {
   public String getRecentLog() {
     return Joiner.on(System.getProperty("line.separator")).join(this.buffer);
   }
-
 }

--- a/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
+++ b/azkaban-common/src/main/java/azkaban/utils/OsMemoryUtil.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 class OsMemoryUtil {
 
-  private static final Logger logger = LoggerFactory.getLogger(OsMemoryUtil.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OsMemoryUtil.class);
 
   // This file is used by Linux. It doesn't exist on Mac for example.
   private static final String MEM_INFO_FILE = "/proc/meminfo";
@@ -61,7 +61,7 @@ class OsMemoryUtil {
       lines = Files.readAllLines(Paths.get(MEM_INFO_FILE), StandardCharsets.UTF_8);
     } catch (final IOException e) {
       final String errMsg = "Failed to open mem info file: " + MEM_INFO_FILE;
-      logger.error(errMsg, e);
+      LOG.error(errMsg, e);
       return 0;
     }
     return getOsTotalFreeMemorySizeFromStrings(lines, memKeysToCombine);
@@ -93,7 +93,7 @@ class OsMemoryUtil {
     if (count != length) {
       final String errMsg = String
           .format("Expect %d keys in the meminfo file. Got %d. content: %s", length, count, lines);
-      logger.error(errMsg);
+      LOG.error(errMsg);
       totalFree = 0;
     }
     return totalFree;
@@ -116,7 +116,7 @@ class OsMemoryUtil {
       return Long.parseLong(sizeString);
     } catch (final NumberFormatException e) {
       final String err = "Failed to parse the meminfo file. Line: " + line;
-      logger.error(err);
+      LOG.error(err);
       return 0;
     }
   }

--- a/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
+++ b/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.IOException;
@@ -33,7 +32,9 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * class handles the communication between the application and a Restful API based web server.
@@ -46,7 +47,7 @@ import org.apache.log4j.Logger;
  */
 public abstract class RestfulApiClient<T> {
 
-  protected static Logger logger = Logger.getLogger(RestfulApiClient.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(RestfulApiClient.class);
 
   /**
    * helper function to build a valid URI.
@@ -117,7 +118,7 @@ public abstract class RestfulApiClient<T> {
   public T httpPost(final URI uri, final List<Pair<String, String>> params) throws IOException {
     // shortcut if the passed url is invalid.
     if (null == uri) {
-      logger.error(" unable to perform httpPost as the passed uri is null.");
+      LOG.error(" unable to perform httpPost as the passed uri is null.");
       return null;
     }
 

--- a/azkaban-common/src/main/java/azkaban/utils/StdOutErrRedirect.java
+++ b/azkaban-common/src/main/java/azkaban/utils/StdOutErrRedirect.java
@@ -13,13 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * A class to encapsulate the redirection of stdout and stderr to log4j This allows us to catch
@@ -28,7 +28,7 @@ import org.apache.log4j.Logger;
 
 public class StdOutErrRedirect {
 
-  private static final Logger logger = Logger.getLogger(StdOutErrRedirect.class);
+  private static final Logger logger = LoggerFactory.getLogger(StdOutErrRedirect.class);
   private static final PrintStream infoStream = createStream(System.out, Level.INFO);
   private static final PrintStream errorStream = createStream(System.out, Level.ERROR);
 
@@ -52,7 +52,11 @@ public class StdOutErrRedirect {
 
     // Underlying mechanism to log to log4j - all print methods will use this
     private void write(final String string) {
-      logger.log(this.level, string);
+      if (Level.INFO.equals(level)) {
+        logger.info(string);
+      } else {
+        logger.error(string);
+      }
     }
 
     // String

--- a/azkaban-common/src/main/java/azkaban/utils/SystemMemoryInfo.java
+++ b/azkaban-common/src/main/java/azkaban/utils/SystemMemoryInfo.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SystemMemoryInfo {
 
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SystemMemoryInfo.class);
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SystemMemoryInfo.class);
   private static final long LOW_MEM_THRESHOLD = 3L * 1024L * 1024L; //3 GB
   private final OsMemoryUtil util;
 
@@ -40,7 +40,7 @@ public class SystemMemoryInfo {
       return true;
     }
     if (freeMemSize - xmx < LOW_MEM_THRESHOLD) {
-      logger.info(String.format(
+      LOG.info(String.format(
           "Free memory amount minus Xmx (%d - %d kb) is less than low mem threshold (%d kb), "
               + "memory request declined.",
           freeMemSize, xmx, LOW_MEM_THRESHOLD));

--- a/azkaban-common/src/main/java/azkaban/utils/TrackingThreadPool.java
+++ b/azkaban-common/src/main/java/azkaban/utils/TrackingThreadPool.java
@@ -22,7 +22,9 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * A simple subclass of {@link ThreadPoolExecutor} to keep track of in progress tasks as well as
@@ -35,7 +37,7 @@ import org.apache.log4j.Logger;
  */
 public class TrackingThreadPool extends ThreadPoolExecutor {
 
-  private static final Logger logger = Logger.getLogger(TrackingThreadPool.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TrackingThreadPool.class);
 
   private final Map<Runnable, Boolean> inProgress =
       new ConcurrentHashMap<>();
@@ -62,7 +64,7 @@ public class TrackingThreadPool extends ThreadPoolExecutor {
       this.executingListener.beforeExecute(r);
     } catch (final Throwable e) {
       // to ensure the listener doesn't cause any issues
-      logger.warn("Listener threw exception", e);
+      LOG.warn("Listener threw exception", e);
     }
     super.beforeExecute(t, r);
     this.inProgress.put(r, Boolean.TRUE);
@@ -82,7 +84,7 @@ public class TrackingThreadPool extends ThreadPoolExecutor {
       this.executingListener.afterExecute(r);
     } catch (final Throwable e) {
       // to ensure the listener doesn't cause any issues
-      logger.warn("Listener threw exception", e);
+      LOG.warn("Listener threw exception", e);
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/InteractiveTestJob.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import static azkaban.flow.CommonJobProperties.JOB_ATTEMPT;
@@ -26,6 +25,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.log4j.Logger;
+
 
 public class InteractiveTestJob extends AbstractProcessJob {
 

--- a/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/executor/JavaJob.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.executor;
 
 import azkaban.jobExecutor.JavaProcessJob;
@@ -21,8 +20,8 @@ import azkaban.utils.FileIOUtils;
 import azkaban.utils.Props;
 import java.io.File;
 import java.util.List;
-import java.util.StringTokenizer;
 import org.apache.log4j.Logger;
+
 
 public class JavaJob extends JavaProcessJob {
 

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -33,7 +33,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Used in unit tests to mock the "DB layer" (the real implementation is JdbcExecutorLoader).
@@ -41,7 +42,7 @@ import org.apache.log4j.Logger;
  */
 public class MockExecutorLoader implements ExecutorLoader {
 
-  private static final Logger logger = Logger.getLogger(MockExecutorLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MockExecutorLoader.class);
 
   Map<Integer, Integer> executionExecutorMapping = new ConcurrentHashMap<>();
   Map<Integer, ExecutableFlow> flows = new ConcurrentHashMap<>();
@@ -141,7 +142,7 @@ public class MockExecutorLoader implements ExecutorLoader {
     for (final File file : files) {
       try {
         final String logs = FileUtils.readFileToString(file, "UTF-8");
-        logger.info("Uploaded log for [" + name + "]:[" + execId + "]:\n" + logs);
+        LOG.info("Uploaded log for [" + name + "]:[" + execId + "]:\n" + logs);
       } catch (final IOException e) {
         throw new RuntimeException(e);
       }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/ProcessJobTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -241,7 +240,7 @@ public class ProcessJobTest {
         Thread.sleep(10);
         super.run();
       } catch (final Exception ex) {
-        this.getLog().error(ex);
+        this.getLog().error("Job Process Failure", ex);
       }
     }
   }

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/WordCountLocal.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobExecutor;
 
 import azkaban.utils.Props;

--- a/azkaban-common/src/test/java/azkaban/jobtype/FakeJavaJob.java
+++ b/azkaban-common/src/test/java/azkaban/jobtype/FakeJavaJob.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.utils.Props;
 import org.apache.log4j.Logger;
+
 
 public class FakeJavaJob extends JavaProcessJob {
 

--- a/azkaban-common/src/test/java/azkaban/jobtype/FakeJavaJob2.java
+++ b/azkaban-common/src/test/java/azkaban/jobtype/FakeJavaJob2.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import azkaban.jobExecutor.JavaProcessJob;
 import azkaban.utils.Props;
 import org.apache.log4j.Logger;
+
 
 public class FakeJavaJob2 extends JavaProcessJob {
 

--- a/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.jobtype;
 
 import static azkaban.test.Utils.initServiceProvider;
@@ -35,6 +34,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 
 /**
  * Test the flow run, especially with embedded flows. Files are in unit/plugins/jobtypes

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class DirectoryYamlFlowLoaderTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoaderTest
+  private static final Logger LOG = LoggerFactory.getLogger(DirectoryYamlFlowLoaderTest
       .class);
 
   private static final String BASIC_FLOW_YAML_DIR = "basicflowyamltest";
@@ -226,7 +226,7 @@ public class DirectoryYamlFlowLoaderTest {
     assertThat(loader.getEdgeMap().get(flowName).size()).isEqualTo(numEdge);
     assertThat(flow.getEdges().size()).isEqualTo(numEdge);
     for (final Edge edge : loader.getEdgeMap().get(flowName)) {
-      this.logger.info(flowName + ".flow has edge: " + edge.getId());
+      this.LOG.info(flowName + ".flow has edge: " + edge.getId());
       if (edge.getError() != null) {
         assertThat(edge.getError()).isEqualTo(edgeError);
       }

--- a/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/LocalStorageTest.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.storage;
 
 import static org.junit.Assert.assertNotNull;
@@ -30,10 +29,11 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class LocalStorageTest {
@@ -41,7 +41,7 @@ public class LocalStorageTest {
   static final String SAMPLE_FILE = "sample_flow_01.zip";
   static final String LOCAL_STORAGE = "LOCAL_STORAGE";
   static final File BASE_DIRECTORY = new File(LOCAL_STORAGE);
-  private static final Logger log = Logger.getLogger(LocalStorageTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStorageTest.class);
   private LocalStorage localStorage;
 
   @Before
@@ -67,7 +67,7 @@ public class LocalStorageTest {
         1, 1, "testuser", Md5Hasher.md5Hash(testFile));
     final String key = this.localStorage.put(metadata, testFile);
     assertNotNull(key);
-    log.info("Key URI: " + key);
+    LOG.info("Key URI: " + key);
 
     final File expectedTargetFile = new File(BASE_DIRECTORY, new StringBuilder()
         .append(metadata.getProjectId())

--- a/azkaban-common/src/test/java/azkaban/utils/PatternLayoutEscapedTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/PatternLayoutEscapedTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.utils;
 
 import static org.junit.Assert.assertTrue;
@@ -24,6 +23,7 @@ import org.apache.log4j.PatternLayout;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.Before;
 import org.junit.Test;
+
 
 /**
  * Test output of PatternLayoutEscapedTest It should be appending stack traces, escaping new lines,

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseOperator.java
@@ -24,7 +24,9 @@ import javax.inject.Inject;
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * This interface is to define Base Data Access Object contract for Azkaban. All azkaban DB related
@@ -35,7 +37,7 @@ import org.apache.log4j.Logger;
  */
 public class DatabaseOperator {
 
-  private static final Logger logger = Logger.getLogger(DatabaseOperator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DatabaseOperator.class);
 
   private final QueryRunner queryRunner;
 
@@ -55,7 +57,6 @@ public class DatabaseOperator {
    * Executes the given Azkaban related SELECT SQL operations. it will call
    * {@link AzkabanDataSource#getConnection()} inside queryrunner.query.
    *
-   * @param sqlQuery The SQL query statement to execute.
    * @param resultHandler The handler used to create the result object
    * @param params Initialize the PreparedStatement's IN parameters
    * @param <T> The type of object that the qeury handler returns
@@ -68,7 +69,7 @@ public class DatabaseOperator {
       return this.queryRunner.query(baseQuery, resultHandler, params);
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
-      logger.error("query failed", ex);
+      LOG.error("query failed", ex);
       if (this.dbMetrics != null) {
         this.dbMetrics.markDBFailQuery();
       }
@@ -97,7 +98,7 @@ public class DatabaseOperator {
       return res;
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
-      logger.error("transaction failed", ex);
+      LOG.error("transaction failed", ex);
       if (this.dbMetrics != null) {
         this.dbMetrics.markDBFailTransaction();
       }
@@ -121,7 +122,7 @@ public class DatabaseOperator {
       return this.queryRunner.update(updateClause, params);
     } catch (final SQLException ex) {
       // todo kunkun-tang: Retry logics should be implemented here.
-      logger.error("update failed", ex);
+      LOG.error("update failed", ex);
       if (this.dbMetrics != null) {
         this.dbMetrics.markDBFailUpdate();
       }

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseSetup.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseSetup.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.db;
 
 import java.io.BufferedInputStream;
@@ -27,7 +26,9 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Creates DB tables. The input to this class is a folder path, which includes all create table
@@ -39,7 +40,7 @@ import org.apache.log4j.Logger;
  */
 public class DatabaseSetup {
 
-  private static final Logger logger = Logger .getLogger(DatabaseSetup.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DatabaseSetup.class);
   private static final String CREATE_SCRIPT_PREFIX = "create.";
   private static final String SQL_SCRIPT_SUFFIX = ".sql";
 
@@ -88,7 +89,7 @@ public class DatabaseSetup {
 
   private void runTableScripts(final Connection conn, final String table)
       throws IOException, SQLException {
-    logger.info("Creating new table " + table);
+    LOG.info("Creating new table " + table);
 
     final String dbSpecificScript = "create." + table + ".sql";
     final File script = new File(this.scriptPath, dbSpecificScript);

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
@@ -21,7 +21,8 @@ import java.sql.SQLException;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.dbutils.handlers.ScalarHandler;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -38,7 +39,7 @@ import org.apache.log4j.Logger;
  */
 public class DatabaseTransOperator {
 
-  private static final Logger logger = Logger.getLogger(DatabaseTransOperator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DatabaseTransOperator.class);
   private final Connection conn;
   private final QueryRunner queryRunner;
 
@@ -61,7 +62,7 @@ public class DatabaseTransOperator {
           .query(this.conn, "SELECT LAST_INSERT_ID();", new ScalarHandler<>(1)))
           .longValue();
     } catch (final SQLException ex) {
-      logger.error("can not get last insertion ID");
+      LOG.error("can not get last insertion ID");
       throw ex;
     }
     return num;

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -23,12 +23,14 @@ import java.sql.Statement;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @Singleton
 public class MySQLDataSource extends AzkabanDataSource {
 
-  private static final Logger logger = Logger.getLogger(MySQLDataSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MySQLDataSource.class);
   private final DBMetrics dbMetrics;
 
   @Inject
@@ -98,9 +100,9 @@ public class MySQLDataSource extends AzkabanDataSource {
         try {
           invalidateConnection(connection);
         } catch (final Exception e) {
-          logger.error( "can not invalidate connection.", e);
+          LOG.error( "can not invalidate connection.", e);
         }
-        logger.error( "Failed to find write-enabled DB connection. Wait 15 seconds and retry."
+        LOG.error( "Failed to find write-enabled DB connection. Wait 15 seconds and retry."
             + " No.Attempt = " + retryAttempt, ex);
         /**
          * When database is completed down, DB connection fails to be fetched immediately. So we need
@@ -127,7 +129,7 @@ public class MySQLDataSource extends AzkabanDataSource {
     try {
       Thread.sleep(milliseconds);
     } catch (final InterruptedException e) {
-      logger.error("Sleep interrupted", e);
+      LOG.error("Sleep interrupted", e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/dag/Dag.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/Dag.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
 
 import static java.util.Objects.requireNonNull;
@@ -21,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * A DAG (Directed acyclic graph) consists of {@link Node}s.

--- a/azkaban-exec-server/src/main/java/azkaban/dag/DagBuilder.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/DagBuilder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
 
 import static java.util.Objects.requireNonNull;
@@ -25,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 
 /**
  * A builder to build DAGs.

--- a/azkaban-exec-server/src/main/java/azkaban/dag/DagException.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/DagException.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
+
 
 public class DagException extends RuntimeException {
 

--- a/azkaban-exec-server/src/main/java/azkaban/dag/DagProcessor.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/DagProcessor.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
+
 
 public interface DagProcessor {
 

--- a/azkaban-exec-server/src/main/java/azkaban/dag/DagService.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/DagService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
 
 import azkaban.utils.ExecutorServiceUtils;
@@ -28,6 +27,7 @@ import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Thread safe and non blocking service for DAG processing.
  *
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class DagService {
 
   private static final Duration SHUTDOWN_WAIT_TIMEOUT = Duration.ofSeconds(10);
-  private static final Logger logger = LoggerFactory.getLogger(DagService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DagService.class);
 
   private final ExecutorServiceUtils executorServiceUtils;
   private final ExecutorService executorService;
@@ -89,7 +89,7 @@ public class DagService {
    * Shuts down the service and waits for the tasks to finish.
    */
   public void shutdownAndAwaitTermination() throws InterruptedException {
-    logger.info("DagService is shutting down.");
+    LOG.info("DagService is shutting down.");
     this.executorServiceUtils.gracefulShutdown(this.executorService, SHUTDOWN_WAIT_TIMEOUT);
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/dag/Node.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/Node.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
 
 import static java.util.Objects.requireNonNull;
@@ -21,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * Node in a DAG: Directed acyclic graph.

--- a/azkaban-exec-server/src/main/java/azkaban/dag/NodeProcessor.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/NodeProcessor.java
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
+
 
 public interface NodeProcessor {
 

--- a/azkaban-exec-server/src/main/java/azkaban/dag/Status.java
+++ b/azkaban-exec-server/src/main/java/azkaban/dag/Status.java
@@ -13,10 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.dag;
 
 import com.google.common.collect.ImmutableSet;
+
 
 public enum Status {
   READY, // ready to run

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.execapp;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EVENT_REPORTING_CLASS_PARAM;
@@ -30,7 +29,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * This Guice module is currently a one place container for all bindings in the current module. This
@@ -39,7 +40,7 @@ import org.apache.log4j.Logger;
  */
 public class AzkabanExecServerModule extends AbstractModule {
 
-  private static final Logger logger = Logger.getLogger(AzkabanExecServerModule.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanExecServerModule.class);
 
   @Override
   protected void configure() {
@@ -55,27 +56,27 @@ public class AzkabanExecServerModule extends AbstractModule {
         props.getBoolean(AZKABAN_EVENT_REPORTING_ENABLED, false);
 
     if (!eventReporterEnabled) {
-      logger.info("Event reporter is not enabled");
+      LOG.info("Event reporter is not enabled");
       return null;
     }
 
     final Class<?> eventReporterClass =
         props.getClass(AZKABAN_EVENT_REPORTING_CLASS_PARAM, null);
     if (eventReporterClass != null && eventReporterClass.getConstructors().length > 0) {
-      this.logger.info("Loading event reporter class " + eventReporterClass.getName());
+      LOG.info("Loading event reporter class " + eventReporterClass.getName());
       try {
         final Constructor<?> eventReporterClassConstructor =
             eventReporterClass.getConstructor(Props.class);
         return (AzkabanEventReporter) eventReporterClassConstructor.newInstance(props);
       } catch (final InvocationTargetException e) {
-        this.logger.error(e.getTargetException().getMessage());
+        LOG.error(e.getTargetException().getMessage());
         if (e.getTargetException() instanceof IllegalArgumentException) {
           throw new IllegalArgumentException(e);
         } else {
           throw new RuntimeException(e);
         }
       } catch (final Exception e) {
-        this.logger.error("Could not instantiate EventReporter " + eventReporterClass.getName());
+        LOG.error("Could not instantiate EventReporter " + eventReporterClass.getName());
         throw new RuntimeException(e);
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecJettyServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecJettyServerModule.java
@@ -6,12 +6,14 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
 import org.mortbay.thread.QueuedThreadPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class ExecJettyServerModule extends AbstractModule {
 
@@ -22,7 +24,7 @@ public class ExecJettyServerModule extends AbstractModule {
   private static final int DEFAULT_HEADER_BUFFER_SIZE = 4096;
   private static final int MAX_FORM_CONTENT_SIZE = 10 * 1024 * 1024;
 
-  private static final Logger logger = Logger.getLogger(ExecJettyServerModule.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ExecJettyServerModule.class);
 
   @Override
   protected void configure() {
@@ -44,16 +46,16 @@ public class ExecJettyServerModule extends AbstractModule {
     server.setThreadPool(httpThreadPool);
 
     final boolean isStatsOn = props.getBoolean("executor.connector.stats", true);
-    logger.info("Setting up connector with stats on: " + isStatsOn);
+    LOG.info("Setting up connector with stats on: " + isStatsOn);
 
     for (final Connector connector : server.getConnectors()) {
       connector.setStatsOn(isStatsOn);
-      logger.info(String.format(
+      LOG.info(String.format(
           "Jetty connector name: %s, default header buffer size: %d",
           connector.getName(), connector.getHeaderBufferSize()));
       connector.setHeaderBufferSize(props.getInt("jetty.headerBufferSize",
           DEFAULT_HEADER_BUFFER_SIZE));
-      logger.info(String.format(
+      LOG.info(String.format(
           "Jetty connector name: %s, (if) new header buffer size: %d",
           connector.getName(), connector.getHeaderBufferSize()));
     }
@@ -74,5 +76,4 @@ public class ExecJettyServerModule extends AbstractModule {
     root.addServlet(new ServletHolder(new ServerStatisticsServlet()), "/serverStatistics");
     return root;
   }
-
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -47,7 +47,7 @@ class FlowPreparer {
   // Name of the file which keeps project directory size
   static final String PROJECT_DIR_SIZE_FILE_NAME = "___azkaban_project_dir_size_in_bytes___";
 
-  private static final Logger log = LoggerFactory.getLogger(FlowPreparer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FlowPreparer.class);
 
   // TODO spyne: move to config class
   private final File executionsDir;
@@ -137,18 +137,18 @@ class FlowPreparer {
         final long start = System.currentTimeMillis();
         execDir = setupExecutionDir(project.getInstalledDir(), flow);
         final long end = System.currentTimeMillis();
-        log.info("Setting up execution dir {} took {} sec(s)", execDir, (end - start) / 1000);
+        LOG.info("Setting up execution dir {} took {} sec(s)", execDir, (end - start) / 1000);
       }
 
       final long flowPrepCompletionTime = System.currentTimeMillis();
-      log.info("Flow preparation completed in {} sec(s), out ot which {} sec(s) was spent inside "
+      LOG.info("Flow preparation completed in {} sec(s), out ot which {} sec(s) was spent inside "
               + "critical section. [execid: {}, path: {}]",
           (flowPrepCompletionTime - flowPrepStartTime) / 1000,
           (flowPrepCompletionTime - criticalSectionStartTime) / 1000,
           flow.getExecutionId(), execDir.getPath());
     } catch (final Exception ex) {
       FileIOUtils.deleteDirectorySilently(tempDir);
-      log.error("Error in preparing flow execution {}", flow.getExecutionId(), ex);
+      LOG.error("Error in preparing flow execution {}", flow.getExecutionId(), ex);
       throw new ExecutorManagerException(ex);
     } finally {
       if (projectFileHandler != null) {
@@ -181,7 +181,7 @@ class FlowPreparer {
     try {
       Files.setLastModifiedTime(path, FileTime.fromMillis(System.currentTimeMillis()));
     } catch (final IOException ex) {
-      log.warn("Error when updating last modified time for {}", path, ex);
+      LOG.warn("Error when updating last modified time for {}", path, ex);
     }
   }
 
@@ -232,7 +232,7 @@ class FlowPreparer {
 
     // If directory exists, assume it's prepared and skip.
     if (proj.getInstalledDir().exists()) {
-      log.info("Project {} already cached. Skipping download. ExecId: {}", proj, execId);
+      LOG.info("Project {} already cached. Skipping download. ExecId: {}", proj, execId);
       // Hit the local cache.
       this.projectCacheHitRatio.markHit();
       // Update last modified time of the file keeping project dir size when the project is
@@ -251,7 +251,7 @@ class FlowPreparer {
     final File tempDir = createTempDir(proj);
     downloadAndUnzipProject(proj, tempDir);
 
-    log.info("Downloading zip file for project {} when preparing execution [execid {}] "
+    LOG.info("Downloading zip file for project {} when preparing execution [execid {}] "
             + "completed in {} second(s)", proj, execId,
         (System.currentTimeMillis() - start) / 1000);
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_HOST_NAME;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -105,7 +104,7 @@ import org.apache.log4j.Logger;
 public class FlowRunnerManager implements EventListener,
     ThreadPoolExecutingListener {
 
-  private static final Logger logger = Logger.getLogger(FlowRunnerManager.class);
+  private static final Logger LOG = Logger.getLogger(FlowRunnerManager.class);
 
   private static final String EXECUTOR_USE_BOUNDED_THREADPOOL_QUEUE = "executor.use.bounded.threadpool.queue";
   private static final String EXECUTOR_THREADPOOL_WORKQUEUE_SIZE = "executor.threadpool.workqueue.size";
@@ -174,7 +173,7 @@ public class FlowRunnerManager implements EventListener,
     this.executionDirRetention = props.getLong("execution.dir.retention",
         this.executionDirRetention);
     this.azkabanEventReporter = azkabanEventReporter;
-    logger.info("Execution dir retention set to " + this.executionDirRetention + " ms");
+    LOG.info("Execution dir retention set to " + this.executionDirRetention + " ms");
 
     this.executionDirectory = new File(props.getString("azkaban.execution.dir", "executions"));
     if (!this.executionDirectory.exists()) {
@@ -232,7 +231,7 @@ public class FlowRunnerManager implements EventListener,
     this.cleanerThread.start();
 
     if (this.azkabanProps.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
-      this.logger.info("Starting polling service.");
+      LOG.info("Starting polling service.");
       this.pollingService = new PollingService(this.azkabanProps
           .getLong(ConfigurationKeys.AZKABAN_POLLING_INTERVAL_MS,
               Constants.DEFAULT_AZKABAN_POLLING_INTERVAL_MS),
@@ -254,7 +253,7 @@ public class FlowRunnerManager implements EventListener,
    * Windows.
    */
   private void setgidPermissionOnExecutionDirectory() throws IOException {
-    logger.info("Creating subprocess to run shell command: chmod g+s "
+    LOG.info("Creating subprocess to run shell command: chmod g+s "
         + this.executionDirectory.toString());
     Runtime.getRuntime().exec("chmod g+s " + this.executionDirectory.toString());
   }
@@ -262,12 +261,12 @@ public class FlowRunnerManager implements EventListener,
   private TrackingThreadPool createExecutorService(final int nThreads) {
     final boolean useNewThreadPool =
         this.azkabanProps.getBoolean(EXECUTOR_USE_BOUNDED_THREADPOOL_QUEUE, false);
-    logger.info("useNewThreadPool: " + useNewThreadPool);
+    LOG.info("useNewThreadPool: " + useNewThreadPool);
 
     if (useNewThreadPool) {
       this.threadPoolQueueSize =
           this.azkabanProps.getInt(EXECUTOR_THREADPOOL_WORKQUEUE_SIZE, nThreads);
-      logger.info("workQueueSize: " + this.threadPoolQueueSize);
+      LOG.info("workQueueSize: " + this.threadPoolQueueSize);
 
       // using a bounded queue for the work queue. The default rejection policy
       // {@ThreadPoolExecutor.AbortPolicy} is used
@@ -293,7 +292,7 @@ public class FlowRunnerManager implements EventListener,
       executor.setActive(isActive);
       this.executorLoader.updateExecutor(executor);
     } else {
-      logger.info(
+      LOG.info(
           "Set active action ignored. Executor is already " + (isActive ? "active" : "inactive"));
     }
     this.active = isActive;
@@ -315,7 +314,7 @@ public class FlowRunnerManager implements EventListener,
   private void waitUntilFlowPreparationFinish() throws InterruptedException {
     final Duration SLEEP_INTERVAL = Duration.ofSeconds(5);
     while (this.preparingFlowCount.intValue() != 0) {
-      logger.info(this.preparingFlowCount + " flow(s) is/are still being setup before complete "
+      LOG.info(this.preparingFlowCount + " flow(s) is/are still being setup before complete "
           + "deactivation.");
       Thread.sleep(SLEEP_INTERVAL.toMillis());
     }
@@ -352,7 +351,7 @@ public class FlowRunnerManager implements EventListener,
 
   private boolean isAlreadyRunning(final int execId) throws ExecutorManagerException {
     if (this.runningFlows.containsKey(execId)) {
-      logger.info("Execution " + execId + " is already in running.");
+      LOG.info("Execution " + execId + " is already in running.");
       if (!this.submittedFlows.containsValue(execId)) {
         // Execution had been added to running flows but not submitted - something's wrong.
         // Return a response with error: this is a cue for the dispatcher to retry or finalize the
@@ -479,7 +478,7 @@ public class FlowRunnerManager implements EventListener,
    * Configure Azkaban metrics tracking for a new flowRunner instance
    */
   private void configureFlowLevelMetrics(final FlowRunner flowRunner) {
-    logger.info("Configuring Azkaban metrics tracking for flow runner object");
+    LOG.info("Configuring Azkaban metrics tracking for flow runner object");
 
     if (MetricReportManager.isAvailable()) {
       final MetricReportManager metricManager = MetricReportManager.getInstance();
@@ -501,7 +500,7 @@ public class FlowRunnerManager implements EventListener,
 
     for (final JobRunner jobRunner : flowRunner.getActiveJobRunners()) {
       if (jobRunner.getJobId().equals(jobId)) {
-        logger.info("Killing job " + jobId + " in execution " + execId + " by SLA");
+        LOG.info("Killing job " + jobId + " in execution " + execId + " by SLA");
         jobRunner.killBySLA();
         break;
       }
@@ -572,7 +571,7 @@ public class FlowRunnerManager implements EventListener,
 
       if (event.getType() == EventType.FLOW_FINISHED) {
         this.recentlyFinishedFlows.put(flow.getExecutionId(), flow);
-        logger.info("Flow " + flow.getExecutionId()
+        LOG.info("Flow " + flow.getExecutionId()
             + " is finished. Adding it to recently finished flows list.");
         this.runningFlows.remove(flow.getExecutionId());
       } else if (event.getType() == EventType.FLOW_STARTED) {
@@ -756,7 +755,7 @@ public class FlowRunnerManager implements EventListener,
       if (execId != null) {
         runningFlowIds.add(execId);
       } else {
-        logger.warn("getRunningFlowIds: got null execId for task: " + task);
+        LOG.warn("getRunningFlowIds: got null execId for task: " + task);
       }
     }
 
@@ -773,8 +772,7 @@ public class FlowRunnerManager implements EventListener,
       if (execId != null) {
         flowIdList.add(execId);
       } else {
-        logger
-            .warn("getQueuedFlowIds: got null execId for queuedTask: " + task);
+        LOG.warn("getQueuedFlowIds: got null execId for queuedTask: " + task);
       }
     }
     Collections.sort(flowIdList);
@@ -810,21 +808,21 @@ public class FlowRunnerManager implements EventListener,
    * This shuts down the flow runner. The call is blocking and awaits execution of all jobs.
    */
   public void shutdown() {
-    logger.warn("Shutting down FlowRunnerManager...");
+    LOG.warn("Shutting down FlowRunnerManager...");
     if (this.azkabanProps.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
       this.pollingService.shutdown();
     }
     this.executorService.shutdown();
     boolean result = false;
     while (!result) {
-      logger.info("Awaiting Shutdown. # of executing flows: " + getNumRunningFlows());
+      LOG.info("Awaiting Shutdown. # of executing flows: " + getNumRunningFlows());
       try {
         result = this.executorService.awaitTermination(1, TimeUnit.MINUTES);
       } catch (final InterruptedException e) {
-        logger.error(e);
+        LOG.error(e);
       }
     }
-    logger.warn("Shutdown FlowRunnerManager complete.");
+    LOG.warn("Shutdown FlowRunnerManager complete.");
   }
 
   /**
@@ -832,7 +830,7 @@ public class FlowRunnerManager implements EventListener,
    * finish but interrupts all threads.
    */
   public void shutdownNow() {
-    logger.warn("Shutting down FlowRunnerManager now...");
+    LOG.warn("Shutting down FlowRunnerManager now...");
     if (this.azkabanProps.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
       this.pollingService.shutdown();
     }
@@ -844,11 +842,11 @@ public class FlowRunnerManager implements EventListener,
    * Deleting old execution directory to free disk space.
    */
   public void deleteExecutionDirectory() {
-    logger.warn("Deleting execution dir: " + this.executionDirectory.getAbsolutePath());
+    LOG.warn("Deleting execution dir: " + this.executionDirectory.getAbsolutePath());
     try {
       FileUtils.deleteDirectory(this.executionDirectory);
     } catch (final IOException e) {
-      logger.error(e);
+      LOG.error(e);
     }
   }
 
@@ -903,18 +901,18 @@ public class FlowRunnerManager implements EventListener,
         synchronized (this) {
           try {
             FlowRunnerManager.this.lastCleanerThreadCheckTime = System.currentTimeMillis();
-            FlowRunnerManager.logger.info("# of executing flows: " + getNumRunningFlows());
+            FlowRunnerManager.LOG.info("# of executing flows: " + getNumRunningFlows());
 
             // Cleanup old stuff.
             final long currentTime = System.currentTimeMillis();
             if (currentTime - RECENTLY_FINISHED_INTERVAL_MS > this.lastRecentlyFinishedCleanTime) {
-              FlowRunnerManager.logger.info("Cleaning recently finished");
+              FlowRunnerManager.LOG.info("Cleaning recently finished");
               cleanRecentlyFinished();
               this.lastRecentlyFinishedCleanTime = currentTime;
             }
 
             if (currentTime - EXECUTION_DIR_CLEAN_INTERVAL_MS > this.lastExecutionDirCleanTime) {
-              FlowRunnerManager.logger.info("Cleaning old execution dirs");
+              FlowRunnerManager.LOG.info("Cleaning old execution dirs");
               cleanOlderExecutionDirs();
               this.lastExecutionDirCleanTime = currentTime;
             }
@@ -922,13 +920,13 @@ public class FlowRunnerManager implements EventListener,
             if (this.flowMaxRunningTimeInMins > 0
                 && currentTime - LONG_RUNNING_FLOW_KILLING_INTERVAL_MS
                 > this.lastLongRunningFlowCleanTime) {
-              FlowRunnerManager.logger
+              FlowRunnerManager.LOG
                   .info(String.format("Killing long jobs running longer than %s mins",
                       this.flowMaxRunningTimeInMins));
               for (final FlowRunner flowRunner : FlowRunnerManager.this.runningFlows.values()) {
                 if (isFlowRunningLongerThan(flowRunner.getExecutableFlow(),
                     this.flowMaxRunningTimeInMins)) {
-                  FlowRunnerManager.logger.info(String
+                  FlowRunnerManager.LOG.info(String
                       .format("Killing job [id: %s, status: %s]. It has been running for %s mins",
                           flowRunner.getExecutableFlow().getId(),
                           flowRunner.getExecutableFlow().getStatus(), TimeUnit.MILLISECONDS
@@ -942,9 +940,9 @@ public class FlowRunnerManager implements EventListener,
 
             wait(FlowRunnerManager.RECENTLY_FINISHED_TIME_TO_LIVE);
           } catch (final InterruptedException e) {
-            FlowRunnerManager.logger.info("Interrupted. Probably to shut down.");
+            FlowRunnerManager.LOG.info("Interrupted. Probably to shut down.");
           } catch (final Throwable t) {
-            FlowRunnerManager.logger.warn(
+            FlowRunnerManager.LOG.warn(
                 "Uncaught throwable, please look into why it is not caught", t);
           }
         }
@@ -968,7 +966,7 @@ public class FlowRunnerManager implements EventListener,
             continue;
           }
         } catch (final NumberFormatException e) {
-          FlowRunnerManager.logger.error("Can't delete exec dir " + exDir.getName()
+          FlowRunnerManager.LOG.error("Can't delete exec dir " + exDir.getName()
               + " it is not a number");
           continue;
         }
@@ -977,7 +975,7 @@ public class FlowRunnerManager implements EventListener,
           try {
             FileUtils.deleteDirectory(exDir);
           } catch (final IOException e) {
-            FlowRunnerManager.logger.error("Error cleaning execution dir " + exDir.getPath(), e);
+            FlowRunnerManager.LOG.error("Error cleaning execution dir " + exDir.getPath(), e);
           }
         }
       }
@@ -994,7 +992,7 @@ public class FlowRunnerManager implements EventListener,
       }
 
       for (final Integer id : executionToKill) {
-        FlowRunnerManager.logger.info("Cleaning execution " + id
+        FlowRunnerManager.LOG.info("Cleaning execution " + id
             + " from recently finished flows list.");
         FlowRunnerManager.this.recentlyFinishedFlows.remove(id);
       }
@@ -1032,7 +1030,7 @@ public class FlowRunnerManager implements EventListener,
                     AzkabanExecutorServer.getApp().getPort()), "The executor can not be null");
             this.executorId = executor.getId();
           } catch (final Exception e) {
-            FlowRunnerManager.logger.error("Failed to fetch executor ", e);
+            FlowRunnerManager.LOG.error("Failed to fetch executor ", e);
           }
         }
       } else if (this.pollingCriteria.shouldPoll()) {
@@ -1040,12 +1038,12 @@ public class FlowRunnerManager implements EventListener,
           final int execId = FlowRunnerManager.this.executorLoader
               .selectAndUpdateExecution(this.executorId, FlowRunnerManager.this.active);
           if (execId != -1) {
-            FlowRunnerManager.logger.info("Submitting flow " + execId);
+            FlowRunnerManager.LOG.info("Submitting flow " + execId);
             submitFlow(execId);
             FlowRunnerManager.this.commonMetrics.markDispatchSuccess();
           }
         } catch (final Exception e) {
-          FlowRunnerManager.logger.error("Failed to submit flow ", e);
+          FlowRunnerManager.LOG.error("Failed to submit flow ", e);
           FlowRunnerManager.this.commonMetrics.markDispatchFail();
         }
       }
@@ -1093,10 +1091,10 @@ public class FlowRunnerManager implements EventListener,
       if (this.areFlowThreadsAvailable != flowThreadsAvailable) {
         this.areFlowThreadsAvailable = flowThreadsAvailable;
         if (flowThreadsAvailable) {
-          FlowRunnerManager.logger.info("Polling criteria satisfied: available flow threads (" +
+          FlowRunnerManager.LOG.info("Polling criteria satisfied: available flow threads (" +
               remainingFlowThreads + ").");
         } else {
-          FlowRunnerManager.logger.info("Polling criteria NOT satisfied: available flow threads (" +
+          FlowRunnerManager.LOG.info("Polling criteria NOT satisfied: available flow threads (" +
               remainingFlowThreads + ").");
         }
       }
@@ -1118,9 +1116,9 @@ public class FlowRunnerManager implements EventListener,
       if (this.isFreeMemoryAvailable != haveEnoughMemory) {
         this.isFreeMemoryAvailable = haveEnoughMemory;
         if (haveEnoughMemory) {
-          FlowRunnerManager.logger.info("Polling criteria satisfied: available free memory.");
+          FlowRunnerManager.LOG.info("Polling criteria satisfied: available free memory.");
         } else {
-          FlowRunnerManager.logger.info("Polling criteria NOT satisfied: available free memory.");
+          FlowRunnerManager.LOG.info("Polling criteria NOT satisfied: available free memory.");
         }
       }
 
@@ -1144,10 +1142,10 @@ public class FlowRunnerManager implements EventListener,
       if (this.isCpuLoadUnderMax != cpuLoadWithinParams) {
         this.isCpuLoadUnderMax = cpuLoadWithinParams;
         if (cpuLoadWithinParams) {
-          FlowRunnerManager.logger.info("Polling criteria satisfied: Cpu utilization (" +
+          FlowRunnerManager.LOG.info("Polling criteria satisfied: Cpu utilization (" +
               cpuLoad + "%).");
         } else {
-          FlowRunnerManager.logger.info("Polling criteria NOT satisfied: Cpu utilization (" +
+          FlowRunnerManager.LOG.info("Polling criteria NOT satisfied: Cpu utilization (" +
               cpuLoad + "%).");
         }
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JMXHttpServlet.java
@@ -27,17 +27,15 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
 
 
 public class JMXHttpServlet extends HttpServlet implements ConnectorParams {
 
   private static final long serialVersionUID = -3085603824826446270L;
-  private static final Logger logger = Logger.getLogger(JMXHttpServlet.class);
   private AzkabanExecutorServer server;
 
   @Override
-  public void init(final ServletConfig config) throws ServletException {
+  public void init(final ServletConfig config) {
     this.server =
         (AzkabanExecutorServer) config.getServletContext().getAttribute(
             Constants.AZKABAN_SERVLET_CONTEXT_KEY);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.Constants;
@@ -61,7 +60,7 @@ public class JobRunner extends EventHandler implements Runnable {
 
   public static final String AZKABAN_WEBSERVER_URL = "azkaban.webserver.url";
 
-  private static final Logger serverLogger = Logger.getLogger(JobRunner.class);
+  private static final Logger LOG = Logger.getLogger(JobRunner.class);
   private static final Object logCreatorLock = new Object();
 
   private static final String DEFAULT_LAYOUT =
@@ -562,7 +561,7 @@ public class JobRunner extends EventHandler implements Runnable {
     try {
       doRun();
     } catch (final Exception e) {
-      serverLogger.error("Unexpected exception", e);
+      LOG.error("Unexpected exception", e);
       throw e;
     }
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectDirectoryMetadata.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectDirectoryMetadata.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ServerStatisticsServlet.java
@@ -25,14 +25,15 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ServerStatisticsServlet extends HttpServlet {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ServerStatisticsServlet.class);
   private static final long serialVersionUID = 1L;
   private static final int cacheTimeInMilliseconds = 1000;
-  private static final Logger logger = Logger.getLogger(ServerStatisticsServlet.class);
   private static final String noCacheParamName = "nocache";
   private static final boolean exists_Bash = new File("/bin/bash").exists();
   private static final boolean exists_Cat = new File("/bin/cat").exists();
@@ -135,7 +136,7 @@ public class ServerStatisticsServlet extends HttpServlet {
             }
           }
         } else {
-          logger.error(
+          LOG.error(
               "failed to get total/free memory info as the bash call returned invalid result."
                   + String.format(" Output from the bash call - %s ", output.toString()));
         }
@@ -145,12 +146,12 @@ public class ServerStatisticsServlet extends HttpServlet {
         stats.setRemainingMemoryPercent(
             totalMemory == 0 ? 0 : ((double) totalFreeMemory / (double) totalMemory) * 100);
       } catch (final Exception ex) {
-        logger.error("failed fetch system memory info "
+        LOG.error("failed fetch system memory info "
             + "as exception is captured when fetching result from bash call. Ex -" + ex
             .getMessage());
       }
     } else {
-      logger.error(
+      LOG.error(
           "failed fetch system memory info, one or more files from the following list are missing -  "
               + "'/bin/bash'," + "'/bin/cat'," + "'/proc/loadavg'");
     }
@@ -162,10 +163,10 @@ public class ServerStatisticsServlet extends HttpServlet {
         && result.split("\\s+").length > 2) {
       try {
         returnResult = Long.parseLong(result.split("\\s+")[1]);
-        logger.debug(field + ":" + returnResult);
+        LOG.debug(field + ":" + returnResult);
       } catch (final NumberFormatException e) {
         returnResult = 0L;
-        logger.error(String.format("yielding 0 for %s as output is invalid - %s", field, result));
+        LOG.error(String.format("yielding 0 for %s as output is invalid - %s", field, result));
       }
     }
     return returnResult;
@@ -205,7 +206,7 @@ public class ServerStatisticsServlet extends HttpServlet {
       stats.setNumberOfAssignedFlows(assignedFlows);
       stats.setLastDispatchedTime(runnerMgr.getLastFlowSubmittedTime());
     } else {
-      logger.error("failed to get data for remaining flow capacity or LastDispatchedTime"
+      LOG.error("failed to get data for remaining flow capacity or LastDispatchedTime"
           + " as the AzkabanExecutorServer has yet been initialized.");
     }
   }
@@ -235,18 +236,18 @@ public class ServerStatisticsServlet extends HttpServlet {
           try {
             cpuUsage = Double.parseDouble(splitedresult[0]);
           } catch (final NumberFormatException e) {
-            logger.error("yielding 0.0 for CPU usage as output is invalid -" + output.get(0));
+            LOG.error("yielding 0.0 for CPU usage as output is invalid -" + output.get(0));
           }
-          logger.info("System load : " + cpuUsage);
+          LOG.info("System load : " + cpuUsage);
           stats.setCpuUpsage(cpuUsage);
         }
       } catch (final Exception ex) {
-        logger.error("failed fetch system load info "
+        LOG.error("failed fetch system load info "
             + "as exception is captured when fetching result from bash call. Ex -" + ex
             .getMessage());
       }
     } else {
-      logger.error(
+      LOG.error(
           "failed fetch system load info, one or more files from the following list are missing -  "
               + "'/bin/bash'," + "'/bin/cat'," + "'/proc/loadavg'");
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/StatsServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.executor.ConnectorParams;
@@ -38,7 +37,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Servlet to communicate with Azkaban exec server This servlet get requests from stats servlet in
@@ -47,7 +48,7 @@ import org.apache.log4j.Logger;
 public class StatsServlet extends HttpServlet implements ConnectorParams {
 
   private static final long serialVersionUID = 2L;
-  private static final Logger logger = Logger.getLogger(StatsServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StatsServlet.class);
 
   public boolean hasParam(final HttpServletRequest request, final String param) {
     return HttpRequestUtils.hasParam(request, param);
@@ -116,7 +117,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
   private void handleChangeManagerStatusRequest(final HttpServletRequest req,
       final Map<String, Object> ret, final boolean enableMetricManager) {
     try {
-      logger.info("Updating metric manager status");
+      LOG.info("Updating metric manager status");
       if ((enableMetricManager && MetricReportManager.isInstantiated())
           || MetricReportManager.isAvailable()) {
         final MetricReportManager metricManager = MetricReportManager.getInstance();
@@ -130,7 +131,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
         ret.put(RESPONSE_ERROR, "MetricManager is not available");
       }
     } catch (final Exception e) {
-      logger.error(e);
+      LOG.error("Handle Change Manager Status Request Failure", e);
       ret.put(RESPONSE_ERROR, e.getMessage());
     }
   }
@@ -152,7 +153,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
         ret.put(RESPONSE_ERROR, "MetricManager is not available");
       }
     } catch (final Exception e) {
-      logger.error(e);
+      LOG.error("Handle Change Emitter Points Failure", e);
       ret.put(RESPONSE_ERROR, e.getMessage());
     }
   }
@@ -174,7 +175,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
         ret.put(RESPONSE_ERROR, "MetricManager is not available");
       }
     } catch (final Exception e) {
-      logger.error(e);
+      LOG.error("Handle Change Cleaning Interval Failure ", e);
       ret.put(RESPONSE_ERROR, e.getMessage());
     }
   }
@@ -257,7 +258,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
    * Update tracking interval for a given metrics
    */
   private void handleChangeMetricInterval(final HttpServletRequest req,
-      final Map<String, Object> ret) throws ServletException {
+      final Map<String, Object> ret) {
     try {
       final String metricName = getParam(req, STATS_MAP_METRICNAMEPARAM);
       final long newInterval = getLongParam(req, STATS_MAP_REPORTINGINTERVAL);
@@ -272,7 +273,7 @@ public class StatsServlet extends HttpServlet implements ConnectorParams {
         ret.put(RESPONSE_ERROR, "MetricManager is not available");
       }
     } catch (final Exception e) {
-      logger.error(e);
+      LOG.error("Handle Change Metric Interval Failure", e);
       ret.put(RESPONSE_ERROR, e.getMessage());
     }
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/Trigger.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/Trigger.java
@@ -13,19 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-
 package azkaban.execapp;
 
 import azkaban.trigger.Condition;
 import azkaban.trigger.TriggerAction;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class Trigger implements Runnable {
 
-  private static final Logger logger = Logger.getLogger(azkaban.execapp.Trigger.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Trigger.class);
   private final int execId;
 
   // condition to trigger actions(ex. flow running longer than X mins)
@@ -51,18 +50,18 @@ public class Trigger implements Runnable {
   @Override
   public void run() {
     if (isTriggerExpired()) {
-      logger.info(this + " expired");
+      LOG.info(this + " expired");
       return;
     }
 
     final boolean isTriggerConditionMet = this.triggerCondition.isMet();
     if (isTriggerConditionMet) {
-      logger.info("Condition " + this.triggerCondition.getExpression() + " met");
+      LOG.info("Condition " + this.triggerCondition.getExpression() + " met");
       for (final TriggerAction action : this.actions) {
         try {
           action.doAction();
         } catch (final Exception e) {
-          logger.error("Failed to do action " + action.getDescription()
+          LOG.error("Failed to do action " + action.getDescription()
               + " for execution " + azkaban.execapp.Trigger.this.execId, e);
         }
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/TriggerManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp;
 
 import azkaban.execapp.action.KillExecutionAction;
@@ -34,14 +33,15 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class TriggerManager {
 
   private static final int SCHEDULED_THREAD_POOL_SIZE = 4;
-  private static final Logger logger = Logger.getLogger(TriggerManager.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerManager.class);
   private final ScheduledExecutorService scheduledService;
 
   @Inject
@@ -60,10 +60,6 @@ public class TriggerManager {
   private List<TriggerAction> createActions(final SlaOption sla, final int execId) {
     final List<TriggerAction> actions = new ArrayList<>();
     if (sla.hasAlert()) {
-      TriggerAction action = new SlaAlertAction(SlaOption.ACTION_ALERT, sla, execId);
-    }
-
-    if (sla.hasAlert()) {
       actions.add(new SlaAlertAction(SlaOption.ACTION_ALERT, sla, execId));
     }
     if(sla.hasKill()) {
@@ -75,7 +71,7 @@ public class TriggerManager {
         actions.add(new KillJobAction(SlaOption.ACTION_KILL_JOB, execId, sla.getJobName()));
           break;
         default:
-          logger.info("Unknown action type " + sla.getType().getComponent());
+          LOG.info("Unknown action type " + sla.getType().getComponent());
           break;
       }
     }
@@ -97,7 +93,7 @@ public class TriggerManager {
       final Duration duration = slaOption.getDuration();
       final long durationInMillis = duration.toMillis();
 
-      logger.info("Adding sla trigger " + slaOption.toString() + " to execution " + execId
+      LOG.info("Adding sla trigger " + slaOption.toString() + " to execution " + execId
           + ", scheduled to trigger in " + durationInMillis / 1000 + " seconds");
       this.scheduledService.schedule(trigger, durationInMillis, TimeUnit.MILLISECONDS);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/action/KillExecutionAction.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/action/KillExecutionAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.action;
 
 import azkaban.Constants;
@@ -22,15 +21,15 @@ import azkaban.execapp.FlowRunnerManager;
 import azkaban.trigger.TriggerAction;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class KillExecutionAction implements TriggerAction {
 
   public static final String type = "KillExecutionAction";
 
-  private static final Logger logger = Logger
-      .getLogger(KillExecutionAction.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KillExecutionAction.class);
 
   private final String actionId;
   private final int execId;
@@ -82,7 +81,7 @@ public class KillExecutionAction implements TriggerAction {
 
   @Override
   public void doAction() throws Exception {
-    logger.info("ready to kill execution " + this.execId);
+    LOG.info("ready to kill execution " + this.execId);
     ServiceProvider.SERVICE_PROVIDER.getInstance(FlowRunnerManager.class)
         .cancelFlow(this.execId, Constants.AZKABAN_SLA_CHECKER_USERNAME);
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/action/KillJobAction.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/action/KillJobAction.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.action;
 
 import azkaban.ServiceProvider;
@@ -21,15 +20,15 @@ import azkaban.execapp.FlowRunnerManager;
 import azkaban.trigger.TriggerAction;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class KillJobAction implements TriggerAction {
 
   public static final String type = "KillJobAction";
 
-  private static final Logger logger = Logger
-      .getLogger(KillJobAction.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KillJobAction.class);
 
   private final String actionId;
   private final int execId;
@@ -82,7 +81,7 @@ public class KillJobAction implements TriggerAction {
 
   @Override
   public void doAction() throws Exception {
-    logger.info("ready to do action " + getDescription());
+    LOG.info("ready to do action " + getDescription());
     final FlowRunnerManager flowRunnerManager = ServiceProvider.SERVICE_PROVIDER
         .getInstance(FlowRunnerManager.class);
     flowRunnerManager.cancelJobBySLA(this.execId, this.jobId);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/FlowWatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.executor.ExecutableFlow;
@@ -23,6 +22,7 @@ import azkaban.executor.Status;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.log4j.Logger;
+
 
 public abstract class FlowWatcher {
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -28,6 +28,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
+
 /**
  * Responsible processing job callback properties on job status change events.
  *
@@ -43,8 +44,7 @@ import org.apache.log4j.Logger;
  */
 public class JobCallbackManager implements EventListener {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackManager.class);
+  private static final Logger LOG = Logger.getLogger(JobCallbackManager.class);
   private static final JobCallbackStatusEnum[] ON_COMPLETION_JOB_CALLBACK_STATUS =
       {SUCCESS, FAILURE, COMPLETED};
   private static boolean isInitialized = false;
@@ -69,17 +69,17 @@ public class JobCallbackManager implements EventListener {
     this.gmtDateFormatter = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
     this.gmtDateFormatter.setTimeZone(TimeZone.getTimeZone("GMT"));
 
-    logger.info("Initialization completed " + getClass().getName());
-    logger.info("azkabanHostName " + this.azkabanHostName);
+    LOG.info("Initialization completed " + getClass().getName());
+    LOG.info("azkabanHostName " + this.azkabanHostName);
   }
 
   public static void initialize(final Props props) {
     if (isInitialized) {
-      logger.info("Already initialized");
+      LOG.info("Already initialized");
       return;
     }
 
-    logger.info("Initializing");
+    LOG.info("Initializing");
     instance = new JobCallbackManager(props);
 
     isInitialized = true;
@@ -121,7 +121,7 @@ public class JobCallbackManager implements EventListener {
             "Encountered error while hanlding job callback event", e);
       }
     } else {
-      logger.warn("((( Got an unsupported runner: "
+      LOG.warn("((( Got an unsupported runner: "
           + event.getRunner().getClass().getName() + " )))");
     }
 
@@ -144,7 +144,7 @@ public class JobCallbackManager implements EventListener {
         JobCallbackUtil.buildJobContextInfoMap(event, this.azkabanHostName);
 
     JobCallbackStatusEnum jobCallBackStatusEnum = null;
-    final Logger jobLogger = jobRunner.getLogger();
+    final org.apache.log4j.Logger jobLogger = jobRunner.getLogger();
 
     final Status jobStatus = eventData.getStatus();
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackRequestMaker.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackRequestMaker.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeoutException;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
@@ -33,6 +32,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpRequestFutureTask;
 import org.apache.log4j.Logger;
 
+
 /**
  * Responsible for making the job callback HTTP requests.
  *
@@ -43,8 +43,7 @@ import org.apache.log4j.Logger;
  */
 public class JobCallbackRequestMaker {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackRequestMaker.class);
+  private static final Logger LOG = Logger.getLogger(JobCallbackRequestMaker.class);
 
   private static final int DEFAULT_TIME_OUT_MS = 3000;
   private static final int DEFAULT_RESPONSE_WAIT_TIME_OUT_MS = 5000;
@@ -70,7 +69,7 @@ public class JobCallbackRequestMaker {
     this.responseWaitTimeoutMS =
         props.getInt(JOBCALLBACK_RESPONSE_WAIT_TIMEOUT, DEFAULT_RESPONSE_WAIT_TIME_OUT_MS);
 
-    logger.info("responseWaitTimeoutMS: " + this.responseWaitTimeoutMS);
+    LOG.info("responseWaitTimeoutMS: " + this.responseWaitTimeoutMS);
 
     final RequestConfig requestConfig =
         RequestConfig.custom()
@@ -78,7 +77,7 @@ public class JobCallbackRequestMaker {
             .setConnectTimeout(connectionTimeout)
             .setSocketTimeout(socketTimeout).build();
 
-    logger.info("Global request configuration " + requestConfig.toString());
+    LOG.info("Global request configuration " + requestConfig.toString());
 
     final HttpClient httpClient =
         HttpClientBuilder.create().setDefaultRequestConfig(requestConfig)
@@ -86,7 +85,7 @@ public class JobCallbackRequestMaker {
 
     final int jobCallbackThreadPoolSize =
         props.getInt(JOBCALLBACK_THREAD_POOL_SIZE, DEFAULT_THREAD_POOL_SIZE);
-    logger.info("Jobcall thread pool size: " + jobCallbackThreadPoolSize);
+    LOG.info("Jobcall thread pool size: " + jobCallbackThreadPoolSize);
 
     final ExecutorService executorService =
         Executors.newFixedThreadPool(jobCallbackThreadPoolSize);
@@ -105,7 +104,7 @@ public class JobCallbackRequestMaker {
 
     instance = new JobCallbackRequestMaker(props);
     isInitialized = true;
-    logger.info("Initialization for " + JobCallbackRequestMaker.class.getName()
+    LOG.info("Initialization for " + JobCallbackRequestMaker.class.getName()
         + " is completed");
   }
 
@@ -192,8 +191,7 @@ public class JobCallbackRequestMaker {
     }
 
     @Override
-    public Integer handleResponse(final HttpResponse response)
-        throws ClientProtocolException, IOException {
+    public Integer handleResponse(final HttpResponse response) {
 
       final int statusCode = response.getStatusLine().getStatusCode();
       BufferedReader bufferedReader = null;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -40,19 +40,22 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
+
 public class JobCallbackUtil {
 
-  private static final Logger logger = Logger.getLogger(JobCallbackUtil.class);
-
+  private static final Logger LOG = Logger.getLogger(JobCallbackUtil.class);
   private static final Map<JobCallbackStatusEnum, String> firstJobcallbackPropertyMap =
-      new HashMap<>(
-          JobCallbackStatusEnum.values().length);
+      new HashMap<>(JobCallbackStatusEnum.values().length);
 
   static {
     for (final JobCallbackStatusEnum statusEnum : JobCallbackStatusEnum.values()) {
       firstJobcallbackPropertyMap.put(statusEnum,
           replaceStatusToken(FIRST_JOB_CALLBACK_URL_TEMPLATE, statusEnum));
     }
+  }
+
+  private JobCallbackUtil() {
+
   }
 
   /**
@@ -91,7 +94,7 @@ public class JobCallbackUtil {
       final int maxNumCallback) {
 
     return parseJobCallbackProperties(props, status, contextInfo,
-        maxNumCallback, logger);
+        maxNumCallback, LOG);
   }
 
   /**
@@ -227,7 +230,7 @@ public class JobCallbackUtil {
   /**
    * This method takes the job context info. and put the values into a map with keys as the tokens.
    *
-   * @return Map<String,String>
+   * @return Map<String , String>
    */
   public static Map<String, String> buildJobContextInfoMap(final Event event,
       final String server) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.execapp.event;
 
 import azkaban.event.Event;
@@ -24,9 +23,11 @@ import azkaban.execapp.JobRunner;
 import azkaban.executor.ExecutableNode;
 import azkaban.spi.EventType;
 
+
 public class LocalFlowWatcher extends FlowWatcher {
 
   private final LocalFlowWatcherListener watcherListener;
+
   private FlowRunner runner;
   private boolean isShutdown = false;
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMBeanManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMBeanManager.java
@@ -11,7 +11,9 @@ import azkaban.utils.Props;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Responsible keeping track of job related MBean attributes through listening to job related
@@ -21,9 +23,7 @@ import org.apache.log4j.Logger;
  */
 public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
 
-  private static final Logger logger = Logger
-      .getLogger(JmxJobMBeanManager.class);
-
+  private static final Logger LOG = LoggerFactory.getLogger(JmxJobMBeanManager.class);
   private static final JmxJobMBeanManager INSTANCE = new JmxJobMBeanManager();
 
   private final AtomicInteger runningJobCount = new AtomicInteger(0);
@@ -47,7 +47,7 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
   }
 
   public void initialize(final Props props) {
-    logger.info("Initializing " + getClass().getName());
+    LOG.info("Initializing " + getClass().getName());
     this.initialized = true;
   }
 
@@ -103,8 +103,8 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
       final EventData eventData = event.getData();
       final ExecutableNode node = jobRunner.getNode();
 
-      if (logger.isDebugEnabled()) {
-        logger.debug("*** got " + event.getType() + " " + node.getId() + " "
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("*** got " + event.getType() + " " + node.getId() + " "
             + event.getRunner().getClass().getName() + " status: "
             + eventData.getStatus());
       }
@@ -116,7 +116,7 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
         if (this.runningJobCount.intValue() > 0) {
           this.runningJobCount.decrementAndGet();
         } else {
-          logger.warn("runningJobCount not messed up, it is already zero "
+          LOG.warn("runningJobCount not messed up, it is already zero "
               + "and we are trying to decrement on job event "
               + EventType.JOB_FINISHED);
         }
@@ -131,8 +131,7 @@ public class JmxJobMBeanManager implements JmxJobMXBean, EventListener {
       }
 
     } else {
-      logger.warn("((((((((( Got a different runner: "
-          + event.getRunner().getClass().getName());
+      LOG.warn("((((((((( Got a different runner: " + event.getRunner().getClass().getName());
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMXBean.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/jmx/JmxJobMXBean.java
@@ -3,6 +3,7 @@ package azkaban.execapp.jmx;
 import azkaban.jmx.DisplayName;
 import java.util.Map;
 
+
 /**
  * Define all the MBean attributes at the job level
  *
@@ -27,5 +28,4 @@ public interface JmxJobMXBean {
 
   @DisplayName("OPERATION: getTotalFailedJobsByJobType")
   public Map<String, Integer> getTotalFailedJobsByJobType();
-
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
@@ -37,7 +37,7 @@ public class NumFailedFlowMetric extends TimeBasedReportingMetric<Integer> imple
   public NumFailedFlowMetric(final MetricReportManager manager, final long interval)
       throws MetricException {
     super(NUM_FAILED_FLOW_METRIC_NAME, NUM_FAILED_FLOW_METRIC_TYPE, 0, manager, interval);
-    logger.debug("Instantiated NumFailedJobMetric");
+    LOG.debug("Instantiated NumFailedJobMetric");
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedJobMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedJobMetric.java
@@ -35,7 +35,7 @@ public class NumFailedJobMetric extends TimeBasedReportingMetric<Integer> implem
   public NumFailedJobMetric(final MetricReportManager manager, final long interval)
       throws MetricException {
     super(NUM_FAILED_JOB_METRIC_NAME, NUM_FAILED_JOB_METRIC_TYPE, 0, manager, interval);
-    logger.debug("Instantiated NumFailedJobMetric");
+    LOG.debug("Instantiated NumFailedJobMetric");
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumQueuedFlowMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumQueuedFlowMetric.java
@@ -40,7 +40,7 @@ public class NumQueuedFlowMetric extends TimeBasedReportingMetric<Integer> {
       final MetricReportManager manager,
       final long interval) throws MetricException {
     super(NUM_QUEUED_FLOW_METRIC_NAME, NUM_QUEUED_FLOW_METRIC_TYPE, 0, manager, interval);
-    logger.debug("Instantiated NumQueuedFlowMetric");
+    LOG.debug("Instantiated NumQueuedFlowMetric");
     this.flowManager = flowRunnerManager;
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumRunningFlowMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumRunningFlowMetric.java
@@ -40,7 +40,7 @@ public class NumRunningFlowMetric extends TimeBasedReportingMetric<Integer> {
       final MetricReportManager manager,
       final long interval) throws MetricException {
     super(NUM_RUNNING_FLOW_METRIC_NAME, NUM_RUNNING_FLOW_METRIC_TYPE, 0, manager, interval);
-    logger.debug("Instantiated NumRunningFlowMetric");
+    LOG.debug("Instantiated NumRunningFlowMetric");
     this.flowManager = flowRunnerManager;
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumRunningJobMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumRunningJobMetric.java
@@ -39,7 +39,7 @@ public class NumRunningJobMetric extends TimeBasedReportingMetric<Integer> imple
   public NumRunningJobMetric(final MetricReportManager manager, final long interval)
       throws MetricException {
     super(NUM_RUNNING_JOB_METRIC_NAME, NUM_RUNNING_JOB_METRIC_TYPE, 0, manager, interval);
-    logger.debug("Instantiated NumRunningJobMetric");
+    LOG.debug("Instantiated NumRunningJobMetric");
   }
 
   /**

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
+
 public abstract class HadoopSecurityManager {
 
   public static final String ENABLE_PROXYING = "azkaban.should.proxy"; // boolean

--- a/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
+++ b/azkaban-solo-server/src/main/java/azkaban/soloserver/AzkabanSingleServer.java
@@ -36,12 +36,13 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class AzkabanSingleServer {
 
-  private static final Logger log = Logger.getLogger(AzkabanWebServer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanWebServer.class);
 
   private final AzkabanWebServer webServer;
   private final AzkabanExecutorServer executor;
@@ -57,13 +58,13 @@ public class AzkabanSingleServer {
     try {
       start(args);
     } catch (final Exception e) {
-      log.error("Failed to start single server. Shutting down.", e);
+      LOG.error("Failed to start single server. Shutting down.", e);
       System.exit(1);
     }
   }
 
   public static void start(String[] args) throws Exception {
-    log.info("Starting Azkaban Server");
+    LOG.info("Starting Azkaban Server");
 
     if (System.getSecurityManager() == null) {
       Policy.setPolicy(new Policy() {
@@ -81,8 +82,8 @@ public class AzkabanSingleServer {
 
     final Props props = AzkabanServer.loadProps(args);
     if (props == null) {
-      log.error("Properties not found. Need it to connect to the db.");
-      log.error("Exiting...");
+      LOG.error("Properties not found. Need it to connect to the db.");
+      LOG.error("Exiting...");
       return;
     }
 
@@ -113,22 +114,22 @@ public class AzkabanSingleServer {
     final File localConfFolder = new File("local/conf");
     if (!localConfFolder.exists()) {
       FileUtils.copyDirectory(templateFolder, localConfFolder.getParentFile());
-      log.info("Copied local conf templates from " + templateFolder.getAbsolutePath());
+      LOG.info("Copied local conf templates from " + templateFolder.getAbsolutePath());
     }
-    log.info("Using conf at " + localConfFolder.getAbsolutePath());
+    LOG.info("Using conf at " + localConfFolder.getAbsolutePath());
     return new String[]{"-conf", "local/conf"};
   }
 
   private void launch() throws Exception {
     // exec server first so that it's ready to accept calls by web server when web initializes
     AzkabanExecutorServer.launch(this.executor);
-    log.info("Azkaban Exec Server started...");
+    LOG.info("Azkaban Exec Server started...");
 
     this.executor.getFlowRunnerManager()
         .setExecutorActive(true, this.executor.getHost(), this.executor.getPort());
-    log.info("Azkaban Exec Server activated...");
+    LOG.info("Azkaban Exec Server activated...");
 
     AzkabanWebServer.launch(this.webServer);
-    log.info("Azkaban Web Server started...");
+    LOG.info("Azkaban Web Server started...");
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger;
 
 import azkaban.Constants;
@@ -41,7 +40,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("FutureReturnValueIgnored")
 public class TriggerInstanceProcessor {
 
-  private static final Logger logger = LoggerFactory.getLogger(TriggerInstanceProcessor.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerInstanceProcessor.class);
   private static final String FAILURE_EMAIL_SUBJECT = "flow trigger for flow '%s', project '%s' "
       + "has been cancelled on %s";
   private final static int THREAD_POOL_SIZE = 32;
@@ -73,7 +72,7 @@ public class TriggerInstanceProcessor {
       this.executorManager.submitExecutableFlow(executableFlow, triggerInst.getSubmitUser());
       triggerInst.setFlowExecId(executableFlow.getExecutionId());
     } catch (final Exception ex) {
-      logger.error("exception when executing the associated flow and updating flow exec id for "
+      LOG.error("exception when executing the associated flow and updating flow exec id for "
               + "trigger instance[id: {}]",
           triggerInst.getId(), ex);
       // if flow fails to be executed(e.g. running execution exceeds the allowed concurrent run

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/JdbcFlowTriggerInstanceLoaderImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/database/JdbcFlowTriggerInstanceLoaderImpl.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger.database;
 
 import azkaban.Constants;
@@ -56,8 +55,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoader {
 
-  private static final Logger logger = LoggerFactory
-      .getLogger(JdbcFlowTriggerInstanceLoaderImpl.class);
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcFlowTriggerInstanceLoaderImpl.class);
   private static final String[] DEPENDENCY_EXECUTIONS_COLUMNS = {"trigger_instance_id", "dep_name",
       "starttime", "endtime", "dep_status", "cancelleation_cause", "project_id", "project_version",
       "flow_id", "flow_version", "flow_exec_id"};
@@ -194,10 +192,10 @@ public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoa
               flowTriggers.put(flowConfigID, flowTrigger);
             }
           } else {
-            logger.error("Unable to find flow file for " + flowConfigID);
+            LOG.error("Unable to find flow file for " + flowConfigID);
           }
         } catch (final Exception ex) {
-          logger.error("error in getting flow file", ex);
+          LOG.error("error in getting flow file", ex);
         } finally {
           FlowLoaderUtils.cleanUpDir(tempDir);
         }
@@ -218,7 +216,7 @@ public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoa
   private void handleSQLException(final SQLException ex)
       throws DependencyException {
     final String error = "exception when accessing db!";
-    logger.error(error, ex);
+    LOG.error(error, ex);
     throw new DependencyException(error, ex);
   }
 
@@ -330,10 +328,10 @@ public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoa
             triggerInstance.setFlowTrigger(flowTrigger);
           }
         } else {
-          logger.error("Unable to find flow file for " + triggerInstance);
+          LOG.error("Unable to find flow file for " + triggerInstance);
         }
       } catch (final Exception ex) {
-        logger.error("error in getting flow file", ex);
+        LOG.error("error in getting flow file", ex);
       } finally {
         FlowLoaderUtils.cleanUpDir(tempDir);
       }
@@ -407,7 +405,7 @@ public class JdbcFlowTriggerInstanceLoaderImpl implements FlowTriggerInstanceLoa
             .collect(Collectors.joining(", "));
         numDeleted = this.dbOperator.update(DELETE_EXECUTIONS.replace("?", ids));
       }
-      logger.info("{} dependency instance record(s) deleted", numDeleted);
+      LOG.info("{} dependency instance record(s) deleted", numDeleted);
       return numDeleted;
     } catch (final SQLException ex) {
       handleSQLException(ex);

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/plugin/FlowTriggerDependencyPluginManager.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/plugin/FlowTriggerDependencyPluginManager.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger.plugin;
 
 import azkaban.flowtrigger.DependencyCheck;
@@ -42,15 +41,16 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 @Singleton
 public class FlowTriggerDependencyPluginManager {
 
+  private static final Logger LOG = LoggerFactory
+      .getLogger(FlowTriggerDependencyPluginManager.class);
   public static final String CONFIG_FILE = "dependency.properties";
   public static final String PRIVATE_CONFIG_FILE = "private.properties";
   public static final String DEPENDENCY_CLASS = "dependency.class";
   public static final String CLASS_PATH = "dependency.classpath";
-  private static final Logger logger = LoggerFactory
-      .getLogger(FlowTriggerDependencyPluginManager.class);
   private final String pluginDir;
   private final Map<String, DependencyCheck> dependencyTypeMap;
   private final ClassLoader prevClassLoader;
@@ -91,7 +91,7 @@ public class FlowTriggerDependencyPluginManager {
       input = new BufferedInputStream(new FileInputStream(file));
       props.load(input);
     } catch (final Exception e) {
-      logger.debug("unable to read the file " + file, e);
+      LOG.debug("unable to read the file " + file, e);
       throw new FlowTriggerDependencyPluginException(e);
     } finally {
       try {
@@ -99,7 +99,7 @@ public class FlowTriggerDependencyPluginManager {
           input.close();
         }
       } catch (final IOException e) {
-        logger.error("unable to close input stream when reading config from file " + file
+        LOG.error("unable to close input stream when reading config from file " + file
             .getAbsolutePath(), e);
       }
     }
@@ -144,7 +144,7 @@ public class FlowTriggerDependencyPluginManager {
           for (final File file : files) {
             final URL cpItem = file.toURI().toURL();
             if (!resources.contains(cpItem)) {
-              logger.info("adding to classpath " + cpItem);
+              LOG.info("adding to classpath " + cpItem);
               resources.add(cpItem);
             }
           }
@@ -179,7 +179,7 @@ public class FlowTriggerDependencyPluginManager {
         depCheck.init(pluginConfig);
         this.dependencyTypeMap.put(pluginName, depCheck);
       } catch (final Exception ex) {
-        logger.error("failed to initializing plugin in " + pluginDir, ex);
+        LOG.error("failed to initializing plugin in " + pluginDir, ex);
         throw new FlowTriggerDependencyPluginException(ex);
       }
     }
@@ -255,7 +255,7 @@ public class FlowTriggerDependencyPluginManager {
       try {
         depCheck.shutdown();
       } catch (final Exception ex) {
-        logger.error("failed to shutdown dependency check " + depCheck, ex);
+        LOG.error("failed to shutdown dependency check " + depCheck, ex);
       }
     }
   }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.flowtrigger.quartz;
 
 import static java.util.Objects.requireNonNull;
@@ -46,10 +45,11 @@ import org.quartz.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 @Singleton
 public class FlowTriggerScheduler {
 
-  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerScheduler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FlowTriggerScheduler.class);
   private final ProjectLoader projectLoader;
   private final QuartzScheduler scheduler;
   private final ProjectManager projectManager;
@@ -101,15 +101,15 @@ public class FlowTriggerScheduler {
                     (FlowTriggerQuartzJob.class, FlowTriggerQuartzJob.JOB_NAME,
                         generateGroupName(flow), contextMap));
             if (scheduleSuccess) {
-              logger.info("Successfully registered flow {}.{} to scheduler", project.getName(),
+              LOG.info("Successfully registered flow {}.{} to scheduler", project.getName(),
                   flow.getId());
             } else {
-              logger.info("Fail to register a duplicate flow {}.{} to scheduler", project.getName(),
+              LOG.info("Fail to register a duplicate flow {}.{} to scheduler", project.getName(),
                   flow.getId());
             }
           }
         } catch (final SchedulerException | IOException ex) {
-          logger.error("Error in registering flow {}.{}", project.getName(), flow.getId(), ex);
+          LOG.error("Error in registering flow {}.{}", project.getName(), flow.getId(), ex);
           throw ex;
         } finally {
           FlowLoaderUtils.cleanUpDir(tempDir);
@@ -161,7 +161,7 @@ public class FlowTriggerScheduler {
               flowId, flowTrigger, submitUser, quartzTriggers.isEmpty() ? null
               : quartzTriggers.get(0), isPaused, flow.isLocked());
         } catch (final Exception ex) {
-          logger.error("Unable to get flow trigger by job key {}", jobKey, ex);
+          LOG.error("Unable to get flow trigger by job key {}", jobKey, ex);
           scheduledFlowTrigger = null;
         }
 
@@ -169,7 +169,7 @@ public class FlowTriggerScheduler {
       }
       return flowTriggerJobDetails;
     } catch (final Exception ex) {
-      logger.error("Unable to get scheduled flow triggers", ex);
+      LOG.error("Unable to get scheduled flow triggers", ex);
       return new ArrayList<>();
     }
   }
@@ -183,10 +183,10 @@ public class FlowTriggerScheduler {
         try {
           if (this.scheduler
               .unscheduleJob(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow))) {
-            logger.info("Flow {}.{} unregistered from scheduler", project.getName(), flow.getId());
+            LOG.info("Flow {}.{} unregistered from scheduler", project.getName(), flow.getId());
           }
         } catch (final SchedulerException e) {
-          logger.error("Fail to unregister flow from scheduler {}.{}", project.getName(),
+          LOG.error("Fail to unregister flow from scheduler {}.{}", project.getName(),
               flow.getId(), e);
           throw e;
         }

--- a/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.scheduler;
 
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -39,6 +38,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Manages Quartz schedules. Azkaban regards QuartzJob and QuartzTrigger as an one-to-one
  * mapping.
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class QuartzScheduler {
 
-  private static final Logger logger = LoggerFactory.getLogger(QuartzScheduler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(QuartzScheduler.class);
   private Scheduler scheduler = null;
 
   @Inject
@@ -72,7 +72,7 @@ public class QuartzScheduler {
 
   public void start() throws SchedulerException {
     this.scheduler.start();
-    logger.info("Quartz Scheduler started.");
+    LOG.info("Quartz Scheduler started.");
   }
 
   @VisibleForTesting
@@ -82,7 +82,7 @@ public class QuartzScheduler {
 
   public void shutdown() throws SchedulerException {
     this.scheduler.shutdown();
-    logger.info("Quartz Scheduler shut down.");
+    LOG.info("Quartz Scheduler shut down.");
   }
 
   /**
@@ -175,7 +175,7 @@ public class QuartzScheduler {
     requireNonNull(jobDescription, "jobDescription is null");
 
     if (ifJobExist(jobDescription.getJobName(), jobDescription.getGroupName())) {
-      logger.warn(String.format("can not register existing job with job name: "
+      LOG.warn(String.format("can not register existing job with job name: "
           + "%s and group name: %s", jobDescription.getJobName(), jobDescription.getGroupName()));
       return false;
     }
@@ -204,7 +204,7 @@ public class QuartzScheduler {
         .build();
 
     this.scheduler.scheduleJob(job, trigger);
-    logger.info("Quartz Schedule with jobDetail " + job.getDescription() + " is registered.");
+    LOG.info("Quartz Schedule with jobDetail " + job.getDescription() + " is registered.");
     return true;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -35,12 +35,13 @@ import com.google.inject.Provides;
 import java.lang.reflect.Constructor;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.log.Log4JLogChute;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.apache.velocity.runtime.resource.loader.JarResourceLoader;
 import org.mortbay.jetty.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This Guice module is currently a one place container for all bindings in the current module. This
@@ -49,7 +50,7 @@ import org.mortbay.jetty.Server;
  */
 public class AzkabanWebServerModule extends AbstractModule {
 
-  private static final Logger log = Logger.getLogger(AzkabanWebServerModule.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AzkabanWebServerModule.class);
   private static final String USER_MANAGER_CLASS_PARAM = "user.manager.class";
   private static final String VELOCITY_DEV_MODE_PARAM = "velocity.dev.mode";
   private final Props props;
@@ -93,12 +94,12 @@ public class AzkabanWebServerModule extends AbstractModule {
     final Class<?> userManagerClass = props.getClass(USER_MANAGER_CLASS_PARAM, null);
     final UserManager manager;
     if (userManagerClass != null && userManagerClass.getConstructors().length > 0) {
-      log.info("Loading user manager class " + userManagerClass.getName());
+      LOG.info("Loading user manager class " + userManagerClass.getName());
       try {
         final Constructor<?> userManagerConstructor = userManagerClass.getConstructor(Props.class);
         manager = (UserManager) userManagerConstructor.newInstance(props);
       } catch (final Exception e) {
-        log.error("Could not instantiate UserManager " + userManagerClass.getName());
+        LOG.error("Could not instantiate UserManager " + userManagerClass.getName());
         throw new RuntimeException(e);
       }
     } else {
@@ -138,7 +139,7 @@ public class AzkabanWebServerModule extends AbstractModule {
     engine.setProperty("runtime.log.invalid.references", devMode);
     engine.setProperty("runtime.log.logsystem.class", Log4JLogChute.class);
     engine.setProperty("runtime.log.logsystem.log4j.logger",
-        Logger.getLogger("org.apache.velocity.Logger"));
+        org.apache.log4j.Logger.getLogger("org.apache.velocity.Logger"));
     engine.setProperty("parser.pool.size", 3);
     return engine;
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/PluginCheckerAndActionsLoader.java
@@ -25,18 +25,19 @@ import java.io.File;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PluginCheckerAndActionsLoader {
 
-  private static final Logger log = Logger.getLogger(PluginCheckerAndActionsLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PluginCheckerAndActionsLoader.class);
 
   public void load(final String pluginPath) {
-    log.info("Loading plug-in checker and action types");
+    LOG.info("Loading plug-in checker and action types");
     final File triggerPluginPath = new File(pluginPath);
     if (!triggerPluginPath.exists()) {
-      log.error("plugin path " + pluginPath + " doesn't exist!");
+      LOG.error("plugin path " + pluginPath + " doesn't exist!");
       return;
     }
 
@@ -57,10 +58,10 @@ public class PluginCheckerAndActionsLoader {
 
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
-        log.error("Trigger class is not set.");
+        LOG.error("Trigger class is not set.");
         continue;
       } else {
-        log.info("Plugin class " + pluginClass);
+        LOG.info("Plugin class " + pluginClass);
       }
 
       URLClassLoader urlClassLoader = PluginUtils
@@ -76,14 +77,14 @@ public class PluginCheckerAndActionsLoader {
       }
 
       final String source = FileIOUtils.getSourcePathFromClass(triggerClass);
-      log.info("Source jar " + source);
+      LOG.info("Source jar " + source);
       jarPaths.add("jar:file:" + source);
 
       try {
         Utils.invokeStaticMethod(urlClassLoader, pluginClass,
             "initiateCheckerTypes", pluginProps, this);
       } catch (final Exception e) {
-        log.error("Unable to initiate checker types for " + pluginClass);
+        LOG.error("Unable to initiate checker types for " + pluginClass);
         continue;
       }
 
@@ -91,7 +92,7 @@ public class PluginCheckerAndActionsLoader {
         Utils.invokeStaticMethod(urlClassLoader, pluginClass,
             "initiateActionTypes", pluginProps, this);
       } catch (final Exception e) {
-        log.error("Unable to initiate action types for " + pluginClass);
+        LOG.error("Unable to initiate action types for " + pluginClass);
         continue;
       }
     }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/StatusService.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/StatusService.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import static azkaban.webapp.servlet.AbstractAzkabanServlet.jarVersion;
@@ -38,10 +37,11 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 @Singleton
 public class StatusService {
 
-  private static final Logger log = LoggerFactory.getLogger(StatusService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StatusService.class);
   private static final File PACKAGE_JAR = new File(
       StatusService.class.getProtectionDomain().getCodeSource().getLocation().getPath());
   private final ExecutorLoader executorLoader;
@@ -60,7 +60,7 @@ public class StatusService {
     try {
       return PACKAGE_JAR.getCanonicalPath();
     } catch (final IOException e) {
-      log.error("Unable to obtain canonical path. Reporting absolute path instead", e);
+      LOG.error("Unable to obtain canonical path. Reporting absolute path instead", e);
       return PACKAGE_JAR.getAbsolutePath();
     }
   }
@@ -87,7 +87,7 @@ public class StatusService {
     try {
       return Files.readFirstLine(pidFile, StandardCharsets.UTF_8).trim();
     } catch (final IOException e) {
-      log.error("Unable to obtain PID", e);
+      LOG.error("Unable to obtain PID", e);
       return "unknown";
     }
   }
@@ -100,7 +100,7 @@ public class StatusService {
         executorMap.put(executor.getId(), executor);
       }
     } catch (final ExecutorManagerException e) {
-      log.error("Fetching executors failed!", e);
+      LOG.error("Fetching executors failed!", e);
     }
     return executorMap;
   }
@@ -109,7 +109,7 @@ public class StatusService {
     try {
       return this.dbOperator.query("SELECT 1", rs -> true);
     } catch (final SQLException e) {
-      log.error("DB Error", e);
+      LOG.error("DB Error", e);
     }
     return false;
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/TriggerPluginLoader.java
@@ -25,20 +25,20 @@ import azkaban.utils.PropsUtils;
 import azkaban.webapp.plugin.TriggerPlugin;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 import org.mortbay.jetty.servlet.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class TriggerPluginLoader {
 
-  private static final Logger log = Logger.getLogger(TriggerPluginLoader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerPluginLoader.class);
   private final String pluginPath;
 
   public TriggerPluginLoader(final Props props) {
@@ -74,10 +74,10 @@ public class TriggerPluginLoader {
 
       final String pluginClass = pluginProps.getString("trigger.class");
       if (pluginClass == null) {
-        log.error("Trigger class is not set.");
+        LOG.error("Trigger class is not set.");
         continue;
       } else {
-        log.info("Plugin class " + pluginClass);
+        LOG.info("Plugin class " + pluginClass);
       }
 
       Class<?> triggerClass =
@@ -87,7 +87,7 @@ public class TriggerPluginLoader {
       }
 
       final String source = FileIOUtils.getSourcePathFromClass(triggerClass);
-      log.info("Source jar " + source);
+      LOG.info("Source jar " + source);
       jarPaths.add("jar:file:" + source);
 
       Constructor<?> constructor = null;
@@ -95,7 +95,7 @@ public class TriggerPluginLoader {
         constructor = triggerClass
             .getConstructor(String.class, Props.class, Context.class, AzkabanWebServer.class);
       } catch (final NoSuchMethodException e) {
-        log.error("Constructor not found in " + pluginClass);
+        LOG.error("Constructor not found in " + pluginClass);
         continue;
       }
 
@@ -103,11 +103,11 @@ public class TriggerPluginLoader {
       try {
         obj = constructor.newInstance(pluginName, pluginProps, root, azkabanWebServer);
       } catch (final Exception e) {
-        log.error(e);
+        LOG.error("Create Plugin Instance Failure", e);
       }
 
       if (!(obj instanceof TriggerPlugin)) {
-        log.error("The object is not an TriggerPlugin");
+        LOG.error("The object is not an TriggerPlugin");
         continue;
       }
 
@@ -117,7 +117,7 @@ public class TriggerPluginLoader {
 
     // Velocity needs the jar resource paths to be set.
     final String jarResourcePath = StringUtils.join(jarPaths, ", ");
-    log.info("Setting jar resource path " + jarResourcePath);
+    LOG.info("Setting jar resource path " + jarResourcePath);
     final VelocityEngine ve = azkabanWebServer.getVelocityEngine();
     ve.addProperty("jar.resource.loader.path", jarResourcePath);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/WebServerProvider.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/WebServerProvider.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.webapp;
 
 import static java.util.Objects.requireNonNull;
@@ -24,16 +23,17 @@ import azkaban.utils.Props;
 import javax.inject.Inject;
 import com.google.inject.Provider;
 import java.util.List;
-import org.apache.log4j.Logger;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.bio.SocketConnector;
 import org.mortbay.jetty.security.SslSocketConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class WebServerProvider implements Provider<Server> {
 
-  private static final Logger logger = Logger.getLogger(WebServerProvider.class);
+  private static final Logger LOG = LoggerFactory.getLogger(WebServerProvider.class);
   private static final int MAX_HEADER_BUFFER_SIZE = 10 * 1024 * 1024;
 
   @Inject
@@ -62,14 +62,14 @@ public class WebServerProvider implements Provider<Server> {
     // setting stats configuration for connectors
     setStatsOnConnectors(server);
 
-    logger.info(String.format(
+    LOG.info(String.format(
         "Starting %sserver on port: %d # Max threads: %d", useSsl ? "SSL " : "", port, maxThreads));
     return server;
   }
 
   private void setStatsOnConnectors(final Server server) {
     final boolean isStatsOn = this.props.getBoolean("jetty.connector.stats", true);
-    logger.info("Setting up connector with stats on: " + isStatsOn);
+    LOG.info("Setting up connector with stats on: " + isStatsOn);
     for (final Connector connector : server.getConnectors()) {
       connector.setStatsOn(isStatsOn);
     }
@@ -95,7 +95,7 @@ public class WebServerProvider implements Provider<Server> {
     // set up vulnerable cipher suites to exclude
     final List<String> cipherSuitesToExclude = this.props
         .getStringList("jetty.excludeCipherSuites");
-    logger.info("Excluded Cipher Suites: " + String.valueOf(cipherSuitesToExclude));
+    LOG.info("Excluded Cipher Suites: " + String.valueOf(cipherSuitesToExclude));
     if (cipherSuitesToExclude != null && !cipherSuitesToExclude.isEmpty()) {
       secureConnector.setExcludeCipherSuites(cipherSuitesToExclude.toArray(new String[0]));
     }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerInstanceServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerInstanceServlet.java
@@ -36,14 +36,12 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 public class FlowTriggerInstanceServlet extends LoginAbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger logger = Logger.getLogger(FlowTriggerInstanceServlet.class);
   private FlowTriggerService triggerService;
   private ProjectManager projectManager;
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/FlowTriggerServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.flowtrigger.quartz.FlowTriggerScheduler;
@@ -35,12 +34,13 @@ import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
 
+  private static final Logger LOG = LoggerFactory.getLogger(FlowTriggerServlet.class);
   private static final long serialVersionUID = 1L;
   private FlowTriggerScheduler scheduler;
   private ProjectManager projectManager;
-  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerServlet.class);
 
   @Override
   public void init(final ServletConfig config) throws ServletException {
@@ -120,15 +120,15 @@ public class FlowTriggerServlet extends LoginAbstractAzkabanServlet {
           try {
             if (ajaxName.equals("pauseTrigger")) {
               if (this.scheduler.pauseFlowTriggerIfPresent(projectId, flowId)) {
-                logger.info("Flow trigger for flow {}.{} is paused", project.getName(), flowId);
+                LOG.info("Flow trigger for flow {}.{} is paused", project.getName(), flowId);
               } else {
-                logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
+                LOG.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
               }
             } else {
               if (this.scheduler.resumeFlowTriggerIfPresent(projectId, flowId)) {
-                logger.info("Flow trigger for flow {}.{} is resumed", project.getName(), flowId);
+                LOG.info("Flow trigger for flow {}.{} is resumed", project.getName(), flowId);
               } else {
-                logger.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
+                LOG.warn("Flow trigger for flow {}.{} doesn't exist", project.getName(), flowId);
               }
             }
             ret.put("status", "success");

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/JMXHttpServlet.java
@@ -19,7 +19,6 @@ import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.server.session.Session;
 import azkaban.trigger.TriggerManager;
-import azkaban.user.UserManager;
 import azkaban.webapp.AzkabanWebServer;
 import java.io.IOException;
 import java.util.HashMap;
@@ -31,7 +30,8 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -41,10 +41,8 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     ConnectorParams {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger logger = Logger.getLogger(JMXHttpServlet.class
-      .getName());
+  private static final Logger LOG = LoggerFactory.getLogger(JMXHttpServlet.class);
 
-  private UserManager userManager;
   private AzkabanWebServer server;
   private ExecutorManagerAdapter executorManagerAdapter;
   private TriggerManager triggerManager;
@@ -54,7 +52,6 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
     super.init(config);
 
     this.server = (AzkabanWebServer) getApplication();
-    this.userManager = this.server.getUserManager();
     this.executorManagerAdapter = this.server.getExecutorManager();
 
     this.triggerManager = this.server.getTriggerManager();
@@ -99,7 +96,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
             ret.put("attributes", info.getAttributes());
             ret.put("description", info.getDescription());
           } catch (final Exception e) {
-            logger.error(e);
+            LOG.error("MBean is invalid", e);
             ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
           }
         } else {
@@ -114,11 +111,11 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
           try {
             final ObjectName name = new ObjectName(mbeanName);
-            final Object obj = this.server.getMBeanRegistrationManager()
-                .getMBeanAttribute(name, attribute);
+            final Object obj =
+                this.server.getMBeanRegistrationManager().getMBeanAttribute(name, attribute);
             ret.put("value", obj);
           } catch (final Exception e) {
-            logger.error(e);
+            LOG.error("MBean is invalid", e);
             ret.put("error", "'" + mbeanName + "' is not a valid mBean name");
           }
         }
@@ -143,7 +140,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
   }
 
   private void handleJMXPage(final HttpServletRequest req, final HttpServletResponse resp,
-      final Session session) throws IOException {
+      final Session session) {
     final Page page =
         newPage(req, resp, session,
             "azkaban/webapp/servlet/velocity/jmxpage.vm");
@@ -158,7 +155,7 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
         executorMBeans.put(hostPort, mbeans.get("mbeans"));
       } catch (final IOException e) {
-        logger.error("Cannot contact executor " + hostPort, e);
+        LOG.error("Cannot contact executor " + hostPort, e);
       }
     }
 
@@ -175,7 +172,6 @@ public class JMXHttpServlet extends LoginAbstractAzkabanServlet implements
 
   @Override
   protected void handlePost(final HttpServletRequest req, final HttpServletResponse resp,
-      final Session session) throws ServletException, IOException {
-
+      final Session session) {
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -43,7 +43,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -53,8 +54,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
 
   private static final long serialVersionUID = 1L;
 
-  private static final Logger logger = Logger
-      .getLogger(LoginAbstractAzkabanServlet.class.getName());
+  private static final Logger LOG = LoggerFactory.getLogger(LoginAbstractAzkabanServlet.class);
   private static final String SESSION_ID_NAME = "azkaban.browser.session.id";
   private static final int DEFAULT_UPLOAD_DISK_SPOOL_SIZE = 20 * 1024 * 1024;
 
@@ -112,8 +112,8 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
     }
 
     if (session != null) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Found session " + session.getUser());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Found session " + session.getUser());
       }
       if (handleFileGet(req, resp)) {
         return;
@@ -165,7 +165,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
       }
     }
 
-    logger.info(buf.toString());
+    LOG.info(buf.toString());
   }
 
   private boolean handleFileGet(final HttpServletRequest req, final HttpServletResponse resp)
@@ -456,7 +456,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
           getApplication().getSessionCache().findSessionsByIP(session.getIp());
 
       // Check potential DDoS attack by bad hosts.
-      logger.info(
+      LOG.info(
           "Session id created for user '" + session.getUser().getUserId() + "' and ip " + session
               .getIp() + ", " + sessionsOfSameIP.size() + " session(s) found from this IP");
       ret.put("status", "success");
@@ -476,7 +476,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
   protected boolean isAjaxCall(final HttpServletRequest req) {
     final String value = req.getHeader("X-Requested-With");
     if (value != null) {
-      logger.info("has X-Requested-With " + value);
+      LOG.info("has X-Requested-With " + value);
       return value.equals("XMLHttpRequest");
     }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/NoteServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/NoteServlet.java
@@ -28,12 +28,14 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class NoteServlet extends LoginAbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger logger = Logger.getLogger(NoteServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NoteServlet.class);
 
   public static String type = null;
   public static String message = null;
@@ -111,7 +113,7 @@ public class NoteServlet extends LoginAbstractAzkabanServlet {
     type = getParam(req, "type");
     message = getParam(req, "message");
     url = getParam(req, "url");
-    logger.info("receive note message. Type: " + type + " message: " + message + " url: " + url);
+    LOG.info("receive note message. Type: " + type + " message: " + message + " url: " + url);
     ret.put("status", "success");
   }
 
@@ -119,7 +121,7 @@ public class NoteServlet extends LoginAbstractAzkabanServlet {
     type = null;
     message = null;
     url = null;
-    logger.info("removing note from memory.");
+    LOG.info("removing note from memory.");
     ret.put("status", "success");
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.project.Project;
@@ -33,15 +32,16 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * The main page
  */
 public class ProjectServlet extends LoginAbstractAzkabanServlet {
 
-  private static final Logger logger = Logger.getLogger(ProjectServlet.class
-      .getName());
+  private static final Logger LOG = LoggerFactory.getLogger(ProjectServlet.class);
   private static final String LOCKDOWN_CREATE_PROJECTS_KEY =
       "lockdown.create.projects";
   private static final long serialVersionUID = -1;
@@ -59,7 +59,7 @@ public class ProjectServlet extends LoginAbstractAzkabanServlet {
     this.lockdownCreateProjects =
         server.getServerProps().getBoolean(LOCKDOWN_CREATE_PROJECTS_KEY, false);
     if (this.lockdownCreateProjects) {
-      logger.info("Creation of projects is locked down");
+      LOG.info("Creation of projects is locked down");
     }
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -49,16 +49,18 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ScheduleServlet.class);
   public static final String PARAM_SLA_EMAILS = "slaEmails";
   public static final String PARAM_SCHEDULE_ID = "scheduleId";
   public static final String PARAM_SETTINGS = "settings";
@@ -66,13 +68,11 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
   public static final String PARAM_ALL_JOB_NAMES = "allJobNames";
   public static final String PARAM_STATUS = "status";
   public static final String PARAM_MESSAGE = "message";
-
   public static final String STATUS_SUCCESS = "success";
   public static final String STATUS_ERROR = "error";
   public static final String SLA_STATUS_SUCCESS = "SUCCESS";
-
   private static final long serialVersionUID = 1L;
-  private static final Logger logger = Logger.getLogger(ScheduleServlet.class);
+
   private ProjectManager projectManager;
   private ScheduleManager scheduleManager;
   private UserManager userManager;
@@ -218,7 +218,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     } catch (final ServletException e) {
       ret.put(PARAM_ERROR, e.getMessage());
     } catch (final ScheduleManagerException e) {
-      logger.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       ret.put(PARAM_ERROR, e.getMessage());
     }
 
@@ -226,7 +226,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
   private SlaOption parseSlaSetting(final String set, String flowName, List<String> emails) throws
       ScheduleManagerException {
-    logger.info("Trying to set sla with the following set: " + set);
+    LOG.info("Trying to set sla with the following set: " + set);
 
     final String[] parts = set.split(",", -1);
     final String id = parts[0];
@@ -266,7 +266,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     }
 
     if (actions.size() > 0) {
-      logger.info("Parsing sla as id:" + id + " type:" + type + " sla:"
+      LOG.info("Parsing sla as id:" + id + " type:" + type + " sla:"
           + rule + " Duration:" + duration + " actions:" + actions);
       return new SlaOptionBuilder(type, flowName, dur).setJobName(id).setActions(actions)
           .setEmails(emails).createSlaOption();
@@ -303,7 +303,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
         ret.put("schedule", jsonObj);
       }
     } catch (final ScheduleManagerException e) {
-      logger.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       ret.put(PARAM_ERROR, e);
     }
   }
@@ -373,7 +373,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     } catch (final ServletException e) {
       ret.put(PARAM_ERROR, e);
     } catch (final ScheduleManagerException e) {
-      logger.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       ret.put(PARAM_ERROR, e);
     }
   }
@@ -460,7 +460,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     }
 
     this.scheduleManager.removeSchedule(sched);
-    logger.info("User '" + user.getUserId() + " has removed schedule "
+    LOG.info("User '" + user.getUserId() + " has removed schedule "
         + sched.getScheduleName());
     this.projectManager
         .postProjectEvent(project, EventType.SCHEDULE, user.getUserId(),
@@ -544,7 +544,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
             "ready", firstSchedTime.getMillis(), endSchedTime, firstSchedTime.getZone(),
             thePeriod, DateTime.now().getMillis(), firstSchedTime.getMillis(),
             firstSchedTime.getMillis(), user.getUserId(), flowOptions);
-    logger.info("User '" + user.getUserId() + "' has scheduled " + "["
+    LOG.info("User '" + user.getUserId() + "' has scheduled " + "["
         + projectName + flowName + " (" + projectId + ")" + "].");
     this.projectManager.postProjectEvent(project, EventType.SCHEDULE,
         user.getUserId(), "Schedule " + schedule.toString()
@@ -596,7 +596,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     try {
       hasFlowTrigger = this.projectManager.hasFlowTrigger(project, flow);
     } catch (final Exception ex) {
-      logger.error(ex);
+      LOG.error("Fail to look for flow trigger", ex);
       ret.put(PARAM_STATUS, STATUS_ERROR);
       ret.put(PARAM_MESSAGE, String.format("Error looking for flow trigger of flow: %s.%s ",
           projectName, flowName));
@@ -658,7 +658,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
             firstSchedTime.getMillis(), user.getUserId(), flowOptions,
             cronExpression);
 
-    logger.info("User '" + user.getUserId() + "' has scheduled " + "["
+    LOG.info("User '" + user.getUserId() + "' has scheduled " + "["
         + projectName + flowName + " (" + projectId + ")" + "].");
     this.projectManager.postProjectEvent(project, EventType.SCHEDULE,
         user.getUserId(), "Schedule " + schedule.toString()

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatsServlet.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.executor.ConnectorParams;
@@ -22,7 +21,6 @@ import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.server.session.Session;
 import azkaban.user.User;
-import azkaban.user.UserManager;
 import azkaban.utils.Pair;
 import azkaban.webapp.AzkabanWebServer;
 import java.io.IOException;
@@ -36,24 +34,24 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * User facing servlet for Azkaban default metric display
  */
 public class StatsServlet extends LoginAbstractAzkabanServlet {
 
-  private static final Logger logger = Logger.getLogger(StatsServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StatsServlet.class);
 
   private static final long serialVersionUID = 1L;
-  private UserManager userManager;
   private ExecutorManagerAdapter execManagerAdapter;
 
   @Override
   public void init(final ServletConfig config) throws ServletException {
     super.init(config);
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
-    this.userManager = server.getUserManager();
     this.execManagerAdapter = server.getExecutorManager();
   }
 
@@ -118,7 +116,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
         ret.put("metricList", result.get("data"));
       }
     } catch (final ExecutorManagerException e) {
-      logger.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       ret.put("error", "Failed to fetch metric names for executor : "
           + executorId);
     }
@@ -130,8 +128,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
    * @param actionName Name of the action
    */
   private void handleChangeConfigurationRequest(final int executorId, final String actionName,
-      final HttpServletRequest req, final HashMap<String, Object> ret)
-      throws ServletException, IOException {
+      final HttpServletRequest req, final HashMap<String, Object> ret) throws IOException {
     try {
       final Map<String, Object> result =
           this.execManagerAdapter
@@ -144,7 +141,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
             result.get(ConnectorParams.STATUS_PARAM));
       }
     } catch (final ExecutorManagerException ex) {
-      logger.error(ex.getMessage(), ex);
+      LOG.error(ex.getMessage(), ex);
       ret.put("error", "Failed to change config change");
     }
   }
@@ -153,8 +150,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
    * Get metric snapshots for a metric and date specification
    */
   private void handleGetMetricHistory(final int executorId, final HttpServletRequest req,
-      final HashMap<String, Object> ret, final User user) throws IOException,
-      ServletException {
+      final HashMap<String, Object> ret, final User user) throws IOException {
     try {
       final Map<String, Object> result =
           this.execManagerAdapter.callExecutorStats(executorId,
@@ -166,7 +162,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
         ret.put("data", result.get("data"));
       }
     } catch (final ExecutorManagerException ex) {
-      logger.error(ex.getMessage(), ex);
+      LOG.error(ex.getMessage(), ex);
       ret.put("error", "Failed to fetch metric history");
     }
   }
@@ -176,8 +172,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
    *
    */
   private void handleStatePageLoad(final HttpServletRequest req, final HttpServletResponse resp,
-      final Session session)
-      throws ServletException {
+      final Session session) {
     final Page page = newPage(req, resp, session, "azkaban/webapp/servlet/velocity/statsPage.vm");
 
     try {
@@ -199,7 +194,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
         page.add("metricList", result.get("data"));
       }
     } catch (final Exception e) {
-      logger.error(e.getMessage(), e);
+      LOG.error(e.getMessage(), e);
       page.add("errorMsg", "Failed to get a response from Azkaban exec server");
     }
 
@@ -208,9 +203,7 @@ public class StatsServlet extends LoginAbstractAzkabanServlet {
 
   @Override
   protected void handlePost(final HttpServletRequest req, final HttpServletResponse resp,
-      final Session session)
-      throws ServletException,
-      IOException {
+      final Session session) {
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatusServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/StatusServlet.java
@@ -14,7 +14,6 @@
  * the License.
  *
  */
-
 package azkaban.webapp.servlet;
 
 import static azkaban.webapp.servlet.AbstractAzkabanServlet.JSON_MIME_TYPE;
@@ -22,16 +21,16 @@ import static azkaban.webapp.servlet.AbstractAzkabanServlet.JSON_MIME_TYPE;
 import azkaban.webapp.StatusService;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class StatusServlet extends HttpServlet {
 
-  private static final Logger log = LoggerFactory.getLogger(StatusServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(StatusServlet.class);
 
   private final StatusService statusService;
 
@@ -41,7 +40,7 @@ public class StatusServlet extends HttpServlet {
 
   @Override
   protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
-      throws ServletException, IOException {
+      throws IOException {
     try {
       resp.setContentType(JSON_MIME_TYPE);
       resp.getOutputStream()
@@ -51,7 +50,7 @@ public class StatusServlet extends HttpServlet {
               .toJson(this.statusService.getStatus()));
       resp.setStatus(HttpServletResponse.SC_OK);
     } catch (final Exception e) {
-      log.error("Error!! while reporting status: ", e);
+      LOG.error("Error!! while reporting status: ", e);
       resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
     } finally {
       resp.getOutputStream().close();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/TriggerManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/TriggerManagerServlet.java
@@ -13,13 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.webapp.servlet;
 
 import azkaban.server.session.Session;
 import azkaban.trigger.Trigger;
 import azkaban.trigger.TriggerManager;
-import azkaban.trigger.TriggerManagerException;
 import azkaban.user.User;
 import azkaban.webapp.AzkabanWebServer;
 import java.io.IOException;
@@ -30,13 +28,14 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class TriggerManagerServlet extends LoginAbstractAzkabanServlet {
 
   private static final long serialVersionUID = 1L;
-  private static final Logger logger = Logger
-      .getLogger(TriggerManagerServlet.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TriggerManagerServlet.class);
   private TriggerManager triggerManager;
 
   @Override
@@ -76,8 +75,7 @@ public class TriggerManagerServlet extends LoginAbstractAzkabanServlet {
   }
 
   private void handleGetAllSchedules(final HttpServletRequest req,
-      final HttpServletResponse resp, final Session session) throws ServletException,
-      IOException {
+      final HttpServletResponse resp, final Session session) {
 
     final Page page =
         newPage(req, resp, session,
@@ -97,8 +95,7 @@ public class TriggerManagerServlet extends LoginAbstractAzkabanServlet {
   }
 
   private void ajaxExpireTrigger(final HttpServletRequest req,
-      final Map<String, Object> ret, final User user) throws ServletException,
-      TriggerManagerException {
+      final Map<String, Object> ret, final User user) throws ServletException {
     final int triggerId = getIntParam(req, "triggerId");
     final Trigger t = this.triggerManager.getTrigger(triggerId);
     if (t == null) {
@@ -108,7 +105,7 @@ public class TriggerManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     this.triggerManager.expireTrigger(triggerId);
-    logger.info("User '" + user.getUserId() + " has removed trigger "
+    LOG.info("User '" + user.getUserId() + " has removed trigger "
         + t.getDescription());
 
     ret.put("status", "success");

--- a/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package azkaban.restli;
 
 import azkaban.restli.user.User;
@@ -28,13 +27,14 @@ import com.linkedin.restli.server.resources.ResourceContextHolder;
 import java.util.Set;
 import java.util.UUID;
 import javax.servlet.ServletException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @RestLiActions(name = "user", namespace = "azkaban.restli")
 public class UserManagerResource extends ResourceContextHolder {
 
-  private static final Logger logger = Logger
-      .getLogger(UserManagerResource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UserManagerResource.class);
 
   public AzkabanWebServer getAzkaban() {
     return AzkabanWebServer.getInstance();
@@ -45,8 +45,7 @@ public class UserManagerResource extends ResourceContextHolder {
       @ActionParam("password") final String password) throws UserManagerException,
       ServletException {
     final String ip = ResourceUtils.getRealClientIpAddr(this.getContext());
-    logger
-        .info("Attempting to login for " + username + " from ip '" + ip + "'");
+    LOG.info("Attempting to login for " + username + " from ip '" + ip + "'");
 
     final Session session = createSession(username, password, ip);
 
@@ -55,7 +54,7 @@ public class UserManagerResource extends ResourceContextHolder {
         .findSessionsByIP(session.getIp());
 
     // Check potential DDoS attack by bad hosts.
-    logger.info(
+    LOG.info(
         "Session id created for user '" + session.getUser().getUserId() + "' and ip " + session
             .getIp() + ", " + sessionsOfSameIP.size() + " session(s) found from this IP");
 

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/FlowTriggerInstanceLoaderTest.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 
 public class FlowTriggerInstanceLoaderTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(FlowTriggerInstanceLoaderTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(FlowTriggerInstanceLoaderTest.class);
   private static final String test_project_zip_dir = "flowtriggeryamltest";
   private static final String test_flow_file = "flow_trigger.flow";
   private static final int project_id = 123;
@@ -79,7 +79,7 @@ public class FlowTriggerInstanceLoaderTest {
       dbOperator.update("DROP ALL OBJECTS");
       dbOperator.update("SHUTDOWN");
     } catch (final SQLException e) {
-      logger.error("unable to destroy db", e);
+      LOG.error("unable to destroy db", e);
     }
   }
 


### PR DESCRIPTION
Review all code base and change all log4j dependencies to slf4j when it is possible. However, the core Job Management part is heavily depending on the log4j. If we want to totally solve the problem, we should review and discuss that offline first. It may introduce back-ward incompatible problem.