### PR TITLE
Revert back the serialVersionUID in CronSchedule class

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
+++ b/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
@@ -29,7 +29,11 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  */
 public class CronSchedule implements Serializable {
 
-  private static final long serialVersionUID = -1330280892166841228L;
+  /**
+   * CAUTION : Please do NOT change this serialVersionUID as it may break
+   * backward compatibility.
+   */
+  private static final long serialVersionUID = -1330280892166841227L;
   private final String cronExpression;
   private final String timeZone;
 


### PR DESCRIPTION
Revert back the serialVersionUID in CronSchedule class as the update was not required.