### PR TITLE
Revert "Adding Job Name and Submit user to the job metadata"

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -55,9 +55,7 @@ public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implem
     String[] tagKeys = new String[]{
         CommonJobProperties.EXEC_ID,
         CommonJobProperties.FLOW_ID,
-        CommonJobProperties.PROJECT_NAME,
-        CommonJobProperties.JOB_ID,
-        CommonJobProperties.SUBMIT_USER
+        CommonJobProperties.PROJECT_NAME
     };
     getJobProps().put(
         HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS,


### PR DESCRIPTION
Reverts azkaban/azkaban#2352

YARN currently does not support configurable tag length. (YARN-9954) azkaban job type name could potentially be very long, which will cause app submission to YARN to fail. Hence reverting the change.