### PR TITLE
Allow executors to be automatically activated

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -116,6 +116,9 @@ public class Constants {
     public static final String AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC =
         "azkaban.polling_criteria.cpu_load_period_sec";
 
+    // Configures whether the exec server should start up activated
+    public static final String AZKABAN_EXECUTOR_INITIALLY_ACTIVE = "azkaban.executor.initallyactive";
+
     // Configures properties for Azkaban executor health check
     public static final String AZKABAN_EXECUTOR_HEALTHCHECK_INTERVAL_MIN = "azkaban.executor.healthcheck.interval.min";
     public static final String AZKABAN_EXECUTOR_MAX_FAILURE_COUNT = "azkaban.executor.max.failurecount";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorDao.java
@@ -107,7 +107,7 @@ public class ExecutorDao {
     }
   }
 
-  Executor addExecutor(final String host, final int port)
+  Executor addExecutor(final String host, final int port, final boolean isActive)
       throws ExecutorManagerException {
     // verify, if executor already exists
     if (fetchExecutor(host, port) != null) {
@@ -115,17 +115,17 @@ public class ExecutorDao {
           "Executor %s:%d already exist", host, port));
     }
     // add new executor
-    addExecutorHelper(host, port);
+    addExecutorHelper(host, port, isActive);
 
     // fetch newly added executor
     return fetchExecutor(host, port);
   }
 
