### PR TITLE
Ensure main thread is not interrupted when running testKillBeforeStart test

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -1092,11 +1092,12 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
       }
     });
 
-    this.runner.run();
+    FlowRunnerTestUtil.startThread(this.runner).join();
     // children jobs shouldn't start
     assertStatus("joba", Status.READY);
     assertStatus("joba1", Status.READY);
     waitForAndAssertFlowStatus(Status.KILLED);
+    this.runner = null;
   }
 
 }


### PR DESCRIPTION
When the main thread is interrupted subsequent tests fail due to an IO channel being closed by the generated _InterruptedException_ in that test.