### PR TITLE
Publish artifacts to bintray via cli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@
  * the License.
  */
 buildscript {
+  apply from: 'gradle/computeVersions.gradle'
   repositories {
     mavenCentral()
     maven {
@@ -21,7 +22,8 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.cinnober.gradle:semver-git:2.2.3'
+//    classpath 'com.cinnober.gradle:semver-git:2.2.3'
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.2'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
   }
 }
@@ -37,8 +39,8 @@ buildScan {
   licenseAgree = 'yes'
 }
 
-apply plugin: 'com.cinnober.gradle.semver-git'
-
+//apply plugin: 'com.cinnober.gradle.semver-git'
+apply plugin: 'java'
 apply plugin: 'compare-gradle-builds'
 
 compareGradleBuilds {
@@ -47,6 +49,7 @@ compareGradleBuilds {
 
 allprojects {
   apply plugin: 'jacoco'
+
 
   repositories {
     mavenCentral()
@@ -130,9 +133,31 @@ ext.deps = [
 subprojects {
   apply plugin: 'java'
   apply plugin: 'net.ltgt.errorprone'
+  apply plugin: 'com.jfrog.bintray'
+
+
+  bintray {
+    user = 'aditya1105'
+    key = project.property('bintray.key')
+    configurations = ['archives']
+    pkg {
+      repo = project.property('bintray.repo')
+      user = 'aditya1105'
+      userOrg = 'linkedin'
+      name = 'azkaban'
+      vcsUrl = 'https://github.com/azkaban/azkaban.git'
+      licenses = ['Apache-2.0']
+      version {
+        name = rootProject.version
+        desc = 'Gradle Bintray Plugin 0.0.1 test'
+        released  = new Date()
+      }
+    }
+  }
 
   // Set the same version for all sub-projects to root project version
-  version = rootProject.version
+  project.version = rootProject.version
+  project.group = rootProject.group
 
   configurations.errorprone {
     dependencies {
@@ -153,15 +178,16 @@ subprojects {
      See: http://stackoverflow.com/questions/16218888/can-gradle-extensions-handle-lazy-evaluation-of-a-property
      See: http://stackoverflow.com/questions/16070567/difference-between-gradles-terms-evaluation-and-execution
      */
-    project.afterEvaluate {
-      // Set the Title and Version fields in the jar
-      jar {
-        manifest {
-          attributes('Implementation-Title': project.name,
-              'Implementation-Version': project.version)
-        }
-      }
-    }
+//    project.afterEvaluate {
+//      // Set the Title and Version fields in the jar
+//
+//      jar {
+//        manifest {
+//          attributes('Implementation-Title': project.name,
+//              'Implementation-Version': project.version)
+//        }
+//      }
+//    }
 
     dependencies {
       compile deps.log4j

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,15 @@
 #
 
 group=com.linkedin
+
+# Properties required when major version is bumped
+project.versionPrefix=0.0.
+project.minorVersionOffset=0
+
+# Key to push to bintray
+bintray.key=<key>
+bintray.repo=maven
+
 # optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
 # optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha>-SNAPSHOT"
 #

--- a/gradle/computeVersions.gradle
+++ b/gradle/computeVersions.gradle
@@ -1,0 +1,50 @@
+if (!project.hasProperty('version') || project.version == 'unspecified') {
+  try {
+    exec {
+      commandLine 'git', 'fetch', '-t', 'https://github.com/azkaban/azkaban.git', 'master'
+    }
+    def versionOut = new ByteArrayOutputStream()
+    exec {
+      commandLine 'git', 'rev-list', 'HEAD', '--count'
+      standardOutput versionOut
+    }
+    def minotVersion = (versionOut.toString().trim()
+            .toInteger() - project.property('project.minorVersionOffset').toInteger()).toString()
+    println 'Calculated minor version: ' + minotVersion
+    def finalVer = project.property('project.versionPrefix') + minotVersion
+    println 'Using version: ' + finalVer
+    def gitBranch = getBranch()
+    println 'Git branch is: ' + gitBranch
+    if (gitBranch.startsWith("master")) {
+      project.version = finalVer
+    } else if (gitBranch.startsWith("cf-engine")) {
+      project.version = finalVer + "-e"
+    } else if (gitBranch.startsWith("cf-control-plane")) {
+      project.version = finalVer + "-c"
+    } else {
+      project.version = finalVer + "-" + gitBranch
+    }
+    println 'Project Version is: ' + project.version
+  }
+  catch (Exception e) {
+    logger.warn("Unable to determine version. Is this a git copy? Using 'unknown'.");
+    logger.warn(e.toString())
+    project.version = 'unknown'
+  }
+}
+
+def getBranch() {
+  def branchInfo = new ByteArrayOutputStream()
+  exec {
+    commandLine 'git', 'branch'
+    standardOutput branchInfo
+  }
+  println 'Branch info: ' + branchInfo
+  def lines = branchInfo.toString().split("\n")
+  for (line in lines) {
+    if (line.startsWith("*")) {
+      return line.split("\\s+")[1]
+    }
+  }
+  throw new GradleException("Could not determine git branch.")
+}


### PR DESCRIPTION
This change is to enable pushing artifacts generated by the build of the cf-control-plane branch to bintray Linkedin organization using CLI.