### PR TITLE
Use Logger.class instead of class of input logger which is native to HadoopJavaJobRunnerMain only.

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -343,7 +343,7 @@ public class HadoopJavaJobRunnerMain {
           + " was not found. Cannot run job.");
     }
 
-    Class<?> loggerClass = logger.getClass();
+    Class<?> loggerClass = Logger.class;
     Class<?> propsClass = null;
     for (String propClassName : PROPS_CLASSES) {
       try {


### PR DESCRIPTION
Use Logger.class instead of class of input logger which is native to HadoopJavaJobRunnerMain only.
This change is required to support jobtype constructors of type,
<String, Props, Props, Logger>