### PR TITLE
Simplify pattern for detecting links in job logs

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/view/job-details.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-details.js
@@ -31,7 +31,7 @@ azkaban.JobLogView = Backbone.View.extend({
   },
 
   render: function () {
-    var re = /(https?:\/\/(([-\w\.]+)+(:\d+)?(\/([\w/_\.]*(\?\S+)?)?)?))/g;
+    var re = /(https?:\/\/\S+)/g;
     var log = this.model.get("logData");
     log = log.replace(re, "<a href=\"$1\" title=\"\">$1</a>");
     $("#logSection").html(log);


### PR DESCRIPTION
This pattern catches anything that starts with http:// or https:// until any whitespace.

I'm not sure why the existing, more complicated pattern, is like that and stops already at `#`. I've seen other tools also stop at `(`, that's not too good either..

In practice, IMHO, it's better to catch links with higher tolerance and assume that there will be whitespace after each link.

Here's a real-life example of what would be cut too early by the existing pattern:

`http://kibana-test-elk.domain.com:8080/app/kibana#/discover?_a=(columns:!(loglevel,class,message),filters:!((meta:(index:'logstash-index-*',key:fields.cluster_id,params:(query:j-3W0WSCST0THQX,type:phrase),type:phrase,value:j-3W0WSCST0THQX),query:(match:(fields.cluster_id:(query:j-3W0WSCST0THQX,type:phrase))))),index:'logstash-index-*')`

So (using https://regex101.com to test):

<img width="1119" alt="Näyttökuva 2019-5-10 kello 23 27 17" src="https://user-images.githubusercontent.com/4446608/57554842-39d5df00-737b-11e9-8d95-5c0cb063246d.png">

vs.

<img width="1116" alt="Näyttökuva 2019-5-10 kello 23 27 37" src="https://user-images.githubusercontent.com/4446608/57554855-3d696600-737b-11e9-9ae5-d12234b7b860.png">

Internally we have been using this modification since Jun 2018, so it's been tested also in practice with many kinds of links in Azkaban job logs.