### PR TITLE
Fix StorageCleanerTest

### DIFF
--- a/azkaban-common/src/test/java/azkaban/storage/StorageCleanerTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/StorageCleanerTest.java
@@ -67,7 +67,7 @@ public class StorageCleanerTest {
     when(this.storage.delete("14/14-10.zip")).thenReturn(true);
     when(this.storage.delete("14/14-9.zip")).thenReturn(true);
     // This one shouldn't be deleted because it's shared with latest version
-    when(this.storage.delete("14/14-8.zip")).thenThrow(Exception.class);
+    when(this.storage.delete("14/14-8.zip")).thenThrow(RuntimeException.class);
     when(this.storage.delete("14/14-7.zip")).thenReturn(false);
     when(this.databaseOperator.update(any(), anyVararg())).thenReturn(1);
   }


### PR DESCRIPTION
We can't throw a checked exception using Mockito that the underlying method doesn't indicate it throws. So we'll throw a `RuntimeException`.