### PR TITLE
Fix overlapping of logs with other UI elements when job/flow names are long

### DIFF
--- a/azkaban-web-server/src/main/less/header.less
+++ b/azkaban-web-server/src/main/less/header.less
@@ -39,13 +39,13 @@
   .header-title {
     padding-left: 15px;
     float: left;
-    width: 40%;
+    width: 65%;
   }
 
   .header-control {
     float: right;
     padding-right: 15px;
-    width: 500px;
+    width: 35%;
 
     .header-form {
       margin: 5px 0 0 0;

--- a/azkaban-web-server/src/main/less/log.less
+++ b/azkaban-web-server/src/main/less/log.less
@@ -1,10 +1,27 @@
+html, body {
+  height: 100%;
+}
+
+#jobLogView {
+  height: 60%;
+}
+
+#flowLogView {
+  height: 65%;
+}
+
 .log-viewer {
   height: 100%;
+  position: relative;
   margin: 0;
   padding: 0;
 
   .panel {
-    position: relative;
+    position: absolute;
+    top:0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     height: 100%;
 
     .panel-heading {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -238,24 +238,20 @@
 
   ## Flow Log View
 
-  <div class="container-full container-fill" id="flowLogView">
-    <div class="row">
-      <div class="col-xs-12 col-content">
-        <div class="log-viewer">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <div class="pull-right">
-                <button type="button" id="updateLogBtn" class="btn btn-xs btn-info">Refresh</button>
-              </div>
-              Flow log
-            </div>
-            <div class="panel-body">
-              <pre id="logSection"></pre>
-            </div>
-          </div><!-- /.panel -->
-        </div><!-- /.log-viewer -->
-      </div><!-- /.col-xs-12 -->
-    </div><!-- /.row -->
+  <div class="container-full" id="flowLogView">
+    <div class="log-viewer">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="pull-right">
+            <button type="button" id="updateLogBtn" class="btn btn-xs btn-info">Refresh</button>
+          </div>
+          Flow log
+        </div>
+        <div class="panel-body">
+          <pre id="logSection"></pre>
+        </div>
+      </div><!-- /.panel -->
+    </div><!-- /.log-viewer -->
   </div><!-- /.container-full -->
 
   ## Stats view.

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -64,25 +64,23 @@
 
   ## Log content.
 
-  <div class="container-full container-fill" id="jobLogView">
-    <div class="row">
-      <div class="col-xs-12 col-content">
-        <div class="log-viewer">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <div class="pull-right">
-                <button type="button" id="updateLogBtn" class="btn btn-xs btn-default">Refresh
-                </button>
-              </div>
-              Job Logs
-            </div>
-            <div class="panel-body">
-              <pre id="logSection"></pre>
-            </div>
+  <div class="container-full" id="jobLogView">
+    <div class="log-viewer">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="pull-right">
+            <button type="button" id="updateLogBtn" class="btn btn-xs btn-info">Refresh
+            </button>
           </div>
+          Job Logs
+        </div>
+        <div class="panel-body">
+          <pre id="logSection"></pre>
         </div>
       </div>
     </div>
+  </div>
+  <div class="container-full">
     <ul id="attemptsPagination" class="pagination"></ul>
   </div>
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=1556216524794" rel="stylesheet">
+<link href="/css/azkaban.css?v=1571871291" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};


### PR DESCRIPTION
Fixes:
<img width="1522" alt="Screen Shot 2019-10-23 at 4 04 17 PM" src="https://user-images.githubusercontent.com/44478711/67441790-16ae8d00-f5b3-11e9-945e-1f1dc82c99ac.png">
Notice that the breadcrumb is not fully visible. It's missing Job name and Attempt.

This is what it would look like after applying the fix:
<img width="1464" alt="Screen Shot 2019-10-24 at 10 59 36 AM" src="https://user-images.githubusercontent.com/44478711/67512377-8a9d7380-f64d-11e9-86be-31c15eb6d4fa.png">