### PR TITLE
Add navigation across logs of job attempts

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -341,6 +341,22 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("jobLinkUrl", jobLinkUrl);
     page.add("jobType", node.getType());
 
+    final Status attemptStatus;
+    if (attempt == node.getAttempt()) {
+      attemptStatus = node.getStatus();
+    } else {
+      attemptStatus = node.getPastAttemptList().get(attempt).getStatus();
+    }
+    page.add("attemptStatus", attemptStatus.toString());
+
+    final int pastAttempts;
+    if (node.getAttempt() > 0) {
+      pastAttempts = node.getPastAttemptList().size();
+    } else {
+      pastAttempts = 0;
+    }
+    page.add("pastAttempts", pastAttempts);
+
     if (node.getStatus() == Status.FAILED || node.getStatus() == Status.KILLED) {
       page.add("jobFailed", true);
     } else {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -340,28 +340,11 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("jobname", node.getId());
     page.add("jobLinkUrl", jobLinkUrl);
     page.add("jobType", node.getType());
-
-    final Status attemptStatus;
-    if (attempt == node.getAttempt()) {
-      attemptStatus = node.getStatus();
-    } else {
-      attemptStatus = node.getPastAttemptList().get(attempt).getStatus();
-    }
-    page.add("attemptStatus", attemptStatus.toString());
-
-    final int pastAttempts;
-    if (node.getAttempt() > 0) {
-      pastAttempts = node.getPastAttemptList().size();
-    } else {
-      pastAttempts = 0;
-    }
-    page.add("pastAttempts", pastAttempts);
-
-    if (node.getStatus() == Status.FAILED || node.getStatus() == Status.KILLED) {
-      page.add("jobFailed", true);
-    } else {
-      page.add("jobFailed", false);
-    }
+    page.add("attemptStatus", attempt == node.getAttempt() ?
+        node.getStatus() : node.getPastAttemptList().get(attempt).getStatus());
+    page.add("pastAttempts", node.getAttempt() > 0 ?
+        node.getPastAttemptList().size() : 0);
+    page.add("jobFailed", node.getStatus() == Status.FAILED || node.getStatus() == Status.KILLED);
 
     page.render();
   }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -21,7 +21,10 @@
     <div class="row">
       <div class="header-title">
         <h1><a href="${context}/executor?execid=${execid}&job=${jobid}">Job Execution
-          <small>$jobid</small>
+          <small>
+            $jobid
+            <span id="flowStatus" class="$attemptStatus">$attemptStatus</span>
+          </small>
         </a></h1>
       </div>
       <div class="header-control">
@@ -53,6 +56,7 @@
       <li><a href="${context}/executor?execid=${execid}#jobslist"><strong>Execution</strong> $execid
       </a></li>
       <li class="active"><strong>Job</strong> $jobid</li>
+      <li class="active"><strong>Attempt</strong> $attempt</li>
     </ol>
   </div>
 </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -21,6 +21,8 @@
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
 
+  <script type="text/javascript" src="${context}/js/jquery.twbsPagination.min.js"></script>
+
   <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/model/job-log.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/job-details.js"></script>
@@ -36,6 +38,17 @@
     var execId = "${execid}";
     var jobId = "${jobid}";
     var attempt = ${attempt};
