### PR TITLE
Add unsafe template var passthrough

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -301,6 +301,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     }
 
     final String errorMsg = getErrorMessageFromCookie(req);
+    final boolean renderErrUnsafely = shouldRenderErrorMessageFromCookieUnsafely(req);
     page.addUNSAFE("error_message", errorMsg == null || errorMsg.isEmpty() ? "null"
         : errorMsg);
     setErrorMessageInCookie(resp, null);
@@ -311,7 +312,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     setWarnMessageInCookie(resp, null);
 
     final String successMsg = getSuccessMessageFromCookie(req);
-    page.addUNSAFE("success_message",
+    page.add("success_message",
         successMsg == null || successMsg.isEmpty() ? "null" : successMsg);
     setSuccessMessageInCookie(resp, null);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -301,17 +301,17 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     }
 
     final String errorMsg = getErrorMessageFromCookie(req);
-    page.add("error_message", errorMsg == null || errorMsg.isEmpty() ? "null"
+    page.addUNSAFE("error_message", errorMsg == null || errorMsg.isEmpty() ? "null"
         : errorMsg);
     setErrorMessageInCookie(resp, null);
 
     final String warnMsg = getWarnMessageFromCookie(req);
-    page.add("warn_message", warnMsg == null || warnMsg.isEmpty() ? "null"
+    page.addUNSAFE("warn_message", warnMsg == null || warnMsg.isEmpty() ? "null"
         : warnMsg);
     setWarnMessageInCookie(resp, null);
 
     final String successMsg = getSuccessMessageFromCookie(req);
-    page.add("success_message",
+    page.addUNSAFE("success_message",
         successMsg == null || successMsg.isEmpty() ? "null" : successMsg);
     setSuccessMessageInCookie(resp, null);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
@@ -78,6 +78,11 @@ public class Page {
     this.context.put(name, value);
   }
 
+  /**
+   * Adds variables to the velocity context, WITHOUT sanitizing the contents
+   * ONLY USE if you are 100% sure the content cannot be manipulated by the user
+   * to stage an XSS attack.
+   */
   public void addUNSAFE(final String name, final Object value) {
     varsToRenderUnsafely.add(name);
     add(name, value);


### PR DESCRIPTION
Add ability to add variable to template without it being sanitized. Also do not sanitize any alerts.

Fixes ability to properly show validator results that by default require rendering of HTML: https://github.com/azkaban/azkaban/blob/8054c13d1c4a619ae551484dc79e867b1ce8a2ff/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java#L1929-L1972