### PR TITLE
Fix not saving group permissions when group name matches an existing user's name.

### DIFF
--- a/azkaban-db/src/main/sql/upgrade.3.76.0.to.3.77.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.76.0.to.3.77.0.sql
@@ -1,0 +1,5 @@
+-- DB Migration from release 3.76.0 to 3.77.0
+-- PR #2311 Fixes issue of group permissions not being saved when group name matches an existing
+-- user's name.
+--
+ALTER TABLE project_permissions DROP PRIMARY KEY, ADD PRIMARY KEY (project_id, name, isGroup);


### PR DESCRIPTION
User and group permissions are stored in the same database table with the 'name' column as the primary key. Groups are differentiated from users by having the 'isGroup' column set to true. Because the 'isGroup' column is not a primary key, attempts to create permissions for a group with the same name as an existing user end up updating the user of that name. To fix this issue is necessary to make 'isGroup' a primary key.
