### PR TITLE
Rename job logs link: Details -> Log

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -398,7 +398,7 @@ azkaban.ExecutionListView = Backbone.View.extend({
       var a = document.createElement("a");
       $(a).attr("href", logURL);
       //$(a).attr("id", node.id + "-log-link");
-      $(a).text("Details");
+      $(a).text("Log");
       $(tdDetails).append(a);
     }
 


### PR DESCRIPTION
For not-so-familiar users it's been confusing to find where the job logs are.

I don't see any reason to use "Details" as a label for the link that points to job log (the latest attempt's log).

I'm still keeping the original table header "Details". I guess that's ok.. For "flow" type nodes there is never log link currently. Maybe something else than just a log link might be added in the future to this column, IDK..

<img width="888" alt="Näyttökuva 2019-5-5 kello 20 40 46" src="https://user-images.githubusercontent.com/4446608/57197986-4d95d580-6f76-11e9-9d9f-f69c4a076838.png">

So, those [Log](#log) links on the right were previously called [Details](#details).