### PR TITLE
XmlUserManagerTest to use mocks & avoid sleeping

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/FileWatcher.java
+++ b/azkaban-common/src/main/java/azkaban/user/FileWatcher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.user;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.List;
+
+public class FileWatcher {
+
+  private final WatchService watchService;
+  private final SensitivityWatchEventModifier sensitivity;
+
+  public FileWatcher() throws IOException {
+    this(SensitivityWatchEventModifier.MEDIUM);
+  }
+
+  public FileWatcher(final SensitivityWatchEventModifier sensitivity) throws IOException {
+    this.sensitivity = sensitivity;
+    this.watchService = FileSystems.getDefault().newWatchService();
+  }
+
+  public WatchKey register(final Path dir) throws IOException {
+    return dir.register(this.watchService,
+        new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_MODIFY},
+        this.sensitivity);
+  }
+
+  public void close() throws IOException {
+    this.watchService.close();
+  }
+
+  public WatchKey take() throws InterruptedException {
+    final WatchKey key = this.watchService.take();
+    // Wait for a second to ensure there is only one event for a modification.
+    // For a file update, WatchService creates two ENTRY_MODIFY events, 1 for content and 1
+    // for modification time.
+    // Adding the sleep consolidates both the events into one with a count of 2 which
+    // avoids multiple reloads of same file.
+    // One second seems excessive, however, these events happen very less often and it is
+    // more important that the config reloads successfully than immediately.
+    // If there is any modification happening to file(s) in the meantime, it is all queued up
+    // in the watch service.
+    Thread.sleep(1000L);
+    return key;
+  }
+
+  public List<WatchEvent<?>> pollEvents(final WatchKey key) {
+    try {
+      return key.pollEvents();
+    } finally {
+      // continue listening – without reset() this key wouldn't be returned by take() any more
+      key.reset();
+    }
+  }
+
+  @FunctionalInterface
+  public interface FileWatcherFactory {
+
+    FileWatcher get() throws IOException;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -16,6 +16,7 @@
 
 package azkaban.user;
 
+import azkaban.user.FileWatcher.FileWatcherFactory;
 import azkaban.user.User.UserPermissions;
 import azkaban.utils.Props;
 import java.io.File;
@@ -70,7 +71,7 @@ public class XmlUserManager implements UserManager {
   /**
    * The constructor.
    */
-  public XmlUserManager(final Props props) {
+  public XmlUserManager(final Props props, final FileWatcherFactory fileWatcherFactory) {
     this.xmlPath = props.getString(XML_FILE_PARAM);
 
     parseXMLFile();
@@ -80,9 +81,9 @@ public class XmlUserManager implements UserManager {
     final Map<String, ParseConfigFile> parseConfigFileMap = new HashMap<>();
     parseConfigFileMap.put(this.xmlPath, this::parseXMLFile);
     try {
-      UserUtils.setupWatch(parseConfigFileMap);
+      UserUtils.setupWatch(parseConfigFileMap, fileWatcherFactory.get());
     } catch (final IOException e) {
-      logger.warn(" Failed to create WatchService " + e.getMessage());
+      logger.warn("Failed to create WatchService", e);
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.user;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileWatcherTest {
+
+  private static final Path PATH = Paths.get("build/tmp/FileWatcherTest");
+  private FileWatcher fileWatcher;
+
+  @Before
+  public void setUp() throws Exception {
+    this.fileWatcher = new FileWatcher(SensitivityWatchEventModifier.HIGH);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (this.fileWatcher != null) {
+      this.fileWatcher.close();
+    }
+  }
+
+  @Test
+  public void registerAndTake() throws Exception {
+    write();
+
+    // start watching
+    final Path dir = Paths.get(PATH.toString()).getParent();
+    this.fileWatcher.register(dir);
+
+    // sleep for a second to have different modification time
+    Thread.sleep(1000L);
+    write();
+
+    final WatchKey key = this.fileWatcher.take();
+    final List<WatchEvent<?>> events = this.fileWatcher.pollEvents(key);
+    assertEquals(1, events.size());
+
+    final WatchEvent<?> event = events.get(0);
+    @SuppressWarnings("unchecked") final Path name = ((WatchEvent<Path>) event).context();
+    final String resolvedFileName = dir.resolve(name).toString();
+    assertEquals(PATH.toString(), resolvedFileName);
+  }
+
+  private void write() throws IOException {
+    // Update the file
+    Files.write(PATH, new ArrayList<>());
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
+++ b/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
@@ -21,6 +21,7 @@ import azkaban.flow.Flow;
 import azkaban.project.DirectoryYamlFlowLoader;
 import azkaban.project.Project;
 import azkaban.test.executions.ExecutionsTestUtil;
+import azkaban.user.FileWatcher;
 import azkaban.user.User;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
@@ -77,7 +78,7 @@ public class TestUtils {
     final Props props = new Props();
     props.put(XmlUserManager.XML_FILE_PARAM, ExecutionsTestUtil.getDataRootDir()
         + "azkaban-users.xml");
-    final UserManager manager = new XmlUserManager(props);
+    final UserManager manager = new XmlUserManager(props, FileWatcher::new);
     return manager;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -27,6 +27,7 @@ import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginException;
 import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginManager;
 import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
+import azkaban.user.FileWatcher;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
 import azkaban.utils.Props;
@@ -102,7 +103,7 @@ public class AzkabanWebServerModule extends AbstractModule {
         throw new RuntimeException(e);
       }
     } else {
-      manager = new XmlUserManager(props);
+      manager = new XmlUserManager(props, FileWatcher::new);
     }
     return manager;
   }


### PR DESCRIPTION
- `XmlUserManagerTest` is almost instant now, < 1s for sure
- Refactored `UserUtils`: extracted real file watching code to a new class: `FileWatcher`
- `FileWatcherTest` takes 3-4s

-> Better separation of concerns & runs quicker in total

For background, comments in https://github.com/azkaban/azkaban/pull/2240