### PR TITLE
Propagate plugin's private properties which use HadoopJavaJob so that they can be accessed by plugin code.

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -37,6 +37,12 @@ public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implem
     this.hadoopProxy = new HadoopProxy(sysProps, jobProps, logger);
   }
 
+  public AbstractHadoopJavaProcessJob(String jobid, Props sysProps, Props jobProps,
+      Props privateProps, Logger logger) {
+    super(jobid, sysProps, jobProps, privateProps, logger);
+    this.hadoopProxy = new HadoopProxy(sysProps, jobProps, logger);
+  }
+
   @Override
   public void run() throws Exception {
     try {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJob.java
@@ -44,6 +44,14 @@ public class HadoopJavaJob extends AbstractHadoopJavaProcessJob {
     noUserClasspath = getSysProps().getBoolean("azkaban.no.user.classpath", false);
   }
 
+  public HadoopJavaJob(String jobid, Props sysProps, Props jobProps,
+      Props privateProps, Logger log)
+      throws RuntimeException {
+    super(jobid, sysProps, jobProps, privateProps, log);
+    getJobProps().put(CommonJobProperties.JOB_ID, jobid);
+    noUserClasspath = getSysProps().getBoolean("azkaban.no.user.classpath", false);
+  }
+
   @Override
   protected String getJVMArguments() {
     String args = super.getJVMArguments();

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
@@ -51,6 +51,11 @@ public class JavaProcessJob extends ProcessJob {
     super(jobid, sysProps, jobProps, logger);
   }
 
+  public JavaProcessJob(final String jobid, final Props sysProps, final Props jobProps,
+      final Props privateProps, final Logger logger) {
+    super(jobid, sysProps, jobProps, privateProps, logger);
+  }
+
   @Override
   protected List<String> getCommandList() {
     final ArrayList<String> list = new ArrayList<>();

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -76,6 +76,13 @@ public class ProcessJob extends AbstractProcessJob {
     this.commonMetrics = SERVICE_PROVIDER.getInstance(CommonMetrics.class);
   }
 
+  public ProcessJob(final String jobId, final Props sysProps,
+      final Props jobProps, final Props privateProps, final Logger log) {
+    super(jobId, sysProps, jobProps, privateProps, log);
+    // TODO: reallocf fully guicify CommonMetrics through ProcessJob dependents
+    this.commonMetrics = SERVICE_PROVIDER.getInstance(CommonMetrics.class);
+  }
+
   /**
    * Splits the command into a unix like command line structure. Quotes and single quotes are
    * treated as nested strings.
@@ -248,10 +255,10 @@ public class ProcessJob extends AbstractProcessJob {
         assignUserFileOwnership(effectiveUser, getWorkingDirectory());
       }
       // Set property file permissions to <uid>:azkaban so user can write to their prop files
-      // in order to pass properties from one job to another
-      for (final File propFile : propFiles) {
+      // in order to pass properties from one job to another, except the last one
+      for (int i = 0; i < 2; i++) {
         info("Changing properties files ownership");
-        assignUserFileOwnership(effectiveUser, propFile.getAbsolutePath());
+        assignUserFileOwnership(effectiveUser, propFiles[i].getAbsolutePath());
       }
     }
 

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypePluginSet.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypePluginSet.java
@@ -34,6 +34,7 @@ public class JobTypePluginSet {
   private final Map<String, Class<? extends Job>> jobToClass;
   private final Map<String, Props> pluginJobPropsMap;
   private final Map<String, Props> pluginLoadPropsMap;
+  private final Map<String, Props> pluginPrivatePropsMap;
 
   private Props commonJobProps;
   private Props commonLoadProps;
@@ -45,6 +46,7 @@ public class JobTypePluginSet {
     this.jobToClass = new HashMap<>();
     this.pluginJobPropsMap = new HashMap<>();
     this.pluginLoadPropsMap = new HashMap<>();
+    this.pluginPrivatePropsMap = new HashMap<>();
   }
 
   /**
@@ -54,6 +56,7 @@ public class JobTypePluginSet {
     this.jobToClass = new HashMap<>(clone.jobToClass);
     this.pluginJobPropsMap = new HashMap<>(clone.pluginJobPropsMap);
     this.pluginLoadPropsMap = new HashMap<>(clone.pluginLoadPropsMap);
+    this.pluginPrivatePropsMap = new HashMap<>(clone.pluginPrivatePropsMap);
     this.commonJobProps = clone.commonJobProps;
     this.commonLoadProps = clone.commonLoadProps;
   }
@@ -94,6 +97,12 @@ public class JobTypePluginSet {
   }
 
   /**
+   * Get the plugin private properties for the jobtype
+   */
+  public Props getPluginPrivateProps(final String jobTypeName) {
+    return this.pluginPrivatePropsMap.get(jobTypeName);
+  }
+  /**
    * Get the properties that will be given to the plugin as default job properties.
    */
   public Props getPluginJobProps(final String jobTypeName) {
@@ -127,5 +136,12 @@ public class JobTypePluginSet {
    */
   public void addPluginLoadProps(final String jobTypeName, final Props props) {
     this.pluginLoadPropsMap.put(jobTypeName, props);
+  }
+
+  /**
+   * Adds plugins private properties used by the plugin
+   */
+  public void addPluginPrivateProps(final String jobTypeName, final Props props) {
+    this.pluginPrivatePropsMap.put(jobTypeName, props);
   }
 }


### PR DESCRIPTION
Propagate plugin's private properties which use HadoopJavaJob so that they can be accessed by plugin code.
This involves changes to the HadoopJavaJob to add 1 more parameter for private props which propagates all the way to AbstractProcessJob.java.

Added util functions to access this privateProp from JobTypePluginSet in JobTypeManager.
Did some code cleanup and refactoring HadoopJavaJobRunnerMain:getMethod()