### PR TITLE
Set maxParallelForks = 1 again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,9 @@ subprojects {
         test {
             // Set maxParallelForks to a large number and let gradle to force it to a the
             // max-workers number when needed.
-            maxParallelForks = 12
+            // NOTE! For some reason anything more than 1 doesn't work well for azkaban build:
+            // any maxParallelForks > 1 seems to make `./gradlew cleanTest test` ~4 times slower
+            maxParallelForks = 1
         }
     }
 


### PR DESCRIPTION
"Revert "Optimize gradle build time (#2113)" (#2163)" This reverts commit 3cda04e3.

> I guess we could set maxParallelForks = 1 again.

, said @ypadron-in at https://github.com/azkaban/azkaban/pull/2163#issuecomment-491461276