### PR TITLE
change checkboxes to use .prop instead of .attr

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -32,7 +32,7 @@
 
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1559149862"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -36,7 +36,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
@@ -21,7 +21,7 @@
   #parse ("azkaban/webapp/servlet/velocity/style.vm")
   #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
-  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js?v=1568065399"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -23,7 +23,7 @@
   #parse ("azkaban/webapp/servlet/velocity/svgflowincludes.vm")
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -120,13 +120,13 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var overrideFailureEmails = this.model.get("failureEmailsOverride");
 
     if (overrideSuccessEmails) {
-      $('#override-success-emails').attr('checked', true);
+      $('#override-success-emails').prop('checked', true);
     }
     else {
       $('#success-emails').attr('disabled', 'disabled');
     }
     if (overrideFailureEmails) {
-      $('#override-failure-emails').attr('checked', true);
+      $('#override-failure-emails').prop('checked', true);
     }
     else {
       $('#failure-emails').attr('disabled', 'disabled');
@@ -143,11 +143,11 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     }
 
     if (notifyFailure.first) {
-      $('#notify-failure-first').attr('checked', true);
+      $('#notify-failure-first').prop('checked', true);
       $('#notify-failure-first').parent('.btn').addClass('active');
     }
     if (notifyFailure.last) {
-      $('#notify-failure-last').attr('checked', true);
+      $('#notify-failure-last').prop('checked', true);
       $('#notify-failure-last').parent('.btn').addClass('active');
     }
 

--- a/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
@@ -234,32 +234,32 @@ azkaban.ChangePermissionView = Backbone.View.extend({
     var perm = this.permission;
 
     if (perm.admin) {
-      $("#admin-change").attr("checked", true);
-      $("#read-change").attr("checked", true);
+      $("#admin-change").prop("checked", true);
+      $("#read-change").prop("checked", true);
       $("#read-change").attr("disabled", "disabled");
 
-      $("#write-change").attr("checked", true);
+      $("#write-change").prop("checked", true);
       $("#write-change").attr("disabled", "disabled");
 
-      $("#execute-change").attr("checked", true);
+      $("#execute-change").prop("checked", true);
       $("#execute-change").attr("disabled", "disabled");
 
-      $("#schedule-change").attr("checked", true);
+      $("#schedule-change").prop("checked", true);
       $("#schedule-change").attr("disabled", "disabled");
     }
     else {
-      $("#admin-change").attr("checked", false);
+      $("#admin-change").prop("checked", false);
 
-      $("#read-change").attr("checked", perm.read);
+      $("#read-change").prop("checked", perm.read);
       $("#read-change").attr("disabled", null);
 
-      $("#write-change").attr("checked", perm.write);
+      $("#write-change").prop("checked", perm.write);
       $("#write-change").attr("disabled", null);
 
-      $("#execute-change").attr("checked", perm.execute);
+      $("#execute-change").prop("checked", perm.execute);
       $("#execute-change").attr("disabled", null);
 
-      $("#schedule-change").attr("checked", perm.schedule);
+      $("#schedule-change").prop("checked", perm.schedule);
       $("#schedule-change").attr("disabled", null);
     }
 

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-options.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-options.js
@@ -266,10 +266,10 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
               $('#scheduleFailureAction').val(data.failureAction);
             }
             if (data.notifyFailureFirst) {
-              $('#scheduleNotifyFailureFirst').attr('checked', true);
+              $('#scheduleNotifyFailureFirst').prop('checked', true);
             }
             if (data.notifyFailureLast) {
-              $('#scheduleNotifyFailureLast').attr('checked', true);
+              $('#scheduleNotifyFailureLast').prop('checked', true);
             }
             if (data.flowParam) {
               var flowParam = data.flowParam;


### PR DESCRIPTION
.attr() cannot modify the 'checked' property of a checkbox, but .prop() can. So .prop() should be used for this purpose.

Previously this showed up as a minor UI glitch where checking the "Admin" permission when adding or changing a user or group did not properly check all the other checkboxes (i.e. read, write, execute and schedule).