### PR TITLE
Use updated kerberos principal to fetch NameNode Tokens

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -91,17 +91,23 @@ public class HadoopJavaJobRunnerMain {
       }
     });
 
+    // Separate try catch for logger
     try {
-      _jobName = System.getenv(ProcessJob.JOB_NAME_ENV);
-      String jobPropsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
-      String privatePropsFile = System.getenv(ProcessJob.JOBTYPE_PRIVATE_PROP_ENV);
-
       _logger = Logger.getRootLogger();
       _logger.removeAllAppenders();
       ConsoleAppender appender = new ConsoleAppender(DEFAULT_LAYOUT);
       appender.activateOptions();
       _logger.addAppender(appender);
       _logger.setLevel(Level.INFO); //Explicitly setting level to INFO
+    } catch (Exception e) {
+      throw e;
+    }
+
+    try {
+      _jobName = System.getenv(ProcessJob.JOB_NAME_ENV);
+      String jobPropsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
+      String privatePropsFile = System.getenv(ProcessJob.JOBTYPE_PRIVATE_PROP_ENV);
+
 
       Properties jobProps = new Properties(), privateProps = new Properties();
 
@@ -225,6 +231,7 @@ public class HadoopJavaJobRunnerMain {
       }
     } catch (Exception e) {
       _isFinished = true;
+      _logger.error("Exception propagated to Azkaban from job code");
       throw e;
     }
   }

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -496,31 +496,33 @@ public class HadoopSecurityManager_H_2_0 extends HadoopSecurityManager {
     fetchJHSToken(props, logger, userToProxyFQN, cred);
 
     try {
-      getProxiedUser(userToProxy).doAs(new PrivilegedExceptionAction<Void>() {
+      getProxiedUser(userToProxyFQN).doAs(new PrivilegedExceptionAction<Void>() {
         @Override
         public Void run() throws Exception {
-          getToken(userToProxy);
+          getToken(userToProxyFQN, userToProxy);
           return null;
         }
 
-        private void getToken(final String userToProxy) throws InterruptedException,
-            IOException, HadoopSecurityManagerException {
-          logger.info("Here is the props for " + HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN + ": "
-              + props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN));
+        private void getToken(final String userToProxyFQN, final String userToProxy)
+            throws InterruptedException, IOException, HadoopSecurityManagerException {
+          logger.info("Here is the props for " + HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN +
+              ": " + props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN));
 
           // Register user secrets by custom credential Object
           if (props.getBoolean(JobProperties.ENABLE_JOB_SSL, false)) {
-            registerCustomCredential(props, cred, userToProxy, logger, Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
+            registerCustomCredential(props, cred, userToProxy, logger,
+                Constants.ConfigurationKeys.CUSTOM_CREDENTIAL_NAME);
           }
 
           // Register oauth tokens by custom oauth credential provider
           if (props.getBoolean(JobProperties.ENABLE_OAUTH, false)) {
-            registerCustomCredential(props, cred, userToProxy, logger, Constants.ConfigurationKeys.OAUTH_CREDENTIAL_NAME);
+            registerCustomCredential(props, cred, userToProxy, logger,
+                Constants.ConfigurationKeys.OAUTH_CREDENTIAL_NAME);
           }
 
-          fetchNameNodeToken(userToProxy, props, logger, cred);
+          fetchNameNodeToken(userToProxyFQN, props, logger, cred);
 
-          fetchJobTrackerToken(userToProxy, props, logger, cred);
+          fetchJobTrackerToken(userToProxyFQN, props, logger, cred);
 
         }
       });


### PR DESCRIPTION
Separate out logger in its own try catch block. This helps in logging out messages when HadoopJavaJob throws exception.