### PR TITLE
Prevent login DDoS by enforcing max number of sessions per IP per user

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -102,7 +102,6 @@ public class Constants {
   // Executors can use cpu load calculated from this period to take/skip polling turns
   public static final int DEFAULT_AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC = 60;
 
-
   public static class ConfigurationKeys {
 
     // Configures Azkaban to use new polling model for dispatching
@@ -263,6 +262,8 @@ public class Constants {
     public static final String QUEUEPROCESSING_ENABLED = "azkaban.queueprocessing.enabled";
 
     public static final String SESSION_TIME_TO_LIVE = "session.time.to.live";
+
+    // allowed max number of sessions per user per IP
     public static final String MAX_SESSION_NUMBER_PER_IP_PER_USER = "azkaban.session"
         + ".max_number_per_ip_per_user";
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -95,14 +95,14 @@ public class Constants {
 
   // Default maximum number of concurrent runs for a single flow
   public static final int DEFAULT_MAX_ONCURRENT_RUNS_ONEFLOW = 30;
-  
+
   // How often executors will poll new executions in Poll Dispatch model
   public static final int DEFAULT_AZKABAN_POLLING_INTERVAL_MS = 1000;
 
   // Executors can use cpu load calculated from this period to take/skip polling turns
   public static final int DEFAULT_AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC = 60;
 
-  
+
   public static class ConfigurationKeys {
 
     // Configures Azkaban to use new polling model for dispatching
@@ -263,6 +263,8 @@ public class Constants {
     public static final String QUEUEPROCESSING_ENABLED = "azkaban.queueprocessing.enabled";
 
     public static final String SESSION_TIME_TO_LIVE = "session.time.to.live";
+    public static final String MAX_SESSION_NUMBER_PER_IP_PER_USER = "azkaban.session"
+        + ".max_number_per_ip_per_user";
 
     // allowed max size of shared project dir (percentage of partition size), e.g 0.8
     public static final String PROJECT_CACHE_SIZE_PERCENTAGE = "azkaban"

--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -449,10 +449,10 @@ public class Props {
    * as output
    */
   public List<String> getStringListFromCluster(final String key) {
-    List<String> curlist = getStringList(key, "\\s*;\\s*");
+    final List<String> curlist = getStringList(key, "\\s*;\\s*");
     // remove empty elements in the array
-    for (Iterator<String> iter = curlist.listIterator(); iter.hasNext(); ) {
-      String a = iter.next();
+    for (final Iterator<String> iter = curlist.listIterator(); iter.hasNext(); ) {
+      final String a = iter.next();
       if (a.length() == 0) {
         iter.remove();
       }
@@ -544,6 +544,8 @@ public class Props {
    * UndefinedPropertyException will be thrown. If the value isn't a long, then a parse exception
    * will be thrown.
    */
+  //todo burgerkingeater: it might be better to return null instead of throwing exception to
+  // avoid repetitive exception handling
   public long getLong(final String name) {
     if (containsKey(name)) {
       return Long.parseLong(get(name));
@@ -700,13 +702,13 @@ public class Props {
    * Returns a java.util.Properties file populated with both current and parent properties.
    */
   public Properties toAllProperties() {
-    Properties allProp = new Properties();
+    final Properties allProp = new Properties();
     // import local properties
     allProp.putAll(toProperties());
 
     // import parent properties
-    if (_parent != null) {
-      allProp.putAll(_parent.toProperties());
+    if (this._parent != null) {
+      allProp.putAll(this._parent.toProperties());
     }
 
     return allProp;

--- a/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
+++ b/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
@@ -58,7 +58,7 @@ public class SessionCache {
     this.effectiveSessionTimeToLive = props.getLong(ConfigurationKeys.SESSION_TIME_TO_LIVE,
         DEFAULT_SESSION_TIME_TO_LIVE);
 
-    Long maxNumberOfSessions = null;
+    Long maxNumberOfSessions;
     try {
       maxNumberOfSessions = props.getLong(ConfigurationKeys.MAX_SESSION_NUMBER_PER_IP_PER_USER);
     } catch (final UndefinedPropertyException exception) {

--- a/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
+++ b/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
@@ -100,8 +100,9 @@ public class SessionCache {
    */
   private boolean isViolatingMaxNumberOfSessionPerIpPerUser(final Session session) {
     if (this.maxNumberOfSessionsPerIpPerUser.isPresent()) {
-      // get sessions sharing the same IP and user
+      // first search for duplicate sessions sharing the same IP
       final Set<Session> sessionsWithSameIP = this.findSessionsByIP(session.getIp());
+      // then search for duplicate sessions sharing the same user
       int duplicateSessionCount = 0;
       for (final Session sessionByIP : sessionsWithSameIP) {
         if (sessionByIP.getUser().equals(session.getUser())) {
@@ -113,6 +114,7 @@ public class SessionCache {
         }
       }
     }
+
     return false;
   }
 

--- a/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
+++ b/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cache for web session.
@@ -49,6 +51,7 @@ public class SessionCache {
 
   private final long effectiveSessionTimeToLive;
   private final Optional<Long> maxNumberOfSessionsPerIpPerUser;
+  private static final Logger log = LoggerFactory.getLogger(SessionCache.class);
 
   /**
    * Constructor taking global props.
@@ -63,6 +66,8 @@ public class SessionCache {
       maxNumberOfSessions = props.getLong(ConfigurationKeys.MAX_SESSION_NUMBER_PER_IP_PER_USER);
     } catch (final UndefinedPropertyException exception) {
       maxNumberOfSessions = null;
+      log.warn("{} is not configured. The number of sessions per IP per user is not being capped.",
+          ConfigurationKeys.MAX_SESSION_NUMBER_PER_IP_PER_USER);
     }
 
     this.maxNumberOfSessionsPerIpPerUser = Optional.ofNullable(maxNumberOfSessions);

--- a/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
+++ b/azkaban-common/src/main/java/azkaban/server/session/SessionCache.java
@@ -101,22 +101,22 @@ public class SessionCache {
    */
   private boolean isViolatingMaxNumberOfSessionPerIpPerUser(final Session session) {
     if (this.maxNumberOfSessionsPerIpPerUser.isPresent()) {
-      // first search for duplicate sessions sharing the same IP
-      final Set<Session> sessionsWithSameIP = this.findSessionsByIP(session.getIp());
-      // then search for duplicate sessions sharing the same user
-      final int duplicateSessionCount = this.getSessionCountByUser(sessionsWithSameIP,
-          session.getUser());
+      final int duplicateSessionCount = this.getSessionCountByUserByIP(session.getUser(),
+          session.getIp());
       return duplicateSessionCount >= this.maxNumberOfSessionsPerIpPerUser.get();
     }
     return false;
   }
 
   /**
-   * return the number of sessions from given session set who have the given user.
+   * Return the number of sessions sharing the given user and ip.
    */
-  private int getSessionCountByUser(final Set<Session> sessions, final User user) {
+  private int getSessionCountByUserByIP(final User user, final String ip) {
+    // first search for duplicate sessions with the given IP
+    final Set<Session> sessionsWithSameIP = this.findSessionsByIP(ip);
+    // then search for duplicate sessions with the given user
     int duplicateSessionCount = 0;
-    for (final Session sessionByIP : sessions) {
+    for (final Session sessionByIP : sessionsWithSameIP) {
       if (sessionByIP.getUser().equals(user)) {
         duplicateSessionCount++;
       }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -465,7 +465,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
         ret.put("session.id", session.getSessionId());
       } else {
         ret.put("error", "Potential DDoS found, the number of sessions for this user and IP "
-            + "reaches allowed limit (" + getApplication().getSessionCache()
+            + "reached allowed limit (" + getApplication().getSessionCache()
             .getMaxNumberOfSessionsPerIpPerUser().get() + ").");
       }
     } else {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -465,8 +465,8 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
         ret.put("session.id", session.getSessionId());
       } else {
         ret.put("error", "Potential DDoS found, the number of sessions for this user and IP "
-            + "exceeds allowed limit " + getApplication().getSessionCache()
-            .getMaxNumberOfSessionsPerIpPerUser());
+            + "reaches allowed limit (" + getApplication().getSessionCache()
+            .getMaxNumberOfSessionsPerIpPerUser().get() + ").");
       }
     } else {
       ret.put("error", "Incorrect Login.");

--- a/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
@@ -85,8 +85,8 @@ public class UserManagerResource extends ResourceContextHolder {
     } else {
       throw new UserManagerException(
           "Potential DDoS found, the number of sessions for this user and IP "
-              + "exceeds allowed limit " + getAzkaban().getSessionCache()
-              .getMaxNumberOfSessionsPerIpPerUser());
+              + "reaches allowed limit (" + getAzkaban().getSessionCache()
+              .getMaxNumberOfSessionsPerIpPerUser().get() + ").");
     }
   }
 

--- a/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
+++ b/azkaban-web-server/src/restli/java/azkaban/restli/UserManagerResource.java
@@ -85,7 +85,7 @@ public class UserManagerResource extends ResourceContextHolder {
     } else {
       throw new UserManagerException(
           "Potential DDoS found, the number of sessions for this user and IP "
-              + "reaches allowed limit (" + getAzkaban().getSessionCache()
+              + "reached allowed limit (" + getAzkaban().getSessionCache()
               .getMaxNumberOfSessionsPerIpPerUser().get() + ").");
     }
   }


### PR DESCRIPTION
This PR adds a configurable upper limit on the number of sessions per IP per User. This is useful when one misbehaving user is creating too many sessions on the same host, kicking out other users' sessions.