### PR TITLE
Handle non-existent flows when asking for isLocked property on Flow Execution page load.

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -466,8 +466,14 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("flowid", flow.getFlowId());
 
     // check the current flow definition to see if the flow is locked.
-    Flow currentFlow = project.getFlow(flow.getFlowId());
-    page.add("isLocked", currentFlow.isLocked());
+    final Flow currentFlow = project.getFlow(flow.getFlowId());
+    boolean isCurrentFlowLocked = false;
+    if(currentFlow != null) {
+      isCurrentFlowLocked = currentFlow.isLocked();
+    } else {
+      logger.info("Flow {} not found in project {}.", flow.getFlowId(), project.getName());
+    }
+    page.add("isLocked", isCurrentFlowLocked);
 
     page.render();
   }


### PR DESCRIPTION
Loading the Flow Execution page of an execution of a flow that doesn't exist anymore (because an update to a project deleted it for example) causes a NullPointerException because we ask whether that non-existent flow is locked or not to enable/disable "Prepare Execution" button in the view.

More details about "locking flows" feature in #2210.