### PR TITLE
Initialize FlowRunnerManager.active from DB

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -265,9 +265,9 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
 
   private void initActive() throws ExecutorManagerException {
     final Executor executor;
-    final String host = requireNonNull(getHost());
     final int port = this.props.getInt(ConfigurationKeys.EXECUTOR_PORT, -1);
     if (port != -1) {
+      final String host = requireNonNull(getHost());
       // Check if this executor exists previously in the DB
       try {
         executor = this.executionLoader.fetchExecutor(host, port);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -306,6 +306,10 @@ public class FlowRunnerManager implements EventListener,
     }
   }
 
+  public void setActiveInternal(final boolean isActive) {
+    this.active = isActive;
+  }
+
   /**
    * Wait until ongoing flow preparation work finishes.
    */


### PR DESCRIPTION
This is a partial fix for Issue #2243: _ExecutorManagerException: executor became inactive before setting up the flow_.

This only fixes the cases where `executor.port` property is defined ie. using a fixed port.

----

A general fix would need to go in this order I suppose:
- guice provisioning
- start executor jetty server (to reserve a random port) but maybe in a state that returns 503 for now (to all requests?)
- init FlowRunnerManager.active from db
- stop returning 503
- However as it's up to jetty server to pick a random port, there's not much point in doing this, other than guaranteeing consistency between executor state & the DB. Any way, if an executor is restarted, it may get the same port as before, but it's more likely that it gets a different port, and in that case the status from previous runtime can't be restored any way.

But it's not really worth doing now. It should be reasonably easy to use fixed port when the behavior of restoring active status from DB is wanted.