### PR TITLE
Fix NPE when SlaOptions have no actions set.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -263,7 +263,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     flowObj.put(SUBMITTIME_PARAM, this.submitTime);
 
     final List<Map<String, Object>> slaOptions = new ArrayList<>();
-    this.executionOptions.getSlaOptions().stream()
+    this.executionOptions.getSlaOptions()
         .forEach((slaOption) -> slaOptions.add(slaOption.toObject()));
 
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -263,8 +263,12 @@ public class ExecutableFlow extends ExecutableFlowBase {
     flowObj.put(SUBMITTIME_PARAM, this.submitTime);
 
     final List<Map<String, Object>> slaOptions = new ArrayList<>();
-    this.executionOptions.getSlaOptions()
-        .forEach((slaOption) -> slaOptions.add(slaOption.toObject()));
+    List<SlaOption> slaOptionList = this.executionOptions.getSlaOptions();
+    if (slaOptionList != null) {
+      for (SlaOption slaOption : this.executionOptions.getSlaOptions()) {
+        slaOptions.add(slaOption.toObject());
+      }
+    }
 
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -265,7 +265,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     final List<Map<String, Object>> slaOptions = new ArrayList<>();
     List<SlaOption> slaOptionList = this.executionOptions.getSlaOptions();
     if (slaOptionList != null) {
-      for (SlaOption slaOption : this.executionOptions.getSlaOptions()) {
+      for (SlaOption slaOption : slaOptionList) {
         slaOptions.add(slaOption.toObject());
       }
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -268,20 +268,19 @@ public class ExecutionFlowDao {
       }
     } catch (final IOException e) {
       flow.setStatus(Status.FAILED);
-      updateExecutableFlowStatus(flow);
+      updateExecutableFlowStatusInDB(flow);
       throw new ExecutorManagerException("Error encoding the execution flow. Execution Id  = "
           + flow.getExecutionId());
     } catch (final RuntimeException re) {
       flow.setStatus(Status.FAILED);
       // Likely due to serialization error
       if ( data == null && re instanceof NullPointerException) {
-        logger.warn("Failed to serialize executable flow for " + flow.getExecutionId()
-        + ". Likely due to SLA missing options. Please re-check the flow SLA");
+        logger.warn("Failed to serialize executable flow for " + flow.getExecutionId());
         logger.warn("NPE stacktrace" + ExceptionUtils.getStackTrace(re));
       }
-      updateExecutableFlowStatus(flow);
-      throw new ExecutorManagerException("Error encoding the execution flow due to NPE. "
-          + "Execution Id  = " + flow.getExecutionId(), re);
+      updateExecutableFlowStatusInDB(flow);
+      throw new ExecutorManagerException("Error encoding the execution flow due to "
+          + "RuntimeException. Execution Id  = " + flow.getExecutionId(), re);
     }
 
     try {
@@ -293,7 +292,7 @@ public class ExecutionFlowDao {
     }
   }
 
-  private void updateExecutableFlowStatus(final ExecutableFlow flow)
+  private void updateExecutableFlowStatusInDB(final ExecutableFlow flow)
     throws ExecutorManagerException {
     final String UPDATE_FLOW_STATUS = "UPDATE execution_flows SET status = ?, update_time = ? "
         + "where exec_id = ?";

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -778,11 +778,11 @@ public class ExecutionFlowDaoTest {
     } catch (ExecutorManagerException e) {
        assert e.getMessage().contains("NPE");
     }
-    // Fetch flow again, the status must be FAILED
-    final ExecutableFlow failedFlow =
+    // Fetch flow again, the status must be READY not PREPARING
+    final ExecutableFlow readyFlow =
         this.executionFlowDao.fetchExecutableFlow(fetchFlow.getExecutionId());
 
-    assertThat(failedFlow.getStatus()).isEqualTo(Status.FAILED);
+    assertThat(readyFlow.getStatus()).isEqualTo(Status.READY);
   }
 
   /*

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -762,6 +762,10 @@ public class ExecutionFlowDaoTest {
     assertThat(finishedFlows2.get(0).getStatus()).isEqualTo(Status.FAILED);
   }
 
+  /**
+   * Test the resiliency of ExecutableFlow when Sla Option is set to NULL.
+   * Make sure that the system overcomes it and the flow proceeds to next valid state.
+   */
   @Test
   public void testUpdateExecutableFlowNullSLAOptions() throws Exception {
     final ExecutableFlow flow = createTestFlow();

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -764,7 +764,8 @@ public class ExecutionFlowDaoTest {
 
   /**
    * Test the resiliency of ExecutableFlow when Sla Option is set to NULL.
-   * Make sure that the system overcomes it and the flow proceeds to next valid state.
+   * Make sure that the serialization of flow object does not break and the flow proceeds to
+   * next valid state.
    */
   @Test
   public void testUpdateExecutableFlowNullSLAOptions() throws Exception {
@@ -782,7 +783,8 @@ public class ExecutionFlowDaoTest {
     } catch (ExecutorManagerException e) {
        assert e.getMessage().contains("NPE");
     }
-    // Fetch flow again, the status must be READY not PREPARING
+    // Fetch flow again, the status must be READY not PREPARING as NPE is handled properly when
+    //flow object is serialized.
     final ExecutableFlow readyFlow =
         this.executionFlowDao.fetchExecutableFlow(fetchFlow.getExecutionId());
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -762,6 +762,29 @@ public class ExecutionFlowDaoTest {
     assertThat(finishedFlows2.get(0).getStatus()).isEqualTo(Status.FAILED);
   }
 
+  @Test
+  public void testUpdateExecutableFlowNullSLAOptions() throws Exception {
+    final ExecutableFlow flow = createTestFlow();
+    this.executionFlowDao.uploadExecutableFlow(flow);
+
+    final ExecutableFlow fetchFlow =
+        this.executionFlowDao.fetchExecutableFlow(flow.getExecutionId());
+
+    // set null sla option
+    fetchFlow.getExecutionOptions().setSlaOptions(null);
+    // Try updating flow
+    try {
+      this.executionFlowDao.updateExecutableFlow(fetchFlow);
+    } catch (ExecutorManagerException e) {
+       assert e.getMessage().contains("NPE");
+    }
+    // Fetch flow again, the status must be FAILED
+    final ExecutableFlow failedFlow =
+        this.executionFlowDao.fetchExecutableFlow(fetchFlow.getExecutionId());
+
+    assertThat(failedFlow.getStatus()).isEqualTo(Status.FAILED);
+  }
+
   /*
    * Updates flow execution status in the DB. After this the value of the status column will be
    * different from the status property in the flow data blob.


### PR DESCRIPTION
Fix NPE when SlaOptions have no actions set which cause flow serialization to fail.

This failure causes excessive logging as the flow is stuck in Preparing state.
Make sure that in such case the flow is finalized to FAILED state.