### PR TITLE
Update the kerberos principal to contain host name and execution id

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
@@ -40,10 +40,8 @@ public abstract class HadoopSecurityManager {
   public static final String OBTAIN_NAMENODE_TOKEN = "obtain.namenode.token";
   public static final String OBTAIN_HCAT_TOKEN = "obtain.hcat.token";
 
-  // Add LDAP user to fetch delegation token in addition to proxy user
-  public static final String APPEND_SUBMIT_USER = "append.submit.user";
-  // Add suffix to user name e.g, for GRID users, GRID.LINKEDIN.COM
-  public static final String SUBMIT_USER_SUFFIX = "submit.user.suffix";
+  // Add domain name
+  public static final String DOMAIN_NAME = "domain.name";
 
   public static boolean shouldProxy(final Properties prop) {
     final String shouldProxy = prop.getProperty(ENABLE_PROXYING);


### PR DESCRIPTION
Update the kerberos principal to contain host name and execution id. This helps in auditing hadoop logs.