### PR TITLE
Reorder job context menu: move log links to bottom

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -148,23 +148,6 @@ var nodeClickCallback = function (event, model, node) {
     // 1. Flow -> Graph tab
     // 2. Execution -> Graph tab
     menu = [];
-    if (node.status != 'READY' && node.status != 'SKIPPED') {
-      // For "Flow Graph" (not an execution) node.status = READY, so this
-      // condition also works correctly for it
-      $.merge(menu, [
-        {
-          title: "Open Log...", callback: function () {
-            window.location.href = logURL;
-          }
-        },
-        {
-          title: "Open Log in New Window...", callback: function () {
-            window.open(logURL);
-          }
-        },
-        {break: 1}
-      ]);
-    }
     $.merge(menu, [
       //  {title: "View Properties...", callback: function() {openJobDisplayCallback(jobId, flowId, event)}},
       //  {break: 1},
@@ -185,6 +168,23 @@ var nodeClickCallback = function (event, model, node) {
         }
       }
     ]);
+    if (node.status != 'READY' && node.status != 'SKIPPED') {
+      // For "Flow Graph" (not an execution) node.status = READY, so this
+      // condition also works correctly for it
+      $.merge(menu, [
+        {break: 1},
+        {
+          title: "Open Log...", callback: function () {
+            window.location.href = logURL;
+          }
+        },
+        {
+          title: "Open Log in New Window...", callback: function () {
+            window.open(logURL);
+          }
+        }
+      ]);
+    }
   }
   contextMenuView.show(event, menu);
 }


### PR DESCRIPTION
As [discussed](https://github.com/azkaban/azkaban/pull/2231#issuecomment-510162091) with @jamiesjc, it makes more sense to show `Open Job` and `Center Job` at the top as this is common to every job and `Open Log` options below them since they are only shown for job nodes that have a start time.

With this change:

<img width="519" alt="Näyttökuva 2019-7-11 kello 10 21 06" src="https://user-images.githubusercontent.com/4446608/61030237-a1cd9380-a3c5-11e9-9f48-8a662be5c151.png">

For the record, [original suggestion](https://github.com/azkaban/azkaban/pull/2231#issuecomment-509851538) was a bit different

> I would keep the first two entries as Open Job and Open Job in new windows, keep the last item as Center, and add the two new entries in the middle.

However this PR puts also `Center` before the log links, as it is also shown in all occasions.