-  private void addExecutorHelper(final String host, final int port)
+  private void addExecutorHelper(final String host, final int port, final boolean isActive)
       throws ExecutorManagerException {
-    final String INSERT = "INSERT INTO executors (host, port) values (?,?)";
+    final String INSERT = "INSERT INTO executors (host, port, active) values (?,?,?)";
     try {
-      this.dbOperator.update(INSERT, host, port);
+      this.dbOperator.update(INSERT, host, port, isActive);
     } catch (final SQLException e) {
       throw new ExecutorManagerException(String.format("Error adding %s:%d ",
           host, port), e);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -125,7 +125,7 @@ public interface ExecutorLoader {
    *
    * @return Executor
    */
-  Executor addExecutor(String host, int port)
+  Executor addExecutor(String host, int port, boolean isActive)
       throws ExecutorManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -300,9 +300,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor addExecutor(final String host, final int port)
+  public Executor addExecutor(final String host, final int port, final boolean isActive)
       throws ExecutorManagerException {
-    return this.executorDao.addExecutor(host, port);
+    return this.executorDao.addExecutor(host, port, isActive);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -274,7 +274,7 @@ public class ExecutionFlowDaoTest {
   public void testAssignAndUnassignExecutor() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    final Executor executor = this.executorDao.addExecutor(host, port);
+    final Executor executor = this.executorDao.addExecutor(host, port, false);
     final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.executionFlowDao.uploadExecutableFlow(flow);
     this.assignExecutor.assignExecutor(executor.getId(), flow.getExecutionId());
@@ -305,7 +305,7 @@ public class ExecutionFlowDaoTest {
   public void testAssignExecutorInvalidExecution() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    final Executor executor = this.executorDao.addExecutor(host, port);
+    final Executor executor = this.executorDao.addExecutor(host, port, false);
 
     // Make 99 a random non-existent execution id.
     assertThatThrownBy(
@@ -377,7 +377,7 @@ public class ExecutionFlowDaoTest {
   }
 
   private List<ExecutableFlow> createExecutions() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("test", 1);
+    final Executor executor = this.executorDao.addExecutor("test", 1, false);
 
     final ExecutableFlow flow1 = createExecutionAndAssign(Status.PREPARING, executor);
 
@@ -393,7 +393,7 @@ public class ExecutionFlowDaoTest {
     flow4.setEndTime(System.currentTimeMillis() - 1);
     this.executionFlowDao.updateExecutableFlow(flow4);
 
-    final Executor executor2 = this.executorDao.addExecutor("test2", 2);
+    final Executor executor2 = this.executorDao.addExecutor("test2", 2, false);
     // flow5 is assigned to an executor that is then removed
     final ExecutableFlow flow5 = createExecutionAndAssign(Status.RUNNING, executor2);
     flow5.setStartTime(System.currentTimeMillis() + 1);
@@ -438,7 +438,7 @@ public class ExecutionFlowDaoTest {
   public void testFetchActiveFlowsStatusChanged() throws Exception {
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.executionFlowDao.uploadExecutableFlow(flow1);
-    final Executor executor = this.executorDao.addExecutor("test", 1);
+    final Executor executor = this.executorDao.addExecutor("test", 1, false);
     this.assignExecutor.assignExecutor(executor.getId(), flow1.getExecutionId());
 
     Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
@@ -509,7 +509,7 @@ public class ExecutionFlowDaoTest {
     flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(System.currentTimeMillis());
     this.executionFlowDao.uploadExecutableFlow(flow);
-    final Executor executor = this.executorDao.addExecutor("localhost", 12345);
+    final Executor executor = this.executorDao.addExecutor("localhost", 12345, false);
     assertThat(this.executionFlowDao.selectAndUpdateExecution(executor.getId(), true))
         .isEqualTo(flow.getExecutionId());
     assertThat(this.executorDao.fetchExecutorByExecutionId(flow.getExecutionId())).isEqualTo

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorDaoTest.java
@@ -97,8 +97,8 @@ public class ExecutorDaoTest {
   public void testDuplicateAddExecutor() throws Exception {
     final String host = "localhost";
     final int port = 12345;
-    this.executorDao.addExecutor(host, port);
-    assertThatThrownBy(() -> this.executorDao.addExecutor(host, port))
+    this.executorDao.addExecutor(host, port, false);
+    assertThatThrownBy(() -> this.executorDao.addExecutor(host, port, false))
         .isInstanceOf(ExecutorManagerException.class)
         .hasMessageContaining("already exist");
   }
@@ -160,16 +160,17 @@ public class ExecutorDaoTest {
   private List<Executor> addTestExecutors()
       throws ExecutorManagerException {
     final List<Executor> executors = new ArrayList<>();
-    executors.add(this.executorDao.addExecutor("localhost1", 12345));
-    executors.add(this.executorDao.addExecutor("localhost2", 12346));
-    executors.add(this.executorDao.addExecutor("localhost1", 12347));
+    executors.add(this.executorDao.addExecutor("localhost1", 12345, false));
+    executors.add(this.executorDao.addExecutor("localhost2", 12346, false));
+    executors.add(this.executorDao.addExecutor("localhost1", 12347, false));
     return executors;
   }
 
   /* Test Removing Executor */
   @Test
   public void testRemovingExecutor() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("localhost1", 12345);
+    final Executor executor = this.executorDao
+        .addExecutor("localhost1", 12345, false);
     assertThat(executor).isNotNull();
     this.executorDao.removeExecutor("localhost1", 12345);
     final Executor fetchedExecutor = this.executorDao.fetchExecutor("localhost1", 12345);
@@ -179,12 +180,26 @@ public class ExecutorDaoTest {
   /* Test Executor reactivation */
   @Test
   public void testExecutorActivation() throws Exception {
-    final Executor executor = this.executorDao.addExecutor("localhost1", 12345);
+    final Executor executor = this.executorDao
+        .addExecutor("localhost1", 12345, false);
     assertThat(executor.isActive()).isFalse();
 
     executor.setActive(true);
     this.executorDao.updateExecutor(executor);
     final Executor fetchedExecutor = this.executorDao.fetchExecutor(executor.getId());
     assertThat(fetchedExecutor.isActive()).isTrue();
+  }
+
+  /* Test Executor initial activation */
+  @Test
+  public void testExecutorInitialActivation() throws Exception {
+    final Executor executor = this.executorDao
+        .addExecutor("localhost1", 12345, true);
+    assertThat(executor.isActive()).isTrue();
+
+    executor.setActive(false);
+    this.executorDao.updateExecutor(executor);
+    final Executor fetchedExecutor = this.executorDao.fetchExecutor(executor.getId());
+    assertThat(fetchedExecutor.isActive()).isFalse();
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -101,8 +101,8 @@ public class ExecutorManagerTest {
   private ExecutorManager createMultiExecutorManagerInstance() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     this.props.put(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, "false");
-    this.loader.addExecutor("localhost", 12345);
-    this.loader.addExecutor("localhost", 12346);
+    this.loader.addExecutor("localhost", 12345, true);
+    this.loader.addExecutor("localhost", 12346, true);
     return createExecutorManager();
   }
 
@@ -134,8 +134,8 @@ public class ExecutorManagerTest {
   @Test
   public void testMultipleExecutorScenario() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, true);
+    final Executor executor2 = this.loader.addExecutor("localhost", 12346, true);
 
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
@@ -170,7 +170,7 @@ public class ExecutorManagerTest {
   @Test
   public void testSetupExecutorsSucess() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, true);
     final ExecutorManager manager = createExecutorManager();
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
         new Executor[]{executor1});
@@ -178,8 +178,8 @@ public class ExecutorManagerTest {
     // mark older executor as inactive
     executor1.setActive(false);
     this.loader.updateExecutor(executor1);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
-    final Executor executor3 = this.loader.addExecutor("localhost", 12347);
+    final Executor executor2 = this.loader.addExecutor("localhost", 12346, true);
+    final Executor executor3 = this.loader.addExecutor("localhost", 12347, true);
     manager.setupExecutors();
 
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
@@ -193,7 +193,7 @@ public class ExecutorManagerTest {
   @Test(expected = ExecutorManagerException.class)
   public void testSetupExecutorsException() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.loader.addExecutor("localhost", 12345, true);
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
         new HashSet(manager.getAllActiveExecutors());

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -353,12 +353,12 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Executor addExecutor(final String host, final int port)
+  public Executor addExecutor(final String host, final int port, final boolean isActive)
       throws ExecutorManagerException {
     Executor executor = null;
     if (fetchExecutor(host, port) == null) {
       this.executorIdCounter++;
-      executor = new Executor(this.executorIdCounter, host, port, true);
+      executor = new Executor(this.executorIdCounter, host, port, isActive);
       this.executors.add(executor);
     }
     return executor;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -265,10 +265,11 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
       final String host = requireNonNull(getHost());
       final int port = getPort();
       checkState(port != -1);
+      final boolean isInitiallyActive = isInitiallyActive();
       final Executor executor = this.executionLoader.fetchExecutor(host, port);
       if (executor == null) {
         logger.info("This executor wasn't found in the DB. Adding self.");
-        this.executionLoader.addExecutor(host, port);
+        this.executionLoader.addExecutor(host, port, isInitiallyActive);
       } else {
         logger.info("This executor is already in the DB. Found: " + executor);
       }
@@ -424,6 +425,10 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
 
     // The first connector is created upon initializing the server. That's the one that has the port.
     return connectors[0].getLocalPort();
+  }
+
+  public boolean isInitiallyActive() {
+    return this.props.getBoolean(ConfigurationKeys.AZKABAN_EXECUTOR_INITIALLY_ACTIVE, false);
   }
 
   /**

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -128,7 +128,7 @@ public class AzkabanWebServerTest {
     final ExecutorLoader executorLoader = injector.getInstance(ExecutorLoader.class);
     assertNotNull(executorLoader);
 
-    final Executor executor = executorLoader.addExecutor("localhost", 60000);
+    final Executor executor = executorLoader.addExecutor("localhost", 60000, false);
     executor.setActive(true);
     executorLoader.updateExecutor(executor);
 


### PR DESCRIPTION
A new configuration property `azkaban.executor.initallyactive`, if set to `true`, causes exec servers to start active rather than inactive.