### PR TITLE
Allow oauth access token fetch by adding custom implemented oauth token provider

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -254,6 +254,8 @@ public class Constants {
 
     public static final String CUSTOM_CREDENTIAL_NAME = "azkaban.security.credential";
 
+    public static final String OAUTH_CREDENTIAL_NAME = "azkaban.oauth.credential";
+
     // dir to keep dependency plugins
     public static final String DEPENDENCY_PLUGIN_DIR = "azkaban.dependency.plugin.dir";
 
@@ -351,6 +353,9 @@ public class Constants {
 
     // If true, AZ will fetches the jobs' certificate from remote Certificate Authority.
     public static final String ENABLE_JOB_SSL = "azkaban.job.enable.ssl";
+
+    // If true, AZ will fetch OAuth token from credential provider
+    public static final String ENABLE_OAUTH = "azkaban.enable.oauth";
 
     // Job properties that indicate maximum memory size
     public static final String JOB_MAX_XMS = "job.max.Xms";


### PR DESCRIPTION
This change will allow user to implement customized oauth token provider in azkaban to generate access token to access  resources that needs authN. (Example use case: Azure storage).

Users need to set `azkaban.enable.oauth` to true in order to use it. (default to false)

Refactor `HadoopSecurityManager_H_2_0.registerCustomCredential` so it can be reused to register custom credential provider.





