### PR TITLE
Fix job link urls of embedded jobs in Execute dialog.

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -32,9 +32,9 @@
 
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1559149862"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1569610022"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -36,7 +36,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -23,7 +23,7 @@
   #parse ("azkaban/webapp/servlet/velocity/svgflowincludes.vm")
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1568065399"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -29,7 +29,7 @@
 <script type="text/javascript" src="${context}/js/azkaban/view/context-menu.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-status.js"></script>
 
-<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1569610022"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/job-list.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -66,8 +66,6 @@ var closeAllSubDisplays = function () {
 }
 
 var nodeClickCallback = function (event, model, node) {
-  console.log("Node clicked callback");
-
   var target = event.currentTarget;
   var type = node.type;
   var flowId = node.parent.flow;
@@ -192,7 +190,6 @@ var nodeClickCallback = function (event, model, node) {
 }
 
 var jobClickCallback = function (event, model, node) {
-  console.log("Job clicked callback");
   var target = event.currentTarget;
   var type = node.type;
   var flowId = node.parent.flow;
@@ -262,12 +259,9 @@ var jobClickCallback = function (event, model, node) {
   contextMenuView.show(event, menu);
 }
 
-var edgeClickCallback = function (event, model) {
-  console.log("Edge clicked callback");
-}
+var edgeClickCallback = function (event, model) {}
 
 var graphClickCallback = function (event, model) {
-  console.log("Graph clicked callback");
   var data = model.get("data");
   var flowId = data.flow;
   var requestURL = contextURL + "/manager?project=" + projectName + "&flow="

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -637,7 +637,6 @@ $(function () {
   }
 
   var successHandler = function (data) {
-    console.log("[exflow.js] data fetched");
     graphModel.addFlow(data);
     graphModel.trigger("change:graph");
 

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -558,95 +558,6 @@ var logUpdaterFunction = function () {
   }
 }
 
-var exNodeClickCallback = function (event) {
-  console.log("Node clicked callback");
-  var jobId = event.currentTarget.jobid;
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId + "&job=" + jobId;
-  var visualizerURL = contextURL + "/pigvisualizer?execid=" + execId + "&jobid="
-      + jobId;
-
-  var menu = [
-    {
-      title: "Open Job...", callback: function () {
-      window.location.href = requestURL;
-    }
-    },
-    {
-      title: "Open Job in New Window...", callback: function () {
-      window.open(requestURL);
-    }
-    },
-    {
-      title: "Visualize Job...", callback: function () {
-      window.location.href = visualizerURL;
-    }
-    }
-  ];
-
-  contextMenuView.show(event, menu);
-}
-
-var exJobClickCallback = function (event) {
-  console.log("Node clicked callback");
-  var jobId = event.currentTarget.jobid;
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId + "&job=" + jobId;
-  var visualizerURL = contextURL + "/pigvisualizer?execid=" + execId + "&jobid="
-      + jobId;
-
-  var menu = [
-    {
-      title: "Open Job...", callback: function () {
-      window.location.href = requestURL;
-    }
-    },
-    {
-      title: "Open Job in New Window...", callback: function () {
-      window.open(requestURL);
-    }
-    },
-    {
-      title: "Visualize Job...", callback: function () {
-      window.location.href = visualizerURL;
-    }
-    }
-  ];
-
-  contextMenuView.show(event, menu);
-}
-
-var exEdgeClickCallback = function (event) {
-  console.log("Edge clicked callback");
-}
-
-var exGraphClickCallback = function (event) {
-  console.log("Graph clicked callback");
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId;
-
-  var menu = [
-    {
-      title: "Open Flow...", callback: function () {
-      window.location.href = requestURL;
-    }
-    },
-    {
-      title: "Open Flow in New Window...", callback: function () {
-      window.open(requestURL);
-    }
-    },
-    {break: 1},
-    {
-      title: "Center Graph", callback: function () {
-      graphModel.trigger("resetPanZoom");
-    }
-    }
-  ];
-
-  contextMenuView.show(event, menu);
-}
-
 var flowStatsView;
 var flowStatsModel;
 
@@ -726,7 +637,7 @@ $(function () {
   }
 
   var successHandler = function (data) {
-    console.log("data fetched");
+    console.log("[exflow.js] data fetched");
     graphModel.addFlow(data);
     graphModel.trigger("change:graph");
 

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -261,7 +261,6 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     };
     var self = this;
     var successHandler = function (data) {
-      console.log("data fetched");
       graphModel.addFlow(data);
 
       if (exgraph) {
@@ -624,9 +623,8 @@ function recurseAllDescendents(node, disable) {
 }
 
 var expanelNodeClickCallback = function (event, model, node) {
-  console.log("Node clicked callback");
   var jobId = node.id;
-  var flowId = executableGraphModel.get("flowId");
+  var flowId = node.parent.flow;
   var type = node.type;
 
   var menu;
@@ -759,13 +757,11 @@ var expanelNodeClickCallback = function (event, model, node) {
   contextMenuView.show(event, menu);
 }
 
-var expanelEdgeClickCallback = function (event) {
-  console.log("Edge clicked callback");
-}
+var expanelEdgeClickCallback = function (event) {}
 
-var expanelGraphClickCallback = function (event) {
-  console.log("Graph clicked callback");
-  var flowId = executableGraphModel.get("flowId");
+var expanelGraphClickCallback = function (event, model) {
+  var data = model.get("data");
+  var flowId = data.flow;
   var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
       + flowId;
 


### PR DESCRIPTION
Urls to embedded jobs in the Execute dialog's "Flow View" tab are not generated correctly due to the way parent flows are determined. One way to reproduce the issue is to use the option "Expand All Flows" followed by "Open Job in New Window" on any embedded job, we will get a page with content "Job XXX not found". 