### PR TITLE
[BUGFIX] The generate instance function name is getInstance instead o…

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -125,7 +125,7 @@ public class HadoopJobUtils {
     HadoopSecurityManager hadoopSecurityManager = null;
 
     try {
-      Method getInstanceMethod = hadoopSecurityManagerClass.getMethod("createInstance", Props.class);
+      Method getInstanceMethod = hadoopSecurityManagerClass.getMethod("getInstance", Props.class);
       hadoopSecurityManager = (HadoopSecurityManager) getInstanceMethod.invoke(
           hadoopSecurityManagerClass, props);
     } catch (InvocationTargetException e) {

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/HdfsBrowserServlet.java
@@ -125,7 +125,7 @@ public class HdfsBrowserServlet extends LoginAbstractAzkabanServlet {
 
     try {
       Method getInstanceMethod =
-          hadoopSecurityManagerClass.getMethod("createInstance", Props.class);
+          hadoopSecurityManagerClass.getMethod("getInstance", Props.class);
       hadoopSecurityManager =
           (HadoopSecurityManager) getInstanceMethod.invoke(
               hadoopSecurityManagerClass, props);

--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -172,7 +172,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
 
     try {
       final Method getInstanceMethod =
-          hadoopSecurityManagerClass.getMethod("createInstance", Props.class);
+          hadoopSecurityManagerClass.getMethod("getInstance", Props.class);
       hadoopSecurityManager =
           (HadoopSecurityManager) getInstanceMethod.invoke(
               hadoopSecurityManagerClass, props);


### PR DESCRIPTION
Fix the bug in previous 'Add Ramp Manager' Feature. The wired hadoopSecurityManagerClass method is getInstance instead of createInstance.