### PR TITLE
Add TokenFetcher, a class to fetch Hadoop tokens and DV-Identity certs.

### DIFF
--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -54,6 +54,8 @@ configurations {
 dependencies {
     compile project(':az-core')
     compile(project(':azkaban-common'))
+    compile(project(':azkaban-hadoop-security-plugin'))
+    compileOnly deps.hadoopCommon
     compile(project(':az-flow-trigger-dependency-plugin'))
 
     compile deps.restliServer

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/AddHardCodedProps.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/AddHardCodedProps.java
@@ -1,0 +1,135 @@
+package azkaban.flowtrigger.security;
+
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
+import static azkaban.flowtrigger.security.SecurityPropName.AZKABAN_KEYTAB_LOCATION;
+import static azkaban.flowtrigger.security.SecurityPropName.AZKABAN_PRINCIPAL;
+import static azkaban.flowtrigger.security.SecurityPropName.HADOOP_SECURITY_MANAGER_CLASS_PARAM;
+import static azkaban.flowtrigger.security.SecurityPropName.OBTAIN_BINARY_TOKEN;
+
+import azkaban.Constants;
+import azkaban.Constants.JobProperties;
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.utils.Props;
+
+/**
+ * Provides methods to populate props file with hard-coded values. This is used for mocking
+ * props, which are otherwise read from configuration files. This file has been created for
+ * a proof-of-concept effort.
+ * TODO(Anish Malhotra) : Remove this post-POC.
+ */
+class AddHardCodedProps {
+
+  /**
+   * @param props The props object into which configuration values will be added.
+   */
+  static void thatEnableTokenPrefetch(final Props props) {
+    // boolean properties
+    // ./plugins/jobtypes/commonprivate.properties:append.submit.user=false
+    props.put(HadoopSecurityManager.APPEND_SUBMIT_USER, "true");
+
+    props.put(HadoopSecurityManager.OBTAIN_JOBTRACKER_TOKEN, "true");
+    props.put(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN, "true");
+    props.put(SecurityPropName.OBTAIN_JOBHISTORYSERVER_TOKEN, "true");
+
+    // ./plugins/jobtypes/commonprivate.properties:obtain.binary.token=true
+    props.put(OBTAIN_BINARY_TOKEN, "true");
+    // ./plugins/jobtypes/hadoopJava/private.properties:azkaban.should.proxy=true
+    //./plugins/jobtypes/reportalteradata/plugin.properties:azkaban.should.proxy=false
+    props.put(HadoopSecurityManager.ENABLE_PROXYING, "true");
+
+    // Job property
+    // ./deploy/PinotBuildAndPushJob/PinotBuildAndPushJob-0.0.385/private.properties
+    //./deploy/PinotBuildAndPushJob/PinotBuildAndPushJob/private.properties
+    //./executions/23582991/common.properties
+    //./executions/23583254/common.properties
+    //./executions/23582494/grid-common.properties
+    props.put(JobProperties.ENABLE_JOB_SSL, "true");
+
+
+    // Why is obtain.hcat.token in jobtype plugins and executions ?
+    // ./plugins/jobtypes/hadoopJava/private.properties
+    // ./executions/23575703/common.properties
+    // ./executions/23581385/war_common.properties
+    props.put(HadoopSecurityManager.OBTAIN_HCAT_TOKEN, "true");
+
+
+    // String properties
+    props.put(JobProperties.USER_TO_PROXY, "azktest");
+    // "hadoop.security.manager.class"
+    // ./plugins/jobtypes/commonprivate.properties:hadoop.security.manager.class=azkaban.security.HadoopSecurityManager_H_2_0
+    props.put(HADOOP_SECURITY_MANAGER_CLASS_PARAM, "azkaban.security.HadoopSecurityManager_H_2_0");
+
+    // ./plugins/jobtypes/commonprivate.properties:azkaban.native.lib=/export/apps/azkaban/native
+    props.put(AZKABAN_SERVER_NATIVE_LIB_FOLDER, "/export/apps/azkaban/native");
+
+    // ./plugins/jobtypes/common.properties:hadoop.home=/export/apps/hadoop/latest
+    // ./executions/23575703/common.properties
+    props.put("hadoop.home", "/export/apps/hadoop/latest");
+
+    // ??
+    // ./conf/azkaban.properties:hadoop.conf.dir.path=/export/apps/hadoop/site/etc/hadoop
+    props.put("hadoop.conf.dir", "");
+
+    // ./plugins/jobtypes/commonprivate.properties:proxy.keytab.location=/export/apps/hadoop/keytabs/azkaban.service.keytab
+    // ./plugins/jobtypes/commonprivate.properties:proxy.user=azkaban/lva1-warazexec07.grid.linkedin.com@GRID.LINKEDIN.COM
+    // ./plugins/jobtypes/commonprivate.properties:azkaban.security.credential=com.linkedin.azkaban.security.DataVaultIdentityProvider
+    props.put(AZKABAN_KEYTAB_LOCATION, "/export/apps/hadoop/keytabs/azkaban.service.keytab");
+    // For War cluster
+    props.put(AZKABAN_PRINCIPAL, "azkaban/lva1-warazexec07.grid.linkedin.com@GRID.LINKEDIN.COM");
+    // For Holdem cluster
+    props.put(AZKABAN_PRINCIPAL, "azkaban/ltx1-holdemaz04.grid.linkedin.com@GRID.LINKEDIN.COM");
+
+    props.put(Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME, "com.linkedin.azkaban.security.DataVaultIdentityProvider");
+
+    // ./plugins/jobtypes/commonprivate.properties:submit.user.suffix=@GRID.LINKEDIN.COM
+    // ./executions/23551858/peoplematch-properties-file_props_7767984632253761928_tmp:azkaban.flow.submituser=jmhe
+    props.put(HadoopSecurityManager.SUBMIT_USER_SUFFIX, "@GRID.LINKEDIN.COM");
+    props.put(Constants.FlowProperties.AZKABAN_FLOW_SUBMIT_USER, "azktest");
+
+
+    // ./plugins/jobtypes/commonprivate.properties:azkaban.csr.endpoint.uri=https://1.grestin.prod-ltx1.atd.prod.linkedin.com:10180/grestin/request_service_certificate?fabric=prod-lva1&application={hadoop-headless-user}&instance=war01&tag=azkaban-exec-server
+    // Used by az-grestin-client
+    /*
+    props.put("azkaban.csr.endpoint.uri",
+        "https://1.grestin.prod-ltx1.atd.prod.linkedin"
+            + ".com:10180/grestin/request_service_certificate?fabric=prod-lva1&application={hadoop-headless-user}&instance=war01&tag=azkaban-exec-server");
+     */
+
+    // Holdem04
+    props.put("azkaban.csr.endpoint.uri",
+        "https://1.grestin.ei-ltx1.atd.stg.linkedin"
+            + ".com:10180/grestin/request_service_certificate?fabric=ei-ltx1&application={hadoop"
+            + "-headless-user}&instance=holdemaz04&tag=azkaban-exec-server");
+
+
+    /*
+     * VALUES FOR KEYS LISTED IN
+     * az-grestin-client/src/main/java/com/linkedin/azkaban/security/CertConstants.java
+     */
+    // ./conf/azkaban.properties:
+    // azkaban.csr.truststore.location=/export/content/security/services/azkaban-exec-server/EI_cacerts;
+
+    // ./plugins/jobtypes/commonprivate.properties:azkaban.csr.truststore.location=/export/content/security/services/azkaban-exec-server/EI_cacerts
+    // Needed ny Data vault/ Grestin
+    props.put("azkaban.csr.truststore.location", "/export/content/security/services/azkaban-exec-server/EI_cacerts");
+    props.put("azkaban.csr.keystore.location", "/export/content/security/services/azkaban-exec-server/azkaban-exec.p12");
+
+    // StringList properties
+    // EXTRA_HCAT_LOCATION
+    // ./executions/23574944/node-properties.flow:
+    //     other_hcat_location: thrift://ltx1-holdemhcat01.grid.linkedin.com:7552
+    // ./executions/23574944/join-edges-node-properties_props_275227555535475485_tmp:
+    //     other_hcat_location=thrift\://ltx1-holdemhcat01.grid.linkedin.com\:7552
+    // ./executions/23579030/grids_war_common.properties:
+    //     other_hcat_location=thrift://lva1-warhcat01.grid.linkedin.com:7552
+
+
+    // StringListFromCluster properties
+    // EXTRA_HCAT_CLUSTERS
+
+
+    /////////
+    ///////// fs.getDelegationToken(p.getString(JobProperties.USER_TO_PROXY));
+    /////////
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/SecurityPropName.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/SecurityPropName.java
@@ -1,0 +1,14 @@
+package azkaban.flowtrigger.security;
+
+/**
+ * Lists some of the keys that are present in the props file. This file has specifically been
+ * created for a proof-of-concept exercise. It will no longer be needed, once we create a
+ * new config system for CloudFlow.
+ */
+class SecurityPropName {
+  static final String HADOOP_SECURITY_MANAGER_CLASS_PARAM = "hadoop.security.manager.class";
+  static final String AZKABAN_KEYTAB_LOCATION = "proxy.keytab.location";
+  static final String AZKABAN_PRINCIPAL = "proxy.user";
+  static final String OBTAIN_JOBHISTORYSERVER_TOKEN = "obtain.jobhistoryserver.token";
+  static final String OBTAIN_BINARY_TOKEN = "obtain.binary.token";
+  }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/TokenFetcher.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/security/TokenFetcher.java
@@ -1,0 +1,156 @@
+package azkaban.flowtrigger.security;
+
+import azkaban.security.commons.HadoopSecurityManager;
+import azkaban.security.commons.HadoopSecurityManagerException;
+import azkaban.utils.Props;
+import com.sun.istack.internal.Nullable;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
+import org.apache.log4j.Logger;
+
+/**
+ * Prefetches the Tokens by using the security manager that's specified in the configurations.
+ *
+ * Example Usage:
+ *   Props fakeProps = new Props();
+ *   AddHardCodedProps.thatEnableTokenPrefetch(fakeProps);
+ *   Logger logger = Logger.getLogger(TokenFetcher.class);
+ *   TokenFetcher tokenFetcher = new TokenFetcher(fakeProps, fakeProps, logger);
+ *   tokenFetcher.createTokenFile(fakeProps, logger);
+ */
+public class TokenFetcher {
+  private HadoopSecurityManager hadoopSecurityManager;
+  private boolean shouldPrefetchTokenForProxyUser = false;
+  private String userToProxy;
+
+  /**
+   * Creates hard-coded props. Values are set so that HadoopSecurityManager_H_2_0 fetches all
+   * the tokens for azktest.
+   */
+  private static void fillValuesThatEnableTokenFetching(final Props props) {
+    AddHardCodedProps.thatEnableTokenPrefetch(props);
+  }
+
+  /**
+   * Loads the HadoopSecurityManager Java class that's specified in the
+   * HADOOP_SECURITY_MANAGER_CLASS_PARAM props,
+   *
+   * @return A HadoopSecurityManager object.
+   * @throws RuntimeException : Will throw exception if any errors occur (including not finding the
+   * HadoopSecurityManager class in the classpath).
+   */
+  private static HadoopSecurityManager loadHadoopSecurityManager(final Props props, final Logger log)
+      throws RuntimeException {
+
+    final Class<?> hadoopSecurityManagerClass =
+        props.getClass(SecurityPropName.HADOOP_SECURITY_MANAGER_CLASS_PARAM, true,
+        TokenFetcher.class.getClassLoader());
+    log.info("Loading hadoop security manager " + hadoopSecurityManagerClass.getName());
+    HadoopSecurityManager hadoopSecurityManager = null;
+
+    try {
+      final Method getInstanceMethod = hadoopSecurityManagerClass.getMethod("getInstance", Props.class);
+      hadoopSecurityManager = (HadoopSecurityManager) getInstanceMethod.invoke(
+          hadoopSecurityManagerClass, props);
+    } catch (final InvocationTargetException e) {
+      final String errMsg = "Could not instantiate Hadoop Security Manager "
+          + hadoopSecurityManagerClass.getName() + e.getCause();
+      log.error(errMsg);
+      throw new RuntimeException(errMsg, e);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    return hadoopSecurityManager;
+  }
+
+
+  /* Creates a TokenFetcher object, which includes the hadoop security manager specified in the
+   * props (for the key HADOOP_SECURITY_MANAGER_CLASS_PARAM).
+   *
+   * This class is essentially a no-op if either of the following property is false:
+   * ENABLE_PROXYING
+   * OBTAIN_BINARY_TOKEN
+   */
+  TokenFetcher(final Props sysProps, final Props jobProps, final Logger logger) {
+    final boolean shouldProxy = sysProps.getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
+    final boolean obtainTokens = sysProps.getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
+    userToProxy = jobProps.getString(HadoopSecurityManager.USER_TO_PROXY);
+
+    shouldPrefetchTokenForProxyUser = shouldProxy && obtainTokens;
+
+    if (shouldProxy) {
+      try {
+        hadoopSecurityManager = loadHadoopSecurityManager(sysProps, logger);
+      } catch (final RuntimeException e) {
+        e.printStackTrace();
+        throw new RuntimeException("Failed to get hadoop security manager!"
+            + e.getCause());
+      }
+    }
+  }
+
+
+  /**
+   * Creates a temp file and writes tokens into it. The tokens are fetched as per the properties
+   * set in the prop file.
+   *
+   * @return The newly created temp file that contains the tokens.
+   */
+  public static File writeTokensToTempFile(
+      final HadoopSecurityManager hadoopSecurityManager, final Props props,
+      final Logger log) throws HadoopSecurityManagerException {
+
+    File tokenFile = null;
+    try {
+      tokenFile = File.createTempFile("mr-azkaban", ".token");
+    } catch (final Exception e) {
+      throw new HadoopSecurityManagerException("Failed to create the token file.", e);
+    }
+
+    hadoopSecurityManager.prefetchToken(tokenFile, props, log);
+
+    return tokenFile;
+  }
+
+  /**
+   * Setup Job Properties when the proxy is enabled
+   *
+   * @param props all properties
+   * @param logger logger handler
+   */
+  public @Nullable File createTokenFile(final Props props, final Logger logger)
+      throws Exception {
+    File tokenFile = null;
+    if (shouldPrefetchTokenForProxyUser) {
+      logger.info("Need to proxy. Getting tokens.");
+      // get tokens in to a file, and put the location in props
+      tokenFile = writeTokensToTempFile(hadoopSecurityManager, props, logger);
+    } else {
+      logger.info("props value are set to not enable prefetching");
+    }
+    return tokenFile;
+  }
+
+  // Creates a Tokem File and prints its location
+  public static void createTokenFileAndPrintLocation() {
+    final Props fakeProps = new Props();
+    fillValuesThatEnableTokenFetching(fakeProps);
+    final Logger logger = Logger.getLogger(TokenFetcher.class);
+    final TokenFetcher tokenFetcher = new TokenFetcher(fakeProps, fakeProps, logger);
+
+    try {
+      logger.info("Token file is located at: " +
+          tokenFetcher.createTokenFile(fakeProps, logger).getAbsolutePath());
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(final String[] args) {
+    TokenFetcher.createTokenFileAndPrintLocation();
+  }
+
+}


### PR DESCRIPTION
This is for proof-of-concept exercise. Therefore certain shortcuts
have been taken, such as hard-coding of property names (SecurityPropName)
and property values(AddHardCodedProps).