### PR TITLE
Implemented conditions support for properties-based projects

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -17,6 +17,7 @@
 package azkaban.project;
 
 import azkaban.flow.CommonJobProperties;
+import azkaban.flow.ConditionOnJobStatus;
 import azkaban.flow.Edge;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowProps;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,8 +189,13 @@ public class DirectoryFlowLoader implements FlowLoader {
             if (type == null) {
               this.errors.add("Job doesn't have type set '" + jobName + "'.");
             }
-
             node.setType(type);
+
+            String condition = prop.getString("condition", null);
+            if (null != condition && !condition.isEmpty()) {
+              logger.info(String.format("Setting condition %s for job %s", condition, jobName));
+              node.setCondition(condition);
+            }
 
             node.setJobSource(relative);
             if (parent != null) {
@@ -210,6 +217,7 @@ public class DirectoryFlowLoader implements FlowLoader {
       }
     }
 
+    validateConditions();
     for (final File file : dir.listFiles(new DirFilter())) {
       loadProjectFromDir(base, file, parent);
     }
@@ -342,6 +350,7 @@ public class DirectoryFlowLoader implements FlowLoader {
     visitedEver.add(node.getId());
 
     flow.addNode(node);
+    flow.setCondition(node.getCondition());
     if (SpecialJobTypes.EMBEDDED_FLOW_TYPE.equals(node.getType())) {
       final Props props = this.jobPropsMap.get(node.getId());
       final String embeddedFlow = props.get(SpecialJobTypes.FLOW_NAME);
@@ -392,4 +401,64 @@ public class DirectoryFlowLoader implements FlowLoader {
   private String getRelativeFilePath(final String basePath, final String filePath) {
     return filePath.substring(basePath.length() + 1);
   }
+
+
+  private void validateConditions() {
+    nodeMap.forEach((name, node) -> {
+      String condition = node.getCondition();
+      boolean foundConditionOnJobStatus = false;
+      if (condition == null) {
+        return;
+      }
+      // First, remove all the whitespaces and parenthesis ().
+      final String replacedCondition = condition.replaceAll("\\s+|\\(|\\)", "");
+      // Second, split the condition by operators &&, ||, ==, !=, >, >=, <, <=
+      final String[] operands = replacedCondition
+          .split(DirectoryYamlFlowLoader.VALID_CONDITION_OPERATORS);
+      // Third, check whether all the operands are valid: only conditionOnJobStatus macros, numbers,
+      // strings, and variable substitution ${jobName:param} are allowed.
+      for (int i = 0; i < operands.length; i++) {
+        final Matcher matcher = DirectoryYamlFlowLoader.CONDITION_ON_JOB_STATUS_PATTERN
+            .matcher(operands[i]);
+        if (matcher.matches()) {
+          this.logger.info("Operand " + operands[i] + " is a condition on job status.");
+          if (foundConditionOnJobStatus) {
+            this.errors.add("Invalid condition for " + node.getId()
+                + ": cannot combine more than one conditionOnJobStatus macros.");
+          }
+          foundConditionOnJobStatus = true;
+          node.setConditionOnJobStatus(ConditionOnJobStatus.fromString(matcher.group(1)));
+        } else {
+          if (operands[i].startsWith("!")) {
+            // Remove the operator '!' from the operand.
+            operands[i] = operands[i].substring(1);
+          }
+          if (operands[i].equals("")) {
+            this.errors
+                .add("Invalid condition fo" +
+                    " " + node.getId() + ": operand is an empty string.");
+          } else if (!DirectoryYamlFlowLoader.DIGIT_STRING_PATTERN.matcher(operands[i]).matches()) {
+            validateVariableSubstitution(operands[i], name);
+          }
+        }
+      }
+    });
+  }
+
+  private void validateVariableSubstitution(final String operand, String name) {
+    final Matcher matcher = DirectoryYamlFlowLoader.CONDITION_VARIABLE_REPLACEMENT_PATTERN
+        .matcher(operand);
+    if (matcher.matches()) {
+      final String jobName = matcher.group(1);
+      final Node conditionNode = nodeMap.get(jobName);
+      if (conditionNode == null) {
+        this.errors.add("Invalid condition for " + name + ": " + jobName
+            + " doesn't exist in the flow.");
+      }
+    } else {
+      this.errors.add("Invalid condition for " + name
+          + ": cannot resolve the condition. Please check the syntax for supported conditions.");
+    }
+  }
+
 }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -51,12 +51,11 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   // Pattern to match conditionOnJobStatus macros, e.g. one_success, all_done
   public static final Pattern CONDITION_ON_JOB_STATUS_PATTERN =
       Pattern.compile("(?i)\\b(" + StringUtils.join(ConditionOnJobStatus.values(), "|") + ")\\b");
-  private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoader.class);
   // Pattern to match a number or a string, e.g. 1234, "hello", 'foo'
-  private static final Pattern DIGIT_STRING_PATTERN = Pattern.compile("\\d+|'.*'|\".*\"");
+  public static final Pattern DIGIT_STRING_PATTERN = Pattern.compile("\\d+|'.*'|\".*\"");
   // Valid operators in condition expressions: &&, ||, ==, !=, >, >=, <, <=
-  private static final String VALID_CONDITION_OPERATORS = "&&|\\|\\||==|!=|>|>=|<|<=";
-
+  public static final String VALID_CONDITION_OPERATORS = "&&|\\|\\||==|!=|>|>=|<|<=";
+  private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoader.class);
   private final Props props;
   private final Set<String> errors = new HashSet<>();
   private final Map<String, Flow> flowMap = new HashMap<>();

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
@@ -16,6 +16,9 @@
 
 package azkaban.project;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import azkaban.flow.Flow;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.Props;
 import com.google.common.io.Files;
@@ -89,6 +92,24 @@ public class DirectoryFlowLoaderTest {
     Assert.assertEquals(2, loader.getFlowMap().size());
     Assert.assertEquals(0, loader.getPropsList().size());
     Assert.assertEquals(9, loader.getJobPropsMap().size());
+  }
+
+  @Test
+  public void testFlowWithValidCondition() {
+    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props());
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir("conditionalflowtest"));
+    String flowName = "jobD";
+    assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();
+    assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();
+    final Flow flow = loader.getFlowMap().get(flowName);
+    assertThat(flow.getNodes().size()).isEqualTo(4);
+    assertThat(flow.getAllFlowProps().size()).isEqualTo(0);
+    assertThat(flow.getEdges().size()).isEqualTo(4);
+    assertThat(flow.getNode("jobA").getCondition()).isNull();
+    assertThat(flow.getNode("jobB").getCondition()).isEqualTo("${jobA:props} == 'foo'");
+    assertThat(flow.getNode("jobC").getCondition()).isEqualTo("${jobA:props} == 'bar'");
+    assertThat(flow.getNode("jobD").getCondition())
+        .isEqualTo("one_success && ${jobA:props} == 'foo'");
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryFlowLoaderTest.java
@@ -95,24 +95,6 @@ public class DirectoryFlowLoaderTest {
   }
 
   @Test
