### PR TITLE
Add workflow id to mapreduce tags

### DIFF
--- a/az-hadoop-jobtype-plugin/build.gradle
+++ b/az-hadoop-jobtype-plugin/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     }
     compile deps.sparkCore
     compile deps.commonsCli
+
+    testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
+    testCompile(project(':azkaban-common').sourceSets.test.output)
 }
 
 /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -83,6 +83,7 @@ public class HadoopJobUtils {
   public static final String MAPREDUCE_JOB_OTHER_NAMENODES = "mapreduce.job.hdfs-servers";
   // MapReduce config for mapreduce job tags
   public static final String MAPREDUCE_JOB_TAGS = "mapreduce.job.tags";
+  protected static final int APPLICATION_TAG_MAX_LENGTH = 100;
   // Root of folder in storage containing startup dependencies
   public static final String DEPENDENCY_STORAGE_ROOT_PATH_PROP = "dependency.storage.path.prefix";
   // Azkaban property for listing additional namenodes for delegation tokens
@@ -590,10 +591,13 @@ public class HadoopJobUtils {
     }
     if (props.containsKey(CommonJobProperties.PROJECT_NAME)
         && props.containsKey(CommonJobProperties.FLOW_ID)) {
-      keysAndValues[keys.length] = "workflowid:"
+      String constructedTag = "workflowid:"
           + props.get(CommonJobProperties.PROJECT_NAME)
           + HadoopConfigurationInjector.WORKFLOW_ID_SEPERATOR
           + props.get(CommonJobProperties.FLOW_ID);
+      constructedTag = constructedTag.substring(0,
+          Math.min(constructedTag.length(), APPLICATION_TAG_MAX_LENGTH));
+      keysAndValues[keys.length] = constructedTag;
     }
     Joiner joiner = Joiner.on(',').skipNulls();
     return joiner.join(keysAndValues);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -15,7 +15,6 @@
  */
 package azkaban.jobtype;
 
-import azkaban.flow.CommonJobProperties;
 import com.google.common.base.Joiner;
 import java.io.BufferedReader;
 import java.io.File;
@@ -583,21 +582,13 @@ public class HadoopJobUtils {
    * @return a CSV of tags
    */
   public static String constructHadoopTags(Props props, String[] keys) {
-    String[] keysAndValues = new String[keys.length + 1];
+    String[] keysAndValues = new String[keys.length];
     for (int i = 0; i < keys.length; i++) {
       if (props.containsKey(keys[i])) {
-        keysAndValues[i] = keys[i] + ":" + props.get(keys[i]);
+        String tag = keys[i] + ":" + props.get(keys[i]);
+        keysAndValues[i] = tag.substring(0,
+            Math.min(tag.length(), HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH));
       }
-    }
-    if (props.containsKey(CommonJobProperties.PROJECT_NAME)
-        && props.containsKey(CommonJobProperties.FLOW_ID)) {
-      String constructedTag = "workflowid:"
-          + props.get(CommonJobProperties.PROJECT_NAME)
-          + HadoopConfigurationInjector.WORKFLOW_ID_SEPERATOR
-          + props.get(CommonJobProperties.FLOW_ID);
-      constructedTag = constructedTag.substring(0,
-          Math.min(constructedTag.length(), APPLICATION_TAG_MAX_LENGTH));
-      keysAndValues[keys.length] = constructedTag;
     }
     Joiner joiner = Joiner.on(',').skipNulls();
     return joiner.join(keysAndValues);

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -15,6 +15,7 @@
  */
 package azkaban.jobtype;
 
+import azkaban.flow.CommonJobProperties;
 import com.google.common.base.Joiner;
 import java.io.BufferedReader;
 import java.io.File;
@@ -581,11 +582,18 @@ public class HadoopJobUtils {
    * @return a CSV of tags
    */
   public static String constructHadoopTags(Props props, String[] keys) {
-    String[] keysAndValues = new String[keys.length];
+    String[] keysAndValues = new String[keys.length + 1];
     for (int i = 0; i < keys.length; i++) {
       if (props.containsKey(keys[i])) {
         keysAndValues[i] = keys[i] + ":" + props.get(keys[i]);
       }
+    }
+    if (props.containsKey(CommonJobProperties.PROJECT_NAME)
+        && props.containsKey(CommonJobProperties.FLOW_ID)) {
+      keysAndValues[keys.length] = "workflowid:"
+          + props.get(CommonJobProperties.PROJECT_NAME)
+          + HadoopConfigurationInjector.WORKFLOW_ID_SEPERATOR
+          + props.get(CommonJobProperties.FLOW_ID);
     }
     Joiner joiner = Joiner.on(',').skipNulls();
     return joiner.join(keysAndValues);

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestAbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestAbstractHadoopJavaProcessJob.java
@@ -1,0 +1,64 @@
+package azkaban.jobtype;
+
+import azkaban.flow.CommonJobProperties;
+import azkaban.utils.Props;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+public class TestAbstractHadoopJavaProcessJob {
+
+  @BeforeClass
+  public static void setUpClass() {
+    azkaban.test.Utils.initServiceProvider();
+  }
+
+  @Test
+  public void testWorkflowIdTag() {
+    Props props = new Props();
+    props.put(CommonJobProperties.EXEC_ID, "123");
+    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
+    props.put(CommonJobProperties.FLOW_ID, "flow-id");
+    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test", new Props(), props, null) {};
+    job.setupHadoopJobProperties();
+    assertThat(job.getJobProps().get(HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS))
+        .isEqualTo("azkaban.flow.execid:123,azkaban.flow.flowid:flow-id"
+            + ",azkaban.flow.projectname:project-name,workflowid:project-name$flow-id");
+  }
+
+  @Test
+  public void testLongWorkflowIdTag() {
+    Props props = new Props();
+    StringBuffer flowIdBuffer = new StringBuffer("flow-id");
+    for (int i = 0; i < 150; i++) {
+      flowIdBuffer.append("f");
+    }
+    props.put(CommonJobProperties.EXEC_ID, "123");
+    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
+    props.put(CommonJobProperties.FLOW_ID, flowIdBuffer.toString());
+    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test2", new Props(), props, null) {};
+    job.setupHadoopJobProperties();
+    String[] actualTags = job.getJobProps().get(
+        HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS)
+        .split(",");
+    assertThat(actualTags.length).isEqualTo(4);
+    assertThat(actualTags[0]).isEqualTo("azkaban.flow.execid:123");
+    String flowPrefix = "azkaban.flow.flowid:flow-id";
+    StringBuffer expectedFlowTagBuffer = new StringBuffer(flowPrefix);
+    for (int i = flowPrefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
+      expectedFlowTagBuffer.append("f");
+    }
+    assertThat(actualTags[1]).isEqualTo(expectedFlowTagBuffer.toString());
+    assertThat(actualTags[2]).isEqualTo("azkaban.flow.projectname:project-name");
+    assertThat(actualTags[3].length()).isLessThanOrEqualTo(HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH);
+    String workflowPrefix = "workflowid:project-name$flow-id";
+    StringBuffer expectedTagBuffer = new StringBuffer();
+    expectedTagBuffer.append(workflowPrefix);
+    for (int i = workflowPrefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
+      expectedTagBuffer.append("f");
+    }
+    assertThat(actualTags[3]).isEqualTo(expectedTagBuffer.toString());
+  }
+}

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
@@ -2,6 +2,7 @@ package azkaban.jobtype;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
 import org.junit.Before;
@@ -46,5 +47,16 @@ public class TestHadoopJobUtilsConstructHadoopTags {
     String[] tags = new String[] { tag0, tag1, tag2 };
     assertThat(HadoopJobUtils.constructHadoopTags(props, tags))
         .isEqualTo("tag0:val0,tag2:val2");
+  }
+
+  @Test
+  public void testWorkflowIdTag() {
+    String tag0 = "tag0";
+    props.put(tag0, "val0");
+    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
+    props.put(CommonJobProperties.FLOW_ID, "flow-id");
+    String[] tags = new String[] { tag0 };
+    assertThat(HadoopJobUtils.constructHadoopTags(props, tags))
+        .isEqualTo("tag0:val0,workflowid:project-name$flow-id");
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
@@ -2,10 +2,8 @@ package azkaban.jobtype;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
-import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,39 +46,5 @@ public class TestHadoopJobUtilsConstructHadoopTags {
     String[] tags = new String[] { tag0, tag1, tag2 };
     assertThat(HadoopJobUtils.constructHadoopTags(props, tags))
         .isEqualTo("tag0:val0,tag2:val2");
-  }
-
-  @Test
-  public void testWorkflowIdTag() {
-    String tag0 = "tag0";
-    props.put(tag0, "val0");
-    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
-    props.put(CommonJobProperties.FLOW_ID, "flow-id");
-    String[] tags = new String[] { tag0 };
-    assertThat(HadoopJobUtils.constructHadoopTags(props, tags))
-        .isEqualTo("tag0:val0,workflowid:project-name$flow-id");
-  }
-
-  @Test
-  public void testLongWorkflowIdTag() {
-    String tag0 = "tag0";
-    props.put(tag0, "val0");
-    StringBuffer flowIdBuffer = new StringBuffer(150);
-    for (int i = 0; i < 150; i++) {
-      flowIdBuffer.append("f");
-    }
-    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
-    props.put(CommonJobProperties.FLOW_ID, flowIdBuffer.toString());
-    String[] tags = new String[] { tag0 };
-    String[] actualTags = HadoopJobUtils.constructHadoopTags(props, tags).split(",");
-    assertThat(actualTags[0]).isEqualTo("tag0:val0");
-    assertThat(actualTags[1].length()).isLessThanOrEqualTo(HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH);
-    String prefix = "workflowid:project-name$";
-    StringBuffer expectedTagBuffer = new StringBuffer();
-    expectedTagBuffer.append(prefix);
-    for (int i = prefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
-      expectedTagBuffer.append("f");
-    }
-    assertThat(actualTags[1]).isEqualTo(expectedTagBuffer.toString());
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
@@ -74,13 +74,13 @@ public class TestHadoopJobUtilsConstructHadoopTags {
     String[] tags = new String[] { tag0 };
     String[] actualTags = HadoopJobUtils.constructHadoopTags(props, tags).split(",");
     assertThat(actualTags[0]).isEqualTo("tag0:val0");
-    assertThat(actualTags[1].length() <= HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH);
+    assertThat(actualTags[1].length()).isLessThanOrEqualTo(HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH);
     String prefix = "workflowid:project-name$";
     StringBuffer expectedTagBuffer = new StringBuffer();
     expectedTagBuffer.append(prefix);
     for (int i = prefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
       expectedTagBuffer.append("f");
     }
-    assertThat(actualTags[1].equals(expectedTagBuffer));
+    assertThat(actualTags[1]).isEqualTo(expectedTagBuffer);
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
 
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,5 +59,28 @@ public class TestHadoopJobUtilsConstructHadoopTags {
     String[] tags = new String[] { tag0 };
     assertThat(HadoopJobUtils.constructHadoopTags(props, tags))
         .isEqualTo("tag0:val0,workflowid:project-name$flow-id");
+  }
+
+  @Test
+  public void testLongWorkflowIdTag() {
+    String tag0 = "tag0";
+    props.put(tag0, "val0");
+    StringBuffer flowIdBuffer = new StringBuffer(150);
+    for (int i = 0; i < 150; i++) {
+      flowIdBuffer.append("f");
+    }
+    props.put(CommonJobProperties.PROJECT_NAME, "project-name");
+    props.put(CommonJobProperties.FLOW_ID, flowIdBuffer.toString());
+    String[] tags = new String[] { tag0 };
+    String[] actualTags = HadoopJobUtils.constructHadoopTags(props, tags).split(",");
+    assertThat(actualTags[0]).isEqualTo("tag0:val0");
+    assertThat(actualTags[1].length() <= HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH);
+    String prefix = "workflowid:project-name$";
+    StringBuffer expectedTagBuffer = new StringBuffer();
+    expectedTagBuffer.append(prefix);
+    for (int i = prefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
+      expectedTagBuffer.append("f");
+    }
+    assertThat(actualTags[1].equals(expectedTagBuffer));
   }
 }

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestHadoopJobUtilsConstructHadoopTags.java
@@ -81,6 +81,6 @@ public class TestHadoopJobUtilsConstructHadoopTags {
     for (int i = prefix.length(); i < HadoopJobUtils.APPLICATION_TAG_MAX_LENGTH; i++) {
       expectedTagBuffer.append("f");
     }
-    assertThat(actualTags[1]).isEqualTo(expectedTagBuffer);
+    assertThat(actualTags[1]).isEqualTo(expectedTagBuffer.toString());
   }
 }


### PR DESCRIPTION
This is in preparation for Hadoop 2.10.0 upgrade - mechanism for passing workflow id from azkaban to Hadoop was changed (see YARN-9760). Now it uses yarn tags.