### PR TITLE
Fixes issue with truncation of application ids when parsing logs

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -503,8 +503,18 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       while (data != null && data.getLength() > 0) {
         this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
             + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
-        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
-        offset = data.getOffset() + data.getLength();
+        String logData = data.getData();
+        final int indexOfLastSpace = logData.lastIndexOf(' ');
+        final int indexOfLastTab = logData.lastIndexOf('\t');
+        final int indexOfLastEoL = logData.lastIndexOf('\n');
+        final int indexOfLastDelim = Math
+            .max(indexOfLastEoL, Math.max(indexOfLastSpace, indexOfLastTab));
+        if (indexOfLastDelim > -1) {
+          // index + 1 to avoid looping forever if indexOfLastDelim is zero
+          logData = logData.substring(0, indexOfLastDelim + 1);
+        }
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(logData));
+        offset = data.getOffset() + logData.length();
         data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -747,8 +747,18 @@ public class ExecutorManager extends EventHandler implements
       while (data != null && data.getLength() > 0) {
         this.logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
             + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
-        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(data.getData()));
-        offset = data.getOffset() + data.getLength();
+        String logData = data.getData();
+        final int indexOfLastSpace = logData.lastIndexOf(' ');
+        final int indexOfLastTab = logData.lastIndexOf('\t');
+        final int indexOfLastEoL = logData.lastIndexOf('\n');
+        final int indexOfLastDelim = Math
+            .max(indexOfLastEoL, Math.max(indexOfLastSpace, indexOfLastTab));
+        if (indexOfLastDelim > -1) {
+          // index + 1 to avoid looping forever if indexOfLastDelim is zero
+          logData = logData.substring(0, indexOfLastDelim + 1);
+        }
+        applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(logData));
+        offset = data.getOffset() + logData.length();
         data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -55,6 +55,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 /**
  * Test class for executor manager
@@ -543,31 +544,52 @@ public class ExecutorManagerTest {
     this.runningExecutions.get().put(1, new Pair<>(this.ref1, this.flow1));
 
     // Verify that application ids are obtained successfully from the log data.
-    final Map<String, Object> logData1 = ImmutableMap.of("offset", 0, "length", 33, "data",
-        "Submitted application_12345_6789.");
-    Map<String, Object> logDataEnd = ImmutableMap.of("offset", 33, "length", 0, "data", "");
+    final String logData1 = "Submitted application_12345_6789.";
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData1, logDataEnd);
+        .then(getLogChunksMock(logData1));
     Set<String> appIds = this.manager.getApplicationIds(this.flow1, "job1", 0);
     Assert.assertEquals(1, appIds.size());
     Assert.assertEquals("12345_6789", appIds.iterator().next());
 
-    final Map<String, Object> logData2 = ImmutableMap.of("offset", 0, "length", 100, "data",
-        "Submitted application_12345_6789.\n AttemptID: attempt_12345_6789. Accepted application_98765_4321. ");
-    logDataEnd = ImmutableMap.of("offset", 100, "length", 0, "data", "");
+    final String logData2 = " Submitted application_12345_6789.\n AttemptID: attempt_12345_6789. "
+        + "Accepted application_98765_4321.";
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData2, logDataEnd);
+        .then(getLogChunksMock(logData2));
     appIds = this.manager.getApplicationIds(this.flow1, "job1", 0);
     Assert.assertEquals(2, appIds.size());
     final Iterator iterator = appIds.iterator();
     Assert.assertEquals("12345_6789", iterator.next());
     Assert.assertEquals("98765_4321", iterator.next());
 
+
     // Verify that an empty list is returned when log data length is 0 (no new data available).
-    final Map<String, Object> logData3 = ImmutableMap.of("offset", 0, "length", 0, "data", "");
     when(this.apiGateway.callWithReference(any(), eq(ConnectorParams.LOG_ACTION), any()))
-        .thenReturn(logData3);
+        .then(getLogChunksMock(""));
     Assert.assertEquals(0, this.manager.getApplicationIds(this.flow1, "job1", 0).size());
+  }
+
+  private Answer<Object> getLogChunksMock(final String logData) {
+    return invocationOnMock -> {
+      String offsetStr = null, lengthStr = null;
+      for (final Object arg : invocationOnMock.getArguments()) {
+        if (!(arg instanceof Pair)) {
+          continue;
+        }
+        final Pair pairArg = (Pair) arg;
+        if ("offset".equals(pairArg.getFirst())) {
+          offsetStr = (String) pairArg.getSecond();
+        } else if ("length".equals(pairArg.getFirst())) {
+          lengthStr = (String) pairArg.getSecond();
+        }
+      }
+      Assert.assertNotNull(offsetStr);
+      Assert.assertNotNull(lengthStr);
+      final int offset = Integer.parseInt(offsetStr);
+      final int length = Integer.parseInt(lengthStr);
+      final int actualLength = Math.min(length, Math.max(0, logData.length() - offset));
+      final String logChunk = logData.substring(offset, offset + actualLength);
+      return ImmutableMap.of("offset", offset, "length", actualLength, "data", logChunk);
+    };
   }
 
   /*


### PR DESCRIPTION
To build the url to job logs in Hadoop/Spark servers (#1695) we currently get the application ids by parsing the Azkaban job logs.
 
This PR fixes a bug that appears when processing job logs by chunks.
-Application ids can be missed when they are accidentally truncated. For example: 
"application_1556244585372_1234567" truncated to "\_155624458537_1234567" which will not match the pattern "application_(\\d+_\\d+)"

-Application ids can also be invalidated. For example:    
"application_1556244585372_1234567" truncated to "application_1556244585372_1"