### PR TITLE
Delete execution directory on flow finishing

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -154,7 +154,6 @@ public class FlowRunnerManager implements EventListener,
   private int threadPoolQueueSize = -1;
   private Props globalProps;
   private long lastCleanerThreadCheckTime = -1;
-  private long executionDirRetention = 60 * 1000; // 1 min
   // date time of the the last flow submitted.
   private long lastFlowSubmittedDate = 0;
   // Indicate if the executor is set to active.
@@ -172,10 +171,7 @@ public class FlowRunnerManager implements EventListener,
       @Nullable final AzkabanEventReporter azkabanEventReporter) throws IOException {
     this.azkabanProps = props;
 
-    this.executionDirRetention = props.getLong("execution.dir.retention",
-        this.executionDirRetention);
     this.azkabanEventReporter = azkabanEventReporter;
-    logger.info("Execution dir retention set to " + this.executionDirRetention + " ms");
 
     this.executionDirectory = new File(props.getString("azkaban.execution.dir", "executions"));
     if (!this.executionDirectory.exists()) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -61,6 +61,8 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.lang.Thread.State;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -564,6 +566,19 @@ public class FlowRunnerManager implements EventListener,
     return runner.getExecutableFlow();
   }
 
+  /**
+   * delete execution dir pertaining to the given execution id
+   */
+  private void deleteExecutionDir(final int executionId) {
+    final Path flowExecutionDir = Paths.get(this.executionDirectory.toPath().toString(),
+        String.valueOf(executionId));
+    try {
+      FileUtils.deleteDirectory(flowExecutionDir.toFile());
+    } catch (final IOException e) {
+      logger.warn("Error when deleting directory " + flowExecutionDir.toAbsolutePath() + ".", e);
+    }
+  }
+
   @Override
   public void handleEvent(final Event event) {
     if (event.getType() == EventType.FLOW_FINISHED || event.getType() == EventType.FLOW_STARTED) {
@@ -575,6 +590,7 @@ public class FlowRunnerManager implements EventListener,
         logger.info("Flow " + flow.getExecutionId()
             + " is finished. Adding it to recently finished flows list.");
         this.runningFlows.remove(flow.getExecutionId());
+        this.deleteExecutionDir(flow.getExecutionId());
       } else if (event.getType() == EventType.FLOW_STARTED) {
         // add flow level SLA checker
         this.triggerManager

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -958,7 +958,6 @@ public class FlowRunnerManager implements EventListener,
         }
       }
     }
-    }
 
     private void cleanRecentlyFinished() {
       final long cleanupThreshold =


### PR DESCRIPTION
This PR moves execution directory cleanup out from CleanerThread, and deletes execution directory on flow finishing. The motivation is to make sure that execution directory gets deleted on time without leaving any orphan disk-consuming dirs. Previously CleanerThread periodically traverses every execution dir periodically and deletes any directories which haven't been modified for some configurable period. The logic is cumbersome and error-prone as it requires checking against shared data structure like running flows to make sure it's not deleting execution directories which are in use.