### PR TITLE
Add a dropdown button in Job Details page to support multiple Hadoop jobs in the Az logs

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,7 +59,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
   private final AlerterHolder alerterHolder;
   private final ExecutorHealthChecker executorHealthChecker;
   private final int maxConcurrentRunsOneFlow;
-  private final Map<Pair<String,String>, Integer> maxConcurrentRunsPerFlowMap;
+  private final Map<Pair<String, String>, Integer> maxConcurrentRunsPerFlowMap;
   private final CommonMetrics commonMetrics;
   private final Props azkProps;
 
@@ -450,57 +452,66 @@ public class ExecutionController extends EventHandler implements ExecutorManager
   }
 
   /**
-   * If the resource manager and job history server urls are configured, fetch the application
-   * id from the job log and then construct the job link url.
+   * If the Resource Manager and Job History server urls are configured, find all the
+   * Hadoop/Spark application ids present in the Azkaban job's log and then construct the url to
+   * job logs in the Hadoop/Spark server for each application id found. Application ids are
+   * returned in the order they appear in the Azkaban job log.
    *
    * @param exFlow The executable flow.
    * @param jobId The job id.
    * @param attempt The job execution attempt.
-   * @return the job link url.
+   * @return The map of (application id, job log url)
    */
   @Override
-  public String getJobLinkUrl(final ExecutableFlow exFlow, final String jobId, final int attempt) {
-    if (!this.azkProps.containsKey(ConfigurationKeys.RESOURCE_MANAGER_JOB_URL) || !this.azkProps
-        .containsKey(ConfigurationKeys.HISTORY_SERVER_JOB_URL) || !this.azkProps
-        .containsKey(ConfigurationKeys.SPARK_HISTORY_SERVER_JOB_URL)) {
-      return null;
+  public Map<String, String> getExternalJobLogUrls(final ExecutableFlow exFlow, final String jobId,
+      final int attempt) {
+
+    final Map<String, String> jobLogUrlsByAppId = new LinkedHashMap<>();
+    if (!this.azkProps.containsKey(ConfigurationKeys.RESOURCE_MANAGER_JOB_URL) ||
+        !this.azkProps.containsKey(ConfigurationKeys.HISTORY_SERVER_JOB_URL) ||
+        !this.azkProps.containsKey(ConfigurationKeys.SPARK_HISTORY_SERVER_JOB_URL)) {
+      return jobLogUrlsByAppId;
     }
-    final String applicationId = getApplicationId(exFlow, jobId, attempt);
-    return ExecutionControllerUtils.createJobLinkUrl(exFlow, jobId, applicationId, this.azkProps);
+    final Set<String> applicationIds = getApplicationIds(exFlow, jobId, attempt);
+    for (final String applicationId : applicationIds) {
+      final String jobLogUrl = ExecutionControllerUtils
+          .createJobLinkUrl(exFlow, jobId, applicationId, this.azkProps);
+      if (jobLogUrl != null) {
+        jobLogUrlsByAppId.put(applicationId, jobLogUrl);
+      }
+    }
+
+    return jobLogUrlsByAppId;
   }
 
   /**
-   * Get the Hadoop/Spark application id from the job log.
+   * Find all the Hadoop/Spark application ids present in the Azkaban job log. When iterating
+   * over the set returned by this method the application ids are in the same order they appear
+   * in the log.
    *
    * @param exFlow The executable flow.
    * @param jobId The job id.
    * @param attempt The job execution attempt.
-   * @return the application id.
+   * @return The application ids found.
    */
-  String getApplicationId(final ExecutableFlow exFlow, final String jobId, final int attempt) {
-    String applicationId;
-    boolean finished = false;
+  Set<String> getApplicationIds(final ExecutableFlow exFlow, final String jobId,
+      final int attempt) {
+    final Set<String> applicationIds = new LinkedHashSet<>();
     int offset = 0;
     try {
-      while (!finished) {
-        final LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
-        if (data != null && data.getLength() != 0) {
-          applicationId = ExecutionControllerUtils.findApplicationIdFromLog(data.getData());
-          if (applicationId != null) {
-            return applicationId;
-          }
-          offset = data.getOffset() + data.getLength();
-          this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
-              + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
-        } else {
-          finished = true;
-        }
+      LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
+      while (data != null && data.getLength() > 0) {
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
+        offset = data.getOffset() + data.getLength();
+        this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
+            + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
+        data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {
       this.logger.error("Failed to get application ID for execution " + exFlow.getExecutionId() +
           ", job " + jobId + ", attempt " + attempt + ", data offset " + offset, e);
     }
-    return null;
+    return applicationIds;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -501,10 +501,10 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     try {
       LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       while (data != null && data.getLength() > 0) {
-        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
-        offset = data.getOffset() + data.getLength();
         this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
             + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
+        offset = data.getOffset() + data.getLength();
         data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -745,10 +745,10 @@ public class ExecutorManager extends EventHandler implements
     try {
       LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       while (data != null && data.getLength() > 0) {
-        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
-        offset = data.getOffset() + data.getLength();
         this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
             + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
+        offset = data.getOffset() + data.getLength();
         data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -40,6 +40,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +60,7 @@ import org.joda.time.DateTime;
 
 /**
  * Executor manager used to manage the client side job.
+ *
  * @deprecated replaced by {@link ExecutionController}
  */
 @Singleton
@@ -78,7 +81,7 @@ public class ExecutorManager extends EventHandler implements
   private final RunningExecutionsUpdaterThread updaterThread;
   private final ExecutorApiGateway apiGateway;
   private final int maxConcurrentRunsOneFlow;
-  private final Map<Pair<String,String>, Integer> maxConcurrentRunsPerFlowMap;
+  private final Map<Pair<String, String>, Integer> maxConcurrentRunsPerFlowMap;
   private final ExecutorManagerUpdaterStage updaterStage;
   private final ExecutionFinalizer executionFinalizer;
   private final ActiveExecutors activeExecutors;
@@ -693,57 +696,66 @@ public class ExecutorManager extends EventHandler implements
   }
 
   /**
-   * If the resource manager and job history server urls are configured, fetch the application
-   * id from the job log and then construct the job link url.
+   * If the Resource Manager and Job History server urls are configured, find all the
+   * Hadoop/Spark application ids present in the Azkaban job's log and then construct the url to
+   * job logs in the Hadoop/Spark server for each application id found. Application ids are
+   * returned in the order they appear in the Azkaban job log.
    *
    * @param exFlow The executable flow.
    * @param jobId The job id.
    * @param attempt The job execution attempt.
-   * @return the job link url.
+   * @return The map of (application id, job log url)
    */
   @Override
-  public String getJobLinkUrl(final ExecutableFlow exFlow, final String jobId, final int attempt) {
-    if (!this.azkProps.containsKey(ConfigurationKeys.RESOURCE_MANAGER_JOB_URL) || !this.azkProps
-        .containsKey(ConfigurationKeys.HISTORY_SERVER_JOB_URL) || !this.azkProps
-        .containsKey(ConfigurationKeys.SPARK_HISTORY_SERVER_JOB_URL)) {
-      return null;
+  public Map<String, String> getExternalJobLogUrls(final ExecutableFlow exFlow, final String jobId,
+      final int attempt) {
+
+    final Map<String, String> jobLogUrlsByAppId = new LinkedHashMap<>();
+    if (!this.azkProps.containsKey(ConfigurationKeys.RESOURCE_MANAGER_JOB_URL) ||
+        !this.azkProps.containsKey(ConfigurationKeys.HISTORY_SERVER_JOB_URL) ||
+        !this.azkProps.containsKey(ConfigurationKeys.SPARK_HISTORY_SERVER_JOB_URL)) {
+      return jobLogUrlsByAppId;
     }
-    final String applicationId = getApplicationId(exFlow, jobId, attempt);
-    return ExecutionControllerUtils.createJobLinkUrl(exFlow, jobId, applicationId, this.azkProps);
+    final Set<String> applicationIds = getApplicationIds(exFlow, jobId, attempt);
+    for (final String applicationId : applicationIds) {
+      final String jobLogUrl = ExecutionControllerUtils
+          .createJobLinkUrl(exFlow, jobId, applicationId, this.azkProps);
+      if (jobLogUrl != null) {
+        jobLogUrlsByAppId.put(applicationId, jobLogUrl);
+      }
+    }
+
+    return jobLogUrlsByAppId;
   }
 
   /**
-   * Get the Hadoop/Spark application id from the job log.
+   * Find all the Hadoop/Spark application ids present in the Azkaban job log. When iterating
+   * over the set returned by this method the application ids are in the same order they appear
+   * in the log.
    *
    * @param exFlow The executable flow.
    * @param jobId The job id.
    * @param attempt The job execution attempt.
-   * @return the application id.
+   * @return The application ids found.
    */
-  String getApplicationId(final ExecutableFlow exFlow, final String jobId, final int attempt) {
-    String applicationId;
-    boolean finished = false;
+  Set<String> getApplicationIds(final ExecutableFlow exFlow, final String jobId,
+      final int attempt) {
+    final Set<String> applicationIds = new LinkedHashSet<>();
     int offset = 0;
     try {
-      while (!finished) {
-        final LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
-        if (data != null && data.getLength() != 0) {
-          applicationId = ExecutionControllerUtils.findApplicationIdFromLog(data.getData());
-          if (applicationId != null) {
-            return applicationId;
-          }
-          offset = data.getOffset() + data.getLength();
-          this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
-              + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
-        } else {
-          finished = true;
-        }
+      LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
+      while (data != null && data.getLength() > 0) {
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
+        offset = data.getOffset() + data.getLength();
+        this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
+            + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
+        data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {
       this.logger.error("Failed to get application ID for execution " + exFlow.getExecutionId() +
           ", job " + jobId + ", attempt " + attempt + ", data offset " + offset, e);
     }
-    return null;
+    return applicationIds;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -83,7 +83,8 @@ public interface ExecutorManagerAdapter {
   public List<Object> getExecutionJobStats(ExecutableFlow exflow, String jobId,
       int attempt) throws ExecutorManagerException;
 
-  public String getJobLinkUrl(ExecutableFlow exFlow, String jobId, int attempt);
+  public Map<String, String> getExternalJobLogUrls(ExecutableFlow exFlow, String jobId,
+      int attempt);
 
   public void cancelFlow(ExecutableFlow exFlow, String userId)
       throws ExecutorManagerException;

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2018 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -262,9 +262,9 @@ public class ExecutionControllerTest {
     Assert.assertEquals(1, appIds.size());
     Assert.assertEquals("12345_6789", appIds.iterator().next());
 
-    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 93, "data",
-        "Submitted application_12345_6789.\n Attempt job_12345_6789. Accepted application_98765_4321. ");
-    logDataEnd = ImmutableMap.of("offset", 93, "length", 0, "data", "");
+    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 100, "data",
+        "Submitted application_12345_6789.\n AttemptID: attempt_12345_6789. Accepted application_98765_4321. ");
+    logDataEnd = ImmutableMap.of("offset", 100, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
         .thenReturn(logData2, logDataEnd);
     appIds = this.controller.getApplicationIds(this.flow1, "job1", 0);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -242,7 +243,7 @@ public class ExecutionControllerTest {
   }
 
   /**
-   * Test fetching application id from log data.
+   * Test fetching application ids from log data.
    *
    * @throws Exception the exception
    */
@@ -250,17 +251,33 @@ public class ExecutionControllerTest {
   public void testGetApplicationIdFromLog() throws Exception {
     when(this.loader.fetchActiveFlowByExecId(this.flow1.getExecutionId()))
         .thenReturn(new Pair<>(this.ref1, this.flow1));
-    // Verify that application id is obtained successfully from the log data.
+
+    // Verify that application ids are obtained successfully from the log data.
     final Map<String, Object> logData1 = ImmutableMap.of("offset", 0, "length", 33, "data",
         "Submitted application_12345_6789.");
+    Map<String, Object> logDataEnd = ImmutableMap.of("offset", 33, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData1);
-    Assert.assertEquals("12345_6789", this.controller.getApplicationId(this.flow1, "job1", 0));
-    // Verify that application id is null when log data length is 0 (no new data available).
-    final Map<String, Object> logData2 = ImmutableMap.of("offset", 33, "length", 0, "data", "");
+        .thenReturn(logData1, logDataEnd);
+    Set<String> appIds = this.controller.getApplicationIds(this.flow1, "job1", 0);
+    Assert.assertEquals(1, appIds.size());
+    Assert.assertEquals("12345_6789", appIds.iterator().next());
+
+    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 93, "data",
+        "Submitted application_12345_6789.\n Attempt job_12345_6789. Accepted application_98765_4321. ");
+    logDataEnd = ImmutableMap.of("offset", 93, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData2);
-    Assert.assertEquals(null, this.controller.getApplicationId(this.flow1, "job1", 0));
+        .thenReturn(logData2, logDataEnd);
+    appIds = this.controller.getApplicationIds(this.flow1, "job1", 0);
+    Assert.assertEquals(2, appIds.size());
+    final Iterator iterator = appIds.iterator();
+    Assert.assertEquals("12345_6789", iterator.next());
+    Assert.assertEquals("98765_4321", iterator.next());
+
+    // Verify that an empty list is returned when log data length is 0 (no new data available).
+    final Map<String, Object> logData3 = ImmutableMap.of("offset", 0, "length", 0, "data", "");
+    when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
+        .thenReturn(logData3);
+    Assert.assertEquals(0, this.controller.getApplicationIds(this.flow1, "job1", 0).size());
   }
 
   private void submitFlow(final ExecutableFlow flow, final ExecutionReference ref) throws

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -532,25 +533,41 @@ public class ExecutorManagerTest {
   }
 
   /**
-   * Test fetching application id from log data.
+   * Test fetching application ids from log data.
    *
    * @throws Exception the exception
    */
   @Test
-  public void testGetApplicationIdFromLog() throws Exception {
+  public void testGetApplicationIdsFromLog() throws Exception {
     testSetUpForRunningFlows();
     this.runningExecutions.get().put(1, new Pair<>(this.ref1, this.flow1));
-    // Verify that application id is obtained successfully from the log data.
+
+    // Verify that application ids are obtained successfully from the log data.
     final Map<String, Object> logData1 = ImmutableMap.of("offset", 0, "length", 33, "data",
         "Submitted application_12345_6789.");
+    Map<String, Object> logDataEnd = ImmutableMap.of("offset", 33, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData1);
-    Assert.assertEquals("12345_6789", this.manager.getApplicationId(this.flow1, "job1", 0));
-    // Verify that application id is null when log data length is 0 (no new data available).
-    final Map<String, Object> logData2 = ImmutableMap.of("offset", 33, "length", 0, "data", "");
+        .thenReturn(logData1, logDataEnd);
+    Set<String> appIds = this.manager.getApplicationIds(this.flow1, "job1", 0);
+    Assert.assertEquals(1, appIds.size());
+    Assert.assertEquals("12345_6789", appIds.iterator().next());
+
+    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 93, "data",
+        "Submitted application_12345_6789.\n Attempt job_12345_6789. Accepted application_98765_4321. ");
+    logDataEnd = ImmutableMap.of("offset", 93, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData2);
-    Assert.assertEquals(null, this.manager.getApplicationId(this.flow1, "job1", 0));
+        .thenReturn(logData2, logDataEnd);
+    appIds = this.manager.getApplicationIds(this.flow1, "job1", 0);
+    Assert.assertEquals(2, appIds.size());
+    final Iterator iterator = appIds.iterator();
+    Assert.assertEquals("12345_6789", iterator.next());
+    Assert.assertEquals("98765_4321", iterator.next());
+
+    // Verify that an empty list is returned when log data length is 0 (no new data available).
+    final Map<String, Object> logData3 = ImmutableMap.of("offset", 0, "length", 0, "data", "");
+    when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
+        .thenReturn(logData3);
+    Assert.assertEquals(0, this.manager.getApplicationIds(this.flow1, "job1", 0).size());
   }
 
   /*

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -552,9 +552,9 @@ public class ExecutorManagerTest {
     Assert.assertEquals(1, appIds.size());
     Assert.assertEquals("12345_6789", appIds.iterator().next());
 
-    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 93, "data",
-        "Submitted application_12345_6789.\n Attempt job_12345_6789. Accepted application_98765_4321. ");
-    logDataEnd = ImmutableMap.of("offset", 93, "length", 0, "data", "");
+    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 100, "data",
+        "Submitted application_12345_6789.\n AttemptID: attempt_12345_6789. Accepted application_98765_4321. ");
+    logDataEnd = ImmutableMap.of("offset", 100, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
         .thenReturn(logData2, logDataEnd);
     appIds = this.manager.getApplicationIds(this.flow1, "job1", 0);

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -29,15 +29,28 @@
       </div>
       <div class="header-control">
         <div class="pull-right header-form">
-          #if ($jobLinkUrl)
-            #if ($jobType == "spark")
-              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm"
-                 id="jobLinkUrl">Spark Job Log</a>
-            #else
-              <a href="$jobLinkUrl" target="_blank" class="btn btn-primary btn-sm"
-                 id="jobLinkUrl">Hadoop Job Log</a>
-            #end
+          #set($jobLogLinkBtnText = "#if($jobType == 'spark')Spark Job Log#{else}Hadoop Job Log#end")
+          #set($jobLogLinkBtnClass = "#if($jobFailed == 'true')btn-danger#{else}btn-primary#end")
+          #if ($jobLogUrlsByAppId.size() == 1)
+            <a href="${jobLogUrlsByAppId.get($jobLogUrlsByAppId.entrySet().iterator().next().getKey())}"
+               target="_blank" class="btn btn-sm ${jobLogLinkBtnClass}" id="jobLogLink">
+              ${jobLogLinkBtnText}
+            </a>
           #end
+          #if ($jobLogUrlsByAppId.size() > 1)
+            <div class="btn-group">
+              <button type="button" class="btn btn-sm dropdown-toggle ${jobLogLinkBtnClass}"
+                      data-toggle="dropdown">
+                ${jobLogLinkBtnText} <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu">
+                #foreach ($jobLogLink in $jobLogUrlsByAppId.entrySet())
+                  <li><a target="_blank" href="$jobLogLink.value">$jobLogLink.key</a></li>
+                #end
+              </ul>
+            </div>
+          #end
+
           <a href="${context}/manager?project=${projectName}&flow=${parentflowid}&job=$jobname"
              class="btn btn-info btn-sm">Job Properties</a>
         </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -50,13 +50,6 @@
       initAttemptPage(attemptPageSettings);
     });
   </script>
-  <script type="text/javascript">
-    $(document).ready(function () {
-      #if ($jobFailed == "true")
-        $("#jobLinkUrl").removeClass("btn-primary").addClass("btn-danger");
-      #end
-    });
-  </script>
 </head>
 <body>
 


### PR DESCRIPTION
There are cases where a single Azkaban job launches multiple Map-Reduce jobs (for example Pig and Hive jobs) and therefore there can be multiple <application_id>s in the job log.

In the Job Details page, in those cases of multiple <application_id>s, there will be a dropdown button listing all the <application_id>s in the Azkaban job log in the order they were launched with links to their respective logs in Spark/Hadoop history servers.

<img width="408" alt="Screen Shot 2019-07-19 at 10 52 17 AM" src="https://user-images.githubusercontent.com/44478711/61558423-d2dc4280-aa1b-11e9-807d-6f5fa0337ba2.png">

This is related to PR #1695