### PR TITLE
Add job status in Job Summary page.

### DIFF
--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -129,6 +129,8 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
     page.add("flowid", flow.getId());
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
+    page.add("attemptStatus", attempt == node.getAttempt() ?
+        node.getStatus() : node.getPastAttemptList().get(attempt).getStatus());
 
     page.render();
   }


### PR DESCRIPTION
Job status ($attemptStatus variable in the picture) was not showing up in Job Summary page.
<img width="700" alt="Screen Shot 2019-10-15 at 2 53 14 PM" src="https://user-images.githubusercontent.com/44478711/66872777-9e651d80-ef5b-11e9-9b89-bedb1ac1a73f.png">
