### PR TITLE
Ensure project files referenced by unfinished executions are not deleted in HDFS during cleanup.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -258,9 +258,8 @@ class AzkabanProjectLoader {
         .collect(Collectors.toList());
     this.projectLoader.cleanOlderProjectVersion(project.getId(),
         project.getVersion() - this.projectVersionRetention, versionsWithUnfinishedExecutions);
-
     // Clean up storage
-    this.storageManager.cleanupProjectArtifacts(project.getId());
+    this.storageManager.cleanupProjectArtifacts(project.getId(), versionsWithUnfinishedExecutions);
   }
 
   private File unzipFile(final File archiveFile) throws IOException {

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.io.IOUtils;
@@ -122,11 +123,12 @@ public class StorageManager {
   }
 
   /**
-   * Clean up project artifacts based on project ID. See {@link StorageCleaner#cleanupProjectArtifacts(int)}
+   * Clean up project artifacts of a given project id, except those with the project versions
+   * provided.
    */
-  public void cleanupProjectArtifacts(final int projectId) {
+  public void cleanupProjectArtifacts(final int projectId, final List<Integer> versionsToExclude) {
     try {
-      this.storageCleaner.cleanupProjectArtifacts(projectId);
+      this.storageCleaner.cleanupProjectArtifacts(projectId, versionsToExclude);
     } catch (final Exception e) {
       log.error("Error occured during cleanup. Ignoring and continuing...", e);
     }
@@ -164,11 +166,11 @@ public class StorageManager {
     final String resourceId = requireNonNull(pfh.getResourceId(),
         String.format("URI is null. project ID: %d version: %d",
             pfh.getProjectId(), pfh.getVersion()));
-    try (InputStream is = this.storage.get(resourceId)) {
+    try (final InputStream is = this.storage.get(resourceId)) {
       final File file = createTempOutputFile(pfh);
 
       /* Copy from storage to output stream */
-      try (FileOutputStream fos = new FileOutputStream(file)) {
+      try (final FileOutputStream fos = new FileOutputStream(file)) {
         IOUtils.copy(is, fos);
       }
 


### PR DESCRIPTION
The cleanup of old project versions should not delete those versions with files still referenced by unfinished executions.
PR #1994 made the changes to prevent those undesirable deletions for project files stored in the database.
This PR complements PR #1994 by doing the same for project files not stored in the database (e.g. HDFS).
