### PR TITLE
Escape HTML except for line breaks

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
@@ -84,12 +84,12 @@ public class Page {
   }
 
   private static String escapeHtmlExceptLineBreaks(String value) {
-    // Convert line breaks to \n
-    String converted = value.replaceAll("<br/?>", "\n");
+    // Convert line breaks to custom newline marker
+    String converted = value.replaceAll("<br/?>", "!NEWLINE!");
     // Escape the converted string
     String escaped = StringEscapeUtils.escapeHtml(converted);
     // Convert newlines back to <br>
-    return escaped.replaceAll("\n", "<br>");
+    return escaped.replaceAll("!NEWLINE!", "<br>");
   }
 
   public void setMimeType(final String type) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/Page.java
@@ -78,9 +78,18 @@ public class Page {
     for(Object key: this.context.getKeys()) {
       Object value = this.context.get((String)key);
       if(key instanceof String && value instanceof String) {
-        this.context.put((String)key, StringEscapeUtils.escapeHtml((String)value));
+        this.context.put((String)key, escapeHtmlExceptLineBreaks((String)value));
       }
     }
+  }
+
+  private static String escapeHtmlExceptLineBreaks(String value) {
+    // Convert line breaks to \n
+    String converted = value.replaceAll("<br/?>", "\n");
+    // Escape the converted string
+    String escaped = StringEscapeUtils.escapeHtml(converted);
+    // Convert newlines back to <br>
+    return escaped.replaceAll("\n", "<br>");
   }
 
   public void setMimeType(final String type) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1945,18 +1945,16 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         }
       }
       if (!report.getErrorMsgs().isEmpty()) {
-        errorMsgs.append("Validator " + reportEntry.getKey() + " reports errors:<ul>");
+        errorMsgs.append("Validator " + reportEntry.getKey() + " reports errors:<br><br>");
         for (final String msg : report.getErrorMsgs()) {
-          errorMsgs.append("<li>" + msg + "</li>");
+          errorMsgs.append(msg + "<br>");
         }
-        errorMsgs.append("</ul>");
       }
       if (!report.getWarningMsgs().isEmpty()) {
-        warnMsgs.append("Validator " + reportEntry.getKey() + " reports warnings:<ul>");
+        warnMsgs.append("Validator " + reportEntry.getKey() + " reports warnings:<br><br>");
         for (final String msg : report.getWarningMsgs()) {
-          warnMsgs.append("<li>" + msg + "</li>");
+          warnMsgs.append(msg + "<br>");
         }
-        warnMsgs.append("</ul>");
       }
     }
     if (errorMsgs.length() > 0) {


### PR DESCRIPTION
This allows for `<br>` and `<br/>` in string variables passed to be rendered in velocity templates to be left as is and not escaped.

This is a better way of fixing what this previous PR tried to address: https://github.com/azkaban/azkaban/pull/2353