### PR TITLE
Updating hadoopJava and pig jobtypes to allow solo-server installation

### DIFF
--- a/az-hadoop-jobtype-plugin/src/examples/java-wc/pig-upload.job
+++ b/az-hadoop-jobtype-plugin/src/examples/java-wc/pig-upload.job
@@ -1,4 +1,4 @@
-type=pig
+type=pig-0.12.0
 pig.script=src/upload.pig
 
 

--- a/az-hadoop-jobtype-plugin/src/jobtypes/common.properties
+++ b/az-hadoop-jobtype-plugin/src/jobtypes/common.properties
@@ -1,8 +1,8 @@
 ## everything that the user job can know
 
-hadoop.home=
+hadoop.home=/export/apps/hadoop/latest
 #hive.home=
-#pig.home=
+pig.home=/export/apps/pig/latest
 #spark.home=
 
 #azkaban.should.proxy=

--- a/az-hadoop-jobtype-plugin/src/jobtypes/commonprivate.properties
+++ b/az-hadoop-jobtype-plugin/src/jobtypes/commonprivate.properties
@@ -1,5 +1,5 @@
 ## hadoop security manager setting common to all hadoop jobs
-hadoop.security.manager.class=azkaban.security.HadoopSecurityManager_H_1_0
+hadoop.security.manager.class=azkaban.security.HadoopSecurityManager_H_2_0
 
 ## hadoop security related settings
 
@@ -12,17 +12,18 @@ hadoop.security.manager.class=azkaban.security.HadoopSecurityManager_H_1_0
 # obtain.jobtracker.token=true
 
 # global classpath items for all jobs. e.g. hadoop-core jar, hadoop conf
