### PR TITLE
fix minor typo on permissions modal

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
@@ -357,7 +357,7 @@
             <div class="alert alert-danger" id="change-permission-error-msg"></div>
             <fieldset class="form-horizontal">
               <div class="form-group">
-                <label for="path" class="col-sm-2 control-label">User</label>
+                <label for="path" class="col-sm-2 control-label" id="change-type">User</label>
                 <div class="col-sm-10">
                   <input type="text" name="userid" id="user-box" class="form-control">
                 </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
@@ -21,7 +21,7 @@
   #parse ("azkaban/webapp/servlet/velocity/style.vm")
   #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
-  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js?v=1567803382578"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
@@ -26,7 +26,6 @@ azkaban.PermissionTableView = Backbone.View.extend({
 
   initialize: function (settings) {
     this.group = settings.group;
-    this.proxy = settings.proxy;
   },
 
   render: function () {
@@ -34,8 +33,7 @@ azkaban.PermissionTableView = Backbone.View.extend({
 
   handleChangePermission: function (evt) {
     var currentTarget = evt.currentTarget;
-    changePermissionView.display(currentTarget.id, false, this.group,
-        this.proxy);
+    changePermissionView.display(currentTarget.id, false, this.group);
   }
 });
 
@@ -317,18 +315,14 @@ azkaban.ChangePermissionView = Backbone.View.extend({
 $(function () {
   permissionTableView = new azkaban.PermissionTableView({
     el: $('#permissions-table'),
-    group: false,
-    proxy: false
+    group: false
   });
   groupPermissionTableView = new azkaban.PermissionTableView({
     el: $('#group-permissions-table'),
-    group: true,
-    proxy: false
+    group: true
   });
   proxyTableView = new azkaban.ProxyTableView({
-    el: $('#proxy-user-table'),
-    group: false,
-    proxy: true
+    el: $('#proxy-user-table')
   });
   changePermissionView = new azkaban.ChangePermissionView({
     el: $('#change-permission')

--- a/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
@@ -171,6 +171,16 @@ azkaban.ChangePermissionView = Backbone.View.extend({
     var executeInput = $("#" + prefix + "-execute-checkbox");
     var scheduleInput = $("#" + prefix + "-schedule-checkbox");
 
+    if (group) {
+      $('#change-type').text("Group");
+    }
+    else if (proxy) {
+      $('#change-type').text("Proxy");
+    }
+    else {
+      $('#change-type').text("User");
+    }
+
     if (newPerm) {
       if (group) {
         $('#change-title').text("Add New Group Permissions");

--- a/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
@@ -148,12 +148,10 @@ azkaban.ChangePermissionView = Backbone.View.extend({
     $('#change-permission-error-msg').hide();
   },
 
-  display: function (userid, newPerm, group, proxy) {
+  display: function (userid, newPerm, group) {
     // 6 is the length of the prefix "group-"
     this.userid = group ? userid.substring(6, userid.length) : userid;
-    if (group == true) {
-      this.userid = userid.substring(6, userid.length)
-    } else if (proxy == true) {
+    if (group) {
       this.userid = userid.substring(6, userid.length)
     } else {
       this.userid = userid
@@ -174,9 +172,6 @@ azkaban.ChangePermissionView = Backbone.View.extend({
     if (group) {
       $('#change-type').text("Group");
     }
-    else if (proxy) {
-      $('#change-type').text("Proxy");
-    }
     else {
       $('#change-type').text("User");
     }
@@ -184,9 +179,6 @@ azkaban.ChangePermissionView = Backbone.View.extend({
     if (newPerm) {
       if (group) {
         $('#change-title').text("Add New Group Permissions");
-      }
-      else if (proxy) {
-        $('#change-title').text("Add New Proxy User Permissions");
       }
       else {
         $('#change-title').text("Add New User Permissions");
@@ -231,12 +223,7 @@ azkaban.ChangePermissionView = Backbone.View.extend({
   handleCheckboxClick: function (evt) {
     console.log("click");
     var targetName = evt.currentTarget.name;
-    if (targetName == "proxy") {
-      this.doProxy = evt.currentTarget.checked;
-    }
-    else {
-      this.permission[targetName] = evt.currentTarget.checked;
-    }
+    this.permission[targetName] = evt.currentTarget.checked;
     this.changeCheckbox(evt);
   },
 
@@ -353,11 +340,11 @@ $(function () {
     el: $('#remove-proxy')
   });
   $('#addUser').bind('click', function () {
-    changePermissionView.display("", true, false, false);
+    changePermissionView.display("", true, false);
   });
 
   $('#addGroup').bind('click', function () {
-    changePermissionView.display("", true, true, false);
+    changePermissionView.display("", true, true);
   });
 
   $('#addProxyUser').bind('click', function () {


### PR DESCRIPTION
The modal for adding a group used to have the input field mislabeled as "User". This fixes that issue and properly labels it as "Group".