### PR TITLE
Enable serial polling for executor using mysql lock

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -125,6 +125,7 @@ public class Constants {
     // Configures Azkaban to use new polling model for dispatching
     public static final String AZKABAN_POLL_MODEL = "azkaban.poll.model";
     public static final String AZKABAN_POLLING_INTERVAL_MS = "azkaban.polling.interval.ms";
+    public static final String AZKABAN_POLLING_LOCK_ENABLED = "azkaban.polling.lock.enabled";
     public static final String AZKABAN_POLLING_CRITERIA_FLOW_THREADS_AVAILABLE =
         "azkaban.polling_criteria.flow_threads_available";
     public static final String AZKABAN_POLLING_CRITERIA_MIN_FREE_MEMORY_GB =

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -286,6 +286,9 @@ public interface ExecutorLoader {
   int selectAndUpdateExecution(final int executorId, boolean isActive)
       throws ExecutorManagerException;
 
+  int selectAndUpdateExecutionWithLocking(final int executorId, boolean isActive)
+      throws ExecutorManagerException;
+
   ExecutableRampMap fetchExecutableRampMap()
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -355,6 +355,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive)
+      throws ExecutorManagerException {
+    return this.executionFlowDao.selectAndUpdateExecutionWithLocking(executorId, isActive);
+  }
+
+  @Override
   public ExecutableRampMap fetchExecutableRampMap() throws ExecutorManagerException {
     return this.executionRampDao.fetchExecutableRampMap();
   }

--- a/azkaban-common/src/main/java/azkaban/executor/MysqlNamedLock.java
+++ b/azkaban-common/src/main/java/azkaban/executor/MysqlNamedLock.java
@@ -1,0 +1,35 @@
+package azkaban.executor;
+
+import azkaban.db.DatabaseTransOperator;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.inject.Singleton;
+import org.apache.commons.dbutils.ResultSetHandler;
+
+/**
+ *  Util class for locking using named lock in mysql
+ */
+
+@Singleton
+public class MysqlNamedLock implements ResultSetHandler<Boolean> {
+  private String getLockTemplate = "SELECT GET_LOCK('%s', %s)";
+  private String releaseLockTemplate = "SELECT RELEASE_LOCK('%s')";
+
+  public boolean getLock(DatabaseTransOperator transOperator, String lockName, int lockTimeoutInSeconds) throws SQLException {
+    String getLockStatement = String.format(getLockTemplate, lockName, lockTimeoutInSeconds);
+    return transOperator.query(getLockStatement, this);
+  }
+
+  public boolean releaseLock(DatabaseTransOperator transOperator, String lockName) throws SQLException {
+    String releaseLockStatement = String.format(releaseLockTemplate, lockName);
+    return transOperator.query(releaseLockStatement, this);
+  }
+
+  @Override
+  public Boolean handle(final ResultSet rs) throws SQLException {
+    if (!rs.next()) {
+      return false;
+    }
+    return rs.getBoolean(1);
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/MysqlNamedLock.java
+++ b/azkaban-common/src/main/java/azkaban/executor/MysqlNamedLock.java
@@ -1,6 +1,7 @@
 package azkaban.executor;
 
 import azkaban.db.DatabaseTransOperator;
+import azkaban.utils.StringUtils;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import javax.inject.Singleton;
@@ -16,11 +17,17 @@ public class MysqlNamedLock implements ResultSetHandler<Boolean> {
   private String releaseLockTemplate = "SELECT RELEASE_LOCK('%s')";
 
   public boolean getLock(DatabaseTransOperator transOperator, String lockName, int lockTimeoutInSeconds) throws SQLException {
+    if (StringUtils.isEmpty(lockName)) {
+      throw new IllegalArgumentException("Lock name cannot be null or empty");
+    }
     String getLockStatement = String.format(getLockTemplate, lockName, lockTimeoutInSeconds);
     return transOperator.query(getLockStatement, this);
   }
 
   public boolean releaseLock(DatabaseTransOperator transOperator, String lockName) throws SQLException {
+    if (StringUtils.isEmpty(lockName)) {
+      throw new IllegalArgumentException("Lock name cannot be null or empty");
+    }
     String releaseLockStatement = String.format(releaseLockTemplate, lockName);
     return transOperator.query(releaseLockStatement, this);
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -500,19 +500,21 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testLockSuccessSelectAndUpdateExecutionWithLocking() throws Exception {
-    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class))).thenReturn(true);
+    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class)))
+        .thenReturn(true);
     when(mysqlNamedLock.releaseLock(any(DatabaseTransOperator.class), any(String.class))).thenReturn(true);
     final long currentTime = System.currentTimeMillis();
     final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", currentTime,
         ExecutionOptions.DEFAULT_FLOW_PRIORITY);
     final Executor executor1 = this.executorDao.addExecutor("localhost", 12345);
-    assertThat(this.executionFlowDao.selectAndUpdateExecutionWithLocking(executor1.getId(), true)).isEqualTo(flow1.getExecutionId());
+    assertThat(this.executionFlowDao.selectAndUpdateExecutionWithLocking(executor1.getId(), true))
+        .isEqualTo(flow1.getExecutionId());
   }
 
   @Test
   public void testLockFailureSelectAndUpdateExecutionWithLocking() throws Exception {
-    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class))).thenReturn(false);
-    when(mysqlNamedLock.releaseLock(any(DatabaseTransOperator.class), any(String.class))).thenReturn(true);
+    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class)))
+        .thenReturn(false);
     final long currentTime = System.currentTimeMillis();
     final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", currentTime,
         ExecutionOptions.DEFAULT_FLOW_PRIORITY);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -18,8 +18,10 @@ package azkaban.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 import azkaban.db.DatabaseOperator;
