### PR TITLE
Add flowLockErrorMessage option to pass customized error message when flow is locked due to calling setFlowLock API

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -49,6 +49,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String SLAOPTIONS_PARAM = "slaOptions";
   public static final String AZKABANFLOWVERSION_PARAM = "azkabanFlowVersion";
   public static final String IS_LOCKED_PARAM = "isLocked";
+  public static final String FLOW_LOCK_ERROR_MESSAGE_PARAM = "flowLockErrorMessage";
+
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
   private int scheduleId = -1;
@@ -64,6 +66,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private double azkabanFlowVersion;
   private boolean isLocked;
   private ExecutableFlowRampMetadata executableFlowRampMetadata;
+  private String flowLockErrorMessage;
 
   public ExecutableFlow(final Project project, final Flow flow) {
     this.projectId = project.getId();
@@ -74,6 +77,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.lastModifiedUser = project.getLastModifiedUser();
     setAzkabanFlowVersion(flow.getAzkabanFlowVersion());
     setLocked(flow.isLocked());
+    setFlowLockErrorMessage(flow.getFlowLockErrorMessage());
     this.setFlow(project, flow);
   }
 
@@ -222,6 +226,14 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
   public void setLocked(boolean locked) { this.isLocked = locked; }
 
+  public String getFlowLockErrorMessage() {
+    return this.flowLockErrorMessage;
+  }
+
+  public void setFlowLockErrorMessage(String flowLockErrorMessage) {
+    this.flowLockErrorMessage = flowLockErrorMessage;
+  }
+
   @Override
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowObj = new HashMap<>();
@@ -256,6 +268,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
 
     flowObj.put(IS_LOCKED_PARAM, this.isLocked);
+    flowObj.put(FLOW_LOCK_ERROR_MESSAGE_PARAM, this.flowLockErrorMessage);
 
     return flowObj;
   }
@@ -300,6 +313,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     }
 
     this.setLocked(flowObj.getBool(IS_LOCKED_PARAM, false));
+    this.setFlowLockErrorMessage(flowObj.getString(FLOW_LOCK_ERROR_MESSAGE_PARAM, null));
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -230,7 +230,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     return this.flowLockErrorMessage;
   }
 
