### PR TITLE
[MySql] partition execution_{flows, jobs, logs} by exec_id to improve performance and simplify retention

### DIFF
--- a/azkaban-sql/src/sql/create.execution_flows.sql
+++ b/azkaban-sql/src/sql/create.execution_flows.sql
@@ -12,9 +12,18 @@ CREATE TABLE execution_flows (
 	enc_type TINYINT,
 	flow_data LONGBLOB,
 	PRIMARY KEY (exec_id)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
 );
 
-CREATE INDEX ex_flows_start_time ON execution_flows(start_time);
-CREATE INDEX ex_flows_end_time ON execution_flows(end_time);
-CREATE INDEX ex_flows_time_range ON execution_flows(start_time, end_time);
-CREATE INDEX ex_flows_flows ON execution_flows(project_id, flow_id);
+CREATE INDEX ex_flow_time_range ON execution_flows(start_time, end_time);
+CREATE INDEX ex_flow_end_time ON execution_flows(end_time);
+CREATE INDEX ex_flow_flows ON execution_flows(project_id, flow_id);
+CREATE INDEX ex_flow_executor_id ON execution_flows(executor_id);

--- a/azkaban-sql/src/sql/create.execution_jobs.sql
+++ b/azkaban-sql/src/sql/create.execution_jobs.sql
@@ -2,18 +2,25 @@ CREATE TABLE execution_jobs (
 	exec_id INT NOT NULL,
 	project_id INT NOT NULL,
 	version INT NOT NULL,
-	flow_id VARCHAR(128) NOT NULL,
-	job_id VARCHAR(128) NOT NULL,
-	attempt INT,
-	start_time BIGINT,
+	flow_id VARCHAR(256) NOT NULL,
+	job_id VARCHAR(512) NOT NULL,
+	attempt INT DEFAULT '0',
+	start_time BIGINT DEFAULT '-1',
 	end_time BIGINT,
 	status TINYINT,
 	input_params LONGBLOB,
 	output_params LONGBLOB,
 	attachments LONGBLOB,
 	PRIMARY KEY (exec_id, job_id, attempt)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
 );
 
-CREATE INDEX exec_job ON execution_jobs(exec_id, job_id);
-CREATE INDEX exec_id ON execution_jobs(exec_id);
 CREATE INDEX ex_job_id ON execution_jobs(project_id, job_id);

--- a/azkaban-sql/src/sql/create.execution_logs.sql
+++ b/azkaban-sql/src/sql/create.execution_logs.sql
@@ -1,14 +1,22 @@
 CREATE TABLE execution_logs (
 	exec_id INT NOT NULL,
-	name VARCHAR(128),
-	attempt INT,
+	name VARCHAR(640) NOT NULL COMMENT 'embedded_flow1:embedded_flow_2:embedded_flow_3:job',
+	attempt INT DEFAULT '0',
 	enc_type TINYINT,
-	start_byte INT,
+	start_byte INT NOT NULL DEFAULT '0',
 	end_byte INT,
 	log LONGBLOB,
 	upload_time BIGINT,
 	PRIMARY KEY (exec_id, name, attempt, start_byte)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
 );
 
-CREATE INDEX ex_log_attempt ON execution_logs(exec_id, name, attempt);
-CREATE INDEX ex_log_index ON execution_logs(exec_id, name);
+CREATE INDEX ex_log_upload_time ON execution_logs(upload_time);

