### PR TITLE
Add credentials to hadoop UGI if hadoop security is not enabled.

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -18,6 +18,7 @@ package azkaban.jobtype;
 import static azkaban.security.commons.SecurityUtils.MAPREDUCE_JOB_CREDENTIALS_BINARY;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
+import azkaban.Constants;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -148,8 +149,13 @@ public class HadoopJavaJobRunnerMain {
           for (Token<?> token : loginUser.getTokens()) {
             proxyUser.addToken(token);
           }
+          proxyUser.addCredentials(loginUser.getCredentials());
         } else {
           proxyUser = UserGroupInformation.createRemoteUser(userToProxy);
+
+          if (props.getProperty(Constants.JobProperties.ENABLE_OAUTH, "false").equals("true")) {
+            proxyUser.addCredentials(UserGroupInformation.getLoginUser().getCredentials());
+          }
         }
         _logger.info("Proxied as user " + userToProxy);
       }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -15,6 +15,7 @@
  */
 package azkaban.jobtype;
 
+import azkaban.Constants;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -108,6 +109,10 @@ public class HadoopSecureWrapperUtils {
         log.info("security enabled, proxying as user " + userToProxy);
       } else {
         proxyUser = UserGroupInformation.createRemoteUser(userToProxy);
+        if (jobProps.getProperty(Constants.JobProperties.ENABLE_OAUTH, "false").equals("true")) {
+          proxyUser.addCredentials(UserGroupInformation.getLoginUser().getCredentials());
+        }
+
         log.info("security not enabled, proxying as user " + userToProxy);
       }
     } catch (IOException e) {


### PR DESCRIPTION
If hadoop security is off, hadoop proxy user needs OAuth token being available in its UGI credentials. This is to make sure that ABFS(Azure blob file system) driver can still get the token to access azure storage.