### PR TITLE
Removed the misleading message in the schedule panel

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -53,8 +53,6 @@
           <div class="form-group">
 
             <div class="col-sm-12" style="height:55px;">
-              <h4 style="color:Coral; font-style:italic;">All schedules are basead on the server
-                timezone: <b id="timeZoneID"></b>.</h4>
               <h6 style="color:#0080ff;">Warning: the execution will be skipped if it is scheduled
                 to run during the hour that is lost when DST starts in the Spring.
                 E.g. there is no 2 - 3 AM when PST switches to PDT.</h6>


### PR DESCRIPTION
This message is causing confusion to the user. While there are multiple things we can do to improve this page, this is a quick fix that will help the users. 

verified that the schedule page loads fine and there no message on the top. 