### PR TITLE
Refactor WebUtils.getRealClientIpAddr() for better reuse.

### DIFF
--- a/az-reportal/src/main/java/azkaban/reportal/util/Reportal.java
+++ b/az-reportal/src/main/java/azkaban/reportal/util/Reportal.java
@@ -352,7 +352,7 @@ public class Reportal {
   }
 
   public void createZipAndUpload(final ProjectManager projectManager, final User user,
-      final String reportalStorageUser, final String uploaderIPAddr) throws Exception {
+      final String reportalStorageUser) throws Exception {
     // Create temp folder to make the zip file for upload
     final File tempDir = Utils.createTempDir();
     final File dataDir = new File(tempDir, "data");
@@ -406,7 +406,7 @@ public class Reportal {
 
     // Upload zip
     projectManager.uploadProject(this.project, archiveFile, "zip", user, null,
-        uploaderIPAddr);
+        null);
 
     // Empty temp
     if (tempDir.exists()) {

--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -1045,19 +1045,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
 
     try {
-      // Fetch the uploader's IP
-      String uploaderIPAddr = "";
-      if (req != null) {
-        uploaderIPAddr = req.getHeader("X-FORWARDED-FOR");
-        if (uploaderIPAddr == null || uploaderIPAddr.isEmpty()) {
-          logger.debug("Failed to fetch remote Address using \"X-FORWARDED-FOR\"");
-          uploaderIPAddr = req.getRemoteAddr();
-        }
-        logger.info("uploaderIPAddr = " + uploaderIPAddr);
-      } else {
-        logger.info("HttpServletRequest is NULL");
-      }
-      report.createZipAndUpload(projectManager, user, this.reportalStorageUser, uploaderIPAddr);
+      report.createZipAndUpload(projectManager, user, this.reportalStorageUser);
     } catch (final Exception e) {
       e.printStackTrace();
       errors.add("Error while creating Azkaban jobs. " + e.getMessage());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -136,7 +136,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
    */
   private void logRequest(final HttpServletRequest req, final Session session) {
     final StringBuilder buf = new StringBuilder();
-    buf.append(getRealClientIpAddr(req)).append(" ");
+    buf.append(WebUtils.getRealClientIpAddr(req)).append(" ");
     if (session != null && session.getUser() != null) {
       buf.append(session.getUser().getUserId()).append(" ");
     } else {
@@ -206,20 +206,6 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
     }
 
     return false;
-  }
-
-  private String getRealClientIpAddr(final HttpServletRequest req) {
-
-    // If some upstream device added an X-Forwarded-For header
-    // use it for the client ip
-    // This will support scenarios where load balancers or gateways
-    // front the Azkaban web server and a changing Ip address invalidates
-    // the session
-    final HashMap<String, String> headers = new HashMap<>();
-    headers.put(WebUtils.X_FORWARDED_FOR_HEADER,
-        req.getHeader(WebUtils.X_FORWARDED_FOR_HEADER.toLowerCase()));
-
-    return WebUtils.getRealClientIpAddr(headers, req.getRemoteAddr());
   }
 
   private Session getSessionFromRequest(final HttpServletRequest req)
@@ -295,7 +281,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
 
         final String username = (String) params.get("username");
         final String password = (String) params.get("password");
-        final String ip = getRealClientIpAddr(req);
+        final String ip = WebUtils.getRealClientIpAddr(req);
 
         try {
           session = createSession(username, password, ip);
@@ -361,7 +347,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
       throws UserManagerException, ServletException {
     final String username = getParam(req, "username");
     final String password = getParam(req, "password");
-    final String ip = getRealClientIpAddr(req);
+    final String ip = WebUtils.getRealClientIpAddr(req);
 
     return createSession(username, password, ip);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1756,6 +1756,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     resp.setStatus(returnCode);
   }
 
+
   private void ajaxHandleUpload(final HttpServletRequest req, final HttpServletResponse resp,
       final Map<String, String> ret, final Map<String, Object> multipart, final Session session)
       throws ServletException, IOException {
@@ -1763,17 +1764,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final String projectName = (String) multipart.get("project");
 
     // Fetch the uploader's IP
-    String uploaderIPAddr = "";
-    if (req != null) {
-      uploaderIPAddr = req.getHeader("X-FORWARDED-FOR");
-      if (uploaderIPAddr == null || uploaderIPAddr.isEmpty()) {
-        logger.debug("Failed to fetch remote Address using \"X-FORWARDED-FOR\"");
-        uploaderIPAddr = req.getRemoteAddr();
-      }
-      logger.info("uploaderIPAddr = " + uploaderIPAddr);
-    } else {
-      logger.info("HttpServletRequest is NULL");
-    }
+    String uploaderIPAddr = WebUtils.getRealClientIpAddr(req);
 
     final Project project = validateUploadAndGetProject(resp, ret, user, projectName);
     if (project == null) {


### PR DESCRIPTION
Use getRealClientIpAddr() to fetch uploader's IP
Cleanup older logic to fetch uploader's IP.
This is a followup to #2486 