### PR TITLE
Fix ajax call detection for POST requests

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -121,7 +121,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
 
       handleGet(req, resp, session);
     } else {
-      if (hasParam(req, "ajax")) {
+      if (isAjaxCall(req)) {
         final HashMap<String, String> retVal = new HashMap<>();
         retVal.put("error", "session");
         this.writeJSON(resp, retVal);
@@ -481,6 +481,10 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
   }
 
   protected boolean isAjaxCall(final HttpServletRequest req) {
+    if (hasParam(req, "ajax")) {
+      return true;
+    }
+
     final String value = req.getHeader("X-Requested-With");
     if (value != null) {
       logger.info("has X-Requested-With " + value);

--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -1272,7 +1272,7 @@ Here's a curl command sample:
 
 .. code-block:: guess
 
-   curl -k --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=pauseFlow&execid=303" https://localhost:8443/executor
+   curl -k --get --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=pauseFlow&execid=303" https://localhost:8443/executor
 
 A response sample (if succeeds, or pauseFlow is called multiple times):
 
@@ -1323,7 +1323,7 @@ Here's a curl command sample:
 
 .. code-block:: guess
 
-   curl -k --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=resumeFlow&execid=303" https://localhost:8443/executor
+   curl -k --get --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=resumeFlow&execid=303" https://localhost:8443/executor
 
 A response sample (if succeeds, or resumeFlow is called multiple times):
 
@@ -1382,7 +1382,7 @@ Here's a curl command sample:
 
 .. code-block:: guess
 
-   curl -k --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=fetchexecflow&execid=304" https://localhost:8443/executor
+   curl -k --get --data "session.id=34ba08fd-5cfa-4b65-94c4-9117aee48dda&ajax=fetchexecflow&execid=304" https://localhost:8443/executor
 
 A response sample:
 
@@ -1508,7 +1508,7 @@ Here's a curl command sample:
 
 .. code-block:: guess
 
-   curl -k --data "session.id=9089beb2-576d-47e3-b040-86dbdc7f523e&ajax=fetchExecJobLogs&execid=297&jobId=test-foobar&offset=0&length=100" https://localhost:8443/executor
+   curl -k --get --data "session.id=9089beb2-576d-47e3-b040-86dbdc7f523e&ajax=fetchExecJobLogs&execid=297&jobId=test-foobar&offset=0&length=100" https://localhost:8443/executor
 
 A response sample:
 
@@ -1690,8 +1690,8 @@ Given a project name, this API call fetches all logs of a project.
 |                                   | **Example values:** [             |
 |                                   | [ "test_user",                    |
 |                                   |   1540885820913,                  |
-|                                   |   "PROPERTY_OVERRIDE",            | 
-|                                   |   "some description" ],           | 
+|                                   |   "PROPERTY_OVERRIDE",            |
+|                                   |   "some description" ],           |
 |                                   | [ ... ], [ ... ],  ]              |
 +-----------------------------------+-----------------------------------+
 
@@ -1707,11 +1707,11 @@ A response sample:
 
 {
   "columns" : [ "user", "time", "type", "message" ],
-  "logData" : [ 
+  "logData" : [
     [ "test_user1", 1543615522936, "PROPERTY_OVERRIDE", "Modified Properties: .... " ],
     [ "test_user2", 1542346639933, "UPLOADED", "Uploaded project files zip " ],
     [ "test_user3", 1519908889338, "CREATED", null ],
-    ... 
+    ...
   ],
   "project" : "azkaban-test-project",
   "projectId" : 1


### PR DESCRIPTION
When a valid session could not be identified for a GET request, the existence of a `ajax` query string param was used to determine if a JSON error or if a rendered HTML login page should be returned.

For POST requests, a different method was used to determine if a request was an ajax call. Now both GET and POST requests use the same method for determining if a request is an ajax call:

IF the request has an `ajax` param (in query string for GET or in body for POST) OR if the request has the header `X-Requested-With: XMLHttpRequest`, the request is determined to be an ajax call.

---

Unrelated: this PR also fixes incorrect cURL sample requests in the docs where an endpoint that should be accessed through GET listed a sample cURL request that actually defaulted to POST.