### PR TITLE
FileWatcherTest fix

### DIFF
--- a/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
@@ -41,7 +41,7 @@ public class FileWatcherTest {
   private Path setPath() {
     final URL configURL = Resources.getResource("test-conf/azkaban-users-test1.xml");
     final String origpath = configURL.getPath();
-    // Copy the file to keep original file unmodified
+    // Generate a path for test file.
     final String path = origpath.replace("test1", "file_watcher");
     return Paths.get(path);
   }

--- a/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
@@ -18,8 +18,10 @@ package azkaban.user;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.io.Resources;
 import com.sun.nio.file.SensitivityWatchEventModifier;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,8 +35,16 @@ import org.junit.Test;
 
 public class FileWatcherTest {
 
-  private static final Path PATH = Paths.get("build/tmp/FileWatcherTest");
+  private final Path PATH = setPath();
   private FileWatcher fileWatcher;
+
+  private Path setPath() {
+    final URL configURL = Resources.getResource("test-conf/azkaban-users-test1.xml");
+    final String origpath = configURL.getPath();
+    // Copy the file to keep original file unmodified
+    final String path = origpath.replace("test1", "file_watcher");
+    return Paths.get(path);
+  }
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
- The test works fine locally, however, it fails on test servers,
  possibly due to permission issues
- Using tried and tested method to create PATH which works in other
  tests.