+import azkaban.db.DatabaseTransOperator;
 import azkaban.project.JdbcProjectImpl;
 import azkaban.project.ProjectLoader;
 import azkaban.test.Utils;
@@ -56,6 +58,7 @@ public class ExecutionFlowDaoTest {
   private FetchActiveFlowDao fetchActiveFlowDao;
   private ExecutionJobDao executionJobDao;
   private ProjectLoader loader;
+  private MysqlNamedLock mysqlNamedLock;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -74,7 +77,8 @@ public class ExecutionFlowDaoTest {
 
   @Before
   public void setup() {
-    this.executionFlowDao = new ExecutionFlowDao(dbOperator);
+    this.mysqlNamedLock = mock(MysqlNamedLock.class);
+    this.executionFlowDao = new ExecutionFlowDao(dbOperator, this.mysqlNamedLock);
     this.executorDao = new ExecutorDao(dbOperator);
     this.assignExecutor = new AssignExecutorDao(dbOperator, this.executorDao);
     this.fetchActiveFlowDao = new FetchActiveFlowDao(dbOperator);
@@ -492,6 +496,28 @@ public class ExecutionFlowDaoTest {
         .isEqualTo(flow.getExecutionId());
     assertThat(this.executorDao.fetchExecutorByExecutionId(flow.getExecutionId())).isEqualTo
         (executor);
+  }
+
+  @Test
+  public void testLockSuccessSelectAndUpdateExecutionWithLocking() throws Exception {
+    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class))).thenReturn(true);
+    when(mysqlNamedLock.releaseLock(any(DatabaseTransOperator.class), any(String.class))).thenReturn(true);
+    final long currentTime = System.currentTimeMillis();
+    final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", currentTime,
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    final Executor executor1 = this.executorDao.addExecutor("localhost", 12345);
+    assertThat(this.executionFlowDao.selectAndUpdateExecutionWithLocking(executor1.getId(), true)).isEqualTo(flow1.getExecutionId());
+  }
+
+  @Test
+  public void testLockFailureSelectAndUpdateExecutionWithLocking() throws Exception {
+    when(mysqlNamedLock.getLock(any(DatabaseTransOperator.class), any(String.class), any(Integer.class))).thenReturn(false);
+    when(mysqlNamedLock.releaseLock(any(DatabaseTransOperator.class), any(String.class))).thenReturn(true);
+    final long currentTime = System.currentTimeMillis();
+    final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", currentTime,
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY);
+    final Executor executor1 = this.executorDao.addExecutor("localhost", 12345);
+    assertThat(this.executionFlowDao.selectAndUpdateExecutionWithLocking(executor1.getId(), true)).isEqualTo(-1);
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -458,6 +458,12 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive)
+      throws ExecutorManagerException {
+    return 1;
+  }
+
+  @Override
   public ExecutableRampMap fetchExecutableRampMap() throws ExecutorManagerException {
     ExecutableRampMap map = ExecutableRampMap.createInstance();
     map.add("rampId",

--- a/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
@@ -27,6 +27,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class NumExecutionsDaoTest {
 
@@ -51,7 +52,8 @@ public class NumExecutionsDaoTest {
 
   @Before
   public void setup() {
-    this.executionFlowDao = new ExecutionFlowDao(dbOperator);
+    MysqlNamedLock mysqlNamedLock = Mockito.mock(MysqlNamedLock.class);
+    this.executionFlowDao = new ExecutionFlowDao(dbOperator, mysqlNamedLock);
     this.numExecutionsDao = new NumExecutionsDao(dbOperator);
   }
 

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
@@ -91,6 +91,18 @@ public class DatabaseTransOperator {
 
   /**
    *
+   * @param querySql
+   * @param resultHandler
+   * @param <T>
+   * @return
+   * @throws SQLException
+   */
+  public <T> T query(final String querySql, final ResultSetHandler<T> resultHandler) throws SQLException {
+      return query(querySql, resultHandler, (Object[])null);
+  }
+
+  /**
+   *
    * @param updateClause
    * @param params
    * @return

--- a/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
+++ b/azkaban-db/src/main/java/azkaban/db/DatabaseTransOperator.java
@@ -91,18 +91,6 @@ public class DatabaseTransOperator {
 
   /**
    *
-   * @param querySql
-   * @param resultHandler
-   * @param <T>
-   * @return
-   * @throws SQLException
-   */
-  public <T> T query(final String querySql, final ResultSetHandler<T> resultHandler) throws SQLException {
-      return query(querySql, resultHandler, (Object[])null);
-  }
-
-  /**
-   *
    * @param updateClause
    * @param params
    * @return

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -1055,8 +1055,14 @@ public class FlowRunnerManager implements EventListener,
         }
       } else if (this.pollingCriteria.shouldPoll()) {
         try {
-          final int execId = FlowRunnerManager.this.executorLoader
-              .selectAndUpdateExecution(this.executorId, FlowRunnerManager.this.active);
+          final int execId;
+          if (FlowRunnerManager.this.azkabanProps.getBoolean(ConfigurationKeys.AZKABAN_POLLING_LOCK_ENABLED, false)) {
+            execId = FlowRunnerManager.this.executorLoader.selectAndUpdateExecutionWithLocking(
+                this.executorId, FlowRunnerManager.this.active);
+          } else {
+            execId = FlowRunnerManager.this.executorLoader.selectAndUpdateExecution(this.executorId,
+                FlowRunnerManager.this.active);
+          }
           if (execId != -1) {
             FlowRunnerManager.LOGGER.info("Submitting flow " + execId);
             try {


### PR DESCRIPTION
Changed polling query to lock single row in mysql by using limit condition in nested query.
Enabled serial polling from execution_flows table using GET_LOCK in mysql.