### PR TITLE
Add links to job logs in job context menu in execution graph

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -75,6 +75,8 @@ var nodeClickCallback = function (event, model, node) {
 
   var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
       + flowId + "&job=" + jobId;
+  var logURL = contextURL + "/executor?execid=" + execId + "&job="
+      + node.nestedId;
   var menu = [];
 
   if (type == "flow") {
@@ -142,7 +144,28 @@ var nodeClickCallback = function (event, model, node) {
     ]);
   }
   else {
-    menu = [
+    // this applies for type != 'flow' ie. job nodes in 2 cases:
+    // 1. Flow -> Graph tab
+    // 2. Execution -> Graph tab
+    menu = [];
+    if (node.status != 'READY' && node.status != 'SKIPPED') {
+      // For "Flow Graph" (not an execution) node.status = READY, so this
+      // condition also works correctly for it
+      $.merge(menu, [
+        {
+          title: "Open Log...", callback: function () {
+            window.location.href = logURL;
+          }
+        },
+        {
+          title: "Open Log in New Window...", callback: function () {
+            window.open(logURL);
+          }
+        },
+        {break: 1}
+      ]);
+    }
+    $.merge(menu, [
       //  {title: "View Properties...", callback: function() {openJobDisplayCallback(jobId, flowId, event)}},
       //  {break: 1},
       {
@@ -161,13 +184,13 @@ var nodeClickCallback = function (event, model, node) {
           model.trigger("centerNode", node)
         }
       }
-    ];
+    ]);
   }
   contextMenuView.show(event, menu);
 }
 
 var jobClickCallback = function (event, model, node) {
-  console.log("Node clicked callback");
+  console.log("Job clicked callback");
   var target = event.currentTarget;
   var type = node.type;
   var flowId = node.parent.flow;


### PR DESCRIPTION
Job log links have been only available in the `Job List` tab of an `Execution`, not on the `Graph` tab.

However, `Graph` is the landing tab for an `Execution`, and the easiest place to see the overall situation. It would be convenient to access job logs directly from the Graph by right-clicking a job.

This PR implements that.

Now the context-menu (with right-click) includes links to job logs 🎉:

<img width="506" alt="Näyttökuva 2019-5-5 kello 20 13 31" src="https://user-images.githubusercontent.com/4446608/57197677-e75b8380-6f72-11e9-98bd-791bd85b801d.png">

----

## Tests & verifications

<img width="703" alt="Näyttökuva 2019-5-5 kello 20 13 44" src="https://user-images.githubusercontent.com/4446608/57197689-078b4280-6f73-11e9-86b1-f74475be141c.png">

^ It works the same inside sub-flows (using nested ID so the URL is correct, too)

----

<img width="571" alt="Näyttökuva 2019-5-5 kello 20 13 56" src="https://user-images.githubusercontent.com/4446608/57197693-17a32200-6f73-11e9-8e62-151d7dd29648.png">

^ Jobs that haven't been run yet don't have log links

----

<img width="453" alt="Näyttökuva 2019-5-5 kello 20 24 01" src="https://user-images.githubusercontent.com/4446608/57197760-f0008980-6f73-11e9-8d1e-51bbc3aba7f2.png">

^ Disabled jobs don't have log links

----

<img width="458" alt="Näyttökuva 2019-5-5 kello 20 14 21" src="https://user-images.githubusercontent.com/4446608/57197756-dd865000-6f73-11e9-9a22-5a9ff8013e2e.png">

^ In Flow view (not an Execution) jobs don't have log links