### PR TITLE
Fix flaky FileWatcherTest

### DIFF
--- a/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java
@@ -16,6 +16,7 @@
 
 package azkaban.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.io.Resources;
@@ -72,12 +73,14 @@ public class FileWatcherTest {
 
     final WatchKey key = this.fileWatcher.take();
     final List<WatchEvent<?>> events = this.fileWatcher.pollEvents(key);
-    assertEquals(1, events.size());
+    // depending on the OS & file system there may be at least 1 or 2 events even with 1 write()
+    assertThat(events.size()).isGreaterThanOrEqualTo(1);
 
-    final WatchEvent<?> event = events.get(0);
-    @SuppressWarnings("unchecked") final Path name = ((WatchEvent<Path>) event).context();
-    final String resolvedFileName = dir.resolve(name).toString();
-    assertEquals(PATH.toString(), resolvedFileName);
+    for (WatchEvent<?> event : events) {
+      @SuppressWarnings("unchecked") final Path name = ((WatchEvent<Path>) event).context();
+      final String resolvedFileName = dir.resolve(name).toString();
+      assertEquals(PATH.toString(), resolvedFileName);
+    }
   }
 
   private void write() throws IOException {


### PR DESCRIPTION
The failure on [Travis](https://travis-ci.org/azkaban/azkaban/builds/539101458?utm_source=github_status&utm_medium=notification) was:

```
  azkaban.user.FileWatcherTest > registerAndTake FAILED
      java.lang.AssertionError: expected:<1> but was:<2>
          at org.junit.Assert.fail(Assert.java:88)
          at org.junit.Assert.failNotEquals(Assert.java:834)
          at org.junit.Assert.assertEquals(Assert.java:645)
          at org.junit.Assert.assertEquals(Assert.java:631)
          at azkaban.user.FileWatcherTest.registerAndTake(FileWatcherTest.java:75)
```

Which is for line 75:
https://github.com/azkaban/azkaban/blob/505d2847eb88f6dae09fc91127dabc8711a9c391/azkaban-common/src/test/java/azkaban/user/FileWatcherTest.java#L74-L75

This is familiar from previous life where we had a multi-threaded test. That test was working because it retried on read error and thus also tolerated 1 or more events from watch service.