### PR TITLE
Fix Upload Project Zip API command

### DIFF
--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -262,7 +262,7 @@ Here's a curl command sample:
 
 .. code-block:: guess
 
-   curl -k -i -H "Content-Type: multipart/mixed" -X POST --form 'session.id=e7a29776-5783-49d7-afa0-b0e688096b5e' --form 'ajax=upload' --form 'file=@myproject.zip;type=application/zip' --form 'project=MyProject;type/plain' https://localhost:8443/manager
+   curl -k -i -X POST --form 'session.id=e7a29776-5783-49d7-afa0-b0e688096b5e' --form 'ajax=upload' --form 'file=@myproject.zip;type=application/zip' --form 'project=MyProject' https://localhost:8443/manager
 
 A response sample:
 


### PR DESCRIPTION
Old command returns a "Login error. Need username and password" error