### PR TITLE
fix for issue: github.com/azkaban/azkaban/issues/1969

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -51,7 +51,24 @@ public class ExecutionFlowDao {
 
     final String useExecutorParam =
         flow.getExecutionOptions().getFlowParameters().get(ExecutionOptions.USE_EXECUTOR);
-    final String executorId = StringUtils.isNotEmpty(useExecutorParam) ? useExecutorParam : null;
+
+    Integer xid = ExecutionOptions.useExecutorById(useExecutorParam);
+    if (xid == null) {
+      //try now using host/port format.
+      ExecutionOptions.HostPort box = ExecutionOptions.useExecutorByHostPort(useExecutorParam);
+      if (box != null) {
+        try {
+          List<Executor> executors = dbOperator.query(ExecutorDao.FetchExecutorHandler.FETCH_EXECUTOR_BY_HOST_PORT, new ExecutorDao.FetchExecutorHandler(), box.host, box.port);
+          if (executors.size() > 0) {
+            xid = executors.get(0).getId();
+          }
+        } catch (SQLException e) {
+          logger.warn("failed to query executor by host: " + box.host + ", port: " + box.port, e);
+        }
+      }
+    }
+
+    final String executorId = xid != null ? String.valueOf(xid) : null;
 
     final String flowPriorityParam =
         flow.getExecutionOptions().getFlowParameters().get(ExecutionOptions.FLOW_PRIORITY);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -1339,25 +1339,24 @@ public class ExecutorManager extends EventHandler implements
           && options.getFlowParameters().containsKey(
           ExecutionOptions.USE_EXECUTOR)) {
         try {
-          final int executorId =
-              Integer.valueOf(options.getFlowParameters().get(
-                  ExecutionOptions.USE_EXECUTOR));
-          executor = fetchExecutor(executorId);
+          final String useExecutorValue = options.getFlowParameters().get(ExecutionOptions.USE_EXECUTOR);
+          final Integer executorId = ExecutionOptions.useExecutorById(useExecutorValue);
+          if (executorId != null) {
+            executor = fetchExecutor(executorId);
+          } else {
+            //try now using host/port format.
+            ExecutionOptions.HostPort box = ExecutionOptions.useExecutorByHostPort(useExecutorValue);
+            if (box != null) {
+              executor = ExecutorManager.this.executorLoader.fetchExecutor(box.host, box.port);
+            }
+          }
 
           if (executor == null) {
             ExecutorManager.logger
-                .warn(String
-                    .format(
-                        "User specified executor id: %d for execution id: %d is not active, Looking up db.",
-                        executorId, executionId));
-            executor = ExecutorManager.this.executorLoader.fetchExecutor(executorId);
-            if (executor == null) {
-              ExecutorManager.logger
-                  .warn(String
-                      .format(
-                          "User specified executor id: %d for execution id: %d is missing from db. Defaulting to availableExecutors",
-                          executorId, executionId));
-            }
+                    .warn(String
+                            .format(
+                                    "Could not find executor specified by user, via 'useExecutor' flow parameter: %s for execution id: %d. Defaulting to availableExecutors",
+                                    useExecutorValue, executionId));
           }
         } catch (final ExecutorManagerException ex) {
           ExecutorManager.logger.error("Failed to fetch user specified executor for exec_id = "

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -141,7 +141,7 @@ public class HttpRequestUtils {
       params.remove(ExecutionOptions.USE_EXECUTOR);
     } else {
       validateIntegerParam(params, ExecutionOptions.FLOW_PRIORITY);
-      validateIntegerParam(params, ExecutionOptions.USE_EXECUTOR);
+      validateUseExecutorParam(params);
     }
   }
 
@@ -151,10 +151,25 @@ public class HttpRequestUtils {
    * @throws ExecutorManagerException if paramName is not a valid integer
    */
   public static boolean validateIntegerParam(final Map<String, String> params,
-      final String paramName) throws ExecutorManagerException {
+                                             final String paramName) throws ExecutorManagerException {
     if (params != null && params.containsKey(paramName)
-        && !StringUtils.isNumeric(params.get(paramName))) {
+            && !StringUtils.isNumeric(params.get(paramName))) {
       throw new ExecutorManagerException(paramName + " should be an integer");
+    }
+    return true;
+  }
+
+  /**
+   * checks is string provided to 'useExecutor' flow parameter is valid or not.
+   *
+   * @throws ExecutorManagerException if value provided is neither in format 'host:port' nor a valid integer.
+   */
+  public static boolean validateUseExecutorParam(final Map<String, String> params) throws ExecutorManagerException {
+    if (params != null && params.containsKey(ExecutionOptions.USE_EXECUTOR)) {
+      String useExecutorParamValue = params.get(ExecutionOptions.USE_EXECUTOR);
+      if (ExecutionOptions.useExecutorById(useExecutorParamValue) == null && ExecutionOptions.useExecutorByHostPort(useExecutorParamValue) == null) {
+        throw new ExecutorManagerException(ExecutionOptions.USE_EXECUTOR + " should either be an integer or in format 'hostName:validPortNumber' !");
+      }
     }
     return true;
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -1,0 +1,29 @@
+package azkaban.executor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExecutionOptionsTest {
+
+    @Test
+    public void testUseExecutorById() {
+        Assert.assertEquals(Integer.valueOf(1), ExecutionOptions.useExecutorById("1"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorById("abc"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorById(""));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorById("  "));
+    }
+
+    @Test
+    public void testUseExecutorByHostPort() {
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("1"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort(" "));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("noSemiColon"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("hostOnly: "));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("hostOnly:"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort(" :9090"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort(":9090"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("host:stringPort"));
+        Assert.assertEquals(null, ExecutionOptions.useExecutorByHostPort("host:-1"));
+        Assert.assertEquals(new ExecutionOptions.HostPort("host", 9090), ExecutionOptions.useExecutorByHostPort("host:9090"));
+    }
+}

--- a/docs/howTo.rst
+++ b/docs/howTo.rst
@@ -7,7 +7,7 @@ Force execution to an executor
 ------------------------------
 
 Only users with admin privileges can use this override. In flow params:
-set ``"useExecutor" = EXECUTOR_ID``.
+set ``"useExecutor" = EXECUTOR_ID`` or set ``"useExecutor" = <azkaban.server.hostname>:<executor:port>`` .
 
 Setting flow priority in multiple executor mode
 -----------------------------------------------


### PR DESCRIPTION
user can now provide alternate value for 'useExecutor' flow parameter. The value will be in the format '<azkaban_executor_host>:>executor_port>'. So if restart of executor happens and executor id changes, the user can still bind a flow using 'host:port' value.