### PR TITLE
Increment Flow fail count everytime a flow fails.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
+++ b/azkaban-common/src/main/java/azkaban/executor/RunningExecutionsUpdater.java
@@ -241,10 +241,6 @@ public class RunningExecutionsUpdater {
     flow.applyUpdateObject(updateData);
     final Status newStatus = flow.getStatus();
 
-    if (oldStatus != newStatus && newStatus == Status.FAILED) {
-      this.commonMetrics.markFlowFail();
-    }
-
     if (oldStatus != newStatus && newStatus.equals(Status.FAILED_FINISHING)) {
       ExecutionControllerUtils.alertUserOnFirstError(flow, this.alerterHolder);
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -685,7 +685,7 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   private void finalizeFlow(final ExecutableFlowBase flow) {
-    final String id = flow == this.flow ? "" : flow.getNestedId();
+    final String id = flow == this.flow ? flow.getNestedId() : "";
 
     // If it's not the starting flow, we'll create set of output props
     // for the finished flow.

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -439,7 +439,7 @@ public class FlowRunnerManager implements EventListener,
 
     final FlowRunner runner =
         new FlowRunner(flow, this.executorLoader, this.projectLoader, this.jobtypeManager,
-            this.azkabanProps, this.azkabanEventReporter, this.alerterHolder);
+            this.azkabanProps, this.azkabanEventReporter, this.alerterHolder, this.commonMetrics);
     runner.setFlowWatcher(watcher)
         .setJobLogSettings(this.jobLogChunkSize, this.jobLogNumFiles)
         .setValidateProxyUser(this.validateProxyUser)

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -36,6 +36,8 @@ import azkaban.executor.Status;
 import azkaban.flow.Flow;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
+import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.MetricsManager;
 import azkaban.project.FlowLoader;
 import azkaban.project.FlowLoaderFactory;
 import azkaban.project.Project;
@@ -45,6 +47,7 @@ import azkaban.test.Utils;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
+import com.codahale.metrics.MetricRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -253,9 +256,10 @@ public class FlowRunnerTestUtil {
     }
     exFlow.getExecutionOptions().addAllFlowParameters(flowParams);
     this.executorLoader.uploadExecutableFlow(exFlow);
+    final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
     final FlowRunner runner =
         new FlowRunner(exFlow, this.executorLoader, this.projectLoader,
-            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), null);
+            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), commonMetrics);
     if (eventCollector != null) {
       runner.addListener(eventCollector);
     }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -255,7 +255,7 @@ public class FlowRunnerTestUtil {
     this.executorLoader.uploadExecutableFlow(exFlow);
     final FlowRunner runner =
         new FlowRunner(exFlow, this.executorLoader, this.projectLoader,
-            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class));
+            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), null);
     if (eventCollector != null) {
       runner.addListener(eventCollector);
     }


### PR DESCRIPTION
In the new flow dispatch logic, the flow fail count is always 0.

Fix the issue by incrementing the count by 1 whenever a flow fails. 

Testing Done:
1. Verified the fail count is incremented by 1 every time a flow fails by adding debug log messages.
2. Verified fail count is reflected on the internal Ingraph dashboard.

