### PR TITLE
Ensure TimeZone is set to default if CronSchedule

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
+++ b/azkaban-common/src/main/java/azkaban/project/CronSchedule.java
@@ -34,6 +34,7 @@ public class CronSchedule implements Serializable {
    * backward compatibility.
    */
   private static final long serialVersionUID = -1330280892166841227L;
+  private static final String DEFAULT_TIMEZONE = TimeZone.getDefault().getID();
   private final String cronExpression;
   private final String timeZone;
 
@@ -41,7 +42,7 @@ public class CronSchedule implements Serializable {
    * @throws IllegalArgumentException if cronExpression is null or blank
    */
   public CronSchedule(final String cronExpression) {
-    this(cronExpression, TimeZone.getDefault().getID());
+    this(cronExpression, DEFAULT_TIMEZONE);
   }
 
   /**
@@ -72,7 +73,7 @@ public class CronSchedule implements Serializable {
 
     return new EqualsBuilder()
         .append(this.cronExpression, that.cronExpression)
-        .append(this.timeZone, that.timeZone)
+        .append(this.getTimeZone(), that.getTimeZone())
         .isEquals();
   }
 
@@ -84,6 +85,9 @@ public class CronSchedule implements Serializable {
   }
 
   public String getTimeZone() {
+    if (null == timeZone) {
+      return DEFAULT_TIMEZONE;
+    }
     return timeZone;
   }
 


### PR DESCRIPTION
Ensure TimeZone is set to default if CronSchedule is pulled from older serialized class.

This avoid any potential NPE.

Derived from contribution from Andrew Charneski.