### PR TITLE
Add remediation for flows assigned to unreachable executors

### DIFF
--- a/azkaban-common/src/main/java/azkaban/alert/Alerter.java
+++ b/azkaban-common/src/main/java/azkaban/alert/Alerter.java
@@ -34,4 +34,8 @@ public interface Alerter {
 
   void alertOnFailedUpdate(Executor executor, List<ExecutableFlow> executions,
       ExecutorManagerException e);
+
+  void alertOnFailedExecutorHealthCheck(Executor executor,
+      List<ExecutableFlow> executions,
+      ExecutorManagerException e, List<String> alertEmails);
 }

--- a/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
+++ b/azkaban-common/src/main/java/azkaban/executor/mail/MailCreator.java
@@ -40,4 +40,12 @@ public interface MailCreator {
       ExecutorManagerException updateException, EmailMessage message,
       String azkabanName, String scheme, String clientHostname,
       String clientPortNumber);
+
+  default boolean createFailedExecutorHealthCheckMessage(List<ExecutableFlow> flows,
+      Executor executor,
+      ExecutorManagerException failureException, EmailMessage message,
+      String azkabanName, String scheme, String clientHostname,
+      String clientPortNumber, List<String> emailList) {
+    return false;
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/mail/DefaultMailCreatorTest.java
@@ -173,4 +173,17 @@ public class DefaultMailCreatorTest {
         .isEqualToIgnoringWhitespace(this.message.getBody());
   }
 
+  @Test
+  public void createFailedHealthCheckMessage() throws Exception {
+    final ExecutorManagerException exception = createTestStracktrace();
+    assertTrue(this.mailCreator
+        .createFailedExecutorHealthCheckMessage(Arrays.asList(this.executableFlow, this.executableFlow),
+            this.executor, exception, this.message, this.azkabanName, this.scheme,
+            this.clientHostname, this.clientPortNumber, ImmutableList.of("test@example.com")));
+    assertEquals("Alert: Executor is unreachable, executor1-host on unit-tests",
+        this.message.getSubject());
+    assertThat(TestUtils.readResource("failedExecutorHealthCheckMessage.html", this))
+        .isEqualToIgnoringWhitespace(this.message.getBody());
+  }
+
 }

--- a/azkaban-common/src/test/resources/azkaban/executor/mail/failedExecutorHealthCheckMessage.html
+++ b/azkaban-common/src/test/resources/azkaban/executor/mail/failedExecutorHealthCheckMessage.html
@@ -1,0 +1,12 @@
+<h2 style="color:#FFA500"> Executor is unreachable. Executor host - executor1-host on Cluster - unit-tests</h2>
+Remedial action will be attempted on affected executions - <br>Following flows were reported as running on the executor and will be finalized.
+<h3>Affected executions</h3>
+<ul>
+	<li>Execution '-1' of flow 'mail-creator-test' of project 'test-project' -  <a href="http://localhost:8081/executor?execid=-1">Execution Link</a></li>
+	<li>Execution '-1' of flow 'mail-creator-test' of project 'test-project' -  <a href="http://localhost:8081/executor?execid=-1">Execution Link</a></li>
+</ul>
+<h3>Error detail</h3>
+Following error was reported for executor-id: 1, executor-host: executor1-host, executor-port: 1234
+<pre>azkaban.executor.ExecutorManagerException: mocked failure
+	at azkaban.executor.mail.DefaultMailCreatorTest.createFailedUpdateMessage(DefaultMailCreatorTest.java:135)
+</pre>


### PR DESCRIPTION
As part of the remediation flows in an `unfinished` state assinged to an unreachable executor are finalized

Additional changes:
- Adds healthcheck alert as a first-class member of alert related interfaces
   - Current code was repurposing Flow Failure related alert mechanism in a less
     than ideal manner
- Customized email format for healthcheck alert message
   - Assumes that only a `single` kind of healthcheck alert message is required.
     But makes future extensions easier, if required.