### PR TITLE
Add Expand All button to job lists

### DIFF
--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -380,10 +380,29 @@ li.tree-list-item {
       font-size: 8pt;
     }
 
+    .expandallarrow {
+      top: 4px;
+    }
+
     .filterHighlight {
       background-color: #FFFF00;
     }
   }
+}
+
+.expandallarrow {
+  float: right;
+  display: inline-block;
+  position: relative;
+  font-size: 8pt;
+  margin-right: 0.6em;
+  margin-left: 1.5em;
+  top: 9px;
+}
+
+.expandallarrow .glyphicon-chevron-down:first-child {
+  position: absolute;
+  top: -3px;
 }
 
 #analyzerButton {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -30,7 +30,8 @@
   <script type="text/javascript" src="${context}/js/flowstats.js"></script>
   <script type="text/javascript" src="${context}/js/flowstats-no-data.js"></script>
 
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1559149862"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -30,7 +30,8 @@
 <script type="text/javascript" src="${context}/js/azkaban/util/job-status.js"></script>
 
 <script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1569610022"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js"></script>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-list-common.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-list-common.js
@@ -1,0 +1,17 @@
+// Common functions for rendering a job list
+
+function atLeastOneChildHasChildren(node) {
+  return node.nodes && node.nodes.reduce((acc, x) => acc || (x.nodes && x.nodes.length), false);
+}
+
+function createExpandAllButton() {
+  var expandAllDiv = document.createElement("div");
+  $(expandAllDiv).addClass("expandallarrow");
+  var firstArrow = document.createElement("span");
+  $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
+  var secondArrow = document.createElement("span");
+  $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
+  $(expandAllDiv).append(firstArrow);
+  $(expandAllDiv).append(secondArrow);
+  return expandAllDiv;
+}

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -294,6 +294,16 @@ azkaban.ExecutionListView = Backbone.View.extend({
     } // else do nothing
   },
 
