### PR TITLE
Fetch flow execution status from database column only.

### DIFF
--- a/az-core/src/main/java/azkaban/utils/TimeUtils.java
+++ b/az-core/src/main/java/azkaban/utils/TimeUtils.java
@@ -16,7 +16,9 @@
 package azkaban.utils;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.joda.time.Days;
@@ -61,6 +63,16 @@ public class TimeUtils {
     final ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(timestampMs),
         ZoneId.systemDefault());
     return formatter.format(zonedDateTime);
+  }
+
+  /**
+   * Takes a date string formatted as "yyyy-MM-dd HH:mm:ss" and converts it into milliseconds
+   * since the Epoch in UTC
+   */
+  public static long convertDateTimeToUTCMillis(final String dateTime) {
+    final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
+    final LocalDateTime parsedDate = LocalDateTime.parse(dateTime, formatter);
+    return parsedDate.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -84,11 +84,12 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public ExecutableFlow() {
   }
 
-  public static ExecutableFlow createExecutableFlowFromObject(final Object obj) {
+  public static ExecutableFlow createExecutableFlow(final Object obj, final Status status) {
     final ExecutableFlow exFlow = new ExecutableFlow();
     final HashMap<String, Object> flowObj = (HashMap<String, Object>) obj;
     exFlow.fillExecutableFromMapObject(flowObj);
-
+    // overwrite status from the flow data blob as that one should NOT be used
+    exFlow.setStatus(status);
     return exFlow;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -409,6 +409,9 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
+
+            // read execution status from the DB column not from the flow data blob to maintain
+            // consistency and have a single source of truth
             Status status = Status.fromInteger(rs.getInt(4));
             exFlow.setStatus(status);
             execFlows.add(exFlow);
@@ -457,6 +460,8 @@ public class ExecutionFlowDao {
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
 
+            // read execution status from the DB column not from the flow data blob to maintain
+            // consistency and have a single source of truth
             Status status = Status.fromInteger(rs.getInt(4));
             exFlow.setStatus(status);
             final ExecutionReference ref = new ExecutionReference(id);
@@ -498,6 +503,9 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
+
+            // read execution status from the DB column not from the flow data blob to maintain
+            // consistency and have a single source of truth
             Status status = Status.fromInteger(rs.getInt(4));
             exFlow.setStatus(status);
             execFlows.add(exFlow);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -405,15 +405,11 @@ public class ExecutionFlowDao {
 
         if (data != null) {
           final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Status status = Status.fromInteger(rs.getInt(4));
           try {
             final ExecutableFlow exFlow =
-                ExecutableFlow.createExecutableFlowFromObject(
-                    GZIPUtils.transformBytesToObject(data, encType));
-
-            // read execution status from the DB column not from the flow data blob to maintain
-            // consistency and have a single source of truth
-            Status status = Status.fromInteger(rs.getInt(4));
-            exFlow.setStatus(status);
+                ExecutableFlow.createExecutableFlow(
+                    GZIPUtils.transformBytesToObject(data, encType), status);
             execFlows.add(exFlow);
           } catch (final IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);
@@ -455,15 +451,11 @@ public class ExecutionFlowDao {
           ExecutionFlowDao.logger.error("Found a flow with empty data blob exec_id: " + id);
         } else {
           final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Status status = Status.fromInteger(rs.getInt(4));
           try {
             final ExecutableFlow exFlow =
-                ExecutableFlow.createExecutableFlowFromObject(
-                    GZIPUtils.transformBytesToObject(data, encType));
-
-            // read execution status from the DB column not from the flow data blob to maintain
-            // consistency and have a single source of truth
-            Status status = Status.fromInteger(rs.getInt(4));
-            exFlow.setStatus(status);
+                ExecutableFlow.createExecutableFlow(
+                    GZIPUtils.transformBytesToObject(data, encType), status);
             final ExecutionReference ref = new ExecutionReference(id);
             execFlows.add(new Pair<>(ref, exFlow));
           } catch (final IOException e) {
@@ -499,15 +491,11 @@ public class ExecutionFlowDao {
 
         if (data != null) {
           final EncodingType encType = EncodingType.fromInteger(encodingType);
+          final Status status = Status.fromInteger(rs.getInt(4));
           try {
             final ExecutableFlow exFlow =
-                ExecutableFlow.createExecutableFlowFromObject(
-                    GZIPUtils.transformBytesToObject(data, encType));
-
-            // read execution status from the DB column not from the flow data blob to maintain
-            // consistency and have a single source of truth
-            Status status = Status.fromInteger(rs.getInt(4));
-            exFlow.setStatus(status);
+                ExecutableFlow.createExecutableFlow(
+                    GZIPUtils.transformBytesToObject(data, encType), status);
             execFlows.add(exFlow);
           } catch (final IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -158,23 +158,22 @@ public class ExecutionFlowDao {
     }
   }
 
-  List<ExecutableFlow> fetchFlowHistory(final String projContain, final String flowContains,
-      final String userNameContains, final int status,
-      final long startTime, final long endTime,
-      final int skip, final int num)
+  List<ExecutableFlow> fetchFlowHistory(final String projectNameContains,
+      final String flowNameContains, final String userNameContains, final int status,
+      final long startTime, final long endTime, final int skip, final int num)
       throws ExecutorManagerException {
     String query = FetchExecutableFlows.FETCH_BASE_EXECUTABLE_FLOW_QUERY;
     final List<Object> params = new ArrayList<>();
 
     boolean first = true;
-    if (projContain != null && !projContain.isEmpty()) {
+    if (projectNameContains != null && !projectNameContains.isEmpty()) {
       query += " JOIN projects p ON ef.project_id = p.id WHERE name LIKE ?";
-      params.add('%' + projContain + '%');
+      params.add('%' + projectNameContains + '%');
       first = false;
     }
 
     // todo kunkun-tang: we don't need the below complicated logics. We should just use a simple way.
-    if (flowContains != null && !flowContains.isEmpty()) {
+    if (flowNameContains != null && !flowNameContains.isEmpty()) {
       if (first) {
         query += " WHERE ";
         first = false;
@@ -183,7 +182,7 @@ public class ExecutionFlowDao {
       }
 
       query += " flow_id LIKE ?";
-      params.add('%' + flowContains + '%');
+      params.add('%' + flowNameContains + '%');
     }
 
     if (userNameContains != null && !userNameContains.isEmpty()) {
@@ -373,22 +372,22 @@ public class ExecutionFlowDao {
       ResultSetHandler<List<ExecutableFlow>> {
 
     static String FETCH_EXECUTABLE_FLOW_BY_START_TIME =
-        "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef WHERE project_id=? "
-            + "AND flow_id=? AND start_time >= ? ORDER BY start_time DESC";
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef WHERE "
+            + "project_id=? AND flow_id=? AND start_time >= ? ORDER BY start_time DESC";
     static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
-        "SELECT ef.exec_id, ef.enc_type, ef.flow_data FROM execution_flows ef";
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef";
     static String FETCH_EXECUTABLE_FLOW =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE exec_id=?";
     static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
     static String FETCH_EXECUTABLE_FLOW_HISTORY =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
     static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? AND status=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
 
@@ -410,6 +409,8 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
+            Status status = Status.fromInteger(rs.getInt(4));
+            exFlow.setStatus(status);
             execFlows.add(exFlow);
           } catch (final IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);
@@ -429,8 +430,8 @@ public class ExecutionFlowDao {
 
     // Select queued unassigned flows
     private static final String FETCH_QUEUED_EXECUTABLE_FLOW =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows"
-            + " Where executor_id is NULL AND status = "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows"
+            + " WHERE executor_id is NULL AND status = "
             + Status.PREPARING.getNumVal();
 
     @Override
@@ -455,6 +456,9 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
+
+            Status status = Status.fromInteger(rs.getInt(4));
+            exFlow.setStatus(status);
             final ExecutionReference ref = new ExecutionReference(id);
             execFlows.add(new Pair<>(ref, exFlow));
           } catch (final IOException e) {
@@ -472,7 +476,7 @@ public class ExecutionFlowDao {
 
     // Execution_flows table is already indexed by end_time
     private static final String FETCH_RECENTLY_FINISHED_FLOW =
-        "SELECT exec_id, enc_type, flow_data FROM execution_flows "
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE end_time > ? AND status IN (?, ?, ?)";
 
     @Override
@@ -494,6 +498,8 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlowFromObject(
                     GZIPUtils.transformBytesToObject(data, encType));
+            Status status = Status.fromInteger(rs.getInt(4));
+            exFlow.setStatus(status);
             execFlows.add(exFlow);
           } catch (final IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -61,12 +61,8 @@ public class FetchActiveFlowDao {
       final EncodingType encType = EncodingType.fromInteger(encodingType);
       final ExecutableFlow exFlow;
       try {
-        exFlow = ExecutableFlow.createExecutableFlowFromObject(
-            GZIPUtils.transformBytesToObject(data, encType));
-
-        // read execution status from the DB column not from the flow data blob to maintain
-        // consistency and have a single source of truth
-        exFlow.setStatus(Status.fromInteger(status));
+        exFlow = ExecutableFlow.createExecutableFlow(
+            GZIPUtils.transformBytesToObject(data, encType), Status.fromInteger(status));
       } catch (final IOException e) {
         throw new SQLException("Error retrieving flow data " + id, e);
       }

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -63,6 +63,9 @@ public class FetchActiveFlowDao {
       try {
         exFlow = ExecutableFlow.createExecutableFlowFromObject(
             GZIPUtils.transformBytesToObject(data, encType));
+
+        // read execution status from the DB column not from the flow data blob to maintain
+        // consistency and have a single source of truth
         exFlow.setStatus(Status.fromInteger(status));
       } catch (final IOException e) {
         throw new SQLException("Error retrieving flow data " + id, e);

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -51,6 +51,7 @@ public class FetchActiveFlowDao {
     final int id = rs.getInt("exec_id");
     final int encodingType = rs.getInt("enc_type");
     final byte[] data = rs.getBytes("flow_data");
+    final int status = rs.getInt("status");
 
     if (data == null) {
       logger.warn("Execution id " + id + " has flow_data = null. To clean up, update status to "
@@ -62,6 +63,7 @@ public class FetchActiveFlowDao {
       try {
         exFlow = ExecutableFlow.createExecutableFlowFromObject(
             GZIPUtils.transformBytesToObject(data, encType));
+        exFlow.setStatus(Status.fromInteger(status));
       } catch (final IOException e) {
         throw new SQLException("Error retrieving flow data " + id, e);
       }
@@ -175,24 +177,24 @@ public class FetchActiveFlowDao {
 
     // Select flows that are not in finished status
     private static final String FETCH_UNFINISHED_EXECUTABLE_FLOWS =
-        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
-            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, ex.status status,"
+            + " et.host host, et.port port, ex.executor_id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
-            + " Where ex.status NOT IN ("
+            + " WHERE ex.status NOT IN ("
             + Status.SUCCEEDED.getNumVal() + ", "
             + Status.KILLED.getNumVal() + ", "
             + Status.FAILED.getNumVal() + ")";
 
     // Select flows that are dispatched and not in finished status
     private static final String FETCH_ACTIVE_EXECUTABLE_FLOWS =
-        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
-            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, ex.status status,"
+            + " et.host host, et.port port, ex.executor_id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
-            + " Where ex.status NOT IN ("
+            + " WHERE ex.status NOT IN ("
             + Status.SUCCEEDED.getNumVal() + ", "
             + Status.KILLED.getNumVal() + ", "
             + Status.FAILED.getNumVal() + ")"
@@ -266,12 +268,12 @@ public class FetchActiveFlowDao {
 
     // Select the flow that is dispatched and not in finished status by execution id
     private static final String FETCH_ACTIVE_EXECUTABLE_FLOW_BY_EXEC_ID =
-        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, et.host host, "
-            + "et.port port, ex.executor_id executorId, et.active executorStatus"
+        "SELECT ex.exec_id exec_id, ex.enc_type enc_type, ex.flow_data flow_data, ex.status status,"
+            + " et.host host, et.port port, ex.executor_id executorId, et.active executorStatus"
             + " FROM execution_flows ex"
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
-            + " Where ex.exec_id = ? AND ex.status NOT IN ("
+            + " WHERE ex.exec_id = ? AND ex.status NOT IN ("
             + Status.SUCCEEDED.getNumVal() + ", "
             + Status.KILLED.getNumVal() + ", "
             + Status.FAILED.getNumVal() + ")"

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
@@ -288,7 +288,7 @@ public class ExecutableFlowTest {
         (Map<String, Object>) JSONUtils.parseJSONFromString(exFlowJSON);
 
     final ExecutableFlow parsedExFlow =
-        ExecutableFlow.createExecutableFlowFromObject(flowObjMap);
+        ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
     testEquals(exFlow, parsedExFlow);
   }
 
@@ -337,7 +337,7 @@ public class ExecutableFlowTest {
     final Map<String, Object> flowObjMap =
         (Map<String, Object>) JSONUtils.parseJSONFromString(exFlowJSON);
     final ExecutableFlow parsedExFlow =
-        ExecutableFlow.createExecutableFlowFromObject(flowObjMap);
+        ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
     testEquals(exFlow, parsedExFlow);
 
     // test backward compatibility: reading in the original JSON format should
@@ -346,7 +346,7 @@ public class ExecutableFlowTest {
         (Map<String, Object>) JSONUtils.parseJSONFromFile(new File
         ("src/test/resources/json/embedded_flow.json"));
     final ExecutableFlow origExFlow =
-        ExecutableFlow.createExecutableFlowFromObject(origObjMap);
+        ExecutableFlow.createExecutableFlow(origObjMap, exFlow.getStatus());
     origExFlow.setUpdateTime(exFlow.getUpdateTime()); // update time changes
     testEquals(exFlow, origExFlow);
   }
@@ -363,7 +363,7 @@ public class ExecutableFlowTest {
     final Map<String, Object> flowObjMap =
         (Map<String, Object>) JSONUtils.parseJSONFromString(exFlowJSON);
     final ExecutableFlow copyFlow =
-        ExecutableFlow.createExecutableFlowFromObject(flowObjMap);
+        ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
 
     testEquals(exFlow, copyFlow);
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -28,15 +28,13 @@ import azkaban.user.User;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
+import azkaban.utils.TimeUtils;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -161,43 +159,27 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void fetchFlowHistoryWithStartTime() throws Exception {
-    class DateUtil {
+    final ExecutableFlow flow1 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.PREPARING);
+    final ExecutableFlow flow2 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
+    final ExecutableFlow flow3 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
+    final ExecutableFlow flow4 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"), Status.PREPARING);
 
-      private long dateStrToLong(final String dateStr) throws ParseException {
-        final SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        final Date d = f.parse(dateStr);
-        final long milliseconds = d.getTime();
-        return milliseconds;
-      }
-    }
+    final List<ExecutableFlow> expectedFlows = new ArrayList<>();
+    expectedFlows.add(flow1);
+    expectedFlows.add(flow2);
+    expectedFlows.add(flow3);
 
-    final DateUtil dateUtil = new DateUtil();
-    final ExecutableFlow flow1 = createTestFlow();
-    flow1.setStartTime(dateUtil.dateStrToLong("2018-09-01 10:00:00"));
-    this.executionFlowDao.uploadExecutableFlow(flow1);
-
-    final ExecutableFlow flow2 = createTestFlow();
-    flow2.setStartTime(dateUtil.dateStrToLong("2018-09-01 09:00:00"));
-    this.executionFlowDao.uploadExecutableFlow(flow2);
-
-    final ExecutableFlow flow3 = createTestFlow();
-    flow3.setStartTime(dateUtil.dateStrToLong("2018-09-01 09:00:00"));
-    this.executionFlowDao.uploadExecutableFlow(flow3);
-
-    final ExecutableFlow flow4 = createTestFlow();
-    flow4.setStartTime(dateUtil.dateStrToLong("2018-09-01 08:00:00"));
-    this.executionFlowDao.uploadExecutableFlow(flow4);
-
-    final List<ExecutableFlow> flowList = this.executionFlowDao.fetchFlowHistory
-        (flow1.getProjectId(), flow1.getFlowId(), dateUtil.dateStrToLong("2018-09-01 09:00:00"));
-    final List<ExecutableFlow> expected = new ArrayList<>();
-    expected.add(flow1);
-    expected.add(flow2);
-    expected.add(flow3);
+    final List<ExecutableFlow> flowList = this.executionFlowDao.fetchFlowHistory(
+        flow1.getProjectId(), flow1.getFlowId(),
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"));
 
     assertThat(flowList).hasSize(3);
     for (int i = 0; i < flowList.size(); i++) {
-      assertTwoFlowSame(flowList.get(i), expected.get(i));
+      assertTwoFlowSame(flowList.get(i), expectedFlows.get(i));
     }
   }
 
@@ -217,9 +199,7 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testFetchRecentlyFinishedFlows() throws Exception {
-    final ExecutableFlow flow1 = createTestFlow();
-    this.executionFlowDao.uploadExecutableFlow(flow1);
-    flow1.setStatus(Status.SUCCEEDED);
+    final ExecutableFlow flow1 = createExecution(System.currentTimeMillis(), Status.SUCCEEDED);
     flow1.setEndTime(System.currentTimeMillis());
     this.executionFlowDao.updateExecutableFlow(flow1);
 
@@ -232,13 +212,11 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testFetchEmptyRecentlyFinishedFlows() throws Exception {
-    final ExecutableFlow flow1 = createTestFlow();
-    this.executionFlowDao.uploadExecutableFlow(flow1);
-    flow1.setStatus(Status.SUCCEEDED);
-    flow1.setEndTime(DateTimeUtils.currentTimeMillis());
+    final ExecutableFlow flow1 = createExecution(System.currentTimeMillis(), Status.SUCCEEDED);
+    flow1.setEndTime(System.currentTimeMillis());
     this.executionFlowDao.updateExecutableFlow(flow1);
     //Todo jamiesjc: use java8.java.time api instead of jodatime
-
+    
     //Mock flow finished time to be 2 min ago.
     DateTimeUtils.setCurrentMillisOffset(-FLOW_FINISHED_TIME.toMillis());
     flow1.setEndTime(DateTimeUtils.currentTimeMillis());
@@ -247,26 +225,23 @@ public class ExecutionFlowDaoTest {
     //Fetch recently finished flows within 1 min. Should be empty.
     final List<ExecutableFlow> flows = this.executionFlowDao
         .fetchRecentlyFinishedFlows(RECENTLY_FINISHED_LIFETIME);
-    assertThat(flows.size()).isEqualTo(0);
+    assertThat(flows).isEmpty();
   }
 
   @Test
   public void testFetchQueuedFlows() throws Exception {
+    final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", System.currentTimeMillis(),
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    final ExecutableFlow flow2 = submitNewFlow("exectest1", "exec2", System.currentTimeMillis(),
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY);
 
-    final ExecutableFlow flow = createTestFlow();
-    flow.setStatus(Status.PREPARING);
-    this.executionFlowDao.uploadExecutableFlow(flow);
-    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
-    flow2.setStatus(Status.PREPARING);
-    this.executionFlowDao.uploadExecutableFlow(flow2);
-
-    final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows = this.executionFlowDao
-        .fetchQueuedFlows();
+    final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows =
+        this.executionFlowDao.fetchQueuedFlows();
     assertThat(fetchedQueuedFlows.size()).isEqualTo(2);
     final Pair<ExecutionReference, ExecutableFlow> fetchedFlow1 = fetchedQueuedFlows.get(0);
     final Pair<ExecutionReference, ExecutableFlow> fetchedFlow2 = fetchedQueuedFlows.get(1);
 
-    assertTwoFlowSame(flow, fetchedFlow1.getSecond());
+    assertTwoFlowSame(flow1, fetchedFlow1.getSecond());
     assertTwoFlowSame(flow2, fetchedFlow2.getSecond());
   }
 
@@ -317,8 +292,8 @@ public class ExecutionFlowDaoTest {
   @Test
   public void testFetchActiveFlowsExecutorAssigned() throws Exception {
     final List<ExecutableFlow> flows = createExecutions();
-    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows = this.fetchActiveFlowDao
-        .fetchActiveFlows();
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows =
+        this.fetchActiveFlowDao.fetchActiveFlows();
     assertFound(activeFlows, flows.get(0), true);
     assertNotFound(activeFlows, flows.get(1), "Returned a queued execution");
     assertFound(activeFlows, flows.get(2), true);
@@ -378,25 +353,26 @@ public class ExecutionFlowDaoTest {
 
   private List<ExecutableFlow> createExecutions() throws Exception {
     final Executor executor = this.executorDao.addExecutor("test", 1);
+    final long currentTime = System.currentTimeMillis();
 
     final ExecutableFlow flow1 = createExecutionAndAssign(Status.PREPARING, executor);
 
     // flow2 is not assigned
-    final ExecutableFlow flow2 = createExecution(Status.PREPARING);
+    final ExecutableFlow flow2 = createExecution(currentTime, Status.PREPARING);
 
     final ExecutableFlow flow3 = createExecutionAndAssign(Status.RUNNING, executor);
-    flow3.setStartTime(System.currentTimeMillis() + 1);
+    flow3.setStartTime(currentTime + 1);
     this.executionFlowDao.updateExecutableFlow(flow3);
 
     final ExecutableFlow flow4 = createExecutionAndAssign(Status.SUCCEEDED, executor);
-    flow4.setStartTime(System.currentTimeMillis() - 2);
-    flow4.setEndTime(System.currentTimeMillis() - 1);
+    flow4.setStartTime(currentTime + 2);
+    flow4.setEndTime(currentTime + 4);
     this.executionFlowDao.updateExecutableFlow(flow4);
 
     final Executor executor2 = this.executorDao.addExecutor("test2", 2);
     // flow5 is assigned to an executor that is then removed
     final ExecutableFlow flow5 = createExecutionAndAssign(Status.RUNNING, executor2);
-    flow5.setStartTime(System.currentTimeMillis() + 1);
+    flow5.setStartTime(currentTime + 6);
     this.executionFlowDao.updateExecutableFlow(flow5);
 
     this.executorDao.removeExecutor(executor2.getHost(), executor2.getPort());
@@ -419,15 +395,18 @@ public class ExecutionFlowDaoTest {
 
   private ExecutableFlow createExecutionAndAssign(final Status status, final Executor executor)
       throws Exception {
-    final ExecutableFlow flow = createExecution(status);
+    final ExecutableFlow flow = createExecution(System.currentTimeMillis(), status);
     this.assignExecutor.assignExecutor(executor.getId(), flow.getExecutionId());
     return flow;
   }
 
-  private ExecutableFlow createExecution(final Status status)
+  private ExecutableFlow createExecution(final long startTime, final Status status)
       throws IOException, ExecutorManagerException {
     final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    flow.setSubmitTime(System.currentTimeMillis());
+    flow.setSubmitUser("testUser");
+    flow.setSubmitTime(startTime - 1);
+    flow.setStartTime(startTime);
+    flow.setStatus(Status.PREPARING);
     this.executionFlowDao.uploadExecutableFlow(flow);
     flow.setStatus(status);
     this.executionFlowDao.updateExecutableFlow(flow);
@@ -586,11 +565,191 @@ public class ExecutionFlowDaoTest {
         .isEqualTo(-1);
   }
 
+  @Test
+  public void testFlowStatusWithFetchExecutableFlows() throws Exception {
+    final ExecutableFlow flow = submitNewFlow("exectest1", "exec1",
+        System.currentTimeMillis(), ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    int execId = flow.getExecutionId();
+    makeFlowStatusInconsistent(execId, Status.FAILED_FINISHING);
+    final ExecutableFlow fetchedFlow = this.executionFlowDao.fetchExecutableFlow(execId);
+    assertThat(fetchedFlow.getStatus()).isEqualTo(Status.FAILED_FINISHING);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchFlowHistory() throws Exception {
+    final ExecutableFlow flow = submitNewFlow("exectest1", "exec1",
+        System.currentTimeMillis(), ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    int execId = flow.getExecutionId();
+    makeFlowStatusInconsistent(execId, Status.FAILED_FINISHING);
+
+    // fetch all executions
+    final List<ExecutableFlow> flowList1 = this.executionFlowDao.fetchFlowHistory(0, 2);
+    assertThat(flowList1).isNotEmpty();
+    assertThat(flowList1.get(0).getStatus()).isEqualTo(Status.FAILED_FINISHING);
+    assertThat(flowList1.get(0).getExecutionId()).isEqualTo(execId);
+
+    // fetch executions of a flow
+    final List<ExecutableFlow> flowList2 = this.executionFlowDao
+        .fetchFlowHistory(flow.getProjectId(), flow.getId(), 0, 3);
+    assertThat(flowList2).isNotEmpty();
+    assertThat(flowList2.get(0).getStatus()).isEqualTo(Status.FAILED_FINISHING);
+    assertThat(flowList2.get(0).getExecutionId()).isEqualTo(execId);
+
+    // fetch flow executions by status
+    final List<ExecutableFlow> flowList3 = this.executionFlowDao.fetchFlowHistory(
+        flow.getProjectId(), flow.getId(), 0, 3, Status.FAILED_FINISHING);
+    assertThat(flowList3).isNotEmpty();
+    assertThat(flowList3.get(0).getExecutionId()).isEqualTo(execId);
+
+    // fetch flow executions by multiple filters
+    final List<ExecutableFlow> flowList4 = this.executionFlowDao
+        .fetchFlowHistory("", "data", "", 0, -1, -1, 0, 16);
+    assertThat(flowList4).isNotEmpty();
+    assertThat(flowList4.get(0).getStatus()).isEqualTo(Status.FAILED_FINISHING);
+    assertThat(flowList4.get(0).getExecutionId()).isEqualTo(execId);
+
+    final ExecutableFlow fetchedFlow = this.executionFlowDao.fetchExecutableFlow(execId);
+    assertTwoFlowSame(fetchedFlow, flowList1.get(0));
+    assertTwoFlowSame(fetchedFlow, flowList2.get(0));
+    assertTwoFlowSame(fetchedFlow, flowList3.get(0));
+    assertTwoFlowSame(fetchedFlow, flowList4.get(0));
+
+  }
+
+  @Test
+  public void fetchFlowStatusWithFlowHistoryByStartTime() throws Exception {
+    final ExecutableFlow flow1 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.PREPARING);
+    final ExecutableFlow flow2 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
+    final ExecutableFlow flow3 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
+    final ExecutableFlow flow4 = createExecution(
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"), Status.QUEUED);
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.FAILED_FINISHING);
+
+    final List<ExecutableFlow> flowList = this.executionFlowDao.fetchFlowHistory(
+        flow1.getProjectId(), flow1.getFlowId(),
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"));
+
+    assertThat(flowList).hasSize(4);
+    assertThat(flowList.get(0).getExecutionId()).isEqualTo(flow1.getExecutionId());
+    assertThat(flowList.get(0).getStatus()).isEqualTo(Status.FAILED_FINISHING);
+    assertThat(flowList.get(3).getExecutionId()).isEqualTo(flow4.getExecutionId());
+    assertThat(flowList.get(3).getStatus()).isEqualTo(Status.QUEUED);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchUnfinishedFlows() throws Exception {
+    final ExecutableFlow flow1 = createExecutionAndAssign(Status.QUEUED,
+        this.executorDao.addExecutor("test", 1));
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows1 =
+        this.fetchActiveFlowDao.fetchUnfinishedFlows();
+    assertThat(unfinishedFlows1.containsKey(flow1.getExecutionId())).isTrue();
+    assertThat(unfinishedFlows1.get(flow1.getExecutionId()).getSecond().getStatus())
+        .isEqualTo(Status.QUEUED);
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.FAILED_FINISHING);
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows2 =
+        this.fetchActiveFlowDao.fetchUnfinishedFlows();
+    assertThat(unfinishedFlows2.containsKey(flow1.getExecutionId())).isTrue();
+    assertThat(unfinishedFlows2.get(flow1.getExecutionId()).getSecond().getStatus())
+        .isEqualTo(Status.FAILED_FINISHING);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchActiveFlows() throws Exception {
+    final ExecutableFlow flow1 = createExecutionAndAssign(Status.RUNNING,
+        this.executorDao.addExecutor("test", 1));
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows1 =
+        this.fetchActiveFlowDao.fetchActiveFlows();
+    assertThat(activeFlows1.containsKey(flow1.getExecutionId())).isTrue();
+    assertThat(activeFlows1.get(flow1.getExecutionId()).getSecond().getStatus())
+        .isEqualTo(Status.RUNNING);
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.KILLING);
+
+    final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows2 =
+        this.fetchActiveFlowDao.fetchActiveFlows();
+    assertThat(activeFlows2.containsKey(flow1.getExecutionId())).isTrue();
+    assertThat(activeFlows2.get(flow1.getExecutionId()).getSecond().getStatus())
+        .isEqualTo(Status.KILLING);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchActiveFlowByExecId() throws Exception {
+    final ExecutableFlow flow1 = createExecutionAndAssign(Status.RUNNING,
+        this.executorDao.addExecutor("test", 1));
+    Pair<ExecutionReference, ExecutableFlow> activeFlow1 =
+        this.fetchActiveFlowDao.fetchActiveFlowByExecId(flow1.getExecutionId());
+    assertThat(activeFlow1).isNotNull();
+    assertTwoFlowSame(activeFlow1.getSecond(), flow1);
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.KILLING);
+
+    Pair<ExecutionReference, ExecutableFlow> activeFlow2 =
+        this.fetchActiveFlowDao.fetchActiveFlowByExecId(flow1.getExecutionId());
+    assertThat(activeFlow2).isNotNull();
+    assertThat(activeFlow2.getSecond().getStatus()).isEqualTo(Status.KILLING);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchQueuedFlows() throws Exception {
+    final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", System.currentTimeMillis(),
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    flow1.setStatus(Status.RUNNING);
+    this.executionFlowDao.updateExecutableFlow(flow1);
+
+    final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows1 =
+        this.executionFlowDao.fetchQueuedFlows();
+    assertThat(fetchedQueuedFlows1).isEmpty();
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.PREPARING);
+
+    final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows2 =
+        this.executionFlowDao.fetchQueuedFlows();
+    assertThat(fetchedQueuedFlows2).isNotEmpty();
+    assertThat(fetchedQueuedFlows2.get(0).getSecond().getStatus()).isEqualTo(Status.PREPARING);
+  }
+
+  @Test
+  public void testFlowStatusWithFetchRecentlyFinishedFlows() throws Exception {
+    final ExecutableFlow flow1 = createExecution(System.currentTimeMillis(), Status.SUCCEEDED);
+    flow1.setEndTime(System.currentTimeMillis());
+    this.executionFlowDao.updateExecutableFlow(flow1);
+
+    final List<ExecutableFlow> finishedFlows1 = this.executionFlowDao.fetchRecentlyFinishedFlows(
+        RECENTLY_FINISHED_LIFETIME);
+    assertThat(finishedFlows1).isNotEmpty();
+    assertTwoFlowSame(flow1, finishedFlows1.get(0));
+
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.FAILED);
+
+    final List<ExecutableFlow> finishedFlows2 = this.executionFlowDao.fetchRecentlyFinishedFlows(
+        RECENTLY_FINISHED_LIFETIME);
+    assertThat(finishedFlows2).isNotEmpty();
+    assertThat(finishedFlows2.get(0).getStatus()).isEqualTo(Status.FAILED);
+  }
+
+  private void makeFlowStatusInconsistent(int executionId, Status status) {
+    final String MODIFY_FLOW_STATUS = "UPDATE execution_flows SET status=? WHERE exec_id=?";
+    try {
+      dbOperator.update(MODIFY_FLOW_STATUS, status.getNumVal(), executionId);
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
   private ExecutableFlow submitNewFlow(final String projectName, final String flowName,
       final long submitTime, final int flowPriority) throws IOException, ExecutorManagerException {
     final ExecutableFlow flow = TestUtils.createTestExecutableFlow(projectName, flowName);
     flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(submitTime);
+    flow.setSubmitUser("testUser");
     flow.getExecutionOptions().getFlowParameters().put(ExecutionOptions.FLOW_PRIORITY,
         String.valueOf(flowPriority));
     this.executionFlowDao.uploadExecutableFlow(flow);

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -56,22 +56,21 @@ public class MockExecutorLoader implements ExecutorLoader {
   Map<Integer, ArrayList<ExecutorLogEvent>> executorEvents = new ConcurrentHashMap<>();
 
   @Override
-  public void uploadExecutableFlow(final ExecutableFlow flow)
-      throws ExecutorManagerException {
+  public void uploadExecutableFlow(final ExecutableFlow flow) throws ExecutorManagerException {
     // Clone the flow node to mimick how it would be saved in DB.
     // If we would keep a handle to the original flow node, we would also see any changes made after
     // this method was called. We must only store a snapshot of the current state.
     // Also to avoid modifying statuses of the original job nodes in this.updateExecutableFlow()
-    final ExecutableFlow exFlow = ExecutableFlow.createExecutableFlowFromObject(flow.toObject());
+    final ExecutableFlow exFlow = ExecutableFlow.createExecutableFlow(flow.toObject(),
+        flow.getStatus());
     this.flows.put(flow.getExecutionId(), exFlow);
     this.flowUpdateCount++;
   }
 
   @Override
-  public ExecutableFlow fetchExecutableFlow(final int execId)
-      throws ExecutorManagerException {
+  public ExecutableFlow fetchExecutableFlow(final int execId) throws ExecutorManagerException {
     final ExecutableFlow flow = this.flows.get(execId);
-    return ExecutableFlow.createExecutableFlowFromObject(flow.toObject());
+    return ExecutableFlow.createExecutableFlow(flow.toObject(), flow.getStatus());
   }
 
   @Override


### PR DESCRIPTION
Currently flow execution status is stored in 2 places: a column in the DB and in the execution's JSON object. Because flow execution status is not read from the same source all the times sometimes we see inconsistency in the UI where different pages show different flow execution status.

This PR addresses this inconsistency by fetching the execution status from DB everywhere in the code.