### PR TITLE
Adding logs to debug why flows are getting stuck in PREPARING state for some usecases

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -154,11 +154,10 @@ class FlowPreparer {
           (flowPrepCompletionTime - flowPrepStartTime) / 1000,
           (flowPrepCompletionTime - criticalSectionStartTime) / 1000,
           flow.getExecutionId(), execDir.getPath());
-    } catch (final Throwable t) {
+    } catch (final Exception ex) {
       FileIOUtils.deleteDirectorySilently(tempDir);
-      LOGGER.error("Error in preparing flow execution {}", flow.getExecutionId(), t);
-      throw new ExecutorManagerException(
-          "Error in preparing flow execution " + flow.getExecutionId(), t);
+      LOGGER.error("Error in preparing flow execution {}", flow.getExecutionId(), ex);
+      throw new ExecutorManagerException(ex);
     } finally {
       if (projectFileHandler != null) {
         projectFileHandler.deleteLocalFile();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -154,10 +154,6 @@ class FlowPreparer {
           (flowPrepCompletionTime - flowPrepStartTime) / 1000,
           (flowPrepCompletionTime - criticalSectionStartTime) / 1000,
           flow.getExecutionId(), execDir.getPath());
-    } catch (final Exception ex) {
-      FileIOUtils.deleteDirectorySilently(tempDir);
-      LOGGER.error("Error in preparing flow execution {}", flow.getExecutionId(), ex);
-      throw new ExecutorManagerException(ex);
     } catch (final Throwable t) {
       FileIOUtils.deleteDirectorySilently(tempDir);
       LOGGER.error("Error in preparing flow execution {}", flow.getExecutionId(), t);


### PR DESCRIPTION
We have seen couple of usecases where executions are stuck in PREPARING state. To unblock these executions, we had to change executor_id to null in database. I am adding these logs to debug the same issue as there was no exception in executor logs for the failure.