### PR TITLE
Moved the db clean up logic out of the push based dispatch-logic

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -74,6 +74,7 @@ public class Constants {
   public static final int DEFAULT_SSL_PORT_NUMBER = 8443;
   public static final int DEFAULT_JETTY_MAX_THREAD_COUNT = 20;
 
+
   // One Schedule's default End Time: 01/01/2050, 00:00:00, UTC
   public static final long DEFAULT_SCHEDULE_END_EPOCH_TIME = 2524608000000L;
 
@@ -325,6 +326,10 @@ public class Constants {
     public static final String AZKABAN_RAMP_STATUS_POLLING_INTERVAL = "azkaban.ramp.status.polling.interval";
     public static final String AZKABAN_RAMP_STATUS_POLLING_CPU_MAX = "azkaban.ramp.status.polling.cpu.max";
     public static final String AZKABAN_RAMP_STATUS_POLLING_MEMORY_MIN = "azkaban.ramp.status.polling.memory.min";
+
+    public static final String EXECUTION_LOGS_RETENTION_MS = "execution.logs.retention.ms";
+    public static final String EXECUTION_LOGS_CLEANUP_INTERVAL_SECONDS =
+        "execution.logs.cleanup.interval.seconds";
   }
 
   public static class FlowProperties {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -146,6 +146,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   private final FlowTriggerScheduler scheduler;
   private final FlowTriggerService flowTriggerService;
   private Map<String, TriggerPlugin> triggerPlugins;
+  private final ExecutionLogsCleaner executionLogsCleaner;
 
   @Inject
   public AzkabanWebServer(final Props props,
@@ -160,7 +161,8 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
       final VelocityEngine velocityEngine,
       final FlowTriggerScheduler scheduler,
       final FlowTriggerService flowTriggerService,
-      final StatusService statusService) {
+      final StatusService statusService,
+      final ExecutionLogsCleaner executionLogsCleaner) {
     this.props = requireNonNull(props, "props is null.");
     this.server = requireNonNull(server, "server is null.");
     this.executorManagerAdapter = requireNonNull(executorManagerAdapter,
@@ -175,7 +177,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     this.statusService = statusService;
     this.scheduler = requireNonNull(scheduler, "scheduler is null.");
     this.flowTriggerService = requireNonNull(flowTriggerService, "flow trigger service is null");
-
+    this.executionLogsCleaner = requireNonNull(executionLogsCleaner, "executionlogcleaner is null");
     loadBuiltinCheckersAndActions();
 
     // load all trigger agents here
@@ -230,6 +232,8 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     app = webServer;
 
     webServer.executorManagerAdapter.start();
+
+    webServer.executionLogsCleaner.start();
 
     // TODO refactor code into ServerProvider
     webServer.prepareAndStartServer();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
@@ -1,0 +1,72 @@
+package azkaban.webapp;
+
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.executor.ExecutorLoader;
+import azkaban.utils.Props;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@SuppressWarnings("FutureReturnValueIgnored")
+public class ExecutionLogsCleaner {
+
+   private static final Logger logger = LoggerFactory.getLogger(ExecutionLogsCleaner.class);
+   private final ScheduledExecutorService scheduler;
+   private final ExecutorLoader executorLoader;
+   private final Props azkProps;
+   private long executionLogsRetentionMs;
+   // 12 weeks
+   private static final long DEFAULT_EXECUTION_LOGS_RETENTION_MS = 3 * 4 * 7
+       * 24 * 60 * 60 * 1000L;
+
+   // 1 hour
+   private static final long DEFAULT_LOG_CLEANUP_INTERVAL_SECONDS = 60 * 60;
+   private long cleanupIntervalInSeconds;
+
+   @Inject
+   public ExecutionLogsCleaner(final Props azkProps, final ExecutorLoader executorLoader) {
+      this.azkProps = azkProps;
+      this.executorLoader = executorLoader;
+      this.scheduler = Executors.newSingleThreadScheduledExecutor();
+      this.executionLogsRetentionMs = this.azkProps.getLong(
+          ConfigurationKeys.EXECUTION_LOGS_RETENTION_MS,
+          DEFAULT_EXECUTION_LOGS_RETENTION_MS);
+      this.cleanupIntervalInSeconds = this.azkProps.getLong(
+          ConfigurationKeys.EXECUTION_LOGS_CLEANUP_INTERVAL_SECONDS,
+          DEFAULT_LOG_CLEANUP_INTERVAL_SECONDS);
+   }
+
+   public void start() {
+      logger.info("Starting execution logs clean up thread");
+      this.scheduler.scheduleAtFixedRate(() -> cleanExecutionLogs(), 0L, cleanupIntervalInSeconds,
+          TimeUnit.SECONDS);
+   }
+
+   private void cleanExecutionLogs() {
+      logger.info("Cleaning old logs from execution_logs");
+      final long cutoff = System.currentTimeMillis() - this.executionLogsRetentionMs;
+      logger.info("Cleaning old log files before "
+          + new DateTime(cutoff).toString());
+      cleanOldExecutionLogs(cutoff);
+   }
+
+
+   private void cleanOldExecutionLogs(final long millis) {
+      final long beforeDeleteLogsTimestamp = System.currentTimeMillis();
+      try {
+         final int count = this.executorLoader.removeExecutionLogsByTime(millis);
+         logger.info("Cleaned up " + count + " log entries.");
+      } catch (final Exception e) {
+         logger.error("log clean up failed. ", e);
+      }
+      logger.info(
+          "log clean up time: " + (System.currentTimeMillis() - beforeDeleteLogsTimestamp)
+              + " ms.");
+   }
+}

--- a/azkaban-web-server/src/test/java/azkaban/webapp/ExecutionLogsCleanerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/ExecutionLogsCleanerTest.java
@@ -1,0 +1,35 @@
+package azkaban.webapp;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+
+import azkaban.Constants.ConfigurationKeys;
+import azkaban.executor.ExecutorLoader;
+import azkaban.utils.Props;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ExecutionLogsCleanerTest {
+  private Props props;
+  private ExecutorLoader loader;
+  private ExecutionLogsCleaner executionLogsCleaner;
+
+  @Before
+  public void setUp() {
+    this.props = new Props();
+    /* This config will set the thread to run every 2 seconds */
+    this.props.put(ConfigurationKeys.EXECUTION_LOGS_CLEANUP_INTERVAL_SECONDS, 2);
+    this.loader = mock(ExecutorLoader.class);
+    this.executionLogsCleaner = new ExecutionLogsCleaner(this.props, this.loader);
+  }
+
+  @Test
+  public void checkIfExecutionCleanerGetsTriggered() throws Exception {
+    executionLogsCleaner.start();
+    TimeUnit.SECONDS.sleep(5);
+    Mockito.verify(this.loader, atLeast(2)).removeExecutionLogsByTime(anyLong());
+  }
+}


### PR DESCRIPTION
Extracted the execution_logs cleanup logic from old dispatcher logic and kept it outside the dispatcher. Independent of the dispatcher logic this clean up would run every 60 minutes. 

Tested manually that the logic is triggered by setting the azkaban.poll.model config to be false and true. I was able to see the ExecutionLogsCleaner getting triggered. Adding unit tests is in progress.