### PR TITLE
Allow execution options to be set in a flow trigger

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/FlowTrigger.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowTrigger.java
@@ -16,6 +16,7 @@
 
 package azkaban.project;
 
+import azkaban.executor.ExecutionOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
@@ -41,13 +42,14 @@ public class FlowTrigger implements Serializable {
   private final Map<String, FlowTriggerDependency> dependencies;
   private final CronSchedule schedule;
   private final Duration maxWaitDuration;
+  private final ExecutionOptions executionOptions;
 
   /**
    * @throws IllegalArgumentException if illegal argument is found or there is duplicate
    * dependency name or duplicate dependency type and params
    */
   public FlowTrigger(final CronSchedule schedule, final List<FlowTriggerDependency> dependencies,
-      @Nullable final Duration maxWaitDuration) {
+      @Nullable final Duration maxWaitDuration, final ExecutionOptions executionOptions) {
     // will perform some basic validation here, and further validation will be performed on
     // parsing time when NodeBeanLoader parses the XML to flow trigger.
     Preconditions.checkNotNull(schedule, "schedule cannot be null");
@@ -61,6 +63,7 @@ public class FlowTrigger implements Serializable {
     dependencies.forEach(dep -> builder.put(dep.getName(), dep));
     this.dependencies = builder.build();
     this.maxWaitDuration = maxWaitDuration;
+    this.executionOptions = executionOptions;
   }
 
   /**
@@ -80,6 +83,7 @@ public class FlowTrigger implements Serializable {
     return "FlowTrigger{" +
         "schedule=" + this.schedule +
         ", maxWaitDurationInMins=" + this.maxWaitDuration +
+        ", executionOptions=" + this.executionOptions +
         "\n " + StringUtils.join(this.dependencies.values(), "\n") + '}';
   }
 
@@ -116,5 +120,9 @@ public class FlowTrigger implements Serializable {
 
   public CronSchedule getSchedule() {
     return this.schedule;
+  }
+
+  public ExecutionOptions getExecutionOptions() {
+    return this.executionOptions;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/project/FlowTriggerBean.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowTriggerBean.java
@@ -29,6 +29,7 @@ public class FlowTriggerBean {
   private Long maxWaitMins = null;
   private Map<String, String> schedule;
   private List<TriggerDependencyBean> triggerDependencies;
+  private Map<String, Object> executionOptions;
 
   public Long getMaxWaitMins() {
     return this.maxWaitMins;
@@ -55,12 +56,21 @@ public class FlowTriggerBean {
     this.triggerDependencies = triggerDependencies;
   }
 
+  public Map<String, Object> getExecutionOptions() {
+    return this.executionOptions;
+  }
+
+  public void setExecutionOptions(final Map<String, Object> executionOptions) {
+    this.executionOptions = executionOptions;
+  }
+
   @Override
   public String toString() {
     return "FlowTriggerBean{" +
         "maxWaitMins='" + this.maxWaitMins + '\'' +
         ", schedule=" + this.schedule +
         ", triggerDependencies=" + this.triggerDependencies +
+        ", executionOptions=" + this.executionOptions +
         '}';
   }
 }

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import azkaban.Constants;
 import azkaban.Constants.FlowTriggerProps;
+import azkaban.executor.ExecutionOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
 import java.io.File;
@@ -202,11 +203,14 @@ public class NodeBeanLoader {
       final Duration duration = flowTriggerBean.getMaxWaitMins() == null ? null : Duration
           .ofMinutes(flowTriggerBean.getMaxWaitMins());
 
+      final ExecutionOptions executionOptions =
+          ExecutionOptions.createFromObject(flowTriggerBean.getExecutionOptions());
+
       return new FlowTrigger(
           new CronSchedule(flowTriggerBean.getSchedule().get(FlowTriggerProps.SCHEDULE_VALUE)),
           flowTriggerBean.getTriggerDependencies().stream()
               .map(d -> new FlowTriggerDependency(d.getName(), d.getType(), d.getParams()))
-              .collect(Collectors.toList()), duration);
+              .collect(Collectors.toList()), duration, executionOptions);
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/project/FlowTriggerTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/FlowTriggerTest.java
@@ -20,6 +20,7 @@ package azkaban.project;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import azkaban.executor.ExecutionOptions;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,16 +61,22 @@ public class FlowTriggerTest {
     final Duration validDuration = Duration.ofMinutes(10);
     final Duration nullDuration = null;
 
-    assertThatThrownBy(() -> new FlowTrigger(nullSchedule, nonEmptyDependencyList, validDuration))
+    final ExecutionOptions nullExecutionOptions = null;
+
+    assertThatThrownBy(() -> new FlowTrigger(nullSchedule, nonEmptyDependencyList, validDuration,
+        nullExecutionOptions))
         .isInstanceOf(NullPointerException.class);
 
-    assertThatThrownBy(() -> new FlowTrigger(validSchedule, nullDependencyList, validDuration))
+    assertThatThrownBy(() -> new FlowTrigger(validSchedule, nullDependencyList, validDuration,
+        nullExecutionOptions))
         .isInstanceOf(NullPointerException.class);
 
-    assertThatThrownBy(() -> new FlowTrigger(validSchedule, nonEmptyDependencyList, nullDuration))
+    assertThatThrownBy(() -> new FlowTrigger(validSchedule, nonEmptyDependencyList, nullDuration,
+        nullExecutionOptions))
         .isInstanceOf(IllegalArgumentException.class);
 
-    assertThatCode(() -> new FlowTrigger(validSchedule, emptyDependencyList, nullDuration))
+    assertThatCode(() -> new FlowTrigger(validSchedule, emptyDependencyList, nullDuration,
+        nullExecutionOptions))
         .doesNotThrowAnyException();
   }
 
@@ -82,7 +89,8 @@ public class FlowTriggerTest {
     dependencyList.add(dep);
     dependencyList.add(dep);
 
-    assertThatThrownBy(() -> new FlowTrigger(schedule, dependencyList, Duration.ofMinutes(10)))
+    assertThatThrownBy(() -> new FlowTrigger(schedule, dependencyList, Duration.ofMinutes(10),
+        null))
         .isInstanceOf
             (IllegalArgumentException
                 .class)
@@ -99,7 +107,8 @@ public class FlowTriggerTest {
     dependencyList.add(dep1);
     dependencyList.add(dep2);
 
-    assertThatThrownBy(() -> new FlowTrigger(schedule, dependencyList, Duration.ofMinutes(10)))
+    assertThatThrownBy(() -> new FlowTrigger(schedule, dependencyList, Duration.ofMinutes(10),
+        null))
         .isInstanceOf
             (IllegalArgumentException
                 .class)

--- a/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/NodeBeanLoaderTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.Constants;
 import azkaban.Constants.FlowTriggerProps;
+import azkaban.executor.ExecutionOptions;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableMap;
@@ -203,6 +204,10 @@ public class NodeBeanLoaderTest {
     validateFlowTrigger(flowTrigger, MAX_WAIT_MINS, CRON_EXPRESSION, 2);
     validateTriggerDependency(flowTrigger, TRIGGER_NAME_1, TRIGGER_TYPE, PARAMS_1);
     validateTriggerDependency(flowTrigger, TRIGGER_NAME_2, TRIGGER_TYPE, PARAMS_2);
+    assertThat(flowTrigger.getExecutionOptions()).isNotNull();
+    assertThat(flowTrigger.getExecutionOptions().getConcurrentOption())
+        .isEqualTo(ExecutionOptions.CONCURRENT_OPTION_PIPELINE);
+    assertThat(flowTrigger.getExecutionOptions().getPipelineLevel()).isEqualTo(2);
   }
 
   @Test

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
@@ -70,6 +70,7 @@ public class TriggerInstanceProcessor {
       final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
       // execute the flow with default execution option(concurrency option being "ignore
       // currently running")
+      executableFlow.setExecutionOptions(triggerInst.getFlowTrigger().getExecutionOptions());
       this.executorManager.submitExecutableFlow(executableFlow, triggerInst.getSubmitUser());
       triggerInst.setFlowExecId(executableFlow.getExecutionId());
     } catch (final Exception ex) {

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/util/TestUtil.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/util/TestUtil.java
@@ -38,6 +38,6 @@ public class TestUtil {
   public static FlowTrigger createTestFlowTrigger(final List<FlowTriggerDependency> deps,
       final Duration maxWaitDuration) {
     return new FlowTrigger(
-        new CronSchedule("* * * * ? *"), deps, maxWaitDuration);
+        new CronSchedule("* * * * ? *"), deps, maxWaitDuration, null);
   }
 }

--- a/test/execution-test-data/flowtriggeryamltest/flow_trigger.flow
+++ b/test/execution-test-data/flowtriggeryamltest/flow_trigger.flow
@@ -23,6 +23,10 @@ trigger:
         delay: 1
         window: 7
 
+  executionOptions:
+    concurrentOption: pipeline
+    pipelineLevel: 2
+
 # All flow level properties here
 config:
   flow-level-parameter: value


### PR DESCRIPTION
This allows execution options, such as pipeline level, to be set for executions triggered by flow triggers.

To set execution options, include something like the following in the flow file under the `trigger:` element:

```
  executionOptions:
    concurrentOption: pipeline
    pipelineLevel: 2
```