### PR TITLE
Make XmlUserManagerTest run quicker

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -18,6 +18,7 @@ package azkaban.user;
 
 import azkaban.user.User.UserPermissions;
 import azkaban.utils.Props;
+import com.sun.nio.file.SensitivityWatchEventModifier;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -45,6 +46,12 @@ import org.xml.sax.SAXException;
 public class XmlUserManager implements UserManager {
 
   public static final String XML_FILE_PARAM = "user.manager.xml.file";
+  /**
+   * value must be from the enum {@link SensitivityWatchEventModifier}
+   */
+  public static final String XML_FILE_WATCH_SENSITIVITY = "user.manager.xml.watchSensitivity";
+  public static final String XML_FILE_WATCH_GRACE_PERIOD_MILLIS =
+      "user.manager.xml.watchGracePeriodMillis";
   public static final String AZKABAN_USERS_TAG = "azkaban-users";
   public static final String USER_TAG = "user";
   public static final String ROLE_TAG = "role";
@@ -80,7 +87,10 @@ public class XmlUserManager implements UserManager {
     final Map<String, ParseConfigFile> parseConfigFileMap = new HashMap<>();
     parseConfigFileMap.put(this.xmlPath, this::parseXMLFile);
     try {
-      UserUtils.setupWatch(parseConfigFileMap);
+      UserUtils.setupWatch(
+          parseConfigFileMap,
+          props.get(XML_FILE_WATCH_SENSITIVITY),
+          props.getLong(XML_FILE_WATCH_GRACE_PERIOD_MILLIS, -1L));
     } catch (final IOException e) {
       logger.warn(" Failed to create WatchService " + e.getMessage());
     }


### PR DESCRIPTION
Optimize XmlUserManagerTest:
- Before: 53 s
- After: 10 s

How:
- Configured for test scope to watch file every 2s instead of every 10s, which allows using shorter polling times & getting the expected update faster.
- Also reduced the sleep time after new notification(s) 1000ms->10ms.

See also https://github.com/azkaban/azkaban/issues/2220#issuecomment-491445541.

----

This is still too much of a system test I think. For example there's no need to have `testAutoReloadFail` as a full multithreaded case. It could be done simpler & without any extra sleeps by calling the reload method directly:
- create empty file
- call reload
- check that reload didn't change the returned value

And the behaviour of UserUtils in case of a parseConfigFile throws exception could be tested as a unit test that mocks both XmlUserManager & watchService (instead of using a real watchService).

----

Also this issue is still there:

> It looks like the test is also modifying a build-generated file (azkaban-common/build/resources/test/test-conf/azkaban-users-test1.xml). Even though test has a finally block to "revert the contents", this shouldn't be done IMHO. Instead, a copy of the file should be made to a temporary folder or something.