### PR TITLE
Don't allow pausing an execution while processing a KILL action.

### DIFF
--- a/az-jobsummary/src/main/resources/azkaban/viewer/jobsummary/velocity/jobsummary.vm
+++ b/az-jobsummary/src/main/resources/azkaban/viewer/jobsummary/velocity/jobsummary.vm
@@ -21,7 +21,7 @@
 #parse ("azkaban/webapp/servlet/velocity/style.vm")
 #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
-    <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+    <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
     <script type="text/javascript" src="${context}/jobsummary/js/azkaban/view/job-summary.js"></script>
     <script type="text/javascript" src="${context}/jobsummary/js/azkaban/model/log-data.js"></script>
     <script type="text/javascript">

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
@@ -77,7 +77,7 @@ public class ExecutorApiGateway {
 
       return callForJsonObjectMap(host, port, "/executor", paramList);
     } catch (final IOException e) {
-      throw new ExecutorManagerException(e);
+      throw new ExecutorManagerException(e.getMessage(), e);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1119,13 +1119,12 @@ public class FlowRunner extends EventHandler implements Runnable {
 
   public void pause(final String user) throws IllegalStateException {
     synchronized (this.mainSyncObj) {
-      this.logger.info("Flow paused by " + user);
+      this.logger.info("Execution pause requested by " + user);
       if (!this.isKilled() && !this.flowFinished) {
-        this.logger.info("Execution " + this.execId + " has been paused.");
         this.flowPaused = true;
         this.flow.setStatus(Status.PAUSED);
-
         updateFlow();
+        this.logger.info("Execution " + this.execId + " has been paused.");
       } else {
         final String errorMessage = "Execution " + this.execId + " with status " +
             this.flow.getStatus() + " cannot be paused.";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -53,8 +53,8 @@ import azkaban.flow.FlowProps;
 import azkaban.flow.FlowUtils;
 import azkaban.jobExecutor.ProcessJob;
 import azkaban.jobtype.JobTypeManager;
-import azkaban.metrics.CommonMetrics;
 import azkaban.metric.MetricReportManager;
+import azkaban.metrics.CommonMetrics;
 import azkaban.project.FlowLoaderUtils;
 import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManagerException;
@@ -608,7 +608,7 @@ public class FlowRunner extends EventHandler implements Runnable {
         this.logger.info("Running flow '" + flow.getNestedId() + "'.");
         flow.setStatus(Status.RUNNING);
         // don't overwrite start time of root flows
-        if(flow.getStartTime() <= 0) {
+        if (flow.getStartTime() <= 0) {
           flow.setStartTime(System.currentTimeMillis());
         }
         prepareJobProperties(flow);
@@ -903,7 +903,7 @@ public class FlowRunner extends EventHandler implements Runnable {
     prepareJobProperties(node);
 
     node.setStatus(Status.QUEUED);
-
+    
     String jobId = node.getId();
     String jobType = node.getInputProps().getString("type");
     Props rampProps = this.flow.getRampPropsForJob(jobId, jobType);
@@ -1117,16 +1117,20 @@ public class FlowRunner extends EventHandler implements Runnable {
     jobRunner.addListener(JmxJobMBeanManager.getInstance());
   }
 
-  public void pause(final String user) {
+  public void pause(final String user) throws IllegalStateException {
     synchronized (this.mainSyncObj) {
-      if (!this.flowFinished) {
-        this.logger.info("Flow paused by " + user);
+      this.logger.info("Flow paused by " + user);
+      if (!this.isKilled() && !this.flowFinished) {
+        this.logger.info("Execution " + this.execId + " has been paused.");
         this.flowPaused = true;
         this.flow.setStatus(Status.PAUSED);
 
         updateFlow();
       } else {
-        this.logger.info("Cannot pause finished flow. Called by user " + user);
+        final String errorMessage = "Execution " + this.execId + " with status " +
+            this.flow.getStatus() + " cannot be paused.";
+        this.logger.warn(errorMessage);
+        throw new IllegalStateException(errorMessage);
       }
     }
 
@@ -1165,7 +1169,7 @@ public class FlowRunner extends EventHandler implements Runnable {
       if (this.flowKilled) {
         return;
       }
-      this.logger.info("Kill has been called on flow " + this.execId);
+      this.logger.info("Kill has been called on execution " + this.execId);
       this.flow.setStatus(Status.KILLING);
       // If the flow is paused, then we'll also unpause
       this.flowPaused = false;

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -249,7 +249,8 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job3", Status.KILLING);
     assertFlowStatus(this.runner.getExecutableFlow(), Status.KILLING);
 
-    // Cannot pause a flow that has already been killed. This should throw IllegalStateException.
+    // Cannot pause a flow that is being killed or that has already been killed. This should throw
+    // IllegalStateException.
     this.runner.pause("me");
 
   }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -35,7 +35,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1569610022"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1579310616"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -23,7 +23,7 @@
 
   <script type="text/javascript" src="${context}/js/jquery.twbsPagination.min.js"></script>
 
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
   <script type="text/javascript" src="${context}/js/azkaban/model/job-log.js?v=1568515440"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/job-details.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
@@ -22,7 +22,7 @@
   #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
   <script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-logs.js?v=1576606441"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -20,7 +20,7 @@
 
 <script type="text/javascript" src="${context}/js/azkaban/util/common.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/util/ajax.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
 
 <script type="text/javascript" src="${context}/js/azkaban/util/svgutils.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/svg-navigate.js"></script>

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-function ajaxCall(requestURL, data, callback) {
+function ajaxCall(requestURL, data, successCallback, beforeSendCallback, requestType) {
   var successHandler = function (data) {
     if (data.error == "session") {
       // We need to relogin.
@@ -33,12 +33,24 @@ function ajaxCall(requestURL, data, callback) {
           }
         });
       }
-    }
-    else {
-      callback.call(this, data);
+    } else {
+      successCallback.call(this, data);
     }
   };
-  $.get(requestURL, data, successHandler, "json");
+
+  var options = {
+    url: requestURL,
+    data: data,
+    dataType: "json",
+    success: successHandler
+  };
+
+  options.type = (typeof requestType !== 'undefined') ? requestType : 'GET';
+  if (typeof beforeSendCallback !== 'undefined') {
+    options.beforeSend = beforeSendCallback;
+  }
+
+  $.ajax(options);
 }
 
 function executeFlow(executingData) {
@@ -47,8 +59,7 @@ function executeFlow(executingData) {
     if (data.error) {
       flowExecuteDialogView.hideExecutionOptionPanel();
       messageDialogView.show("Error Executing Flow", data.error);
-    }
-    else {
+    } else {
       flowExecuteDialogView.hideExecutionOptionPanel();
       messageDialogView.show("Flow submitted", data.message,
           function () {
@@ -72,8 +83,7 @@ function fetchFlowInfo(model, projectName, flowId, execId) {
   var successHandler = function (data) {
     if (data.error) {
       alert(data.error);
-    }
-    else {
+    } else {
       model.set({
         "successEmails": data.successEmails,
         "failureEmails": data.failureEmails,
@@ -115,8 +125,7 @@ function fetchFlow(model, projectName, flowId, sync) {
   var successHandler = function (data) {
     if (data.error) {
       alert(data.error);
-    }
-    else {
+    } else {
       var disabled = data.disabled ? data.disabled : {};
       model.set({
         flowId: data.flowId,
@@ -185,8 +194,7 @@ function flowExecutingStatus(projectName, flowId) {
           }
         });
       }
-    }
-    else {
+    } else {
       executionIds = data.execIds;
     }
   };


### PR DESCRIPTION
The KILL action can take a while to be processed. During that waiting time the user was able to click the PAUSE button. If they did the execution would be marked as PAUSED even though all the running jobs would be killed anyway. In addition to persisting an incorrect flow status this causes that long running flows are not killed automatically and that executor server processes waiting for all executions to finish before stopping will be stuck.

In addition to the backend changes the PAUSE button will be disabled in the UI after the KILL button is clicked. The page will look like:

<img width="1024" alt="Screen Shot 2020-01-20 at 10 39 10 PM" src="https://user-images.githubusercontent.com/44478711/72784897-c14c4100-3bde-11ea-9886-12817d009f27.png">
