### PR TITLE
Add more metrics to flow and job executions.

### DIFF
--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -60,13 +60,10 @@ public class MetricsManager {
   }
 
   /**
-   * A {@link Meter} measures the rate of events over time (e.g., “requests per second”). Here we
-   * track 1-minute moving averages.
+   * A {@link Meter} measures the rate of events over time (e.g., “requests per second”).
    */
   public Meter addMeter(final String name) {
-    final Meter curr = this.registry.meter(name);
-    this.registry.register(name + "-gauge", (Gauge<Double>) curr::getOneMinuteRate);
-    return curr;
+    return this.registry.meter(name);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
@@ -17,7 +17,6 @@
 package azkaban.metrics;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -38,7 +37,6 @@ public class CommonMetrics {
   public static final String SUBMIT_FLOW_FAIL_METER_NAME = "submit-flow-fail-meter";
   public static final String SUBMIT_FLOW_SKIP_METER_NAME = "submit-flow-skip-meter";
   public static final String OOM_WAITING_JOB_COUNT_NAME = "OOM-waiting-job-count";
-  public static final String QUEUE_WAIT_HISTOGRAM_NAME = "queue-wait-histogram";
   public static final String UPLOAD_FAT_PROJECT_METER_NAME = "upload-fat-project-meter";
   public static final String UPLOAD_THIN_PROJECT_METER_NAME = "upload-thin-project-meter";
 
@@ -54,7 +52,6 @@ public class CommonMetrics {
   private Meter submitFlowSkipMeter;
   private Meter uploadFatProjectMeter;
   private Meter uploadThinProjectMeter;
-  private Histogram queueWaitMeter;
 
   @Inject
   public CommonMetrics(final MetricsManager metricsManager) {
@@ -72,7 +69,6 @@ public class CommonMetrics {
     this.submitFlowFailMeter = this.metricsManager.addMeter(SUBMIT_FLOW_FAIL_METER_NAME);
     this.submitFlowSkipMeter = this.metricsManager.addMeter(SUBMIT_FLOW_SKIP_METER_NAME);
     this.OOMWaitingJobCount = this.metricsManager.addCounter(OOM_WAITING_JOB_COUNT_NAME);
-    this.queueWaitMeter = this.metricsManager.addHistogram(QUEUE_WAIT_HISTOGRAM_NAME);
     this.uploadFatProjectMeter = this.metricsManager.addMeter(UPLOAD_FAT_PROJECT_METER_NAME);
     this.uploadThinProjectMeter = this.metricsManager.addMeter(UPLOAD_THIN_PROJECT_METER_NAME);
   }
@@ -156,14 +152,5 @@ public class CommonMetrics {
    */
   public void decrementOOMJobWaitCount() {
     this.OOMWaitingJobCount.dec();
-  }
-
-  /**
-   * Add the queue wait time for a flow to the metrics.
-   *
-   * @param time queue wait time for a flow.
-   */
-  public void addQueueWait(final long time) {
-    this.queueWaitMeter.update(time);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/CommonMetrics.java
@@ -141,14 +141,14 @@ public class CommonMetrics {
   public void markUploadThinProject() { this.uploadThinProjectMeter.mark(); }
 
   /**
-   * Mark the occurrence of an job waiting event due to OOM
+   * Mark the occurrence of a job waiting event due to OOM
    */
   public void incrementOOMJobWaitCount() {
     this.OOMWaitingJobCount.inc();
   }
 
   /**
-   * Unmark the occurrence of an job waiting event due to OOM
+   * Unmark the occurrence of a job waiting event due to OOM
    */
   public void decrementOOMJobWaitCount() {
     this.OOMWaitingJobCount.dec();

--- a/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
+++ b/azkaban-common/src/test/java/azkaban/metrics/CommonMetricsTest.java
@@ -17,10 +17,8 @@
 package azkaban.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Snapshot;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,20 +60,5 @@ public class CommonMetricsTest {
     assertThat(this.testUtil.getMeterValue(CommonMetrics.SUBMIT_FLOW_SUCCESS_METER_NAME)).isEqualTo(0);
     this.metrics.markSubmitFlowSuccess();
     assertThat(this.testUtil.getMeterValue(CommonMetrics.SUBMIT_FLOW_SUCCESS_METER_NAME)).isEqualTo(1);
-  }
-
-  @Test
-  public void testQueueWaitMetrics() {
-    final double delta = 0.001;
-
-    this.metrics.addQueueWait(500L);
-    this.metrics.addQueueWait(600L);
-    this.metrics.addQueueWait(1000L);
-    final Snapshot snapshot = this.testUtil
-        .getHistogramSnapshot(CommonMetrics.QUEUE_WAIT_HISTOGRAM_NAME);
-    assertThat(snapshot.getMedian()).isCloseTo(600.0, within(delta));
-    assertThat(snapshot.getMean()).isCloseTo(700.0, within(delta));
-    assertThat(snapshot.getMin()).isEqualTo(500);
-    assertThat( snapshot.getMax()).isEqualTo(1000);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
@@ -18,6 +18,7 @@ package azkaban.execapp;
 
 import azkaban.execapp.metric.ProjectCacheHitRatio;
 import azkaban.metrics.MetricsManager;
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
@@ -33,9 +34,7 @@ public class ExecMetrics {
   public static final String NUM_QUEUED_FLOWS_NAME = "EXEC-NumQueuedFlows";
   public static final String PROJECT_DIR_CACHE_HIT_RATIO_NAME = "project-dir-cache-hit-ratio";
   public static final String FLOW_SETUP_TIMER_NAME = "flow-setup-timer";
-  public static final String QUEUE_WAIT_HISTOGRAM_NAME = "queue-wait-histogram";
-  public static final String FLOW_TIME_TO_START_HISTOGRAM_NAME= "flow-time-to-start-histogram";
-  public static final String FLOW_KILLING_METER_NAME = "flow-killing-meter";
+  public static final String FLOW_KILLING_COUNTER_NAME = "flow-killing-counter";
   public static final String FLOW_TIME_TO_KILL_HISTOGRAM_NAME = "flow-time-to-kill-histogram";
   public static final String FLOW_KILLED_METER_NAME = "flow-killed-meter";
   public static final String FLOW_SUCCESS_METER_NAME = "flow-success-meter";
@@ -46,9 +45,7 @@ public class ExecMetrics {
   private final MetricsManager metricsManager;
   private Timer flowSetupTimer;
   private final ProjectCacheHitRatio projectCacheHitRatio;
-  private Histogram queueWaitHistogram;
-  private Histogram flowTimeToStartHistogram;
-  private Meter flowKillingMeter;
+  private Counter flowKillingCounter;
   private Histogram flowTimeToKillHistogram;
   private Meter flowKilledMeter;
   private Meter flowSuccessMeter;
@@ -64,10 +61,7 @@ public class ExecMetrics {
     this.metricsManager.addGauge(PROJECT_DIR_CACHE_HIT_RATIO_NAME,
         this.projectCacheHitRatio::getValue);
     this.flowSetupTimer = this.metricsManager.addTimer(FLOW_SETUP_TIMER_NAME);
-    this.queueWaitHistogram = this.metricsManager.addHistogram(QUEUE_WAIT_HISTOGRAM_NAME);
-    this.flowTimeToStartHistogram =
-        this.metricsManager.addHistogram(FLOW_TIME_TO_START_HISTOGRAM_NAME);
-    this.flowKillingMeter = this.metricsManager.addMeter(FLOW_KILLING_METER_NAME);
+    this.flowKillingCounter = this.metricsManager.addCounter(FLOW_KILLING_COUNTER_NAME);
     this.flowTimeToKillHistogram =
         this.metricsManager.addHistogram(FLOW_TIME_TO_KILL_HISTOGRAM_NAME);
     this.flowKilledMeter = this.metricsManager.addMeter(FLOW_KILLED_METER_NAME);
@@ -96,28 +90,17 @@ public class ExecMetrics {
   }
 
   /**
-   * Add the time between submission and when the flow preparation starts.
-   *
-   * @param time queue wait time for a flow.
+   * Increment the number of flow executions in killing status.
    */
-  public void addQueueWait(final long time) {
-    this.queueWaitHistogram.update(time);
+  public void incrementFlowKillingCount() {
+    this.flowKillingCounter.inc();
   }
 
   /**
-   * Add the time between submission and start of execution for a flow.
-   *
-   * @param time submission-to-start time for a flow
+   * Decrement the number of flow executions in killing status.
    */
-  public void addFlowTimeToStart(final long time) {
-    this.flowTimeToStartHistogram.update(time);
-  }
-
-  /**
-   * Record the start of the flow killing procedure.
-   */
-  public void markFlowKilling() {
-    this.flowKillingMeter.mark();
+  public void decrementFlowKillingCount() {
+    this.flowKillingCounter.dec();
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
@@ -52,6 +52,8 @@ public class ExecMetrics {
   private Meter jobFailMeter;
   private Meter jobSuccessMeter;
   private Meter jobKilledMeter;
+  // TODO ypadron-in: add metrics to measure the time between flow submission and flow execution
+  // preparation/start after clock skew issues in execution times are resolved.
 
   @Inject
   ExecMetrics(final MetricsManager metricsManager) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ExecMetrics.java
@@ -18,6 +18,8 @@ package azkaban.execapp;
 
 import azkaban.execapp.metric.ProjectCacheHitRatio;
 import azkaban.metrics.MetricsManager;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -29,21 +31,50 @@ import javax.inject.Singleton;
 public class ExecMetrics {
   public static final String NUM_RUNNING_FLOWS_NAME = "EXEC-NumRunningFlows";
   public static final String NUM_QUEUED_FLOWS_NAME = "EXEC-NumQueuedFlows";
-  public static final String PROJECT_DIR_CACHE_HIT_RATIO_NAME = "EXEC-ProjectDirCacheHitRatio";
-  public static final String FLOW_SETUP_TIMER_NAME = "EXEC-flow-setup-timer";
+  public static final String PROJECT_DIR_CACHE_HIT_RATIO_NAME = "project-dir-cache-hit-ratio";
+  public static final String FLOW_SETUP_TIMER_NAME = "flow-setup-timer";
+  public static final String QUEUE_WAIT_HISTOGRAM_NAME = "queue-wait-histogram";
+  public static final String FLOW_TIME_TO_START_HISTOGRAM_NAME= "flow-time-to-start-histogram";
+  public static final String FLOW_KILLING_METER_NAME = "flow-killing-meter";
+  public static final String FLOW_TIME_TO_KILL_HISTOGRAM_NAME = "flow-time-to-kill-histogram";
+  public static final String FLOW_KILLED_METER_NAME = "flow-killed-meter";
+  public static final String FLOW_SUCCESS_METER_NAME = "flow-success-meter";
+  public static final String JOB_FAIL_METER_NAME = "job-fail-meter";
+  public static final String JOB_SUCCESS_METER_NAME = "job-success-meter";
+  public static final String JOB_KILLED_METER_NAME = "job-killed-meter";
 
   private final MetricsManager metricsManager;
   private Timer flowSetupTimer;
   private final ProjectCacheHitRatio projectCacheHitRatio;
+  private Histogram queueWaitHistogram;
+  private Histogram flowTimeToStartHistogram;
+  private Meter flowKillingMeter;
+  private Histogram flowTimeToKillHistogram;
+  private Meter flowKilledMeter;
+  private Meter flowSuccessMeter;
+  private Meter jobFailMeter;
+  private Meter jobSuccessMeter;
+  private Meter jobKilledMeter;
 
   @Inject
   ExecMetrics(final MetricsManager metricsManager) {
     this.metricsManager = metricsManager;
     // setup project cache ratio metrics
     this.projectCacheHitRatio = new ProjectCacheHitRatio();
-    metricsManager.addGauge("EXEC-ProjectDirCacheHitRatio",
-        this.projectCacheHitRatio::getRatio);
+    this.metricsManager.addGauge(PROJECT_DIR_CACHE_HIT_RATIO_NAME,
+        this.projectCacheHitRatio::getValue);
     this.flowSetupTimer = this.metricsManager.addTimer(FLOW_SETUP_TIMER_NAME);
+    this.queueWaitHistogram = this.metricsManager.addHistogram(QUEUE_WAIT_HISTOGRAM_NAME);
+    this.flowTimeToStartHistogram =
+        this.metricsManager.addHistogram(FLOW_TIME_TO_START_HISTOGRAM_NAME);
+    this.flowKillingMeter = this.metricsManager.addMeter(FLOW_KILLING_METER_NAME);
+    this.flowTimeToKillHistogram =
+        this.metricsManager.addHistogram(FLOW_TIME_TO_KILL_HISTOGRAM_NAME);
+    this.flowKilledMeter = this.metricsManager.addMeter(FLOW_KILLED_METER_NAME);
+    this.flowSuccessMeter = this.metricsManager.addMeter(FLOW_SUCCESS_METER_NAME);
+    this.jobFailMeter = this.metricsManager.addMeter(JOB_FAIL_METER_NAME);
+    this.jobSuccessMeter = this.metricsManager.addMeter(JOB_SUCCESS_METER_NAME);
+    this.jobKilledMeter = this.metricsManager.addMeter(JOB_KILLED_METER_NAME);
   }
 
   ProjectCacheHitRatio getProjectCacheHitRatio() {
@@ -60,5 +91,66 @@ public class ExecMetrics {
   /**
    * @return the {@link Timer.Context} for the timer.
    */
-  public Timer.Context getFlowSetupTimerContext() { return this.flowSetupTimer.time(); }
+  public Timer.Context getFlowSetupTimerContext() {
+    return this.flowSetupTimer.time();
+  }
+
+  /**
+   * Add the time between submission and when the flow preparation starts.
+   *
+   * @param time queue wait time for a flow.
+   */
+  public void addQueueWait(final long time) {
+    this.queueWaitHistogram.update(time);
+  }
+
+  /**
+   * Add the time between submission and start of execution for a flow.
+   *
+   * @param time submission-to-start time for a flow
+   */
+  public void addFlowTimeToStart(final long time) {
+    this.flowTimeToStartHistogram.update(time);
+  }
+
+  /**
+   * Record the start of the flow killing procedure.
+   */
+  public void markFlowKilling() {
+    this.flowKillingMeter.mark();
+  }
+
+  /**
+   * Add the time it took to kill all the jobs in an execution.
+   *
+   * @param time killing-to-killed time for a flow
+   */
+  public void addFlowTimeToKill(final long time) {
+    this.flowTimeToKillHistogram.update(time);
+  }
+
+  /**
+   * Record a killed flow execution event.
+   */
+  public void markFlowKilled() { this.flowKilledMeter.mark(); }
+
+  /**
+   * Record a successful flow execution event.
+   */
+  public void markFlowSuccess() { this.flowSuccessMeter.mark(); }
+
+  /**
+   * Record a failed job execution event.
+   */
+  public void markJobFail() { this.jobFailMeter.mark(); }
+
+  /**
+   * Record a successful job execution event.
+   */
+  public void markJobSuccess() { this.jobSuccessMeter.mark(); }
+
+  /**
+   * Record a killed job execution event.
+   */
+  public void markJobKilled() { this.jobKilledMeter.mark(); }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -432,10 +432,10 @@ public class FlowRunnerManager implements EventListener,
 
     // Sets up the project files and execution directory.
     this.preparingFlowCount.incrementAndGet();
-    // Record the time between submission, and when the flow preparation/execution starts.
+    // Record the time between submission and the start of flow execution preparation.
     // Note that since submit time is recorded on the web server, while flow preparation is on
     // the executor, there could be some inaccuracies due to clock skew.
-    this.commonMetrics.addQueueWait(System.currentTimeMillis() -
+    this.execMetrics.addQueueWait(System.currentTimeMillis() -
         flow.getExecutableFlow().getSubmitTime());
 
     final Timer.Context flowPrepTimerContext = this.execMetrics.getFlowSetupTimerContext();
@@ -495,7 +495,8 @@ public class FlowRunnerManager implements EventListener,
 
     final FlowRunner runner =
         new FlowRunner(flow, this.executorLoader, this.projectLoader, this.jobtypeManager,
-            this.azkabanProps, this.azkabanEventReporter, this.alerterHolder, this.commonMetrics);
+            this.azkabanProps, this.azkabanEventReporter, this.alerterHolder, this.commonMetrics,
+            this.execMetrics);
     runner.setFlowWatcher(watcher)
         .setJobLogSettings(this.jobLogChunkSize, this.jobLogNumFiles)
         .setValidateProxyUser(this.validateProxyUser)

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -432,11 +432,6 @@ public class FlowRunnerManager implements EventListener,
 
     // Sets up the project files and execution directory.
     this.preparingFlowCount.incrementAndGet();
-    // Record the time between submission and the start of flow execution preparation.
-    // Note that since submit time is recorded on the web server, while flow preparation is on
-    // the executor, there could be some inaccuracies due to clock skew.
-    this.execMetrics.addQueueWait(System.currentTimeMillis() -
-        flow.getExecutableFlow().getSubmitTime());
 
     final Timer.Context flowPrepTimerContext = this.execMetrics.getFlowSetupTimerContext();
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/ExecMetricsTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/ExecMetricsTest.java
@@ -55,4 +55,19 @@ public class ExecMetricsTest {
     assertThat(snapshot.getMax()).isGreaterThanOrEqualTo(10);
   }
 
+  @Test
+  public void testQueueWaitMetrics() {
+    final double delta = 0.001;
+
+    this.metrics.addQueueWait(500L);
+    this.metrics.addQueueWait(600L);
+    this.metrics.addQueueWait(1000L);
+    final Snapshot snapshot = this.testUtil
+        .getHistogramSnapshot(ExecMetrics.QUEUE_WAIT_HISTOGRAM_NAME);
+    assertThat(snapshot.getMedian()).isCloseTo(600.0, within(delta));
+    assertThat(snapshot.getMean()).isCloseTo(700.0, within(delta));
+    assertThat(snapshot.getMin()).isEqualTo(500);
+    assertThat( snapshot.getMax()).isEqualTo(1000);
+  }
+
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/ExecMetricsTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/ExecMetricsTest.java
@@ -55,19 +55,4 @@ public class ExecMetricsTest {
     assertThat(snapshot.getMax()).isGreaterThanOrEqualTo(10);
   }
 
-  @Test
-  public void testQueueWaitMetrics() {
-    final double delta = 0.001;
-
-    this.metrics.addQueueWait(500L);
-    this.metrics.addQueueWait(600L);
-    this.metrics.addQueueWait(1000L);
-    final Snapshot snapshot = this.testUtil
-        .getHistogramSnapshot(ExecMetrics.QUEUE_WAIT_HISTOGRAM_NAME);
-    assertThat(snapshot.getMedian()).isCloseTo(600.0, within(delta));
-    assertThat(snapshot.getMean()).isCloseTo(700.0, within(delta));
-    assertThat(snapshot.getMin()).isEqualTo(500);
-    assertThat( snapshot.getMax()).isEqualTo(1000);
-  }
-
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -255,10 +255,13 @@ public class FlowRunnerTestUtil {
     }
     exFlow.getExecutionOptions().addAllFlowParameters(flowParams);
     this.executorLoader.uploadExecutableFlow(exFlow);
-    final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
+    final MetricsManager metricsManager = new MetricsManager(new MetricRegistry());
+    final CommonMetrics commonMetrics = new CommonMetrics(metricsManager);
+    final ExecMetrics execMetrics = new ExecMetrics(metricsManager);
     final FlowRunner runner =
         new FlowRunner(exFlow, this.executorLoader, this.projectLoader,
-            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), commonMetrics);
+            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), commonMetrics,
+            execMetrics);
     if (eventCollector != null) {
       runner.addListener(eventCollector);
     }


### PR DESCRIPTION
Metrics added:
-`flow-success-meter`: Records when flow executions are marked as SUCCEEDED.
-`flow-killed-meter`: Records when flow executions are marked as KILLED.
-`flow-killing-counter`: Tracks the number of flow executions in KILLING status (the starting point of the killing procedure).
-`flow-time-to-kill-histogram`: Records the time it takes to kill all the jobs in an execution, in other words the time it takes to transit from KILLING to KILLED status
-`job-success-meter`: Records when job executions are marked as SUCCEEDED.
-`job-fail-meter`: Records when job execution are marked as FAILED.
-`job-killed-meter`: Records when job executions are marked as KILLED.

Additional changes:
-fixed `project-dir-cache-hit-ratio`. Call the correct method at the time of emission for a Gauge metric.
-removed `queue-wait-histogram` until execution times (submission, start, update, end) are not affected by time differences between web and executor servers' machines.