### PR TITLE
Fix the NullPointerException thrown when an execution is killed before it has started.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -598,11 +598,11 @@ public class FlowRunner extends EventHandler implements Runnable {
     if (nextNodeStatus == Status.CANCELLED) {
       // if node is root flow
       if (node instanceof ExecutableFlow && node.getParentFlow() == null)  {
-        logger.info(String.format("Flow '%s' was cancelled before execution had started.",
+        this.logger.info(String.format("Flow '%s' was cancelled before execution had started.",
             node.getId()));
         finalizeFlow((ExecutableFlow) node);
       } else {
-        this.logger.info("Cancelling '" + node.getNestedId() + "' due to prior errors.");
+        this.logger.info(String.format("Cancelling '%s' due to prior errors.", node.getNestedId()));
         node.cancelNode(System.currentTimeMillis());
         finishExecutableNode(node);
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -596,10 +596,16 @@ public class FlowRunner extends EventHandler implements Runnable {
     }
 
     if (nextNodeStatus == Status.CANCELLED) {
-      this.logger.info("Cancelling '" + node.getNestedId()
-          + "' due to prior errors.");
-      node.cancelNode(System.currentTimeMillis());
-      finishExecutableNode(node);
+      // if node is root flow
+      if (node instanceof ExecutableFlow && node.getParentFlow() == null)  {
+        logger.info(String.format("Flow '%s' was cancelled before execution had started.",
+            node.getId()));
+        finalizeFlow((ExecutableFlow) node);
+      } else {
+        this.logger.info("Cancelling '" + node.getNestedId() + "' due to prior errors.");
+        node.cancelNode(System.currentTimeMillis());
+        finishExecutableNode(node);
+      }
     } else if (nextNodeStatus == Status.SKIPPED) {
       this.logger.info("Skipping disabled job '" + node.getId() + "'.");
       node.skipNode(System.currentTimeMillis());
@@ -1147,7 +1153,7 @@ public class FlowRunner extends EventHandler implements Runnable {
         this.flowPaused = false;
         if (this.flowFailed) {
           this.flow.setStatus(Status.FAILED_FINISHING);
-        } else if (this.flowKilled) {
+        } else if (isKilled()) {
           this.flow.setStatus(Status.KILLING);
         } else {
           this.flow.setStatus(Status.RUNNING);
@@ -1167,7 +1173,7 @@ public class FlowRunner extends EventHandler implements Runnable {
 
   public void kill() {
     synchronized (this.mainSyncObj) {
-      if (this.flowKilled) {
+      if (isKilled()) {
         return;
       }
       this.logger.info("Kill has been called on execution " + this.execId);
@@ -1301,7 +1307,9 @@ public class FlowRunner extends EventHandler implements Runnable {
   }
 
   private void interrupt() {
-    this.flowRunnerThread.interrupt();
+    if(this.flowRunnerThread != null) {
+      this.flowRunnerThread.interrupt();
+    }
   }
 
   public boolean isKilled() {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -27,6 +27,7 @@ import azkaban.executor.ExecutionOptions.FailureAction;
 import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.Status;
 import azkaban.flow.CommonJobProperties;
+import azkaban.spi.EventType;
 import azkaban.utils.Props;
 import java.util.HashMap;
 import java.util.Map;
@@ -1067,6 +1068,35 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+  }
+
+  /**
+   * Tests the case when an execution is killed before it has started. The final execution
+   * status should "KILLED".
+   */
+  @Test
+  public void testKillBeforeStart() throws Exception {
+    this.runner = this.testUtil.createFromFlowMap("jobf", FailureAction.FINISH_ALL_POSSIBLE);
+    this.runner.addListener((event) -> {
+      if (event.getType().equals(EventType.FLOW_STARTED)) {
+        // kill interrupts the current thread which would cause an exception if called directly,
+        // so do it from another thread.
+        Thread aThread = new Thread( () -> this.runner.kill());
+        aThread.start();
+        try {
+          // give the thread a chance to kill the execution
+          aThread.join();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+    });
+
+    this.runner.run();
+    // children jobs shouldn't start
+    assertStatus("joba", Status.READY);
+    assertStatus("joba1", Status.READY);
+    waitForAndAssertFlowStatus(Status.KILLED);
   }
 
 }


### PR DESCRIPTION
This issue can be reproduced when Poll Dispatch model(#2038) is used and `azkaban.polling_criteria.flow_threads_available` isn't enabled (#2195). When there are no more flow threads available executions will be queued on the executor side. If one of them is killed while waiting for a thread a NPE will be seen in the flow logs. 