### PR TITLE
New runtime flow parametter

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -116,7 +116,7 @@ public class CommonJobProperties {
   public static final String EXEC_ID = "azkaban.flow.execid";
 
   /**
-   * Root directory of the the flow execution.
+   * Root directory of the execution.
    */
   public static final String FLOW_EXECUTION_DIR = "azkaban.flow.execution.dir";
 

--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -116,6 +116,11 @@ public class CommonJobProperties {
   public static final String EXEC_ID = "azkaban.flow.execid";
 
   /**
+   * Root directory of the the flow execution.
+   */
+  public static final String FLOW_EXECUTION_DIR = "azkaban.flow.execution.dir";
+
+  /**
    * The numerical project id identifier.
    */
   public static final String PROJECT_ID = "azkaban.flow.projectid";

--- a/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
@@ -31,15 +31,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.joda.time.DateTime;
+import java.io.File;
 
 public class FlowUtils {
 
   public static Props addCommonFlowProperties(final Props parentProps,
-      final ExecutableFlowBase flow) {
+      final ExecutableFlow flow) {
     final Props props = new Props(parentProps);
 
     props.put(CommonJobProperties.FLOW_ID, flow.getFlowId());
     props.put(CommonJobProperties.EXEC_ID, flow.getExecutionId());
+    props.put(CommonJobProperties.FLOW_EXECUTION_DIR , new File(flow.getExecutionPath()).getAbsolutePath());
     props.put(CommonJobProperties.PROJECT_ID, flow.getProjectId());
     props.put(CommonJobProperties.PROJECT_NAME, flow.getProjectName());
     props.put(CommonJobProperties.PROJECT_VERSION, flow.getVersion());


### PR DESCRIPTION
added new run time parameter azkaban.flow.execution.dir which is set to root directory of flow.

usage 
`commad=${azkaban.flow.execution.dir}/myfolder/myjobs/myscript`