### PR TITLE
Don't use synchronous Ajax call to get job logs

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -24,7 +24,7 @@
   <script type="text/javascript" src="${context}/js/jquery.twbsPagination.min.js"></script>
 
   <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/model/job-log.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/model/job-log.js?v=1568515440"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/job-details.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/web/js/azkaban/model/job-log.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/job-log.js
@@ -24,47 +24,42 @@ azkaban.JobLogModel = Backbone.Model.extend({
 
   refresh: function () {
     var requestURL = contextURL + "/executor";
-    var finished = false;
 
-    while (!finished) {
-      var requestData = {
-        "execid": execId,
-        "jobId": jobId,
-        "ajax": "fetchExecJobLogs",
-        "offset": this.get("offset"),
-        "length": 50000,
-        "attempt": attempt
-      };
+    var requestData = {
+      "execid": execId,
+      "jobId": jobId,
+      "ajax": "fetchExecJobLogs",
+      "offset": this.get("offset"),
+      "length": 50000,
+      "attempt": attempt
+    };
 
-      var self = this;
+    var self = this;
 
-      var successHandler = function (data) {
-        console.log("fetchLogs");
-        if (data.error) {
-          console.log(data.error);
-          finished = true;
-        }
-        else if (data.length == 0) {
-          finished = true;
-        }
-        else {
-          self.set("offset", data.offset + data.length);
-          self.set("logData", self.get("logData") + data.data);
+    var successHandler = function (data) {
+      console.log("fetchLogs " + data.offset);
+      if (data.error) {
+        console.log(data.error);
+      }
+      else {
+        self.set("offset", data.offset + data.length);
+        self.set("logData", self.get("logData") + data.data);
+        if (data.length != 0) {
+          // There may be more data available so request the next chunk
+          self.refresh();
         }
       }
+    };
 
-      $.ajax({
-        url: requestURL,
-        type: "get",
-        async: false,
-        data: requestData,
-        dataType: "json",
-        error: function (data) {
-          console.log(data);
-          finished = true;
-        },
-        success: successHandler
-      });
-    }
+    $.ajax({
+      url: requestURL,
+      type: "get",
+      data: requestData,
+      dataType: "json",
+      error: function (data) {
+        console.log(data);
+      },
+      success: successHandler
+    });
   },
 });


### PR DESCRIPTION
A synchronous Ajax call causes the UI thread to block until the Ajax call completes. While the UI thread is blocked, the page is unresponsive as that is the thread in charge of responding to user input. For large job logs, several Ajax calls are needed, which if made in synchronous in a loop cause the page to become unresponsive for too long.
The solution to the problem: use asynchronous Ajax calls.