### PR TITLE
Address a deadlock occurring between the polling query and the query updating running executions

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -23,6 +23,7 @@ import azkaban.utils.GZIPUtils;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Pair;
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -316,6 +317,8 @@ public class ExecutionFlowDao {
         SelectFromExecutionFlows.SELECT_EXECUTION_FOR_UPDATE_INACTIVE;
 
     final SQLTransaction<Integer> selectAndUpdateExecution = transOperator -> {
+      transOperator.getConnection().setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+
       final List<Integer> execIds = transOperator.query(selectExecutionForUpdate,
           new SelectFromExecutionFlows(), executorId);
 

--- a/azkaban-db/src/main/java/azkaban/db/AzDBUtil.java
+++ b/azkaban-db/src/main/java/azkaban/db/AzDBUtil.java
@@ -20,4 +20,9 @@ public class AzDBUtil {
 
   // A very big Integer
   static final int MAX_DB_RETRY_COUNT = 999999;
+
+  static final int MAX_RETRIES_ON_DEADLOCK = 3;
+
+  // in milliseconds
+  static final int RETRY_WAIT_TIME = 1000;
 }

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -28,6 +28,8 @@ import org.apache.log4j.Logger;
 @Singleton
 public class MySQLDataSource extends AzkabanDataSource {
 
+  public static final int MYSQL_ER_LOCK_DEADLOCK = 1213;
+
   private static final Logger logger = Logger.getLogger(MySQLDataSource.class);
   private final DBMetrics dbMetrics;
 


### PR DESCRIPTION
Address a deadlock occurring between:
 - the polling query: `SELECT exec_id FROM execution_flows WHERE status = 20 AND executor_id IS NULL AND flow_data IS NOT NULL AND (use_executor IS NULL OR use_executor = ?) ORDER BY flow_priority DESC, update_time ASC, exec_id ASC LIMIT 1 FOR UPDATE; `
 - and the query updating a running execution: `UPDATE execution_flows SET status=?,update_time=?,start_time=?,end_time=?,enc_type=?,flow_data=? WHERE exec_id=?`

By: 
- introducing retry logic in the flow update query to mitigate the effect of any deadlocks.
- lowering the transaction isolation level of the polling query to TRANSACTION_READ_COMMITTED to reduce the chance of the deadlock appearing since it requires less locks to be acquired than MySQL's default read mode REPEATABLE-READ.
