### PR TITLE
Job callback to support multiple occurrences of the same token

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -213,7 +213,7 @@ public class JobCallbackUtil {
 
   private static String replaceStatusToken(final String template,
       final JobCallbackStatusEnum status) {
-    return template.replaceFirst(STATUS_TOKEN, status.name().toLowerCase());
+    return template.replaceAll(STATUS_TOKEN, status.name().toLowerCase());
   }
 
   private static StringEntity createStringEntity(final String str) {
@@ -277,25 +277,25 @@ public class JobCallbackUtil {
     String result = value;
     String tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_SERVER_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_SERVER_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_SERVER_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_PROJECT_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_PROJECT_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_PROJECT_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_FLOW_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_FLOW_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_FLOW_TOKEN), tokenValue);
 
     tokenValue = encodeQueryParam(contextInfo.get(CONTEXT_JOB_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_JOB_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_JOB_TOKEN), tokenValue);
 
     tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_EXECUTION_ID_TOKEN), withEncoding);
-    result = result.replaceFirst(Pattern.quote(CONTEXT_EXECUTION_ID_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_EXECUTION_ID_TOKEN), tokenValue);
 
     tokenValue =
         encodeQueryParam(contextInfo.get(CONTEXT_JOB_STATUS_TOKEN), withEncoding);
 
-    result = result.replaceFirst(Pattern.quote(CONTEXT_JOB_STATUS_TOKEN), tokenValue);
+    result = result.replaceAll(Pattern.quote(CONTEXT_JOB_STATUS_TOKEN), tokenValue);
 
     return result;
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/JobCallbackUtilTest.java
@@ -189,6 +189,15 @@ public class JobCallbackUtilTest {
   }
 
   @Test
+  public void multipleOccurrencesOfTheSameTokenTest() {
+    final String urlWithOneToken =
+        "test1=" + CONTEXT_FLOW_TOKEN + "&test2=" + CONTEXT_FLOW_TOKEN;
+    final String result =
+        JobCallbackUtil.replaceTokens(urlWithOneToken, contextInfo, true);
+    Assert.assertEquals("test1=" + FLOW_NAME + "&test2=" + FLOW_NAME, result);
+  }
+
+  @Test
   public void allTokensTest() {
 
     final String urlWithOneToken =


### PR DESCRIPTION
This can be useful for example when formatting a callback payload that contains some title & more detailed message, and both want to include the job status, or any other provided token.