-  public void testFlowWithValidCondition() {
-    final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props());
-    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir("conditionalflowtest"));
-    String flowName = "jobD";
-    assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();
-    assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();
-    final Flow flow = loader.getFlowMap().get(flowName);
-    assertThat(flow.getNodes().size()).isEqualTo(4);
-    assertThat(flow.getAllFlowProps().size()).isEqualTo(0);
-    assertThat(flow.getEdges().size()).isEqualTo(4);
-    assertThat(flow.getNode("jobA").getCondition()).isNull();
-    assertThat(flow.getNode("jobB").getCondition()).isEqualTo("${jobA:props} == 'foo'");
-    assertThat(flow.getNode("jobC").getCondition()).isEqualTo("${jobA:props} == 'bar'");
-    assertThat(flow.getNode("jobD").getCondition())
-        .isEqualTo("one_success && ${jobA:props} == 'foo'");
-  }
-
-  @Test
   public void testRecursiveLoadEmbeddedFlow() {
     final DirectoryFlowLoader loader = new DirectoryFlowLoader(new Props());
 

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -31,9 +31,10 @@ import org.slf4j.LoggerFactory;
 
 public class DirectoryYamlFlowLoaderTest {
 
+  public static final String CONDITION_YAML_DIR = "conditionalflowyamltest";
+  public static final String CONDITIONAL_FLOW = "conditional_flow6";
   private static final Logger logger = LoggerFactory.getLogger(DirectoryYamlFlowLoaderTest
       .class);
-
   private static final String BASIC_FLOW_YAML_DIR = "basicflowyamltest";
   private static final String MULTIPLE_FLOW_YAML_DIR = "multipleflowyamltest";
   private static final String RECURSIVE_DIRECTORY_FLOW_YAML_DIR = "recursivedirectoryyamltest";
@@ -44,7 +45,6 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String DEPENDENCY_UNDEFINED_YAML_DIR = "dependencyundefinedyamltest";
   private static final String INVALID_JOBPROPS_YAML_DIR = "invalidjobpropsyamltest";
   private static final String NO_FLOW_YAML_DIR = "noflowyamltest";
-  private static final String CONDITION_YAML_DIR = "conditionalflowyamltest";
   private static final String INVALID_CONDITION_YAML_DIR = "invalidconditionalflowyamltest";
   private static final String BASIC_FLOW_1 = "basic_flow";
   private static final String BASIC_FLOW_2 = "basic_flow2";
@@ -60,7 +60,6 @@ public class DirectoryYamlFlowLoaderTest {
   private static final String EMBEDDED_FLOW_B2 =
       "embedded_flow_b" + Constants.PATH_DELIMITER + "embedded_flow1" + Constants.PATH_DELIMITER
           + "embedded_flow2";
-  private static final String CONDITIONAL_FLOW = "conditional_flow6";
   private static final String DUPLICATE_NODENAME_FLOW_FILE = "duplicate_nodename.flow";
   private static final String DEPENDENCY_UNDEFINED_FLOW_FILE = "dependency_undefined.flow";
   private static final String CYCLE_FOUND_FLOW = "cycle_found";
@@ -211,7 +210,7 @@ public class DirectoryYamlFlowLoaderTest {
     assertThat(loader.getEdgeMap().size()).isEqualTo(numEdgeMap);
   }
 
-  private void checkFlowProperties(final DirectoryYamlFlowLoader loader, final String flowName,
+  public void checkFlowProperties(final DirectoryYamlFlowLoader loader, final String flowName,
       final int numError, final int numNode, final int numFlowProps, final int numEdge, final
   String edgeError) {
     assertThat(loader.getFlowMap().containsKey(flowName)).isTrue();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.execapp;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.InteractiveTestJob;
+import azkaban.executor.Status;
+import azkaban.project.Project;
+import azkaban.test.executions.ExecutionsTestUtil;
+import azkaban.utils.Props;
+import java.io.File;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class FlowRunnerConditionalJobsTest extends FlowRunnerTestBase {
+
+  private static final String FLOW_DIR = "conditionalflowtest";
+  private static final String CONDITIONAL_FLOW_1 = "conditional_flow1";
+  private static final String CONDITIONAL_FLOW_2 = "conditional_flow2";
+  private static final String CONDITIONAL_FLOW_3 = "conditional_flow3";
+  private static final String CONDITIONAL_FLOW_4 = "conditional_flow4";
+  private static final String CONDITIONAL_FLOW_5 = "conditional_flow5";
+  private static final String CONDITIONAL_FLOW_6 = "conditional_flow6";
+  private static final String CONDITIONAL_FLOW_7 = "conditional_flow7";
+  private FlowRunnerTestUtil testUtil;
+  private Project project;
+
+
+  @Ignore
+  @Test
+  public void runFlowOnJobPropsCondition() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    flowProps.put("azkaban.server.name", "foo");
+    setUp(CONDITIONAL_FLOW_1, flowProps, "jobD");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.CANCELLED);
+    assertFlowStatus(flow, Status.KILLED);
+  }
+
+  @Test
+  public void runFlowOnJobOutputCondition() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_2, flowProps, "jobD");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.RUNNING);
+    final Props generatedProperties = new Props();
+    generatedProperties.put("key1", "value1");
+    generatedProperties.put("key2", "value2");
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_2 + ":") + "jobA").succeedJob(generatedProperties);
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.CANCELLED);
+    assertFlowStatus(flow, Status.KILLED);
+  }
+
+  @Test
+  public void runFlowOnJobStatusAllFailed() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_4, flowProps, "jobC");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_4 + ":") + "jobA").failJob();
+    assertStatus(flow, "jobA", Status.FAILED);
+    assertStatus(flow, "jobB", Status.RUNNING);
+    assertStatus(flow, "jobC", Status.READY);
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_4 + ":") + "jobB").failJob();
+    assertStatus(flow, "jobB", Status.FAILED);
+    assertStatus(flow, "jobC", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
+  @Test
+  public void runFlowOnJobStatusOneSuccess() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_5, flowProps, "jobC");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_5 + ":") + "jobA").succeedJob();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.RUNNING);
+    assertStatus(flow, "jobC", Status.READY);
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_5 + ":") + "jobB").failJob();
+    assertStatus(flow, "jobB", Status.FAILED);
+    assertStatus(flow, "jobC", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
+  @Test
+  public void runFlowOnBothJobStatusAndPropsCondition() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_6, flowProps, "jobD");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    final Props generatedProperties = new Props();
+    generatedProperties.put("props", "foo");
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_6 + ":") + "jobA").succeedJob(generatedProperties);
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
+  @Test
+  public void runFlowOnJobStatusConditionNull() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_3, flowProps, "jobC");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    flow.getExecutableNode("jobC").setConditionOnJobStatus(null);
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_3 + ":") + "jobA").succeedJob();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_3 + ":") + "jobB").succeedJob();
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
+  /**
+   * JobB has defined "condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var
+   * f = new File('new'); f.createNewFile(); }"
+   * Null ProtectionDomain will restrict this arbitrary code from creating a new file.
+   * However it will not kick in when the change for condition whitelisting is implemented.
+   * As a result, this test case will be ignored.
+   *
+   * @throws Exception the exception
+   */
+  @Ignore
+  @Test
+  public void runFlowOnArbitraryCondition() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_7, flowProps, "jobD");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.CANCELLED);
+    assertFlowStatus(flow, Status.KILLED);
+    // The arbitrary code should be restricted from creating a new file.
+    final File file = new File("new.txt");
+    Assert.assertFalse(file.exists());
+  }
+
+  private void setUp(final String flowName, final HashMap<String, String> flowProps, String rootJob)
+      throws Exception {
+    String dir = FLOW_DIR + "/" + flowName;
+    this.testUtil = new FlowRunnerTestUtil(dir, this.temporaryFolder);
+    if (System.getSecurityManager() == null) {
+      Policy.setPolicy(new Policy() {
+        @Override
+        public boolean implies(final ProtectionDomain domain, final Permission permission) {
+          return true; // allow all
+        }
+      });
+      System.setSecurityManager(new SecurityManager());
+    }
+
+    this.project = this.testUtil.getProject();
+    for (String job : Arrays.asList("jobA", "jobB", "jobC", "jobD")) {
+      final String jobFile = job + ".job";
+      when(this.testUtil.getProjectLoader()
+          .getLatestFlowVersion(
+              this.project.getId(),
+              this.project.getVersion(),
+              jobFile
+          ))
+          .thenReturn(1);
+      when(this.testUtil.getProjectLoader()
+          .getUploadedFlowFile(
+              eq(this.project.getId()),
+              eq(this.project.getVersion()),
+              eq(jobFile),
+              eq(1),
+              any(File.class)
+          ))
+          .thenReturn(ExecutionsTestUtil.getFlowFile(dir, jobFile));
+    }
+    this.runner = this.testUtil.createFromFlowMap(rootJob, flowName);
+    FlowRunnerTestUtil.startThread(this.runner);
+  }
+}

