### PR TITLE
feature:allow use smtp ssl,default mail.port=465,enable config is mai…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
+++ b/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
@@ -16,8 +16,10 @@
 
 package azkaban.utils;
 
+import com.sun.net.ssl.internal.ssl.Provider;
 import java.io.File;
 import java.io.InputStream;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -52,6 +54,7 @@ public class EmailMessage {
   private String _fromAddress;
   private String _mimeType = "text/plain";
   private String _tls;
+  private String _ssl;
   private long _totalAttachmentSizeSoFar;
   private boolean _usesAuth = true;
   private boolean _enableAttachementEmbedment = true;
@@ -104,6 +107,10 @@ public class EmailMessage {
 
   public EmailMessage setTLS(final String tls) {
     this._tls = tls;
+    return this;
+  }
+  public EmailMessage setSSL(final String ssl) {
+    this._ssl = ssl;
     return this;
   }
 
@@ -178,6 +185,13 @@ public class EmailMessage {
     props.put("mail.smtp.connectiontimeout", _connectionTimeout);
     props.put("mail.smtp.starttls.enable", this._tls);
     props.put("mail.smtp.ssl.trust", this._mailHost);
+    if ("true".equalsIgnoreCase(this._ssl)) {
+      Security.addProvider(new Provider());
+      final String sslFactory = "javax.net.ssl.SSLSocketFactory";
+      props.put("mail.smtp.socketFactory.class", sslFactory);
+      props.put("mail.smtp.socketFactory.fallback", "false");
+      props.put("mail.smtp.socketFactory.port", this._mailPort);
+    }
 
     final JavaxMailSender sender = this.creator.createSender(props);
     final Message message = sender.createMessage();

--- a/azkaban-common/src/main/java/azkaban/utils/EmailMessageCreator.java
+++ b/azkaban-common/src/main/java/azkaban/utils/EmailMessageCreator.java
@@ -24,6 +24,7 @@ import javax.mail.NoSuchProviderException;
 public class EmailMessageCreator {
 
   public static final int DEFAULT_SMTP_PORT = 25;
+  public static final int DEFAULT_SMTP_SSL_PORT = 465;
 
   private final String mailHost;
   private final int mailPort;
@@ -31,12 +32,14 @@ public class EmailMessageCreator {
   private final String mailPassword;
   private final String mailSender;
   private final String tls;
+  private final String ssl;
   private final boolean usesAuth;
 
   @Inject
   public EmailMessageCreator(final Props props) {
     this.mailHost = props.getString("mail.host", "localhost");
-    this.mailPort = props.getInt("mail.port", DEFAULT_SMTP_PORT);
+    this.ssl = props.getString("mail.ssl", "false");
+    this.mailPort = props.getInt("mail.port", "false".equalsIgnoreCase(this.ssl) ? DEFAULT_SMTP_PORT : DEFAULT_SMTP_SSL_PORT);
     this.mailUser = props.getString("mail.user", "");
     this.mailPassword = props.getString("mail.password", "");
     this.mailSender = props.getString("mail.sender", "");
@@ -49,6 +52,7 @@ public class EmailMessageCreator {
         this.mailHost, this.mailPort, this.mailUser, this.mailPassword, this);
     message.setFromAddress(this.mailSender);
     message.setTLS(this.tls);
+    message.setSSL(this.ssl);
     message.setAuth(this.usesAuth);
     return message;
   }


### PR DESCRIPTION
Smtp without ssl enabled default port is 25. However, for security, 25 port is filtered.
Smtp with ssl default port is 465, 465 port is open.
we can enable ssl config by config mail.ssl=true，and set smtp default port from 25 to 465.