### PR TITLE
Check that an execution is not in a final state already before killing it

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -553,8 +553,14 @@ public class FlowRunnerManager implements EventListener,
     final FlowRunner flowRunner = this.runningFlows.get(execId);
 
     if (flowRunner == null) {
-      throw new ExecutorManagerException("Execution " + execId
-          + " is not running.");
+      throw new ExecutorManagerException("Execution " + execId + " is not running.");
+    }
+
+    // account for those unexpected cases where a completed execution remains in the runningFlows
+    //collection due to, for example, the FLOW_FINISHED event not being emitted/handled.
+    if(Status.isStatusFinished(flowRunner.getExecutableFlow().getStatus())) {
+      LOGGER.warn("Found a finished execution in the list of running flows: " + execId);
+      throw new ExecutorManagerException("Execution " + execId + " is already finished.");
     }
 
     flowRunner.kill(user);


### PR DESCRIPTION
This PR is related to #2458
A `FLOW_FINISHED` event is emitted when a flow finishes. Two important things happen when handling that event:
-the flow is removed from the `runningFlows` collection
-the execution directory is deleted
If for some reason `FLOW_FINISHED` event fails to be emitted/handled one side effect of not removing flows from the `runningFlows` collection is that flows can get stuck in KILLING status forever.

This happens when there is an SLA rule set to kill the executions if they haven't reached a final state in a certain time. When proceeding with the SLA `KillExecutionAction` the `runningFlows` collection is examined: 
-if a flow is in the list (regardless of its status) `kill()` will be called and we can transition a flow which is not running anymore from a final status to a non-final one. 

The only thing we can do to recover from that is to change the flow status back to a final one directly in the DB.

This PR adds execution status to the checks before killing an execution to account for those unexpected cases when `FLOW_FINISHED` event was not emitted/handled.