### PR TITLE
Flow override properties to also override job properties

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -786,6 +786,13 @@ public class FlowRunner extends EventHandler implements Runnable {
       props = jobSource;
     }
 
+    // 5. If there are any runtime flow overrides, we apply them now.
+    final Map<String, String> flowParam =
+        this.flow.getExecutionOptions().getFlowParameters();
+    if (flowParam != null && !flowParam.isEmpty()) {
+      props.putAll(flowParam);
+    }
+
     node.setInputProps(props);
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -40,10 +40,10 @@ import org.junit.Test;
  * The tests are contained in execpropstest, and should be resolved in the following fashion, where
  * the later props take precedence over the previous ones.
  *
- * 1. Global props (set in the FlowRunner) 2. Shared job props (depends on job directory) 3. Flow
- * Override properties 4. Previous job outputs to the embedded flow (Only if contained in embedded
- * flow) 5. Embedded flow properties (Only if contained in embedded flow) 6. Previous job outputs
- * (if exists) 7. Job Props
+ * 1. Global props (set in the FlowRunner) 2. Shared job props (depends on job directory) 3.
+ * Previous job outputs to the embedded flow (Only if contained in embedded flow) 4. Embedded flow
+ * properties (Only if contained in embedded flow) 5. Previous job outputs (if exists) 6. Job Props
+ * 7. Flow Override properties
  *
  * The test contains the following structure: job2 -> innerFlow (job1 -> job4 ) -> job3
  *
@@ -107,7 +107,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("shared1", job2Props.get("props1"));
     Assert.assertEquals("job2", job2Props.get("props2"));
     Assert.assertEquals("moo3", job2Props.get("props3"));
-    Assert.assertEquals("job7", job2Props.get("props7"));
+    Assert.assertEquals("flow7", job2Props.get("props7"));
     Assert.assertEquals("flow5", job2Props.get("props5"));
     Assert.assertEquals("flow6", job2Props.get("props6"));
     Assert.assertEquals("shared4", job2Props.get("props4"));
@@ -115,7 +115,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
     // Job 1 is inside another flow, and is nested in a different directory
     // The priority order should be:
-    // job1->innerflow->job2.output->flow.overrides->job1 shared props
+    // job1->innerflow->job2.output->job1.sharedprops->flow.overrides
     final Props job2Generated = new Props();
     job2Generated.put("props6", "gjob6");
     job2Generated.put("props9", "gjob9");
@@ -129,16 +129,15 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("job8", job1Props.get("props8"));
     Assert.assertEquals("gjob9", job1Props.get("props9"));
     Assert.assertEquals("gjob10", job1Props.get("props10"));
-    Assert.assertEquals("innerflow6", job1Props.get("props6"));
-    Assert.assertEquals("innerflow5", job1Props.get("props5"));
+    Assert.assertEquals("flow6", job1Props.get("props6"));
+    Assert.assertEquals("flow5", job1Props.get("props5"));
     Assert.assertEquals("flow7", job1Props.get("props7"));
     Assert.assertEquals("moo3", job1Props.get("props3"));
     Assert.assertEquals("moo4", job1Props.get("props4"));
 
     // Job 4 is inside another flow and takes output from job 1
     // The priority order should be:
-    // job4->job1.output->innerflow->job2.output->flow.overrides->job4 shared
-    // props
+    // job4->job1.output->innerflow->job2.output->job4.sharedprops->flow.overrides
     final Props job1GeneratedProps = new Props();
     job1GeneratedProps.put("props9", "g2job9");
     job1GeneratedProps.put("props7", "g2job7");
@@ -148,9 +147,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
     Assert.assertEquals("job8", job4Props.get("props8"));
     Assert.assertEquals("job9", job4Props.get("props9"));
-    Assert.assertEquals("g2job7", job4Props.get("props7"));
-    Assert.assertEquals("innerflow5", job4Props.get("props5"));
-    Assert.assertEquals("innerflow6", job4Props.get("props6"));
+    Assert.assertEquals("flow7", job4Props.get("props7"));
+    Assert.assertEquals("flow5", job4Props.get("props5"));
+    Assert.assertEquals("flow6", job4Props.get("props6"));
     Assert.assertEquals("gjob10", job4Props.get("props10"));
     Assert.assertEquals("shared4", job4Props.get("props4"));
     Assert.assertEquals("shared1", job4Props.get("props1"));
@@ -159,7 +158,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
     // Job 3 is a normal job taking props from an embedded flow
     // The priority order should be:
-    // job3->innerflow.output->flow.overrides->job3.sharedprops
+    // job3->innerflow.output->job3.sharedprops->flow.overrides
     final Props job4GeneratedProps = new Props();
     job4GeneratedProps.put("props9", "g4job9");
     job4GeneratedProps.put("props6", "g4job6");
@@ -168,7 +167,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     assertStatus(flow, FLOW_NAME, Status.RUNNING);
     final Props job3Props = nodeMap.get("job3").getInputProps();
     Assert.assertEquals("job3", job3Props.get("props3"));
-    Assert.assertEquals("g4job6", job3Props.get("props6"));
+    Assert.assertEquals("flow6", job3Props.get("props6"));
     Assert.assertEquals("g4job9", job3Props.get("props9"));
     Assert.assertEquals("flow7", job3Props.get("props7"));
     Assert.assertEquals("flow5", job3Props.get("props5"));


### PR DESCRIPTION
Currently job properties always win over flow override properties.

However in practice it's quite handy to be able to override even those.

The UI currently says:

> Flow Parameters / Flow Property Override
> Add temporary flow parameters that are used to override global settings for each job

Also the [docs](https://azkaban.readthedocs.io/en/latest/useAzkaban.html?highlight=override#flow-parameters) read:

> The flow parameters override the global properties for a job, but not the properties of the job itself.

It seems like the intention has been that only flow level props are overridden, and if a job defines the same property, it still wins.

This is kinda confusing. Because on the other hand an overridden flow property is passed to the job, if the job itself doesn't set that property at all.

In other words, if a property that's provided as flow parameter is not (originally) defined by job, it still "bleeds" to that job.

----

As a side note, I would like to implement a feature that additionally allows overriding properties for specific jobs (or sub-flows) only. Currently it of course affects all jobs. On the UI the flow override tab could be extended to be similar with job level SLA settings: there's a dropdown picker for job name etc.