### PR TITLE
[Logging] Fixed the md5 hash non-printable characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,14 @@ vendor/
 **/velocity.log
 docs/_build/
 
+executor.port
+
 # local & temp directories are ignored so that they can be used to store temporary files such as local testing configurations.
 local/
 temp/
+conf/
+projects/
+LOCAL_STORAGE/
 
 # Intellij files
 .idea
@@ -27,7 +32,6 @@ temp/
 .shelf
 # Intellij default build output directory
 out/
-
 currentpid
 
 # direnv files see https://github.com/direnv/direnv

--- a/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
+++ b/azkaban-common/src/main/java/azkaban/storage/StorageManager.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import javax.inject.Inject;
@@ -191,8 +190,8 @@ public class StorageManager {
     checkState(Arrays.equals(pfh.getMd5Hash(), hash),
         String.format("MD5 HASH Failed. project ID: %d version: %d Expected: %s Actual: %s",
             pfh.getProjectId(), pfh.getVersion(),
-            new String(pfh.getMd5Hash(), StandardCharsets.UTF_8),
-            new String(hash, StandardCharsets.UTF_8))
+            Arrays.toString(pfh.getMd5Hash()),
+            Arrays.toString(hash))
     );
   }
 


### PR DESCRIPTION
Modified the md5 hash to print the Array of numbers instead of the non-printable characters when there is a mismatch. 

Added few files that are generated locally in the gitignore.

How to test in local?

set the property azkaban.storage.type=LOCAL in the azkaban.properties. This enabled the zip to be stored in LOCAL file system. After that deliberately added few bytes in the validateCheckSum `hash`. When I ran a flow, it failed with IllegalStateException indicating the mismatch between the hashes. 

The flow went through fine when there is a match in the md5 hashes.