### PR TITLE
Changing json column from BLOB to MEDIUMBLOB in project_flows table.

### DIFF
--- a/azkaban-db/src/main/sql/create.project_flows.sql
+++ b/azkaban-db/src/main/sql/create.project_flows.sql
@@ -4,7 +4,7 @@ CREATE TABLE project_flows (
   flow_id       VARCHAR(128),
   modified_time BIGINT NOT NULL,
   encoding_type TINYINT,
-  json          BLOB,
+  json          MEDIUMBLOB,
   PRIMARY KEY (project_id, version, flow_id)
 );
 

--- a/azkaban-db/src/main/sql/migrations/patch-1.sql
+++ b/azkaban-db/src/main/sql/migrations/patch-1.sql
@@ -1,0 +1,3 @@
+-- DB Migration from release 3.83.0
+-- Increasing the side of json column in project_flows table.
+ALTER TABLE project_flows MODIFY COLUMN json MEDIUMBLOB;

--- a/azkaban-db/src/main/sql/migrations/patch-1.sql
+++ b/azkaban-db/src/main/sql/migrations/patch-1.sql
@@ -1,3 +1,3 @@
 -- DB Migration from release 3.83.0
--- Increasing the side of json column in project_flows table.
+-- Increasing the size of json column in project_flows table.
 ALTER TABLE project_flows MODIFY COLUMN json MEDIUMBLOB;

--- a/azkaban-db/src/main/sql/upgrade.3.83.0.to.3.84.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.3.83.0.to.3.84.0.sql
@@ -1,3 +1,3 @@
--- DB Migration from release 3.83.0
+-- DB Migration from release 3.83.0 to 3.84.0
 -- Increasing the size of json column in project_flows table.
 ALTER TABLE project_flows MODIFY COLUMN json MEDIUMBLOB;


### PR DESCRIPTION
BLOB type of json column is small and we are exceeding limit of it for few projects. I am increasing size to MEDIUMBLOB. I have verified that is is not affecting webserver startup time.