### PR TITLE
Fix XmlUserManager bug: add back the mandatory constructor

### DIFF
--- a/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
+++ b/azkaban-common/src/main/java/azkaban/user/XmlUserManager.java
@@ -69,9 +69,13 @@ public class XmlUserManager implements UserManager {
   private HashMap<String, Set<String>> proxyUserMap;
 
   /**
-   * The constructor.
+   * The mandatory UserManager(Props) constructor, which is called via reflection.
    */
-  public XmlUserManager(final Props props, final FileWatcherFactory fileWatcherFactory) {
+  public XmlUserManager(final Props props) {
+    this(props, FileWatcher::new);
+  }
+
+  XmlUserManager(final Props props, final FileWatcherFactory fileWatcherFactory) {
     this.xmlPath = props.getString(XML_FILE_PARAM);
 
     parseXMLFile();

--- a/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
+++ b/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
@@ -21,17 +21,15 @@ import azkaban.flow.Flow;
 import azkaban.project.DirectoryYamlFlowLoader;
 import azkaban.project.Project;
 import azkaban.test.executions.ExecutionsTestUtil;
-import azkaban.user.FileWatcher;
 import azkaban.user.User;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
 import com.google.common.base.Charsets;
-import org.apache.commons.io.IOUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Commonly used utils method for unit/integration tests
@@ -78,7 +76,7 @@ public class TestUtils {
     final Props props = new Props();
     props.put(XmlUserManager.XML_FILE_PARAM, ExecutionsTestUtil.getDataRootDir()
         + "azkaban-users.xml");
-    final UserManager manager = new XmlUserManager(props, FileWatcher::new);
+    final UserManager manager = new XmlUserManager(props);
     return manager;
   }
 

--- a/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
+++ b/azkaban-solo-server/src/test/java/azkaban/soloserver/AzkabanSingleServerTest.java
@@ -86,6 +86,7 @@ public class AzkabanSingleServerTest {
     props.put("server.useSSL", "true");
     props.put("jetty.use.ssl", "false");
     props.put("user.manager.xml.file", new File(confPath, "azkaban-users.xml").getPath());
+    props.put("user.manager.class", "azkaban.user.XmlUserManager");
     props.put(ConfigurationKeys.EXECUTOR_PORT, "12321");
 
     // Quartz settings

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -27,7 +27,6 @@ import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginException;
 import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginManager;
 import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
-import azkaban.user.FileWatcher;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
 import azkaban.utils.Props;
@@ -103,7 +102,7 @@ public class AzkabanWebServerModule extends AbstractModule {
         throw new RuntimeException(e);
       }
     } else {
-      manager = new XmlUserManager(props, FileWatcher::new);
+      manager = new XmlUserManager(props);
     }
     return manager;
   }


### PR DESCRIPTION
Bug reported by @jamiesjc: https://github.com/azkaban/azkaban/pull/2244#issuecomment-497119712

Now AzkabanSingleServerTest covers the reflection-created user manager.

----

Please merge https://github.com/azkaban/azkaban/pull/2259 soon so that Travis build can succeed.