### PR TITLE
Add an optional flow display name

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ExecutableFlowBase extends ExecutableNode {
 
   public static final String FLOW_ID_PARAM = "flowId";
+  public static final String FLOW_DISPLAY_NAME_PARAM = "flowDisplayName";
   public static final String NODES_PARAM = "nodes";
   public static final String PROPERTIES_PARAM = "properties";
   public static final String SOURCE_PARAM = "source";
@@ -46,6 +47,7 @@ public class ExecutableFlowBase extends ExecutableNode {
   private ArrayList<String> startNodes;
   private ArrayList<String> endNodes;
   private String flowId;
+  private String flowDisplayName;
 
   public ExecutableFlowBase(final Project project, final Node node, final Flow flow,
       final ExecutableFlowBase parent) {
@@ -113,8 +115,13 @@ public class ExecutableFlowBase extends ExecutableNode {
     return this.flowId;
   }
 
+  public String getFlowDisplayName() {
+    return this.flowDisplayName == null ? getFlowId() : this.flowDisplayName;
+  }
+
   protected void setFlow(final Project project, final Flow flow) {
     this.flowId = flow.getId();
+    this.flowDisplayName = flow.getDisplayName();
     this.flowProps.putAll(flow.getAllFlowProps());
 
     for (final Node node : flow.getNodes()) {
@@ -219,6 +226,7 @@ public class ExecutableFlowBase extends ExecutableNode {
     super.fillMapFromExecutable(flowObjMap);
 
     flowObjMap.put(FLOW_ID_PARAM, this.flowId);
+    flowObjMap.put(FLOW_DISPLAY_NAME_PARAM, this.flowDisplayName);
 
     final ArrayList<Object> nodes = new ArrayList<>();
     for (final ExecutableNode node : this.executableNodes.values()) {
@@ -248,6 +256,7 @@ public class ExecutableFlowBase extends ExecutableNode {
     super.fillExecutableFromMapObject(flowObjMap);
 
     this.flowId = flowObjMap.getString(FLOW_ID_PARAM);
+    this.flowDisplayName = flowObjMap.getString(FLOW_DISPLAY_NAME_PARAM);
     final List<Object> nodes = flowObjMap.<Object>getList(NODES_PARAM);
 
     if (nodes != null) {

--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -61,6 +61,11 @@ public class CommonJobProperties {
    */
   public static final String FAILURE_EMAILS = "failure.emails";
 
+  /**
+   * Name to display in the UI instead of the flow id
+   */
+  public static final String DISPLAY_NAME = "displayName";
+
   /*
    * The following are the common props that will be added to the job by azkaban
    */
@@ -89,7 +94,7 @@ public class CommonJobProperties {
    * The job's log file absolute path.
    */
   public static final String JOB_LOG_FILE = "azkaban.job.log.file";
-  
+
   /**
    * The executing flow id
    */

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -52,6 +52,7 @@ public class Flow {
   private double azkabanFlowVersion = Constants.DEFAULT_AZKABAN_FLOW_VERSION;
   private String condition = null;
   private boolean isLocked = false;
+  private String displayName;
 
   public Flow(final String id) {
     this.id = id;
@@ -61,6 +62,7 @@ public class Flow {
     final Map<String, Object> flowObject = (Map<String, Object>) object;
 
     final String id = (String) flowObject.get("id");
+    final String displayName = (String) flowObject.get("displayName");
     final Boolean layedout = (Boolean) flowObject.get("layedout");
     final Boolean isEmbeddedFlow = (Boolean) flowObject.get("embeddedFlow");
     final Double azkabanFlowVersion = (Double) flowObject.get("azkabanFlowVersion");
@@ -68,6 +70,8 @@ public class Flow {
     final Boolean isLocked = (Boolean) flowObject.get("isLocked");
 
     final Flow flow = new Flow(id);
+    flow.displayName = displayName;
+
     if (layedout != null) {
       flow.setLayedOut(layedout);
     }
@@ -280,6 +284,15 @@ public class Flow {
     return this.id;
   }
 
+
+  public String getDisplayName() {
+    return this.displayName == null ? getId() : this.displayName;
+  }
+
+  public void setDisplayName(final String displayName) {
+    this.displayName = displayName;
+  }
+
   public void addError(final String error) {
     if (this.errors == null) {
       this.errors = new ArrayList<>();
@@ -341,6 +354,9 @@ public class Flow {
     final HashMap<String, Object> flowObj = new HashMap<>();
     flowObj.put("type", "flow");
     flowObj.put("id", getId());
+    if (this.displayName != null) {
+      flowObj.put("displayName", this.displayName);
+    }
     flowObj.put("project.id", this.projectId);
     flowObj.put("version", this.version);
     flowObj.put("props", objectizeProperties());
@@ -467,7 +483,11 @@ public class Flow {
     this.projectId = projectId;
   }
 
-  public boolean isLocked() { return this.isLocked; }
+  public boolean isLocked() {
+    return this.isLocked;
+  }
 
-  public void setLocked(boolean locked) { this.isLocked = locked; }
+  public void setLocked(final boolean locked) {
+    this.isLocked = locked;
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -324,6 +324,7 @@ public class DirectoryFlowLoader implements FlowLoader {
         final Props jobProp = this.jobPropsMap.get(base.getId());
 
         FlowLoaderUtils.addEmailPropsToFlow(flow, jobProp);
+        FlowLoaderUtils.addDisplayNameToFlow(flow, jobProp);
 
         flow.addAllFlowProperties(this.flowPropsList);
         final Set<String> visitedNodesOnPath = new HashSet<>();

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2017 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package azkaban.project;
 
@@ -151,6 +151,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     flow.setAzkabanFlowVersion(Constants.AZKABAN_FLOW_VERSION_2_0);
     final Props props = azkabanFlow.getProps();
     FlowLoaderUtils.addEmailPropsToFlow(flow, props);
+    FlowLoaderUtils.addDisplayNameToFlow(flow, props);
     props.setSource(flowFile.getName());
 
     flow.addAllFlowProperties(ImmutableList.of(new FlowProps(props)));

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
@@ -225,6 +225,10 @@ public class FlowLoaderUtils {
     flow.addSuccessEmails(successEmail);
   }
 
+  public static void addDisplayNameToFlow(final Flow flow, final Props props) {
+    flow.setDisplayName(props.getString(CommonJobProperties.DISPLAY_NAME, null));
+  }
+
   /**
    * Generate flow loader report validation report.
    *

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerQuartzJob.java
@@ -33,6 +33,7 @@ public class FlowTriggerQuartzJob extends AbstractQuartzJob {
   public static final String FLOW_TRIGGER = "FLOW_TRIGGER";
   public static final String FLOW_ID = "FLOW_ID";
   public static final String FLOW_VERSION = "FLOW_VERSION";
+  public static final String FLOW_DISPLAY_NAME = "FLOW_DISPLAY_NAME";
 
   public static final String JOB_NAME = "FLOW_TRIGGER";
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -404,6 +404,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", triggerInst.getFlowId());
+    final Flow flow = project.getFlow(triggerInst.getFlowId());
+    page.add("flowdisplayname", flow == null ? triggerInst.getFlowId() : flow.getDisplayName());
 
     page.render();
   }
@@ -464,6 +466,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", flow.getFlowId());
+    page.add("flowdisplayname", flow.getFlowDisplayName());
 
     // check the current flow definition to see if the flow is locked.
     final Flow currentFlow = project.getFlow(flow.getFlowId());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -91,6 +91,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   static final String FLOW_IS_LOCKED_PARAM = "isLocked";
   static final String FLOW_NAME_PARAM = "flowName";
   static final String FLOW_ID_PARAM = "flowId";
+  static final String FLOW_DISPLAY_NAME_PARAM = "flowDisplayName";
   static final String ERROR_PARAM = "error";
   private static final String APPLICATION_ZIP_MIME_TYPE = "application/zip";
   private static final long serialVersionUID = 1;
@@ -453,6 +454,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       final HashMap<String, Object> flowInfo = new HashMap<>();
       flowInfo.put("execId", flow.getExecutionId());
       flowInfo.put(FLOW_ID_PARAM, flow.getFlowId());
+      flowInfo.put(FLOW_DISPLAY_NAME_PARAM, flow.getFlowDisplayName());
       flowInfo.put("projectId", flow.getProjectId());
       flowInfo.put("status", flow.getStatus().toString());
       flowInfo.put("submitTime", flow.getSubmitTime());
@@ -792,6 +794,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       if (!flow.isEmbeddedFlow()) {
         final HashMap<String, Object> flowObj = new HashMap<>();
         flowObj.put(FLOW_ID_PARAM, flow.getId());
+        flowObj.put(FLOW_DISPLAY_NAME_PARAM, flow.getDisplayName());
         flowList.add(flowObj);
       }
     }
@@ -826,6 +829,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
       if (node.getEmbeddedFlowId() != null) {
         nodeObj.put(FLOW_ID_PARAM, node.getEmbeddedFlowId());
+        // embedded flows don't have display names
+        nodeObj.put(FLOW_DISPLAY_NAME_PARAM, node.getEmbeddedFlowId());
         fillFlowInfo(project, node.getEmbeddedFlowId(), nodeObj);
       }
 
@@ -930,6 +935,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     ret.put(FLOW_ID_PARAM, flowId);
+    ret.put(FLOW_DISPLAY_NAME_PARAM, flow.getDisplayName());
     ret.put("nodes", nodeList);
     ret.put(FLOW_IS_LOCKED_PARAM, flow.isLocked());
   }
@@ -1167,6 +1173,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     flow.setLocked(isLocked);
     ret.put(FLOW_IS_LOCKED_PARAM, flow.isLocked());
     ret.put(FLOW_ID_PARAM, flow.getId());
+    ret.put(FLOW_DISPLAY_NAME_PARAM, flow.getDisplayName());
     this.projectManager.updateFlow(project, flow);
   }
 
@@ -1190,6 +1197,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     ret.put(FLOW_ID_PARAM, flow.getId());
+    ret.put(FLOW_DISPLAY_NAME_PARAM, flow.getDisplayName());
     ret.put(FLOW_IS_LOCKED_PARAM, flow.isLocked());
   }
 
@@ -1413,6 +1421,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
+      page.add("flowdisplayname", flow.getDisplayName());
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1524,6 +1533,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
+      page.add("flowdisplayname", flow.getDisplayName());
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1617,6 +1627,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("errorMsg", "Flow " + flowName + " not found.");
       } else {
         page.add("flowid", flow.getId());
+        page.add("flowdisplayname", flow.getDisplayName());
         page.add("isLocked", flow.isLocked());
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -101,7 +101,7 @@
         </a></li>
         <li><a
             href="${context}/manager?project=${projectName}&flow=${flowid}"><strong>Flow</strong>
-          $flowid
+          $flowdisplayname
         </a></li>
         <li class="active"><strong>Execution</strong> $execid</li>
       </ol>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
@@ -143,7 +143,7 @@
               </td>
             #*todo chengren311: keep result of vmutils.getProjectName as a variable *#
               <td><a
-                  href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})&flow=${trigger.getFlowId()}">${trigger.getFlowId()}</a>
+                  href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})&flow=${trigger.getFlowId()}">${trigger.getFlowDiplayName()}</a>
               </td>
               <td>
                 <a href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})">$vmutils.getProjectName(${trigger.getProject().getId()})</a>
@@ -298,7 +298,7 @@
               </td>
             #*todo chengren311: keep result of vmutils.getProjectName as a variable *#
               <td><a
-                  href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})&flow=${trigger.getFlowId()}">${trigger.getFlowId()}</a>
+                  href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})&flow=${trigger.getFlowId()}">${trigger.getFlowDisplayName()}</a>
               </td>
               <td>
                 <a href="${context}/manager?project=$vmutils.getProjectName(${trigger.getProject().getId()})">$vmutils.getProjectName(${trigger.getProject().getId()})</a>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -100,7 +100,7 @@
                 #end
               </td>
               <td><a
-                  href="${context}/manager?project=$vmutils.getProjectName(${flow.getFirst().projectId})&flow=${flow.getFirst().flowId}">${flow.getFirst().flowId}</a>
+                  href="${context}/manager?project=$vmutils.getProjectName(${flow.getFirst().projectId})&flow=${flow.getFirst().flowId}">${flow.getFirst().flowDisplayName}</a>
               </td>
               <td>
                 <a href="${context}/manager?project=$vmutils.getProjectName(${flow.getFirst().projectId})">$vmutils.getProjectName(${flow.getFirst().projectId})</a>
@@ -165,7 +165,7 @@
                 <a href="${context}/executor?execid=${flow.executionId}">${flow.executionId}</a>
               </td>
               <td><a
-                  href="${context}/manager?project=$vmutils.getProjectName(${flow.projectId})&flow=${flow.flowId}">${flow.flowId}</a>
+                  href="${context}/manager?project=$vmutils.getProjectName(${flow.projectId})&flow=${flow.flowId}">${flow.flowDisplayName}</a>
               </td>
               <td>
                 <a href="${context}/manager?project=$vmutils.getProjectName(${flow.projectId})">$vmutils.getProjectName(${flow.projectId})</a>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -48,6 +48,7 @@
     var projectId = ${project.id};
     var projectName = "${project.name}";
     var flowId = "${flowid}";
+    var flowdisplayname = "${flowdisplayname}";
     var execId = null;
     var pageSize = "${size}";
 
@@ -55,6 +56,7 @@
       projectId: ${project.id},
       projectName: "${project.name}",
       flowId: "${flowid}",
+      flowDisplayName: "${flowdisplayname}",
       pageSize: ${size},
 
       executionUrl: contextURL + "/executor",
@@ -92,7 +94,7 @@
       <div class="row">
         <div class="header-title">
           <h1><a href="${context}/manager?project=${project.name}&flow=${flowid}">Flow
-            <small>$flowid</small>
+            <small>$flowdisplayname</small>
           </a></h1>
         </div>
         <div class="header-control">
@@ -112,7 +114,7 @@
         <li><a
             href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
         </a></li>
-        <li class="active"><strong>Flow</strong> $flowid</li>
+        <li class="active"><strong>Flow</strong> $flowdisplayname</li>
       </ol>
     </div>
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -118,7 +118,7 @@
               </td>
             #*todo chengren311: keep result of vmutils.getProjectName as a variable *#
               <td><a
-                  href="${context}/manager?project=${trigger.getProjectName()}&flow=${trigger.getFlowId()}">${trigger.getFlowId()}</a>
+                  href="${context}/manager?project=${trigger.getProjectName()}&flow=${trigger.getFlowId()}">${trigger.getFlowDisplayName()}</a>
               </td>
               <td>
                 <a href="${context}/manager?project=${trigger.getProjectName()}">${trigger.getProjectName()}</a>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -109,7 +109,7 @@
                   <a href="${context}/executor?execid=${flow.executionId}">${flow.executionId}</a>
                 </td>
                 <td class="tb-name">
-                  <a href="${context}/executor?execid=${flow.executionId}">${flow.flowId}</a>
+                  <a href="${context}/executor?execid=${flow.executionId}">${flow.flowDisplayName}</a>
                 </td>
                 <td>
                   <a href="${context}/manager?project=$vmutils.getProjectName(${flow.projectId})">$vmutils.getProjectName(${flow.projectId})</a>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -48,7 +48,7 @@
       <li><a href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName
       </a></li>
       <li><a
-          href="${context}/manager?project=${projectName}&flow=${flowid}"><strong>Flow</strong> $flowid
+          href="${context}/manager?project=${projectName}&flow=${flowid}"><strong>Flow</strong> $flowdisplayname
       </a></li>
       <li><a href="${context}/executor?execid=${execid}#jobslist"><strong>Execution</strong> $execid
       </a></li>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -69,7 +69,7 @@
             href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
         </a></li>
         <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowid
+            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowdisplayname
         </a></li>
         <li class="active"><strong>Job</strong> $jobid</li>
       </ol>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -76,7 +76,8 @@
                       <button type="button"
                               title=""
                               class="btn btn-xs btn-success execute-flow ${isDisabled}"
-                              flowId="${flow.id}">Execute Flow
+                              flowId="${flow.id}"
+                              flowDisplayName="${flow.displayName}">Execute Flow
                       </button>
                       <a href="${context}/manager?project=${project.name}&flow=${flow.id}#executions"
                          class="btn btn-info btn-xs">Executions</a>
@@ -85,7 +86,7 @@
                     </div>
                   #end
                   <span class="glyphicon glyphicon-chevron-down flow-expander-icon"></span>
-                  <a href="${context}/manager?project=${project.name}&flow=${flow.id}">${flow.id}</a>
+                  <a href="${context}/manager?project=${project.name}&flow=${flow.id}">${flow.displayName}</a>
                 </div>
                 <div id="${flow.id}-child" class="panel-collapse panel-list collapse">
                   <ul class="list-group list-group-collapse expanded-flow-job-list"

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
@@ -57,7 +57,7 @@
             href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
         </a></li>
         <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowid
+            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowdisplayname
         </a></li>
         <li><a
             href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}"><strong>Job</strong> $jobid

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -278,6 +278,7 @@ azkaban.FlowTabView = Backbone.View.extend({
       project: projectName,
       ajax: "executeFlow",
       flow: flowId,
+      flowDisplayName: flowDisplayName,
       execid: execId,
       exgraph: data
     };

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -175,6 +175,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
   show: function (data) {
     var projectName = data.project;
     var flowId = data.flow;
+    var flowDisplayName = data.flowDisplayName
     var jobId = data.job;
 
     // ExecId is optional
@@ -187,10 +188,10 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var self = this;
     var loadCallback = function () {
       if (jobId) {
-        self.showExecuteJob(projectName, flowId, jobId, data.withDep);
+        self.showExecuteJob(projectName, flowId, flowDisplayName, jobId, data.withDep);
       }
       else {
-        self.showExecuteFlow(projectName, flowId);
+        self.showExecuteFlow(projectName, flowId, flowDisplayName);
       }
     }
 
@@ -199,17 +200,17 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     this.loadFlowInfo(projectName, flowId, execId);
   },
 
-  showExecuteFlow: function (projectName, flowId) {
-    $("#execute-flow-panel-title").text("Execute Flow " + flowId);
+  showExecuteFlow: function (projectName, flowId, flowDisplayName) {
+    $("#execute-flow-panel-title").text("Execute Flow " + flowDisplayName);
     this.showExecutionOptionPanel();
 
     // Triggers a render
     this.model.trigger("change:graph");
   },
 
-  showExecuteJob: function (projectName, flowId, jobId, withDep) {
+  showExecuteJob: function (projectName, flowId, flowDisplayName, jobId, withDep) {
     sideMenuDialogView.menuSelect($("#flow-option"));
-    $("#execute-flow-panel-title").text("Execute Flow " + flowId);
+    $("#execute-flow-panel-title").text("Execute Flow " + flowDisplayName);
 
     var data = this.model.get("data");
     var disabled = this.model.get("disabled");

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -591,7 +591,8 @@ var initFlowPage = function (settings) {
     var executingData = {
       project: settings.projectName,
       ajax: "executeFlow",
-      flow: settings.flowId
+      flow: settings.flowId,
+      flowDisplayName: settings.flowDisplayName
     };
 
     flowExecuteDialogView.show(executingData);

--- a/azkaban-web-server/src/web/js/azkaban/view/main.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/main.js
@@ -97,9 +97,10 @@ azkaban.ProjectTableView = Backbone.View.extend({
     var requestURL = contextURL + "/manager?project=" + data.project + "&flow=";
     for (var i = 0; i < flows.length; ++i) {
       var id = flows[i].flowId;
+      var displayName = flows[i].flowDisplayName
       var ida = document.createElement("a");
       ida.project = data.project;
-      $(ida).text(id);
+      $(ida).text(displayName);
       $(ida).attr("href", requestURL + id);
       $(ida).addClass('list-group-item');
       $(innerTable).append(ida);

--- a/azkaban-web-server/src/web/js/azkaban/view/project.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project.js
@@ -86,6 +86,7 @@ azkaban.FlowTableView = Backbone.View.extend({
   createJobListTable: function (data, innerTable) {
     var nodes = data.nodes;
     var flowId = data.flowId;
+    var flowDisplayName = data.flowDisplayName;
     var project = data.project;
     var requestURL = contextURL + "/manager?project=" + project + "&flow="
         + flowId + "&job=";
@@ -118,6 +119,7 @@ azkaban.FlowTableView = Backbone.View.extend({
           $(divRunJob).text("Run Job");
           divRunJob.jobName = name;
           divRunJob.flowId = flowId;
+          divRunJob.flowDisplayName = flowDisplayName;
           $(hoverMenuDiv).append(divRunJob);
 
           var divRunWithDep = document.createElement("button");
@@ -129,6 +131,7 @@ azkaban.FlowTableView = Backbone.View.extend({
           $(divRunWithDep).text("Run With Dependencies");
           divRunWithDep.jobName = name;
           divRunWithDep.flowId = flowId;
+          divRunWithDep.flowDisplayName = flowDisplayName;
           $(hoverMenuDiv).append(divRunWithDep);
         }
         $(li).append(hoverMenuDiv);
@@ -196,11 +199,13 @@ azkaban.FlowTableView = Backbone.View.extend({
     console.log("Run Job");
     var jobId = evt.currentTarget.jobName;
     var flowId = evt.currentTarget.flowId;
+    var flowDisplayName = evt.currentTarget.flowDisplayName;
 
     var executingData = {
       project: projectName,
       ajax: "executeFlow",
       flow: flowId,
+      flowDisplayName: flowDisplayName,
       job: jobId
     };
 
@@ -210,12 +215,14 @@ azkaban.FlowTableView = Backbone.View.extend({
   runWithDep: function (evt) {
     var jobId = evt.currentTarget.jobName;
     var flowId = evt.currentTarget.flowId;
+    var flowDisplayName = evt.currentTarget.flowDisplayName;
     console.log("Run With Dep");
 
     var executingData = {
       project: projectName,
       ajax: "executeFlow",
       flow: flowId,
+      flowDisplayName: flowDisplayName,
       job: jobId,
       withDep: true
     };
@@ -225,6 +232,7 @@ azkaban.FlowTableView = Backbone.View.extend({
   executeFlow: function (evt) {
     console.log("Execute Flow");
     var flowId = $(evt.currentTarget).attr('flowid');
+    var flowDisplayName = $(evt.currentTarget).attr('flowdisplayname');
 
     var isFlowLocked = $(evt.currentTarget).hasClass("disabled");
     if (isFlowLocked) {
@@ -235,7 +243,8 @@ azkaban.FlowTableView = Backbone.View.extend({
     var executingData = {
       project: projectName,
       ajax: "executeFlow",
-      flow: flowId
+      flow: flowId,
+      flowDisplayName: flowDisplayName,
     };
 
     this.executeFlowDialog(executingData);


### PR DESCRIPTION
The flow display name can be set in the YAML file by specify `displayName`
under `config`, e.g.:

```
config:
  displayName: Display Name
```

The display name is shown in the web UI if it is set instead of the flow
id.