+
+    var attemptPageSettings = {
+      projectName: "${projectName}",
+      flowId: "${flowid}",
+      attempt: ${attempt},
+      pastAttempts: ${pastAttempts},
+    };
+
+    $(function () {
+      initAttemptPage(attemptPageSettings);
+    });
   </script>
   <script type="text/javascript">
     $(document).ready(function () {
@@ -77,6 +90,7 @@
         </div>
       </div>
     </div>
+    <ul id="attemptsPagination" class="pagination"></ul>
   </div>
 
   ## Error message message dialog.

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -76,7 +76,7 @@ var nodeClickCallback = function (event, model, node) {
   var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
       + flowId + "&job=" + jobId;
   var logURL = contextURL + "/executor?execid=" + execId + "&job="
-      + node.nestedId;
+      + node.nestedId + "&attempt=" + node.attempt;
   var menu = [];
 
   if (type == "flow") {

--- a/azkaban-web-server/src/web/js/azkaban/view/job-details.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-details.js
@@ -16,6 +16,55 @@
 
 $.namespace('azkaban');
 
+var initPagination = function (elem, model) {
+  var totalPages = model.get("totalPages");
+  if (!totalPages) {
+    return;
+  }
+
+  // intercept TwbsPagination, because it only supports page >= 1
+  // while azkaban job attempts start at 0
+  var twbsPaginationPrototype =
+      $.prototype.twbsPagination.prototype.constructor.Constructor.prototype;
+  var originalBuildItem = twbsPaginationPrototype.buildItem;
+  twbsPaginationPrototype.buildItem = function (type, page) {
+    var $itemContainer = originalBuildItem.call(this, type, page);
+    if (type == "page") {
+      // apply page offset -1 as "attempt 0" == "page 1"
+      $itemContainer.find('a').text(page - 1);
+    }
+    return $itemContainer;
+  };
+
+  $(elem).twbsPagination({
+    totalPages: model.get("totalPages"),
+    startPage: model.get("page"),
+    initiateStartPageClick: false,
+    visiblePages: model.get("visiblePages"),
+    onPageClick: function (event, page) {
+      model.set({"page": page});
+    }
+  });
+
+};
+
+var initAttemptPage = function (settings) {
+
+  var jobLogModel = new azkaban.JobLogModel({
+    page: settings.attempt + 1,
+    totalPages: settings.pastAttempts + 1,
+    visiblePages: 10,
+    projectName: settings.projectName,
+    flowId: settings.flowId
+  });
+  jobLogView = new azkaban.JobLogView({
+    el: $('#jobLogView'),
+    model: jobLogModel
+  });
+  jobLogModel.refresh();
+
+}
+
 var jobLogView;
 azkaban.JobLogView = Backbone.View.extend({
   events: {
@@ -23,7 +72,9 @@ azkaban.JobLogView = Backbone.View.extend({
   },
 
   initialize: function () {
+    this.handleInitView();
     this.listenTo(this.model, "change:logData", this.render);
+    this.model.bind('change:page', this.handlePageChange, this);
   },
 
   refresh: function () {
@@ -35,7 +86,19 @@ azkaban.JobLogView = Backbone.View.extend({
     var log = this.model.get("logData");
     log = log.replace(re, "<a href=\"$1\" title=\"\">$1</a>");
     $("#logSection").html(log);
-  }
+  },
+
+  handleInitView: function () {
+    initPagination('#attemptsPagination', this.model);
+  },
+
+  handlePageChange: function () {
+    var requestURL = contextURL + "/executor?project=" + projectName
+        + "&execid=" + execId + "&job=" + jobId
+        + "&attempt=" + (this.model.get("page") - 1);
+    window.location.href = requestURL;
+  },
+
 });
 
 var showDialog = function (title, message) {
@@ -53,12 +116,3 @@ var showDialog = function (title, message) {
     }
   });
 }
-
-$(function () {
-  var jobLogModel = new azkaban.JobLogModel();
-  jobLogView = new azkaban.JobLogView({
-    el: $('#jobLogView'),
-    model: jobLogModel
-  });
-  jobLogModel.refresh();
-});


### PR DESCRIPTION
Add navigation across logs of job attempts

Extras:
- Link to latest attempt logs also from Graph view (to match with Job List view)
- Include attempt status on job details page (attempt log page)

To test I ran this kind of execution:

<img width="1047" alt="Näyttökuva 2019-6-2 kello 11 51 04" src="https://user-images.githubusercontent.com/4446608/58759045-b8faa500-852c-11e9-8d6c-e0cc3aa0e538.png">

When accessing logs, links lead to last attempt. For example:

<img width="1201" alt="Näyttökuva 2019-6-2 kello 16 41 37" src="https://user-images.githubusercontent.com/4446608/58762146-700b1680-8555-11e9-8278-6722fd20668e.png">

But it's now easy to navigate to previous attempts:

<img width="1199" alt="Näyttökuva 2019-6-2 kello 16 42 12" src="https://user-images.githubusercontent.com/4446608/58762147-74373400-8555-11e9-9fbc-733778e25a88.png">

See how the attempt status is also shown on the attempt logs page \o/