--- a/test/execution-test-data/conditionalflowtest/conditional_flow1/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow1/jobA.job
@@ -1,0 +1,3 @@
+type=test
+fail=false
+seconds=0

--- a/test/execution-test-data/conditionalflowtest/conditional_flow1/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow1/jobB.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:azkaban.server.name} == 'foo'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow1/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow1/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:azkaban.server.name} == 'bar'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow1/jobD.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow1/jobD.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:azkaban.server.name} == 'foo'
+dependencies=jobB,jobC

--- a/test/execution-test-data/conditionalflowtest/conditional_flow2/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow2/jobA.job
@@ -1,0 +1,2 @@
+type=test
+fail=false

--- a/test/execution-test-data/conditionalflowtest/conditional_flow2/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow2/jobB.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:key1} == 'value1'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow2/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow2/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:key3} == 'value3'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow2/jobD.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow2/jobD.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:key2} == 'value2'
+dependencies=jobB,jobC

--- a/test/execution-test-data/conditionalflowtest/conditional_flow3/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow3/jobA.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow3/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow3/jobB.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow3/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow3/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=one_failed
+dependencies=jobA,jobB

--- a/test/execution-test-data/conditionalflowtest/conditional_flow4/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow4/jobA.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow4/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow4/jobB.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow4/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow4/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=all_failed
+dependencies=jobA,jobB

--- a/test/execution-test-data/conditionalflowtest/conditional_flow5/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow5/jobA.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow5/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow5/jobB.job
@@ -1,0 +1,1 @@
+type=test

--- a/test/execution-test-data/conditionalflowtest/conditional_flow5/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow5/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=one_success
+dependencies=jobA,jobB

--- a/test/execution-test-data/conditionalflowtest/conditional_flow6/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow6/jobA.job
@@ -1,0 +1,2 @@
+type=test
+seconds=0

--- a/test/execution-test-data/conditionalflowtest/conditional_flow6/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow6/jobB.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:props} == 'foo'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow6/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow6/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:props} == 'bar'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow6/jobD.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow6/jobD.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=one_success && ${jobA:props} == 'foo'
+dependencies=jobB,jobC


### PR DESCRIPTION
Existing conditional properties in the model simply needed to be set when parsing a properties file. The validation code is copied based closely on the yaml version. Added test cases and test jobs to demonstrate conditional handling.