### PR TITLE
Fix project upload failure recovery

### DIFF
--- a/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
+++ b/azkaban-common/src/test/java/azkaban/ServiceProviderTest.java
@@ -108,7 +108,7 @@ public class ServiceProviderTest {
     props.put("database.type", "h2");
     props.put("h2.path", "h2");
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_TYPE, AZKABAN_TEST_HDFS_STORAGE_TYPE);
-    props.put(Constants.ConfigurationKeys.HADOOP_CONF_DIR_PATH, "./");
+    props.put(Constants.ConfigurationKeys.HADOOP_CONF_DIR_PATH, "./src/test/resources/hdfs_conf/");
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_HDFS_PROJECT_ROOT_URI, AZKABAN_TEST_STORAGE_PROJECT_HDFS_URI);
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_CACHE_DEPENDENCY_ROOT_URI, AZKABAN_TEST_STORAGE_DEPENDENCY_HDFS_URI);
     props.put(Constants.ConfigurationKeys.AZKABAN_STORAGE_ORIGIN_DEPENDENCY_ROOT_URI, AZKABAN_TEST_STORAGE_CHTTP_DEPENDENCY_ROOT_URI);

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -26,7 +26,9 @@ import java.io.File;
 import java.net.URI;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,7 +45,7 @@ public class HdfsStorageTest {
 
   private HdfsAuth hdfsAuth;
   private HdfsStorage hdfsStorage;
-  private FileSystem hdfs;
+  private DistributedFileSystem hdfs;
   private FileSystem http;
   private AzkabanCommonModuleConfig config;
 
@@ -55,7 +57,7 @@ public class HdfsStorageTest {
 
   @Before
   public void setUp() throws Exception {
-    this.hdfs = mock(FileSystem.class);
+    this.hdfs = mock(DistributedFileSystem.class);
     this.http = mock(FileSystem.class);
     this.hdfsAuth = mock(HdfsAuth.class);
     this.config = mock(AzkabanCommonModuleConfig.class);
@@ -110,7 +112,8 @@ public class HdfsStorageTest {
     Assert.assertEquals(expectedName, key);
 
     final String expectedPath = "/path/to/prj/" + expectedName;
-    verify(this.hdfs).copyFromLocalFile(new Path(file.getAbsolutePath()), new Path(expectedPath));
+    verify(this.hdfs).copyFromLocalFile(eq(false), eq(true), any(Path.class), any(Path.class));
+    verify(this.hdfs).rename(any(Path.class), eq(new Path(expectedPath)), eq(Options.Rename.OVERWRITE));
   }
 
   @Test

--- a/azkaban-common/src/test/resources/hdfs_conf/hdfs-site.xml
+++ b/azkaban-common/src/test/resources/hdfs_conf/hdfs-site.xml
@@ -1,0 +1,6 @@
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://test.com:9000</value>
+  </property>
+</configuration>


### PR DESCRIPTION
Originally if a project upload failed, the corrupted zip may still be left in HDFS with the finalized name. Then, future uploads will see that the zip already exists and skip uploading it and go ahead and create a new version associated with that zip (causing problems with execution).

Now, we first upload to a temporary file and then rename it only if the upload succeeds.