### PR TITLE
Force projects to have at least one additional admin user or group

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -217,6 +217,17 @@ public class Project {
     return users;
   }
 
+  public List<String> getGroupsWithPermission(final Type type) {
+    final ArrayList<String> groups = new ArrayList<>();
+    for (final Map.Entry<String, Permission> entry : this.groupPermissionMap.entrySet()) {
+      final Permission perm = entry.getValue();
+      if (perm.isPermissionSet(type)) {
+        groups.add(entry.getKey());
+      }
+    }
+    return groups;
+  }
+
   public List<Pair<String, Permission>> getUserPermissions() {
     final ArrayList<Pair<String, Permission>> permissions =
         new ArrayList<>();

--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -207,7 +207,7 @@ public class Project {
   }
 
   public List<String> getUsersWithPermission(final Type type) {
-    final ArrayList<String> users = new ArrayList<>();
+    final List<String> users = new ArrayList<>();
     for (final Map.Entry<String, Permission> entry : this.userPermissionMap.entrySet()) {
       final Permission perm = entry.getValue();
       if (perm.isPermissionSet(type)) {
@@ -218,7 +218,7 @@ public class Project {
   }
 
   public List<String> getGroupsWithPermission(final Type type) {
-    final ArrayList<String> groups = new ArrayList<>();
+    final List<String> groups = new ArrayList<>();
     for (final Map.Entry<String, Permission> entry : this.groupPermissionMap.entrySet()) {
       final Permission perm = entry.getValue();
       if (perm.isPermissionSet(type)) {
@@ -229,8 +229,7 @@ public class Project {
   }
 
   public List<Pair<String, Permission>> getUserPermissions() {
-    final ArrayList<Pair<String, Permission>> permissions =
-        new ArrayList<>();
+    final List<Pair<String, Permission>> permissions = new ArrayList<>();
 
     for (final Map.Entry<String, Permission> entry : this.userPermissionMap.entrySet()) {
       permissions.add(new Pair<>(entry.getKey(), entry
@@ -241,8 +240,7 @@ public class Project {
   }
 
   public List<Pair<String, Permission>> getGroupPermissions() {
-    final ArrayList<Pair<String, Permission>> permissions =
-        new ArrayList<>();
+    final List<Pair<String, Permission>> permissions = new ArrayList<>();
 
     for (final Map.Entry<String, Permission> entry : this.groupPermissionMap.entrySet()) {
       permissions.add(new Pair<>(entry.getKey(), entry
@@ -330,7 +328,7 @@ public class Project {
       projectObject.put("metadata", this.metadata);
     }
 
-    final ArrayList<String> proxyUserList = new ArrayList<>(this.proxyUsers);
+    final List<String> proxyUserList = new ArrayList<>(this.proxyUsers);
     projectObject.put("proxyUsers", proxyUserList);
 
     return projectObject;

--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -3,6 +3,7 @@ azkaban.name=Test
 azkaban.label=My Local Azkaban
 azkaban.color=#FF3601
 azkaban.default.servlet.path=/index
+azkaban.forceMultipleUsers=false
 web.resource.dir=web/
 default.timezone.id=America/Los_Angeles
 # Azkaban UserManager class

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1993,10 +1993,10 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     // If it does AND the forceMultipleUsers flag is set AND the current user has the ability to add
     // an admin, let's force the user to do so before allowing any execution or scheduling of flows.
 
-    boolean hasEnoughUsersGroups = project.getUsersWithPermission(Type.ADMIN).size() > 1
+    boolean hasEnoughUsersGroups = !this.forceMultipleUsers
+                              || project.getUsersWithPermission(Type.ADMIN).size() > 1
                               || project.getGroupsWithPermission(Type.ADMIN).size() > 0
-                              || !hasPermission(session.getUser(), Type.ADMIN)
-                              || !this.forceMultipleUsers;
+                              || !hasPermission(session.getUser(), Type.ADMIN);
 
     page.add("hasEnoughUsersGroups", hasEnoughUsersGroups);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -104,6 +104,9 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
   private static final String PROJECT_DOWNLOAD_BUFFER_SIZE_IN_BYTES =
       "project.download.buffer.size";
+
+  private static final String AZKABAN_FORCE_MULTIPLE_USERS =
+      "executor.connector.stats";
   private static final Comparator<Flow> FLOW_ID_COMPARATOR = new Comparator<Flow>() {
     @Override
     public int compare(final Flow f1, final Flow f2) {
@@ -148,7 +151,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         server.getServerProps().getInt(PROJECT_DOWNLOAD_BUFFER_SIZE_IN_BYTES,
             8192);
 
-    this.forceMultipleUsers = server.getServerProps().getBoolean("azkaban.forceMultipleUsers", false);
+    this.forceMultipleUsers = server.getServerProps().getBoolean(AZKABAN_FORCE_MULTIPLE_USERS, false);
 
     logger.info("downloadBufferSize: " + this.downloadBufferSize);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -106,7 +106,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       "project.download.buffer.size";
 
   private static final String AZKABAN_FORCE_MULTIPLE_USERS =
-      "executor.connector.stats";
+      "azkaban.forceMultipleUsers";
+
   private static final Comparator<Flow> FLOW_ID_COMPARATOR = new Comparator<Flow>() {
     @Override
     public int compare(final Flow f1, final Flow f2) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -123,7 +123,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private boolean lockdownCreateProjects = false;
   private boolean lockdownUploadProjects = false;
   private boolean enableQuartz = false;
-  private boolean forceMultipleUsers;
+  private boolean forceMultipleUsers = false;
 
   @Override
   public void init(final ServletConfig config) throws ServletException {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -440,7 +440,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final int from = Integer.valueOf(getParam(req, "start"));
     final int length = Integer.valueOf(getParam(req, "length"));
 
-    final ArrayList<ExecutableFlow> exFlows = new ArrayList<>();
+    final List<ExecutableFlow> exFlows = new ArrayList<>();
     int total = 0;
     try {
       total =
@@ -455,7 +455,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     ret.put("from", from);
     ret.put("length", length);
 
-    final ArrayList<Object> history = new ArrayList<>();
+    final List<Object> history = new ArrayList<>();
     for (final ExecutableFlow flow : exFlows) {
       final HashMap<String, Object> flowInfo = new HashMap<>();
       flowInfo.put("execId", flow.getExecutionId());
@@ -793,8 +793,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private void ajaxFetchProjectFlows(final Project project,
       final HashMap<String, Object> ret, final HttpServletRequest req)
       throws ServletException {
-    final ArrayList<Map<String, Object>> flowList =
-        new ArrayList<>();
+    final List<Map<String, Object>> flowList = new ArrayList<>();
     for (final Flow flow : project.getFlows()) {
       if (!flow.isEmbeddedFlow()) {
         final HashMap<String, Object> flowObj = new HashMap<>();
@@ -822,8 +821,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
-    final ArrayList<Map<String, Object>> nodeList =
-        new ArrayList<>();
+    final List<Map<String, Object>> nodeList = new ArrayList<>();
     for (final Node node : flow.getNodes()) {
       final HashMap<String, Object> nodeObj = new HashMap<>();
       nodeObj.put("id", node.getId());
@@ -839,7 +837,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       nodeList.add(nodeObj);
       final Set<Edge> inEdges = flow.getInEdges(node.getId());
       if (inEdges != null && !inEdges.isEmpty()) {
-        final ArrayList<String> inEdgesList = new ArrayList<>();
+        final List<String> inEdgesList = new ArrayList<>();
         for (final Edge edge : inEdges) {
           inEdgesList.add(edge.getSourceId());
         }
@@ -906,15 +904,15 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final String flowId = getParam(req, "flow");
     final Flow flow = project.getFlow(flowId);
 
-    final ArrayList<Node> flowNodes = new ArrayList<>(flow.getNodes());
+    final List<Node> flowNodes = new ArrayList<>(flow.getNodes());
     Collections.sort(flowNodes, NODE_LEVEL_COMPARATOR);
 
-    final ArrayList<Object> nodeList = new ArrayList<>();
+    final List<Object> nodeList = new ArrayList<>();
     for (final Node node : flowNodes) {
       final HashMap<String, Object> nodeObj = new HashMap<>();
       nodeObj.put("id", node.getId());
 
-      final ArrayList<String> dependencies = new ArrayList<>();
+      final List<String> dependencies = new ArrayList<>();
       Collection<Edge> collection = flow.getInEdges(node.getId());
       if (collection != null) {
         for (final Edge edge : collection) {
@@ -922,7 +920,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         }
       }
 
-      final ArrayList<String> dependents = new ArrayList<>();
+      final List<String> dependents = new ArrayList<>();
       collection = flow.getOutEdges(node.getId());
       if (collection != null) {
         for (final Edge edge : collection) {
@@ -1083,8 +1081,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
    * this only returns user permissions, but not group permissions and proxy users
    */
   private void ajaxGetPermissions(final Project project, final HashMap<String, Object> ret) {
-    final ArrayList<HashMap<String, Object>> permissions =
-        new ArrayList<>();
+    final List<HashMap<String, Object>> permissions = new ArrayList<>();
     for (final Pair<String, Permission> perm : project.getUserPermissions()) {
       final HashMap<String, Object> permObj = new HashMap<>();
       final String userId = perm.getFirst();
@@ -1099,8 +1096,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
   private void ajaxGetGroupPermissions(final Project project,
       final HashMap<String, Object> ret) {
-    final ArrayList<HashMap<String, Object>> permissions =
-        new ArrayList<>();
+    final List<HashMap<String, Object>> permissions = new ArrayList<>();
     for (final Pair<String, Permission> perm : project.getGroupPermissions()) {
       final HashMap<String, Object> permObj = new HashMap<>();
       final String userId = perm.getFirst();
@@ -1314,7 +1310,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       if (CollectionUtils.isNotEmpty(jobInfo)) {
         page.add("history", jobInfo);
 
-        final ArrayList<Object> dataSeries = new ArrayList<>();
+        final List<Object> dataSeries = new ArrayList<>();
         for (final ExecutableJobInfo info : jobInfo) {
           final Map<String, Object> map = info.toObject();
           dataSeries.add(map);
@@ -1445,7 +1441,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("condition", node.getCondition());
       }
 
-      final ArrayList<String> dependencies = new ArrayList<>();
+      final List<String> dependencies = new ArrayList<>();
       final Set<Edge> inEdges = flow.getInEdges(node.getId());
       if (inEdges != null) {
         for (final Edge dependency : inEdges) {
@@ -1456,7 +1452,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("dependencies", dependencies);
       }
 
-      final ArrayList<String> dependents = new ArrayList<>();
+      final List<String> dependents = new ArrayList<>();
       final Set<Edge> outEdges = flow.getOutEdges(node.getId());
       if (outEdges != null) {
         for (final Edge dependent : outEdges) {
@@ -1468,7 +1464,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       // Resolve property dependencies
-      final ArrayList<String> source = new ArrayList<>();
+      final List<String> source = new ArrayList<>();
       final String nodeSource = node.getPropsSource();
       if (nodeSource != null) {
         source.add(nodeSource);
@@ -1482,8 +1478,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("properties", source);
       }
 
-      final ArrayList<Pair<String, String>> parameters =
-          new ArrayList<>();
+      final List<Pair<String, String>> parameters = new ArrayList<>();
       // Parameter
       for (final String key : jobProp.getKeySet()) {
         final String value = jobProp.get(key);
@@ -1560,7 +1555,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       page.add("jobid", node.getId());
 
       // Resolve property dependencies
-      final ArrayList<String> inheritProps = new ArrayList<>();
+      final List<String> inheritProps = new ArrayList<>();
       FlowProps parent = flow.getFlowProps(propSource);
       while (parent.getInheritedSource() != null) {
         inheritProps.add(parent.getInheritedSource());
@@ -1570,7 +1565,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("inheritedproperties", inheritProps);
       }
 
-      final ArrayList<String> dependingProps = new ArrayList<>();
+      final List<String> dependingProps = new ArrayList<>();
       FlowProps child =
           flow.getFlowProps(flow.getNode(jobName).getPropsSource());
       while (!child.getSource().equals(propSource)) {
@@ -1581,8 +1576,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("dependingproperties", dependingProps);
       }
 
-      final ArrayList<Pair<String, String>> parameters =
-          new ArrayList<>();
+      final List<Pair<String, String>> parameters = new ArrayList<>();
       // Parameter
       for (final String key : prop.getKeySet()) {
         final String value = prop.get(key);

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm
@@ -1,0 +1,21 @@
+#*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*#
+
+#if (!$hasEnoughUsersGroups)
+<div class="alert alert-warning" role="alert">
+  <b>NOTE:</b> All projects must have at least two admin users or an additional group with admin privileges. This project needs an additional admin user or group added in the <a href="${context}/manager?project=${project.name}&permissions" class="alert-link">Permissions</a> tab.
+</div>
+#end

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm
@@ -1,0 +1,35 @@
+#*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*#
+
+## Modal forcing user to add an additional user or group to project
+
+<div class="modal" id="force-additional-user-modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;
+        </button>
+        <h4 class="modal-title" id="change-title">Please Add a User or Group</h4>
+      </div>
+      <div class="modal-body">
+        <p>To ensure projects do not become inaccessible if a user is removed, all projects must have at least two users with <b>admin</b> privileges (or a group with <b>admin</b> privileges).<br /><br />Please add an additional user or group in the Permissions tab, then try again. Make sure this additional user or group has <b>admin</b> privileges!</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -37,13 +37,16 @@
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow.js?v=1567820073"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/add-more-users-groups-modal.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};
     var timezone = "${timezone}";
     var errorMessage = null;
     var successMessage = null;
+
+    var hasEnoughUsersGroups = $hasEnoughUsersGroups;
 
     var projectId = ${project.id};
     var projectName = "${project.name}";
@@ -119,6 +122,7 @@
 
   <div class="container-full">
 
+    #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm")
     #parse ("azkaban/webapp/servlet/velocity/alerts.vm")
 
   ## Tabs
@@ -223,6 +227,7 @@
     #parse ("azkaban/webapp/servlet/velocity/flowexecutionpanel.vm")
     #parse ("azkaban/webapp/servlet/velocity/messagedialog.vm")
     #parse ("azkaban/webapp/servlet/velocity/slapanel.vm")
+    #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm")
   </div><!-- /.container -->
   #end
 </body>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
@@ -23,6 +23,7 @@
 
   <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/add-more-users-groups-modal.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};
@@ -56,6 +57,7 @@
       <div class="col-xs-12 col-sm-9">
 
         #set ($project_page = "permissions")
+        #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm")
         #parse ("azkaban/webapp/servlet/velocity/projectnav.vm")
 
       ## User permissions table.
@@ -398,6 +400,7 @@
 
     #parse ("azkaban/webapp/servlet/velocity/projectmodals.vm")
     #parse ("azkaban/webapp/servlet/velocity/invalidsessionmodal.vm")
+    #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm")
   </div><!-- /container-full -->
   #end
 </body>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
@@ -25,6 +25,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-logs.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/add-more-users-groups-modal.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};
@@ -59,6 +60,7 @@
       <div class="col-xs-12 col-sm-9">
 
         #set ($project_page = "logs")
+        #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm")
         #parse ("azkaban/webapp/servlet/velocity/projectnav.vm")
 
         <div class="panel panel-default" id="flow-tabs">
@@ -88,6 +90,7 @@
     </div>
 
     #parse ("azkaban/webapp/servlet/velocity/projectmodals.vm")
+    #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm")
 
   </div><!-- /container-full -->
   #end

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -24,14 +24,17 @@
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1567820073"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/add-more-users-groups-modal.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};
     var timezone = "${timezone}";
     var errorMessage = null;
     var successMessage = null;
+
+    var hasEnoughUsersGroups = $hasEnoughUsersGroups;
 
     var projectId = ${project.id};
     var execAccess = ${exec};
@@ -63,6 +66,7 @@
       <div class="col-xs-12 col-sm-9" id="flow-tabs">
 
         #set ($project_page = "flows")
+        #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsalert.vm")
         #parse ("azkaban/webapp/servlet/velocity/projectnav.vm")
 
         <div id="flow-tabs">
@@ -111,6 +115,7 @@
     #parse ("azkaban/webapp/servlet/velocity/invalidsessionmodal.vm")
     #parse ("azkaban/webapp/servlet/velocity/flowexecutionpanel.vm")
     #parse ("azkaban/webapp/servlet/velocity/messagedialog.vm")
+    #parse ("azkaban/webapp/servlet/velocity/addmoreusersgroupsmodal.vm")
 
   </div><!-- /container -->
   #end

--- a/azkaban-web-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-web-server/src/main/resources/conf/azkaban.properties
@@ -3,6 +3,7 @@ azkaban.name=Test
 azkaban.label=My Local Azkaban
 azkaban.color=#FF3601
 azkaban.default.servlet.path=/index
+azkaban.forceMultipleUsers=false
 web.resource.dir=web/
 default.timezone.id=America/Los_Angeles
 # Azkaban UserManager class

--- a/azkaban-web-server/src/web/js/azkaban/view/add-more-users-groups-modal.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/add-more-users-groups-modal.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+$.namespace('azkaban');
+
+var forceAdditionalUserView;
+azkaban.ForceAdditionalUserView = Backbone.View.extend({
+  initialize: function () {
+  },
+
+  show: function() {
+    $('#force-additional-user-modal').modal();
+  },
+
+  render: function () {
+  }
+});
+
+$(function () {
+  forceAdditionalUserView = new azkaban.ForceAdditionalUserView({
+    el: $('#force-additional-user-modal')
+  });
+});

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -594,6 +594,11 @@ var initFlowPage = function (settings) {
       flow: settings.flowId
     };
 
+    if (!hasEnoughUsersGroups) {
+      forceAdditionalUserView.show();
+      return;
+    }
+
     flowExecuteDialogView.show(executingData);
   });
 

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -594,6 +594,8 @@ var initFlowPage = function (settings) {
       flow: settings.flowId
     };
 
+    // Before showing the executeFlowDialog - see if we should force the user
+    // to add more users/groups with admin privileges to the project.
     if (!hasEnoughUsersGroups) {
       forceAdditionalUserView.show();
       return;

--- a/azkaban-web-server/src/web/js/azkaban/view/project.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project.js
@@ -242,6 +242,8 @@ azkaban.FlowTableView = Backbone.View.extend({
   },
 
   executeFlowDialog: function (executingData) {
+    // Before showing the executeFlowDialog - see if we should force the user
+    // to add more users/groups with admin privileges to the project.
     if (!hasEnoughUsersGroups) {
       forceAdditionalUserView.show();
       return;

--- a/azkaban-web-server/src/web/js/azkaban/view/project.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project.js
@@ -242,6 +242,11 @@ azkaban.FlowTableView = Backbone.View.extend({
   },
 
   executeFlowDialog: function (executingData) {
+    if (!hasEnoughUsersGroups) {
+      forceAdditionalUserView.show();
+      return;
+    }
+
     flowExecuteDialogView.show(executingData);
   },
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,122 +18,136 @@ These are properties to configure the web server. They should be set in ``azkaba
 General Properties
 ########
 
-+-----------------------+-----------------------+-----------------------+
-| Parameter             | Description           | Default               |
-+=======================+=======================+=======================+
-|   azkaban.name        | The name of the       | Local                 |
-|                       | azkaban instance that |                       |
-|                       | will show up in the   |                       |
-|                       | UI. Useful if you run |                       |
-|                       | more than one Azkaban |                       |
-|                       | instance.             |                       |
-+-----------------------+-----------------------+-----------------------+
-|   azkaban.label       | A label to describe   | My Local Azkaban      |
-|                       | the Azkaban instance. |                       |
-+-----------------------+-----------------------+-----------------------+
-|   azkaban.color       | Hex value that allows | #FF3601               |
-|                       | you to set a style    |                       |
-|                       | color for the Azkaban |                       |
-|                       | UI.                   |                       |
-+-----------------------+-----------------------+-----------------------+
-|   web.resource.dir    | Sets the directory    | web/                  |
-|                       | for the ui’s css and  |                       |
-|                       | javascript files.     |                       |
-+-----------------------+-----------------------+-----------------------+
-|   default.timezone    | The timezone that     | America/Los_Angeles   |
-|                       | will be displayed by  |                       |
-|                       | Azkaban.              |                       |
-+-----------------------+-----------------------+-----------------------+
-|   viewer.plugin.dir   | Directory where       | plugins/viewer        |
-|                       | viewer plugins are    |                       |
-|                       | installed.            |                       |
-+-----------------------+-----------------------+-----------------------+
-|   job.max.Xms         | The maximum initial   | 1GB                   |
-|                       | amount of memory each |                       |
-|                       | job can request. This |                       |
-|                       | validation is         |                       |
-|                       | performed at project  |                       |
-|                       | upload time           |                       |
-+-----------------------+-----------------------+-----------------------+
-|   job.max.Xmx         | The maximum amount of | 2GB                   |
-|                       | memory each job can   |                       |
-|                       | request. This         |                       |
-|                       | validation is         |                       |
-|                       | performed at project  |                       |
-|                       | upload time           |                       |
-+-----------------------+-----------------------+-----------------------+
++----------------------------+-------------------------+---------------------+
+|         Parameter          |       Description       |       Default       |
++============================+=========================+=====================+
+| azkaban.name               | The name of the         | Local               |
+|                            | azkaban instance that   |                     |
+|                            | will show up in the     |                     |
+|                            | UI. Useful if you run   |                     |
+|                            | more than one Azkaban   |                     |
+|                            | instance.               |                     |
++----------------------------+-------------------------+---------------------+
+| azkaban.label              | A label to describe     | My Local Azkaban    |
+|                            | the Azkaban instance.   |                     |
++----------------------------+-------------------------+---------------------+
+| azkaban.color              | Hex value that allows   | #FF3601             |
+|                            | you to set a style      |                     |
+|                            | color for the Azkaban   |                     |
+|                            | UI.                     |                     |
++----------------------------+-------------------------+---------------------+
+| azkaban.forceMultipleUsers | Force projects to have  | false               |
+|                            | at least one additional |                     |
+|                            | user or group with      |                     |
+|                            | admin privileges before |                     |
+|                            | they can be scheduled   |                     |
+|                            | or run.                 |                     |
++----------------------------+-------------------------+---------------------+
+| web.resource.dir           | Sets the directory      | web/                |
+|                            | for the ui’s css and    |                     |
+|                            | javascript files.       |                     |
++----------------------------+-------------------------+---------------------+
+| default.timezone           | The timezone that       | America/Los_Angeles |
+|                            | will be displayed by    |                     |
+|                            | Azkaban.                |                     |
++----------------------------+-------------------------+---------------------+
+| viewer.plugin.dir          | Directory where         | plugins/viewer      |
+|                            | viewer plugins are      |                     |
+|                            | installed.              |                     |
++----------------------------+-------------------------+---------------------+
+| job.max.Xms                | The maximum initial     | 1GB                 |
+|                            | amount of memory each   |                     |
+|                            | job can request. This   |                     |
+|                            | validation is           |                     |
+|                            | performed at project    |                     |
+|                            | upload time             |                     |
++----------------------------+-------------------------+---------------------+
+| job.max.Xmx                | The maximum amount of   | 2GB                 |
+|                            | memory each job can     |                     |
+|                            | request. This           |                     |
+|                            | validation is           |                     |
+|                            | performed at project    |                     |
+|                            | upload time             |                     |
++----------------------------+-------------------------+---------------------+
+| job.max.Xmx                | The maximum amount of   | 2GB                 |
+|                            | memory each job can     |                     |
+|                            | request. This           |                     |
+|                            | validation is           |                     |
+|                            | performed at project    |                     |
+|                            | upload time             |                     |
++----------------------------+-------------------------+---------------------+
 
 Multiple Executor Mode Parameters
 ########
 
-+------------------------------------------------------+-----------------------+-----------------------+
-| Parameter                                            | Description           | Default               |
-+======================================================+=======================+=======================+
-| azkaban.use.multiple.executors                       | Should azkaban run in | false                 |
-|                                                      | multi-executor mode.  |                       |
-|                                                      | Required for multiple |                       |
-|                                                      | executor mode.        |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.executorselector.filters                     | A common separated    |                       |
-|                                                      | list of hard filters  |                       |
-|                                                      | to be used while      |                       |
-|                                                      | dispatching. To be    |                       |
-|                                                      | choosen from          |                       |
-|                                                      | StaticRemaining,      |                       |
-|                                                      | FlowSize,             |                       |
-|                                                      | MinimumFreeMemory and |                       |
-|                                                      | CpuStatus. Order of   |                       |
-|                                                      | filter do not matter. |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.executorselector.comparator.{ComparatorName} | Integer weight to be  |                       |
-|                                                      | used to rank          |                       |
-|                                                      | available executors   |                       |
-|                                                      | for a given flow.     |                       |
-|                                                      | Currently,            |                       |
-|                                                      | {ComparatorName} can  |                       |
-|                                                      | be                    |                       |
-|                                                      | NumberOfAssignedFlowC |                       |
-|                                                      | omparator,            |                       |
-|                                                      | Memory,               |                       |
-|                                                      | LastDispatched and    |                       |
-|                                                      | CpuUsage as           |                       |
-|                                                      | ComparatorName. For   |                       |
-|                                                      | example:-             |                       |
-|                                                      | azkaban.executorselec |                       |
-|                                                      | tor.comparator.Memory |                       |
-|                                                      | =2                    |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.queueprocessing.enabled                      | Hhould queue          | true                  |
-|                                                      | processor be enabled  |                       |
-|                                                      | from webserver        |                       |
-|                                                      | initialization        |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.webserver.queue.size                         | Maximum flows that    | 100000                |
-|                                                      | can be queued at      |                       |
-|                                                      | webserver             |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.activeexecutor.refresh.milisecinterval       | Maximum time in       | 50000                 |
-|                                                      | milliseconds that can |                       |
-|                                                      | be processed without  |                       |
-|                                                      | executor statistics   |                       |
-|                                                      | refresh               |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.activeexecutor.refresh.flowinterval          | Maximum number of     | 5                     |
-|                                                      | queued flows that can |                       |
-|                                                      | be processed without  |                       |
-|                                                      | executor statistics   |                       |
-|                                                      | refresh               |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
-| azkaban.executorinfo.refresh.maxThreads              | Maximum number of     | 5                     |
-|                                                      | threads to refresh    |                       |
-|                                                      | executor statistics   |                       |
-+------------------------------------------------------+-----------------------+-----------------------+
++------------------------------------------------------+-----------------------+---------+
+|                      Parameter                       |      Description      | Default |
++======================================================+=======================+=========+
+| azkaban.use.multiple.executors                       | Should azkaban run in | false   |
+|                                                      | multi-executor mode.  |         |
+|                                                      | Required for multiple |         |
+|                                                      | executor mode.        |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.executorselector.filters                     | A common separated    |         |
+|                                                      | list of hard filters  |         |
+|                                                      | to be used while      |         |
+|                                                      | dispatching. To be    |         |
+|                                                      | choosen from          |         |
+|                                                      | StaticRemaining,      |         |
+|                                                      | FlowSize,             |         |
+|                                                      | MinimumFreeMemory and |         |
+|                                                      | CpuStatus. Order of   |         |
+|                                                      | filter do not matter. |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.executorselector.comparator.{ComparatorName} | Integer weight to be  |         |
+|                                                      | used to rank          |         |
+|                                                      | available executors   |         |
+|                                                      | for a given flow.     |         |
+|                                                      | Currently,            |         |
+|                                                      | {ComparatorName} can  |         |
+|                                                      | be                    |         |
+|                                                      | NumberOfAssignedFlowC |         |
+|                                                      | omparator,            |         |
+|                                                      | Memory,               |         |
+|                                                      | LastDispatched and    |         |
+|                                                      | CpuUsage as           |         |
+|                                                      | ComparatorName. For   |         |
+|                                                      | example:-             |         |
+|                                                      | azkaban.executorselec |         |
+|                                                      | tor.comparator.Memory |         |
+|                                                      | =2                    |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.queueprocessing.enabled                      | Hhould queue          | true    |
+|                                                      | processor be enabled  |         |
+|                                                      | from webserver        |         |
+|                                                      | initialization        |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.webserver.queue.size                         | Maximum flows that    | 100000  |
+|                                                      | can be queued at      |         |
+|                                                      | webserver             |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.activeexecutor.refresh.milisecinterval       | Maximum time in       | 50000   |
+|                                                      | milliseconds that can |         |
+|                                                      | be processed without  |         |
+|                                                      | executor statistics   |         |
+|                                                      | refresh               |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.activeexecutor.refresh.flowinterval          | Maximum number of     | 5       |
+|                                                      | queued flows that can |         |
+|                                                      | be processed without  |         |
+|                                                      | executor statistics   |         |
+|                                                      | refresh               |         |
++------------------------------------------------------+-----------------------+---------+
+| azkaban.executorinfo.refresh.maxThreads              | Maximum number of     | 5       |
+|                                                      | threads to refresh    |         |
+|                                                      | executor statistics   |         |
++------------------------------------------------------+-----------------------+---------+
 
 Jetty Parameters
 ########
 
 +---------------------+---------------------+---------+
-| Parameter           | Description         | Default |
+|      Parameter      |     Description     | Default |
 +=====================+=====================+=========+
 | jetty.maxThreads    | Max request threads | 25      |
 +---------------------+---------------------+---------+
@@ -153,79 +167,79 @@ Jetty Parameters
 Project Manager Settings
 ########
 
-+---------------------------+-----------------------+-----------------------+
-| Parameter                 | Description           | Default               |
-+===========================+=======================+=======================+
-| project.temp.dir          | The temporary         | temp                  |
-|                           | directory used when   |                       |
-|                           | uploading projects    |                       |
-+---------------------------+-----------------------+-----------------------+
-| project.version.retention | The number of unused  | 3                     |
-|                           | project versions      |                       |
-|                           | retained before       |                       |
-|                           | cleaning              |                       |
-+---------------------------+-----------------------+-----------------------+
-| creator.default.proxy     | Auto add the creator  | true                  |
-|                           | of the projects as a  |                       |
-|                           | proxy user to the     |                       |
-|                           | project.              |                       |
-+---------------------------+-----------------------+-----------------------+
-| lockdown.create.projects  | Prevents anyone       | false                 |
-|                           | except those with     |                       |
-|                           | Admin roles to create |                       |
-|                           | new projects.         |                       |
-+---------------------------+-----------------------+-----------------------+
-| lockdown.upload.projects  | Prevents anyone but   | false                 |
-|                           | admin users and users |                       |
-|                           | with permissions to   |                       |
-|                           | upload projects.      |                       |
-+---------------------------+-----------------------+-----------------------+
++---------------------------+-----------------------+---------+
+|         Parameter         |      Description      | Default |
++===========================+=======================+=========+
+| project.temp.dir          | The temporary         | temp    |
+|                           | directory used when   |         |
+|                           | uploading projects    |         |
++---------------------------+-----------------------+---------+
+| project.version.retention | The number of unused  | 3       |
+|                           | project versions      |         |
+|                           | retained before       |         |
+|                           | cleaning              |         |
++---------------------------+-----------------------+---------+
+| creator.default.proxy     | Auto add the creator  | true    |
+|                           | of the projects as a  |         |
+|                           | proxy user to the     |         |
+|                           | project.              |         |
++---------------------------+-----------------------+---------+
+| lockdown.create.projects  | Prevents anyone       | false   |
+|                           | except those with     |         |
+|                           | Admin roles to create |         |
+|                           | new projects.         |         |
++---------------------------+-----------------------+---------+
+| lockdown.upload.projects  | Prevents anyone but   | false   |
+|                           | admin users and users |         |
+|                           | with permissions to   |         |
+|                           | upload projects.      |         |
++---------------------------+-----------------------+---------+
 
 MySQL Connection Parameter
 ########
 
-+-----------------------+-----------------------+-----------------------+
-| Parameter             | Description           | Default               |
-+=======================+=======================+=======================+
-| database.type         | The database type.    | mysql                 |
-|                       | Currently, the only   |                       |
-|                       | database supported is |                       |
-|                       | mysql.                |                       |
-+-----------------------+-----------------------+-----------------------+
-| mysql.port            | The port to the mysql | 3306                  |
-|                       | db                    |                       |
-+-----------------------+-----------------------+-----------------------+
-| mysql.host            | The mysql host        | localhost             |
-+-----------------------+-----------------------+-----------------------+
-| mysql.database        | The mysql database    |                       |
-+-----------------------+-----------------------+-----------------------+
-| mysql.user            | The mysql user        |                       |
-+-----------------------+-----------------------+-----------------------+
-| mysql.password        | The mysql password    |                       |
-+-----------------------+-----------------------+-----------------------+
-| mysql.numconnections  | The number of         | 100                   |
-|                       | connections that      |                       |
-|                       | Azkaban web client    |                       |
-|                       | can open to the       |                       |
-|                       | database              |                       |
-+-----------------------+-----------------------+-----------------------+
++----------------------+-----------------------+-----------+
+|      Parameter       |      Description      |  Default  |
++======================+=======================+===========+
+| database.type        | The database type.    | mysql     |
+|                      | Currently, the only   |           |
+|                      | database supported is |           |
+|                      | mysql.                |           |
++----------------------+-----------------------+-----------+
+| mysql.port           | The port to the mysql | 3306      |
+|                      | db                    |           |
++----------------------+-----------------------+-----------+
+| mysql.host           | The mysql host        | localhost |
++----------------------+-----------------------+-----------+
+| mysql.database       | The mysql database    |           |
++----------------------+-----------------------+-----------+
+| mysql.user           | The mysql user        |           |
++----------------------+-----------------------+-----------+
+| mysql.password       | The mysql password    |           |
++----------------------+-----------------------+-----------+
+| mysql.numconnections | The number of         | 100       |
+|                      | connections that      |           |
+|                      | Azkaban web client    |           |
+|                      | can open to the       |           |
+|                      | database              |           |
++----------------------+-----------------------+-----------+
 
 Executor Manager Properties
 ########
 
-+-----------------------------+-----------------------+-----------------------+
-| Parameter                   | Description           | Default               |
-+=============================+=======================+=======================+
-| execution.logs.retention.ms | Time in milliseconds  | 7257600000L (12       |
-|                             | that execution logs   | weeks)                |
-|                             | are retained          |                       |
-+-----------------------------+-----------------------+-----------------------+
++-----------------------------+----------------------+-----------------+
+|          Parameter          |     Description      |     Default     |
++=============================+======================+=================+
+| execution.logs.retention.ms | Time in milliseconds | 7257600000L (12 |
+|                             | that execution logs  | weeks)          |
+|                             | are retained         |                 |
++-----------------------------+----------------------+-----------------+
 
 Notification Email Properties
 ########
 
 +---------------+-----------------------------------------------------+---------+
-| Parameter     | Description                                         | Default |
+|   Parameter   |                     Description                     | Default |
 +===============+=====================================================+=========+
 | mail.sender   | The email address that azkaban uses to send emails. |         |
 +---------------+-----------------------------------------------------+---------+
@@ -240,7 +254,7 @@ User Manager Properties
 ########
 
 +-----------------------+-----------------------+-----------------------+
-| Parameter             | Description           | Default               |
+|       Parameter       |      Description      |        Default        |
 +=======================+=======================+=======================+
 | user.manager.class    | The user manager that | azkaban.user.XmlUserM |
 |                       | is used to            | anager                |
@@ -260,16 +274,16 @@ User Manager Properties
 User Session Properties
 ########
 
-+-----------------------+-----------------------+-----------------------+
-| Parameter             | Description           | Default               |
-+=======================+=======================+=======================+
-| session.time.to.live  | The session time to   | 86400000              |
-|                       | live in ms seconds    |                       |
-+-----------------------+-----------------------+-----------------------+
-| max.num.sessions      | The maximum number of | 10000                 |
-|                       | sessions before       |                       |
-|                       | people are evicted.   |                       |
-+-----------------------+-----------------------+-----------------------+
++----------------------+-----------------------+----------+
+|      Parameter       |      Description      | Default  |
++======================+=======================+==========+
+| session.time.to.live | The session time to   | 86400000 |
+|                      | live in ms seconds    |          |
++----------------------+-----------------------+----------+
+| max.num.sessions     | The maximum number of | 10000    |
+|                      | sessions before       |          |
+|                      | people are evicted.   |          |
++----------------------+-----------------------+----------+
 
 *****
 Azkaban Executor Server Configuration
@@ -278,107 +292,107 @@ Azkaban Executor Server Configuration
 Executor Server Properties
 ########
 
-+-------------------------------------------+-----------------------+-----------------------+
-| Parameter                                 | Description           | Default               |
-+===========================================+=======================+=======================+
-| executor.port                             | The port for azkaban  | 0 (any free port)     |
-|                                           | executor server       |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| executor.global.properties                | A path to the         |   none                |
-|                                           | properties that will  |                       |
-|                                           | be the parent for all |                       |
-|                                           | jobs.                 |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| azkaban.execution.dir                     | The folder for        | executions            |
-|                                           | executing working     |                       |
-|                                           | directories           |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| azkaban.project.dir                       | The folder for        | projects              |
-|                                           | storing temporary     |                       |
-|                                           | copies of project     |                       |
-|                                           | files used for        |                       |
-|                                           | executions            |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| executor.flow.threads                     | The number of         | 30                    |
-|                                           | simulateous flows     |                       |
-|                                           | that can be run.      |                       |
-|                                           | These threads are     |                       |
-|                                           | mostly idle.          |                       |
-+-----------------------+-----------------------+-----------------------+
-| job.log.chunk.size                        | For rolling job logs. | 5MB                   |
-|                                           | The chuck size for    |                       |
-|                                           | each roll over        |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| job.log.backup.index                      | The number of log     | 4                     |
-|                                           | chunks. The max size  |                       |
-|                                           | of each logs is then  |                       |
-|                                           | the index \*          |                       |
-|                                           | chunksize             |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-| flow.num.job.threads                      | The number of         | 10                    |
-|                                           | concurrent running    |                       |
-|                                           | jobs in each flow.    |                       |
-|                                           | These threads are     |                       |
-|                                           | mostly idle.          |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-|   job.max.Xms                             | The maximum initial   | 1GB                   |
-|                                           | amount of memory each |                       |
-|                                           | job can request. If a |                       |
-|                                           | job requests more     |                       |
-|                                           | than this, then       |                       |
-|                                           | Azkaban server will   |                       |
-|                                           | not launch this job   |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-|   job.max.Xmx                             | The maximum amount of | 2GB                   |
-|                                           | memory each job can   |                       |
-|                                           | request. If a job     |                       |
-|                                           | requests more than    |                       |
-|                                           | this, then Azkaban    |                       |
-|                                           | server will not       |                       |
-|                                           | launch this job       |                       |
-+-------------------------------------------+-----------------------+-----------------------+
-|   azkaban.server.flow.max.running.minutes | The maximum time in   | -1                    |
-|                                           | minutes a flow will   |                       |
-|                                           | be living inside      |                       |
-|                                           | azkaban after being   |                       |
-|                                           | executed. If a flow   |                       |
-|                                           | runs longer than      |                       |
-|                                           | this, it will be      |                       |
-|                                           | killed. If smaller or |                       |
-|                                           | equal to 0, there's   |                       |
-|                                           | no restriction on     |                       |
-|                                           | running time.         |                       |
-+-------------------------------------------+-----------------------+-----------------------+
++-----------------------------------------+-----------------------+-------------------+
+|                Parameter                |      Description      |      Default      |
++=========================================+=======================+===================+
+| executor.port                           | The port for azkaban  | 0 (any free port) |
+|                                         | executor server       |                   |
++-----------------------------------------+-----------------------+-------------------+
+| executor.global.properties              | A path to the         | none              |
+|                                         | properties that will  |                   |
+|                                         | be the parent for all |                   |
+|                                         | jobs.                 |                   |
++-----------------------------------------+-----------------------+-------------------+
+| azkaban.execution.dir                   | The folder for        | executions        |
+|                                         | executing working     |                   |
+|                                         | directories           |                   |
++-----------------------------------------+-----------------------+-------------------+
+| azkaban.project.dir                     | The folder for        | projects          |
+|                                         | storing temporary     |                   |
+|                                         | copies of project     |                   |
+|                                         | files used for        |                   |
+|                                         | executions            |                   |
++-----------------------------------------+-----------------------+-------------------+
+| executor.flow.threads                   | The number of         | 30                |
+|                                         | simulateous flows     |                   |
+|                                         | that can be run.      |                   |
+|                                         | These threads are     |                   |
+|                                         | mostly idle.          |                   |
++-----------------------------------------+-----------------------+-------------------+
+| job.log.chunk.size                      | For rolling job logs. | 5MB               |
+|                                         | The chuck size for    |                   |
+|                                         | each roll over        |                   |
++-----------------------------------------+-----------------------+-------------------+
+| job.log.backup.index                    | The number of log     | 4                 |
+|                                         | chunks. The max size  |                   |
+|                                         | of each logs is then  |                   |
+|                                         | the index \*          |                   |
+|                                         | chunksize             |                   |
++-----------------------------------------+-----------------------+-------------------+
+| flow.num.job.threads                    | The number of         | 10                |
+|                                         | concurrent running    |                   |
+|                                         | jobs in each flow.    |                   |
+|                                         | These threads are     |                   |
+|                                         | mostly idle.          |                   |
++-----------------------------------------+-----------------------+-------------------+
+| job.max.Xms                             | The maximum initial   | 1GB               |
+|                                         | amount of memory each |                   |
+|                                         | job can request. If a |                   |
+|                                         | job requests more     |                   |
+|                                         | than this, then       |                   |
+|                                         | Azkaban server will   |                   |
+|                                         | not launch this job   |                   |
++-----------------------------------------+-----------------------+-------------------+
+| job.max.Xmx                             | The maximum amount of | 2GB               |
+|                                         | memory each job can   |                   |
+|                                         | request. If a job     |                   |
+|                                         | requests more than    |                   |
+|                                         | this, then Azkaban    |                   |
+|                                         | server will not       |                   |
+|                                         | launch this job       |                   |
++-----------------------------------------+-----------------------+-------------------+
+| azkaban.server.flow.max.running.minutes | The maximum time in   | -1                |
+|                                         | minutes a flow will   |                   |
+|                                         | be living inside      |                   |
+|                                         | azkaban after being   |                   |
+|                                         | executed. If a flow   |                   |
+|                                         | runs longer than      |                   |
+|                                         | this, it will be      |                   |
+|                                         | killed. If smaller or |                   |
+|                                         | equal to 0, there's   |                   |
+|                                         | no restriction on     |                   |
+|                                         | running time.         |                   |
++-----------------------------------------+-----------------------+-------------------+
 
 
 MySQL Connection Parameter
 ########
 
-+-----------------------+-----------------------+-----------------------+
-| Parameter             | Description           | Default               |
-+=======================+=======================+=======================+
-|  database.type        | The database type.    | mysql                 |
-|                       | Currently, the only   |                       |
-|                       | database supported is |                       |
-|                       | mysql.                |                       |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.port           | The port to the mysql | 3306                  |
-|                       | db                    |                       |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.host           | The mysql host        | localhost             |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.database       | The mysql database    |                       |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.user           | The mysql user        |                       |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.password       | The mysql password    |                       |
-+-----------------------+-----------------------+-----------------------+
-|  mysql.numconnections | The number of         | 100                   |
-|                       | connections that      |                       |
-|                       | Azkaban web client    |                       |
-|                       | can open to the       |                       |
-|                       | database              |                       |
-+-----------------------+-----------------------+-----------------------+
++----------------------+-----------------------+-----------+
+|      Parameter       |      Description      |  Default  |
++======================+=======================+===========+
+| database.type        | The database type.    | mysql     |
+|                      | Currently, the only   |           |
+|                      | database supported is |           |
+|                      | mysql.                |           |
++----------------------+-----------------------+-----------+
+| mysql.port           | The port to the mysql | 3306      |
+|                      | db                    |           |
++----------------------+-----------------------+-----------+
+| mysql.host           | The mysql host        | localhost |
++----------------------+-----------------------+-----------+
+| mysql.database       | The mysql database    |           |
++----------------------+-----------------------+-----------+
+| mysql.user           | The mysql user        |           |
++----------------------+-----------------------+-----------+
+| mysql.password       | The mysql password    |           |
++----------------------+-----------------------+-----------+
+| mysql.numconnections | The number of         | 100       |
+|                      | connections that      |           |
+|                      | Azkaban web client    |           |
+|                      | can open to the       |           |
+|                      | database              |           |
++----------------------+-----------------------+-----------+
 
 
 *****


### PR DESCRIPTION
By setting the `azkaban.forceMultipleUsers` flag to `true` (default is `false`). Administrators will be forced to add another user or group with admin privileges before scheduling or executing any jobs. This reduces the chance that a project is left inaccessible because the only admin leaves the company or for any reason no longer works on the project.

---

UX Changes:
If a user has admin privileges for the current project AND the current project has no other admin users or groups with admin privileges:

1. /manager?project=something, /manager?project=something&permissions, /manager?project=something&logs will all show an alert banner prompting the user to add another admin user or group.
2. Clicking _Execute Flow_ from /manager?project=something will result in a modal prompting the user to add another admin user or group (preventing the requested action).
3. Clicking _Run Job_ or _Run With Dependencies_ on a specific job in a project from /manager?project=something will result in the same modal as above (preventing the requested action).
3. /manager?project=something&flow=otherthing will show the same alert banner as described in 1. and clicking on _Schedule / Execute Flow_ at the top right will result in the same modal as described in 2. and 3.

---

NOTE: This blocking behaviour ONLY applies to admin users. Users who do not have admin privileges, but have execute privileges will still be able to execute the project even if the project has only one admin user. This is because a non-admin user has no ability to add other admin users so they can't do anything to rectify the situation, thus blocking them is pointless and will only create hassle for them.

---

Also, I didn't add any tests because it didn't look like any functionality/methods in the surrounding modified areas were tested either - but I can add some if necessary.