-  public void setFlowLockErrorMessage(String flowLockErrorMessage) {
+  public void setFlowLockErrorMessage(final String flowLockErrorMessage) {
     this.flowLockErrorMessage = flowLockErrorMessage;
   }
 

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -52,6 +52,7 @@ public class Flow {
   private double azkabanFlowVersion = Constants.DEFAULT_AZKABAN_FLOW_VERSION;
   private String condition = null;
   private boolean isLocked = false;
+  private String flowLockErrorMessage = null;
 
   public Flow(final String id) {
     this.id = id;
@@ -66,6 +67,7 @@ public class Flow {
     final Double azkabanFlowVersion = (Double) flowObject.get("azkabanFlowVersion");
     final String condition = (String) flowObject.get("condition");
     final Boolean isLocked = (Boolean) flowObject.get("isLocked");
+    final String flowLockErrorMessage = (String) flowObject.get("flowLockErrorMessage");
 
     final Flow flow = new Flow(id);
     if (layedout != null) {
@@ -86,6 +88,10 @@ public class Flow {
 
     if (isLocked != null) {
       flow.setLocked(isLocked);
+    }
+
+    if (flowLockErrorMessage != null) {
+      flow.setFlowLockErrorMessage(flowLockErrorMessage);
     }
 
     final int projId = (Integer) flowObject.get("project.id");
@@ -354,6 +360,7 @@ public class Flow {
     flowObj.put("azkabanFlowVersion", this.azkabanFlowVersion);
     flowObj.put("condition", this.condition);
     flowObj.put("isLocked", this.isLocked);
+    flowObj.put("flowLockErrorMessage", this.flowLockErrorMessage);
 
     if (this.errors != null) {
       flowObj.put("errors", this.errors);
@@ -470,4 +477,12 @@ public class Flow {
   public boolean isLocked() { return this.isLocked; }
 
   public void setLocked(boolean locked) { this.isLocked = locked; }
+
+  public String getFlowLockErrorMessage() {
+    return this.flowLockErrorMessage;
+  }
+
+  public void setFlowLockErrorMessage(String flowLockErrorMessage) {
+    this.flowLockErrorMessage = flowLockErrorMessage;
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -482,7 +482,7 @@ public class Flow {
     return this.flowLockErrorMessage;
   }
 
-  public void setFlowLockErrorMessage(String flowLockErrorMessage) {
+  public void setFlowLockErrorMessage(final String flowLockErrorMessage) {
     this.flowLockErrorMessage = flowLockErrorMessage;
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1633,7 +1633,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();
           final String flowLockErrorMessage = flow.getFlowLockErrorMessage();
-          final String lockedFlowMsg = flowLockErrorMessage != null ? flowLockErrorMessage : String.format(props.getString(ConfigurationKeys
+          final String lockedFlowMsg = flowLockErrorMessage != null ? flowLockErrorMessage :
+              String.format(props.getString(ConfigurationKeys
                   .AZKABAN_LOCKED_FLOW_ERROR_MESSAGE, Constants.DEFAULT_LOCKED_FLOW_ERROR_MESSAGE),
               flow.getId(), projectName);
           page.add("error_message", lockedFlowMsg);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -93,6 +93,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   static final String FLOW_NAME_PARAM = "flowName";
   static final String FLOW_ID_PARAM = "flowId";
   static final String ERROR_PARAM = "error";
+  static final String FLOW_LOCK_ERROR_MESSAGE_PARAM = "flowLockErrorMessage";
   private static final String APPLICATION_ZIP_MIME_TYPE = "application/zip";
   private static final long serialVersionUID = 1;
   private static final Logger logger = LoggerFactory.getLogger(ProjectManagerServlet.class);
@@ -1137,6 +1138,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     final boolean isLocked = Boolean.parseBoolean(getParam(req, FLOW_IS_LOCKED_PARAM));
 
+    String flowLockErrorMessage = null;
+    try {
+      flowLockErrorMessage = getParam(req, FLOW_LOCK_ERROR_MESSAGE_PARAM);
+    } catch(final Exception e) {
+      logger.info("Unable to get flow lock error message");
+    }
+
     // if there is a change in the locked value, then check to see if the project has a flow trigger
     // that needs to be paused/resumed.
     if (isLocked != flow.isLocked()) {
@@ -1166,8 +1174,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     flow.setLocked(isLocked);
+    flow.setFlowLockErrorMessage(isLocked ? flowLockErrorMessage : null);
+
     ret.put(FLOW_IS_LOCKED_PARAM, flow.isLocked());
     ret.put(FLOW_ID_PARAM, flow.getId());
+    ret.put(FLOW_LOCK_ERROR_MESSAGE_PARAM, flow.getFlowLockErrorMessage());
     this.projectManager.updateFlow(project, flow);
   }
 
@@ -1621,7 +1632,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("isLocked", flow.isLocked());
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();
-          final String lockedFlowMsg = String.format(props.getString(ConfigurationKeys
+          final String flowLockErrorMessage = flow.getFlowLockErrorMessage();
+          final String lockedFlowMsg = flowLockErrorMessage != null ? flowLockErrorMessage : String.format(props.getString(ConfigurationKeys
                   .AZKABAN_LOCKED_FLOW_ERROR_MESSAGE, Constants.DEFAULT_LOCKED_FLOW_ERROR_MESSAGE),
               flow.getId(), projectName);
           page.add("error_message", lockedFlowMsg);


### PR DESCRIPTION
This PR adds flowLockErrorMessage option in ProjectManagerServlet which allows user to pass customized error message to show in flow page when flow is locked due to calling setFlowLock API.