### PR TITLE
Fix missing job callbacks issue.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/event/EventHandler.java
+++ b/azkaban-common/src/main/java/azkaban/event/EventHandler.java
@@ -17,10 +17,13 @@ package azkaban.event;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EventHandler {
 
   private final HashSet<EventListener> listeners = new HashSet<>();
+  private static final Logger logger = LoggerFactory.getLogger(EventHandler.class);
 
   public EventHandler() {
   }
@@ -41,7 +44,12 @@ public class EventHandler {
     final ArrayList<EventListener> listeners =
         new ArrayList<>(this.listeners);
     for (final EventListener listener : listeners) {
-      listener.handleEvent(event);
+      try {
+        listener.handleEvent(event);
+      } catch (RuntimeException e) {
+        logger.warn("Error while calling handleEvent for: " + listener.getClass());
+        logger.warn(e.getMessage(), e);
+      }
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -633,20 +633,10 @@ public class FlowRunnerManager implements EventListener,
 
   @Override
   public void handleEvent(final Event event) {
-    //TODO: Revert this logging code. It is temporary to debug executions directory related issue.
-    // Adding extra logging for debuggability of execution directory cleanup call
-    final FlowRunner flowRunner = (FlowRunner) event.getRunner();
-    final ExecutableFlow flow = flowRunner.getExecutableFlow();
-
-    if (event.getType() != null && flow != null) {
-      LOGGER.info(
-          "Handling event for Flow execution " + flow.getExecutionId() + " and the event type is "
-              + event.getType());
-    } else {
-      LOGGER.info("Invalid event type or flow.");
-    }
-
     if (event.getType() == EventType.FLOW_FINISHED || event.getType() == EventType.FLOW_STARTED) {
+      final FlowRunner flowRunner = (FlowRunner) event.getRunner();
+      final ExecutableFlow flow = flowRunner.getExecutableFlow();
+
       if (event.getType() == EventType.FLOW_FINISHED) {
         this.recentlyFinishedFlows.put(flow.getExecutionId(), flow);
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -625,9 +625,15 @@ public class JobRunner extends EventHandler implements Runnable {
       finalizeAttachmentFile();
       writeStatus();
     } finally {
-      // note that FlowRunner thread does node.attempt++ when it receives the JOB_FINISHED event
-      fireEvent(Event.create(this, EventType.JOB_FINISHED,
-          new EventData(finalStatus, this.node.getNestedId())), false);
+      try {
+        // note that FlowRunner thread does node.attempt++ when it receives the JOB_FINISHED event
+        fireEvent(Event.create(this, EventType.JOB_FINISHED,
+            new EventData(finalStatus, this.node.getNestedId())), false);
+      } catch (RuntimeException e) {
+        serverLogger.warn("Error in fireEvent for JOB_FINISHED for execId:" +  this.executionId
+            + " jobId: " + this.jobId);
+        serverLogger.warn(e.getMessage(), e);
+      }
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackManager.java
@@ -26,7 +26,8 @@ import java.util.Map;
 import java.util.TimeZone;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.message.BasicHeader;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Responsible processing job callback properties on job status change events.
@@ -43,8 +44,7 @@ import org.apache.log4j.Logger;
  */
 public class JobCallbackManager implements EventListener {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(JobCallbackManager.class);
   private static final JobCallbackStatusEnum[] ON_COMPLETION_JOB_CALLBACK_STATUS =
       {SUCCESS, FAILURE, COMPLETED};
   private static boolean isInitialized = false;
@@ -118,13 +118,15 @@ public class JobCallbackManager implements EventListener {
         // Use job runner logger so user can see the issue in their job log
         final JobRunner jobRunner = (JobRunner) event.getRunner();
         jobRunner.getLogger().error(
-            "Encountered error while hanlding job callback event", e);
+            "Encountered error while handling job callback event", e);
+        this.logger.warn("Error during handleEvent for event {}, execId: {}",
+            event.getData().getStatus(), jobRunner.getNode().getParentFlow().getExecutionId());
+        this.logger.warn(e.getMessage(), e);
       }
     } else {
       logger.warn("((( Got an unsupported runner: "
           + event.getRunner().getClass().getName() + " )))");
     }
-
   }
 
   private void processJobCallOnFinish(final Event event) {
@@ -133,6 +135,8 @@ public class JobCallbackManager implements EventListener {
 
     if (!JobCallbackUtil.isThereJobCallbackProperty(jobRunner.getProps(),
         ON_COMPLETION_JOB_CALLBACK_STATUS)) {
+      this.logger.info("No callback property for {}, exec id: {}", eventData.getStatus(),
+          jobRunner.getNode().getParentFlow().getExecutionId());
       return;
     }
 
@@ -144,20 +148,15 @@ public class JobCallbackManager implements EventListener {
         JobCallbackUtil.buildJobContextInfoMap(event, this.azkabanHostName);
 
     JobCallbackStatusEnum jobCallBackStatusEnum = null;
-    final Logger jobLogger = jobRunner.getLogger();
-
     final Status jobStatus = eventData.getStatus();
 
     if (jobStatus == Status.SUCCEEDED) {
-
       jobCallBackStatusEnum = JobCallbackStatusEnum.SUCCESS;
-
     } else if (jobStatus == Status.FAILED
         || jobStatus == Status.FAILED_FINISHING || jobStatus == Status.KILLED) {
-
       jobCallBackStatusEnum = JobCallbackStatusEnum.FAILURE;
     } else {
-      jobLogger.info("!!!! WE ARE NOT SUPPORTING JOB CALLBACKS FOR STATUS: "
+      this.logger.info("!!!! WE ARE NOT SUPPORTING JOB CALLBACKS FOR STATUS: "
           + jobStatus);
       jobCallBackStatusEnum = null; // to be explicit
     }
@@ -167,38 +166,38 @@ public class JobCallbackManager implements EventListener {
     if (jobCallBackStatusEnum != null) {
       final List<HttpRequestBase> jobCallbackHttpRequests =
           JobCallbackUtil.parseJobCallbackProperties(props,
-              jobCallBackStatusEnum, contextInfo, maxNumCallBack, jobLogger);
+              jobCallBackStatusEnum, contextInfo, maxNumCallBack, this.logger);
 
       if (!jobCallbackHttpRequests.isEmpty()) {
         final String msg =
             String.format("Making %d job callbacks for status: %s",
                 jobCallbackHttpRequests.size(), jobCallBackStatusEnum.name());
-        jobLogger.info(msg);
+        this.logger.info(msg);
 
         addDefaultHeaders(jobCallbackHttpRequests);
 
-        JobCallbackRequestMaker.getInstance().makeHttpRequest(jobId, jobLogger,
+        JobCallbackRequestMaker.getInstance().makeHttpRequest(jobId, this.logger,
             jobCallbackHttpRequests);
       } else {
-        jobLogger.info("No job callbacks for status: " + jobCallBackStatusEnum);
+        this.logger.info("No job callbacks for status: " + jobCallBackStatusEnum);
       }
     }
 
     // for completed status
     final List<HttpRequestBase> httpRequestsForCompletedStatus =
         JobCallbackUtil.parseJobCallbackProperties(props, COMPLETED,
-            contextInfo, maxNumCallBack, jobLogger);
+            contextInfo, maxNumCallBack, this.logger);
 
     // now make the call
     if (!httpRequestsForCompletedStatus.isEmpty()) {
-      jobLogger.info("Making " + httpRequestsForCompletedStatus.size()
+      this.logger.info("Making " + httpRequestsForCompletedStatus.size()
           + " job callbacks for status: " + COMPLETED);
 
       addDefaultHeaders(httpRequestsForCompletedStatus);
-      JobCallbackRequestMaker.getInstance().makeHttpRequest(jobId, jobLogger,
+      JobCallbackRequestMaker.getInstance().makeHttpRequest(jobId, this.logger,
           httpRequestsForCompletedStatus);
     } else {
-      jobLogger.info("No job callbacks for status: " + COMPLETED);
+      this.logger.info("No job callbacks for status: " + COMPLETED);
     }
   }
 
@@ -217,7 +216,7 @@ public class JobCallbackManager implements EventListener {
 
       final List<HttpRequestBase> jobCallbackHttpRequests =
           JobCallbackUtil.parseJobCallbackProperties(props, STARTED,
-              contextInfo, maxNumCallBack, jobRunner.getLogger());
+              contextInfo, maxNumCallBack, this.logger);
 
       final String jobId = contextInfo.get(CONTEXT_JOB_TOKEN);
       final String msg =
@@ -229,7 +228,7 @@ public class JobCallbackManager implements EventListener {
       addDefaultHeaders(jobCallbackHttpRequests);
 
       JobCallbackRequestMaker.getInstance().makeHttpRequest(jobId,
-          jobRunner.getLogger(), jobCallbackHttpRequests);
+          this.logger, jobCallbackHttpRequests);
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackRequestMaker.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackRequestMaker.java
@@ -31,7 +31,8 @@ import org.apache.http.impl.client.FutureRequestExecutionMetrics;
 import org.apache.http.impl.client.FutureRequestExecutionService;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpRequestFutureTask;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Responsible for making the job callback HTTP requests.
@@ -43,8 +44,7 @@ import org.apache.log4j.Logger;
  */
 public class JobCallbackRequestMaker {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackRequestMaker.class);
+  private static final Logger logger = LoggerFactory.getLogger(JobCallbackRequestMaker.class);
 
   private static final int DEFAULT_TIME_OUT_MS = 3000;
   private static final int DEFAULT_RESPONSE_WAIT_TIME_OUT_MS = 5000;
@@ -127,21 +127,19 @@ public class JobCallbackRequestMaker {
 
   public void makeHttpRequest(final String jobId, final Logger logger,
       final List<HttpRequestBase> httpRequestList) {
-
     if (httpRequestList == null || httpRequestList.isEmpty()) {
       logger.info("No HTTP requests to make");
       return;
     }
 
     for (final HttpRequestBase httpRequest : httpRequestList) {
-
-      logger.info("Job callback http request: " + httpRequest.toString());
-      logger.info("headers [");
+      logger.debug("Job callback http request: " + httpRequest.toString());
+      logger.debug("headers [");
       for (final Header header : httpRequest.getAllHeaders()) {
-        logger.info(String.format("  %s : %s", header.getName(),
+        logger.debug(String.format("  %s : %s", header.getName(),
             header.getValue()));
       }
-      logger.info("]");
+      logger.debug("]");
 
       final HttpRequestFutureTask<Integer> task =
           this.futureRequestExecutionService.execute(httpRequest,
@@ -169,7 +167,8 @@ public class JobCallbackRequestMaker {
         }
       } catch (final Throwable e) {
         logger.warn(
-            "Encountered error while waiting for job callback to complete", e);
+            "Encountered error while waiting for job callback to complete for: " + jobId,
+            e.getMessage());
       }
     }
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/JobCallbackUtil.java
@@ -38,11 +38,12 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JobCallbackUtil {
 
-  private static final Logger logger = Logger.getLogger(JobCallbackUtil.class);
+  private static final Logger logger = LoggerFactory.getLogger(JobCallbackUtil.class);
 
   private static final Map<JobCallbackStatusEnum, String> firstJobcallbackPropertyMap =
       new HashMap<>(

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/JobCallbackRequestMakerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/JobCallbackRequestMakerTest.java
@@ -25,18 +25,18 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
+import org.slf4j.LoggerFactory;
 
 public class JobCallbackRequestMakerTest {
 
-  private static final Logger logger = Logger
-      .getLogger(JobCallbackRequestMakerTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(JobCallbackRequestMakerTest.class);
 
   private static final String SLEEP_DURATION_PARAM = "sleepDuration";
   private static final String STATUS_CODE_PARAM = "returnedStatusCode";


### PR DESCRIPTION
FlowManager event handlers are invoked by one of JobRunner event handler. Fix is not to access the runner object in flow event handler during handling of job events.