### PR TITLE
Don't set start time of root flows twice.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -607,7 +607,10 @@ public class FlowRunner extends EventHandler implements Runnable {
         final ExecutableFlowBase flow = ((ExecutableFlowBase) node);
         this.logger.info("Running flow '" + flow.getNestedId() + "'.");
         flow.setStatus(Status.RUNNING);
-        flow.setStartTime(System.currentTimeMillis());
+        // don't overwrite start time of root flows
+        if(flow.getStartTime() <= 0) {
+          flow.setStartTime(System.currentTimeMillis());
+        }
         prepareJobProperties(flow);
 
         for (final String startNodeId : ((ExecutableFlowBase) node).getStartNodes()) {


### PR DESCRIPTION
Root flow's start time was set twice: in `FlowRunner.run()` and `FlowRunner.runReadyJob()`. This causes that missed SLAs are not processed occasionally.
SLA checks are scheduled based on the first start time set on the root flow. If this start time is overwritten the SLA check could fail to recognize a miss (it determines that it's not yet time to check SLA) and therefore not kill the flow when it should.