--- a/azkaban-sql/src/sql/update.execution_logs.3.1.sql
+++ b/azkaban-sql/src/sql/update.execution_logs.3.1.sql
@@ -1,0 +1,138 @@
+-- execution_logs and execution_jobs can grow very big
+-- partition execution_flows, execution_jobs, and execution_logs by the range of exec_id
+-- can improve the query performance and make retention easier
+
+
+-- 1. partition execution_logs
+CREATE TABLE execution_logs__new (
+	exec_id INT NOT NULL,
+	name VARCHAR(640) NOT NULL COMMENT 'embedded_flow1:embedded_flow_2:embedded_flow_3:job',
+	attempt INT DEFAULT '0',
+	enc_type TINYINT,
+	start_byte INT NOT NULL DEFAULT '0',
+	end_byte INT,
+	log LONGBLOB,
+	upload_time BIGINT,
+	PRIMARY KEY (exec_id, name, attempt, start_byte)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+
+INSERT INTO execution_logs__new
+SELECT * FROM execution_logs;
+
+
+-- 2. partition execution_jobs
+CREATE TABLE execution_jobs__new (
+	exec_id INT NOT NULL,
+	project_id INT NOT NULL,
+	version INT NOT NULL,
+	flow_id VARCHAR(256) NOT NULL,
+	job_id VARCHAR(512) NOT NULL,
+	attempt INT DEFAULT '0',
+	start_time BIGINT,
+	end_time BIGINT,
+	status TINYINT,
+	input_params LONGBLOB,
+	output_params LONGBLOB,
+	attachments LONGBLOB,
+	PRIMARY KEY (exec_id, job_id, attempt)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+
+INSERT INTO execution_jobs__new
+SELECT * FROM execution_jobs;
+
+
+-- 3. partition execution_flows
+CREATE TABLE execution_flows__new (
+	exec_id INT NOT NULL AUTO_INCREMENT,
+	project_id INT NOT NULL,
+	version INT NOT NULL,
+	flow_id VARCHAR(128) NOT NULL,
+	status TINYINT,
+	submit_user VARCHAR(64),
+	submit_time BIGINT,
+	update_time BIGINT,
+	start_time BIGINT,
+	end_time BIGINT,
+	enc_type TINYINT,
+	flow_data LONGBLOB,
+	PRIMARY KEY (exec_id)
+)
+PARTITION BY RANGE (exec_id) (
+  PARTITION P004M VALUES LESS THAN (05000000),
+  PARTITION P009M VALUES LESS THAN (10000000),
+  PARTITION P014M VALUES LESS THAN (15000000),
+  PARTITION P019M VALUES LESS THAN (20000000),
+  PARTITION P024M VALUES LESS THAN (25000000),
+  PARTITION P029M VALUES LESS THAN (30000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+
+INSERT INTO execution_flows__new
+SELECT * FROM execution_flows;
+
+
+-- 4. rename tables
+RENAME TABLE execution_logs  TO execution_logs__old,
+             execution_jobs  TO execution_jobs__old,
+             execution_flows TO execution_flows__old;
+
+RENAME TABLE execution_logs__new  TO execution_logs,
+             execution_jobs__new  TO execution_jobs,
+             execution_flows__new TO execution_flows;
+
+CREATE INDEX ex_log_upload_time ON execution_logs(upload_time);
+
+CREATE INDEX ex_job_id ON execution_jobs(project_id, job_id);
+
+CREATE INDEX ex_flow_time_range ON execution_flows(start_time, end_time);
+CREATE INDEX ex_flow_end_time ON execution_flows(end_time);
+CREATE INDEX ex_flow_flows ON execution_flows(project_id, flow_id);
+CREATE INDEX ex_flow_executor_id ON execution_flows(executor_id);
+
+-- 5. analyze tables
+ANALYZE TABLE execution_flows,
+              execution_jobs,
+              execution_logs;
+
+-- 6. future partition maintenance (examples)
+/*
+ALTER TABLE execution_logs REORGANIZE
+  PARTITION P999M INTO (
+  PARTITION P034M VALUES LESS THAN (35000000),
+  PARTITION P039M VALUES LESS THAN (40000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+
+ALTER TABLE execution_jobs REORGANIZE
+  PARTITION P999M INTO (
+  PARTITION P034M VALUES LESS THAN (35000000),
+  PARTITION P039M VALUES LESS THAN (40000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+
+ALTER TABLE execution_flows REORGANIZE
+  PARTITION P999M INTO (
+  PARTITION P034M VALUES LESS THAN (35000000),
+  PARTITION P039M VALUES LESS THAN (40000000),
+  PARTITION P999M VALUES LESS THAN (MAXVALUE)
+);
+*/
+


### PR DESCRIPTION
execution_logs, execution_flows and execution_jobs are the biggest and heavily-accessed tables in Azkaban's MySql backend, DBA has to manually clean up the old records from these tables.

There are 2 tuning aspects we want to tune here, in order to improve the performance without changing its Java backend service.

- Identify the unused indices and remove them
- Partition the PK by range(exec_id)

The partition split can be automated with a monthly cron job in Azkaban Web Server, or it can still be handled by MySql DBA. Partitioning will reduce the maintenance time and effort, since naturally "exec_id" grows monotonically along with "upload_time" together. So the old logs are always kept in the partitions with smaller exec_id values.

- The BTree of PK will be much smaller and shorter because each partition will contain much less entries.
- The archival/pruning operation will be faster and easier because only the oldest partition will be affected. DBA can even run `TRUNCATE PARTITION` now.


![execution_logs optimization](https://user-images.githubusercontent.com/8866410/66623739-f1c51d80-eba1-11e9-8b53-84bd79bcc976.png)

A script is provided in update.execution_logs.3.1.sql to migrate the data from existing execution_{logs,flows,jobs} to the partitioned tables.

Each partition will have 5~20M records for 5M exec_id(s), if on average each flow contains 20 jobs. In the future, DBA can split/reorganize the max partition to new range. Please see the sample DDL in update.execution_logs.3.1.sql