-#jobtype.global.classpath=${hadoop.home}/*,${hadoop.home}/conf
+jobtype.global.classpath=${hadoop.conf},${hadoop.home}/share/hadoop/common/*,${hadoop.home}/share/hadoop/common/lib/*,${hadoop.home}/share/hadoop/mapreduce/*,${hadoop.home}/share/hadoop/mapreduce/lib/*,${hadoop.home}/share/hadoop/yarn/*,${hadoop.home}/share/hadoop/yarn/lib/*,${hadoop.home}/share/hadoop/hdfs/*,${hadoop.home}/share/hadoop/hdfs/lib/*
+hadoop.conf=/export/apps/hadoop/latest/etc/hadoop
 
 # global jvm args for all jobs. e.g. java.io.temp.dir, java.library.path
 #jobtype.global.jvm.args=
 
 # hadoop
-hadoop.home=
+hadoop.home=/export/apps/hadoop/latest
 #pig.home=
 #hive.home=
 #spark.home=
 
 # configs for jobtype security settings
-execute.as.user=true
+execute.as.user=false
 azkaban.native.lib=

--- a/az-hadoop-jobtype-plugin/src/jobtypes/pig-0.12.0/plugin.properties
+++ b/az-hadoop-jobtype-plugin/src/jobtypes/pig-0.12.0/plugin.properties
@@ -1,4 +1,3 @@
 pig.listener.visualizer=false
 
 jobtype.classpath=${pig.home}/lib/*,${pig.home}/*
-pig.home=

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     compile deps.jsr305
     compile deps.kafkaLog4jAppender
     runtime(project(':azkaban-hadoop-security-plugin'))
+    runtime(project(':az-hadoop-jobtype-plugin')) {
+        transitive = false
+    }
 
     testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
     testCompile(project(':azkaban-common').sourceSets.test.output)

--- a/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
+++ b/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
@@ -29,7 +29,7 @@ HADOOP_HOME=${HADOOP_HOME:-""}  # needed for set -o nounset aove
 
 if [ "$HADOOP_HOME" != "" ]; then
   echo "Using Hadoop from $HADOOP_HOME"
-  CLASSPATH="${CLASSPATH}:${HADOOP_HOME}/conf:${HADOOP_HOME}/*"
+  CLASSPATH="${CLASSPATH}:${HADOOP_HOME}/conf:${HADOOP_HOME}/*:${HADOOP_HOME}/share/hadoop/common/*:${HADOOP_HOME}/share/hadoop/yarn/*"
   JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native/Linux-amd64-64"
 else
   echo "Error: HADOOP_HOME is not set. Hadoop job types will not run properly."
@@ -39,6 +39,12 @@ HIVE_HOME=${HIVE_HOME:-""}  # Needed for set -o nounset above
 if [ "$HIVE_HOME" != "" ]; then
   echo "Using Hive from $HIVE_HOME"
   CLASSPATH="${CLASSPATH}:${HIVE_HOME}/conf:${HIVE_HOME}/lib/*"
+fi
+
+PIG_HOME=${PIG_HOME:-""}  # Needed for set -o nounset above
+if [ "$PIG_HOME" != "" ]; then
+  echo "Using Pig from $PIG_HOME"
+  CLASSPATH="${CLASSPATH}:${PIG_HOME}/conf:${PIG_HOME}/lib/*"
 fi
 
 CLASSPATH=${CLASSPATH:-""}  # Needed for set -o nounset above

--- a/docs/jobTypes.rst
+++ b/docs/jobTypes.rst
@@ -1191,4 +1191,57 @@ server. You can reload all jobtype plugins as follows:
 
    curl http://localhost:EXEC_SERVER_PORT/executor?action=reloadJobTypePlugins
 
+--------------
 
+*****
+Examples
+*****
+
+The project az-hadoop-jobtype-plugin provides examples that show how to
+use some of the included jobtypes. Below you can find how to setup a
+solo-server to run some of them.
+
+java-wc
+~~~~~~~
+
+This example uses the pig-0.12.0 job type to upload an input file to HDFS and the
+hadoopJava job type to count the number of instances that each word is found.
+
+We need to install
+`Hadoop <https://archive.apache.org/dist/hadoop/core/hadoop-2.6.1/>`__ and
+`Pig <https://archive.apache.org/dist/pig/pig-0.11.0/>`__ on the solo-server by
+expanding the tar into /export/apps/hadoop/latest and /export/apps/pig/latest
+resepectively. Then set the HADOOP_HOME and PIG_HOME variables with their paths:
+
+.. code-block:: guess
+
+   export HADOOP_HOME=/export/apps/hadoop/latest
+   export PIG_HOME=/export/apps/pig/latest
+
+If you prefer to install Hadoop and Pig under a different path, please update
+common.properties and commonprivate.properties under
+./az-hadoop-jobtype-plugin/src/jobtypes/ to match it.
+
+Follow the `Hadoop Single Cluster instructions
+<https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html>`__
+to run HDFS on a single cluster. You will need to modify etc/hadoop/core-site.xml
+and run sbin/start-dfs.sh.
+
+Build the source code and copy the pig-0.12.0 and hadoopJava job type
+directories, along with common.properties and commonprivate.properties, from
+./az-hadoop-jobtype-plugin/src/jobtypes to
+./azkaban-solo-server/build/install/azkaban-solo-server/plugins/jobtypes. Then
+start the solo server by running:
+
+.. code-block:: guess
+
+   ./azkaban-solo-server/build/install/azkaban-solo-server/bin/start-solo.sh
+
+Create a zip file with the contents under
+./az-hadoop-jobtype-plugin/src/examples/java-wc
+
+Launch Azkaban by going to http://localhost:8081 and enter the credentials found
+under /azkaban-solo-server/conf/azkaban-users.xml.
+
+Select Create Project, enter your project details and click Upload. Then select
+the zip created in the step above. Start the job by clicking on Execute Flow.


### PR DESCRIPTION
Adding dependency to needed for execution of az-hadoop-jobtype-plugin jobtypes
Adding classpath to Pig home needed for execution of HadoopPig jobs
Updating some common*.properties to make it easier to install jobtypes on a solo-server
Adding documentation to help set up a solo-server with the hadoopJava and pig jobtypes