### PR TITLE
Adding printStackTrace statement to get more information

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -1002,6 +1002,7 @@ public class FlowRunnerManager implements EventListener,
           } catch (final InterruptedException e) {
             FlowRunnerManager.LOGGER.info("Interrupted. Probably to shut down.");
           } catch (final Throwable t) {
+            t.printStackTrace();
             FlowRunnerManager.LOGGER.warn(
                 "Uncaught throwable, please look into why it is not caught", t);
           }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -1000,11 +1000,11 @@ public class FlowRunnerManager implements EventListener,
 
             wait(FlowRunnerManager.RECENTLY_FINISHED_TIME_TO_LIVE);
           } catch (final InterruptedException e) {
-            FlowRunnerManager.LOGGER.info("Interrupted. Probably to shut down.");
+            FlowRunnerManager.LOGGER.info("Interrupted. Probably to shut down.", e.getMessage());
           } catch (final Throwable t) {
             t.printStackTrace();
             FlowRunnerManager.LOGGER.warn(
-                "Uncaught throwable, please look into why it is not caught", t);
+                "Uncaught throwable, please look into why it is not caught", t.getMessage());
           }
         }
       }


### PR DESCRIPTION
We are seeing Uncaught throwable exception sometimes related to NullPointerException. We do not have full stack trace about where and how this exception is coming. It is not happening that often. But for future cases, it will be better to have stack trace for this issue.