### PR TITLE
Use String Interning to reuse copy from String Constant Pool for Flow…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/FlowProps.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowProps.java
@@ -27,8 +27,20 @@ public class FlowProps {
   private Props props = null;
 
   public FlowProps(final String parentSource, final String propSource) {
-    this.parentSource = parentSource;
-    this.propSource = propSource;
+    /**
+     * Use String interning so that just 1 copy of the string value exists in String Constant Pool
+     * and the value is reused. Azkaban Heap dump analysis indicated a  high percentage of heap
+     * usage is coming from duplicate strings of FlowProps fields.
+     *
+     * Using intern() eliminates all the duplicate values, thereby significantly reducing heap
+     * memory usage.
+     */
+    if(parentSource != null) {
+      this.parentSource = parentSource.intern();
+    }
+    if (propSource != null) {
+      this.propSource = propSource.intern();
+    }
   }
 
   public FlowProps(final Props props) {


### PR DESCRIPTION
…Props class.

Problem: Analysis of Azkaban heap dump from 3 internal clusters revealed a high percentage of Heap memory usage (between 17% to 40% of heap usage) is due to duplicate strings.

Tops 2 contributors to duplicate strings account for 99% of total duplicates. The top 2 contributors are:
1.	HashMap keys (the HashMap is in azkaban.flow.Flow.flowProps)
2.	azkaban.flow.Flow.flowProps.parentSource

Both can be traced to Flow.flowProps data fields. Change how Flow.flowProps is initialized and dedup the stringsi by using intern().