+  propagateExpansionDown: function(flow) {
+    var children = $(flow.joblistrow.subflowrow).find("> td > table > tbody > tr.jobListRow");
+    for (var i = 0; i < children.length; i++) {
+      this.propagateExpansionDown(children[i].node);
+    }
+    if (children.length) {
+      this.setFlowExpansion(flow, true);
+    }
+  },
+
   expandRunningFailedOrKilledJobs: function (nodes) {
     var isRunningFailedOrKilled = false;
     for (var i = 0; i < nodes.length; ++i) {
@@ -379,6 +389,21 @@ azkaban.ExecutionListView = Backbone.View.extend({
         var parent = $(evt.currentTarget).parents("tr")[0];
         self.setFlowExpansion(parent.node);
       });
+
+      // Add the double down expand all
+      var expandAllDiv = document.createElement("div");
+      $(expandAllDiv).addClass("expandallarrow");
+      var firstArrow = document.createElement("span");
+      $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
+      var secondArrow = document.createElement("span");
+      $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
+      $(expandAllDiv).append(firstArrow);
+      $(expandAllDiv).append(secondArrow);
+      $(expandAllDiv).click(function (evt) {
+        var parent = $(evt.currentTarget).parents("tr")[0];
+        self.propagateExpansionDown(parent.node);
+      });
+      $(tdName).append(expandAllDiv);
     }
 
     var status = document.createElement("div");

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -390,18 +390,9 @@ azkaban.ExecutionListView = Backbone.View.extend({
         self.setFlowExpansion(parent.node);
       });
 
-      var atLeastOneChildHasChildren = node.nodes
-          && node.nodes.reduce((acc, x) => acc || (x.nodes && x.nodes.length), false);
-      if (atLeastOneChildHasChildren) {
+      if (atLeastOneChildHasChildren(node)) {
         // Add the double down expand all
-        var expandAllDiv = document.createElement("div");
-        $(expandAllDiv).addClass("expandallarrow");
-        var firstArrow = document.createElement("span");
-        $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
-        var secondArrow = document.createElement("span");
-        $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
-        $(expandAllDiv).append(firstArrow);
-        $(expandAllDiv).append(secondArrow);
+        var expandAllDiv = createExpandAllButton();
         $(expandAllDiv).click(function (evt) {
           var parent = $(evt.currentTarget).parents("tr")[0];
           self.propagateExpansionDown(parent.node);

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -390,20 +390,24 @@ azkaban.ExecutionListView = Backbone.View.extend({
         self.setFlowExpansion(parent.node);
       });
 
-      // Add the double down expand all
-      var expandAllDiv = document.createElement("div");
-      $(expandAllDiv).addClass("expandallarrow");
-      var firstArrow = document.createElement("span");
-      $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
-      var secondArrow = document.createElement("span");
-      $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
-      $(expandAllDiv).append(firstArrow);
-      $(expandAllDiv).append(secondArrow);
-      $(expandAllDiv).click(function (evt) {
-        var parent = $(evt.currentTarget).parents("tr")[0];
-        self.propagateExpansionDown(parent.node);
-      });
-      $(tdName).append(expandAllDiv);
+      var atLeastOneChildHasChildren = node.nodes
+          && node.nodes.reduce((acc, x) => acc || (x.nodes && x.nodes.length), false);
+      if (atLeastOneChildHasChildren) {
+        // Add the double down expand all
+        var expandAllDiv = document.createElement("div");
+        $(expandAllDiv).addClass("expandallarrow");
+        var firstArrow = document.createElement("span");
+        $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
+        var secondArrow = document.createElement("span");
+        $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
+        $(expandAllDiv).append(firstArrow);
+        $(expandAllDiv).append(secondArrow);
+        $(expandAllDiv).click(function (evt) {
+          var parent = $(evt.currentTarget).parents("tr")[0];
+          self.propagateExpansionDown(parent.node);
+        });
+        $(tdName).append(expandAllDiv);
+      }
     }
 
     var status = document.createElement("div");

--- a/azkaban-web-server/src/web/js/azkaban/view/job-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-list.js
@@ -198,16 +198,20 @@ azkaban.JobListView = Backbone.View.extend({
         $(expandDiv).addClass("expandarrow glyphicon glyphicon-chevron-down");
         $(a).append(expandDiv);
 
-        // Add the double down expand all
-        var expandAllDiv = document.createElement("div");
-        $(expandAllDiv).addClass("expandallarrow");
-        var firstArrow = document.createElement("span");
-        $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
-        var secondArrow = document.createElement("span");
-        $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
-        $(expandAllDiv).append(firstArrow);
-        $(expandAllDiv).append(secondArrow);
-        $(a).append(expandAllDiv);
+        var atLeastOneChildHasChildren = nodeArray[i].nodes
+            && nodeArray[i].nodes.reduce((acc, x) => acc || (x.nodes && x.nodes.length), false);
+        if (atLeastOneChildHasChildren) {
+          // Add the double down expand all
+          var expandAllDiv = document.createElement("div");
+          $(expandAllDiv).addClass("expandallarrow");
+          var firstArrow = document.createElement("span");
+          $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
+          var secondArrow = document.createElement("span");
+          $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
+          $(expandAllDiv).append(firstArrow);
+          $(expandAllDiv).append(secondArrow);
+          $(a).append(expandAllDiv);
+        }
 
         // Create subtree
         var subul = this.renderTree(li, nodeArray[i], listNodeName + ":");

--- a/azkaban-web-server/src/web/js/azkaban/view/job-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-list.js
@@ -26,6 +26,7 @@ azkaban.JobListView = Backbone.View.extend({
     "click #autoPanZoomBtn": "handleAutoPanZoom",
     "contextmenu li.listElement": "handleContextMenuClick",
     "click .expandarrow": "handleToggleMenuExpand",
+    "click .expandallarrow": "handleToggleMenuExpandAll",
     "click #close-btn": "handleClose"
   },
 
@@ -197,6 +198,17 @@ azkaban.JobListView = Backbone.View.extend({
         $(expandDiv).addClass("expandarrow glyphicon glyphicon-chevron-down");
         $(a).append(expandDiv);
 
+        // Add the double down expand all
+        var expandAllDiv = document.createElement("div");
+        $(expandAllDiv).addClass("expandallarrow");
+        var firstArrow = document.createElement("span");
+        $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
+        var secondArrow = document.createElement("span");
+        $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
+        $(expandAllDiv).append(firstArrow);
+        $(expandAllDiv).append(secondArrow);
+        $(a).append(expandAllDiv);
+
         // Create subtree
         var subul = this.renderTree(li, nodeArray[i], listNodeName + ":");
         $(subul).hide();
@@ -236,6 +248,15 @@ azkaban.JobListView = Backbone.View.extend({
     else {
       this.handleMenuExpand(li);
     }
+
+    evt.stopImmediatePropagation();
+  },
+
+  handleToggleMenuExpandAll: function (evt) {
+    var expandarrow = evt.currentTarget;
+    var li = $(evt.currentTarget).closest("li.listElement");
+
+    this.propagateExpansionDown(li);
 
     evt.stopImmediatePropagation();
   },
@@ -305,15 +326,23 @@ azkaban.JobListView = Backbone.View.extend({
 
     if (current) {
       $(current.listElement).addClass("active");
-      this.propagateExpansion(current.listElement);
+      this.propagateExpansionUp(current.listElement);
     }
   },
 
-  propagateExpansion: function (li) {
+  propagateExpansionUp: function (li) {
     var li = $(li).parent().closest("li.listElement")[0];
     if (li) {
-      this.propagateExpansion(li);
+      this.propagateExpansionUp(li);
       this.handleMenuExpand(li);
+    }
+  },
+
+  propagateExpansionDown: function (li) {
+    this.handleMenuExpand(li);
+    var children = $(li).find("> ul > li.listElement");
+    for (var i = 0; i < children.length; i++) {
+      this.propagateExpansionDown(children[i]);
     }
   },
 

--- a/azkaban-web-server/src/web/js/azkaban/view/job-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-list.js
@@ -198,18 +198,9 @@ azkaban.JobListView = Backbone.View.extend({
         $(expandDiv).addClass("expandarrow glyphicon glyphicon-chevron-down");
         $(a).append(expandDiv);
 
-        var atLeastOneChildHasChildren = nodeArray[i].nodes
-            && nodeArray[i].nodes.reduce((acc, x) => acc || (x.nodes && x.nodes.length), false);
-        if (atLeastOneChildHasChildren) {
+        if (atLeastOneChildHasChildren(nodeArray[i])) {
           // Add the double down expand all
-          var expandAllDiv = document.createElement("div");
-          $(expandAllDiv).addClass("expandallarrow");
-          var firstArrow = document.createElement("span");
-          $(firstArrow).addClass("glyphicon glyphicon-chevron-down");
-          var secondArrow = document.createElement("span");
-          $(secondArrow).addClass("glyphicon glyphicon-chevron-down");
-          $(expandAllDiv).append(firstArrow);
-          $(expandAllDiv).append(secondArrow);
+          var expandAllDiv = createExpandAllButton();
           $(a).append(expandAllDiv);
         }
 


### PR DESCRIPTION
Add Expand All button to job lists on both graph job sidebar and execution job list. When clicked, that job and all its sub jobs will be expanded recursively.

Note: The button only appears on jobs who have at least one child who has at least one child :smile: In other words, the button only appears on jobs containing more than one level of nested jobs.

Examples:
https://drive.google.com/file/d/1jhCoFm4INzXV9SUx8Sld_57LEsdAsGZi/view?usp=sharing
https://drive.google.com/file/d/1Fq9hRb1qFSC0ftnHEYTg05W-RqGEBAHW/view?usp=sharing