### PR TITLE
Add pipeline Level 3: block all jobs until the previous flow has completed

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -235,6 +235,9 @@ public class JobRunner extends EventHandler implements Runnable {
           }
         }
       }
+    } else if (this.pipelineLevel == 3) {
+      final ExecutableFlowBase parentFlow = this.node.getParentFlow();
+      findAllEndingNodes(parentFlow, this.pipelineJobs);
     }
   }
 
@@ -244,6 +247,18 @@ public class JobRunner extends EventHandler implements Runnable {
       final ExecutableNode node = flow.getExecutableNode(startingNode);
       if (node instanceof ExecutableFlowBase) {
         findAllStartingNodes((ExecutableFlowBase) node, pipelineJobs);
+      } else {
+        pipelineJobs.add(node.getNestedId());
+      }
+    }
+  }
+
+  private void findAllEndingNodes(final ExecutableFlowBase flow,
+      final Set<String> pipelineJobs) {
+    for (final String endingNode : flow.getEndNodes()) {
+      final ExecutableNode node = flow.getExecutableNode(endingNode);
+      if (node instanceof ExecutableFlowBase) {
+        findAllEndingNodes((ExecutableFlowBase) node, pipelineJobs);
       } else {
         pipelineJobs.add(node.getNestedId());
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -236,9 +236,16 @@ public class JobRunner extends EventHandler implements Runnable {
         }
       }
     } else if (this.pipelineLevel == 3) {
-      final ExecutableFlowBase parentFlow = this.node.getParentFlow();
+      final ExecutableFlowBase parentFlow = findRootParentFlow(this.node.getParentFlow());
       findAllEndingNodes(parentFlow, this.pipelineJobs);
     }
+  }
+
+  private ExecutableFlowBase findRootParentFlow(final ExecutableFlowBase node) {
+    if (node.getParentFlow() != null) {
+      return findRootParentFlow(node.getParentFlow());
+    }
+    return node;
   }
 
   private void findAllStartingNodes(final ExecutableFlowBase flow,

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPipelineTest.java
@@ -18,10 +18,12 @@ package azkaban.execapp;
 
 import azkaban.execapp.event.FlowWatcher;
 import azkaban.execapp.event.LocalFlowWatcher;
+import azkaban.executor.DisabledJob;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.Status;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -318,12 +320,14 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobA")
         .succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow4:innerJobA").succeedJob();
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobA",
         Status.SUCCEEDED);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobB",
         Status.RUNNING);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobC",
         Status.RUNNING);
+    assertStatus(previousFlow, "pipelineEmbeddedFlow4:innerJobA", Status.SUCCEEDED);
     assertStatus(pipelineFlow, "pipeline2", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("pipe:pipeline2").succeedJob();
@@ -362,6 +366,7 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerFlow",
         Status.SUCCEEDED);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow4:innerFlow2").succeedJob();
     assertStatus(previousFlow, "pipeline4", Status.RUNNING);
     assertStatus(pipelineFlow, "pipelineEmbeddedFlow3:innerJobC",
         Status.RUNNING);
@@ -395,6 +400,8 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
     assertStatus(pipelineFlow, "pipelineEmbeddedFlow3:innerFlow",
         Status.SUCCEEDED);
     assertStatus(pipelineFlow, "pipelineEmbeddedFlow3", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerJobA").succeedJob();
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerFlow2").succeedJob();
     assertStatus(pipelineFlow, "pipeline4", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("pipe:pipeline4").succeedJob();
@@ -484,6 +491,115 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
   }
 
   @Test
+  public void testBasicPipelineLevel3RunWithDisabledSubFlows() throws Exception {
+    // disable either sub-flow in each execution: pipelineEmbeddedFlow4 or pipelineEmbeddedFlow3
+
+    final ExecutionOptions prevOptions = new ExecutionOptions();
+    prevOptions.setDisabledJobs(Arrays.asList(new DisabledJob("pipelineEmbeddedFlow4")));
+    final FlowRunner previousRunner = this.testUtil.createFromFlowMap("pipelineFlow", "prev",
+        prevOptions);
+
+    final ExecutionOptions pipeOptions = new ExecutionOptions();
+    pipeOptions.setPipelineExecutionId(previousRunner.getExecutableFlow()
+        .getExecutionId());
+    pipeOptions.setPipelineLevel(3);
+    pipeOptions.setDisabledJobs(Arrays.asList(new DisabledJob("pipelineEmbeddedFlow3")));
+    final FlowWatcher watcher = new LocalFlowWatcher(previousRunner);
+    final FlowRunner pipelineRunner = this.testUtil
+        .createFromFlowMap("pipelineFlow", "pipe", pipeOptions);
+    pipelineRunner.setFlowWatcher(watcher);
+
+    // 1. START FLOW
+    final ExecutableFlow pipelineFlow = pipelineRunner.getExecutableFlow();
+    final ExecutableFlow previousFlow = previousRunner.getExecutableFlow();
+    FlowRunnerTestUtil.startThread(previousRunner);
+    FlowRunnerTestUtil.startThread(pipelineRunner);
+
+    assertStatus(previousFlow, "pipeline1", Status.RUNNING);
+    assertStatus(pipelineFlow, "pipeline1", Status.QUEUED);
+
+    InteractiveTestJob.getTestJob("prev:pipeline1").succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipeline2").succeedJob();
+
+    assertStatus(previousFlow, "pipelineEmbeddedFlow3", Status.RUNNING);
+    assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobA",
+        Status.RUNNING);
+
+    // this should still be queued because some jobs are still running in previousFlow
+    assertStatus(pipelineFlow, "pipeline1", Status.QUEUED);
+  }
+
+  @Test
+  public void testBasicPipelineLevel3RunWithMoreDisabledJobs() throws Exception {
+    // disable either sub-flow in each execution: pipelineEmbeddedFlow4 or pipelineEmbeddedFlow3
+    // also disable pipeline1 & pipeline2 in both flows so that the first job that should be blocked
+    // is actually inside a sub-flow
+
+    final ExecutionOptions prevOptions = new ExecutionOptions();
+    prevOptions.setDisabledJobs(Arrays.asList(new DisabledJob("pipelineEmbeddedFlow4"),
+        new DisabledJob("pipeline1"), new DisabledJob("pipeline2"), new DisabledJob("pipelineFlow")
+    ));
+    final FlowRunner previousRunner = this.testUtil.createFromFlowMap("pipelineFlow", "prev",
+        prevOptions);
+
+    final ExecutionOptions pipeOptions = new ExecutionOptions();
+    pipeOptions.setPipelineExecutionId(previousRunner.getExecutableFlow()
+        .getExecutionId());
+    pipeOptions.setPipelineLevel(3);
+    pipeOptions.setDisabledJobs(Arrays.asList(new DisabledJob("pipelineEmbeddedFlow3"),
+        new DisabledJob("pipeline1"), new DisabledJob("pipeline2")));
+    final FlowWatcher watcher = new LocalFlowWatcher(previousRunner);
+    final FlowRunner pipelineRunner = this.testUtil
+        .createFromFlowMap("pipelineFlow", "pipe", pipeOptions);
+    pipelineRunner.setFlowWatcher(watcher);
+
+    // 1. START FLOW
+    final ExecutableFlow pipelineFlow = pipelineRunner.getExecutableFlow();
+    final ExecutableFlow previousFlow = previousRunner.getExecutableFlow();
+    FlowRunnerTestUtil.startThread(previousRunner);
+    FlowRunnerTestUtil.startThread(pipelineRunner);
+
+    assertStatus(previousFlow, "pipelineEmbeddedFlow3", Status.RUNNING);
+    assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobA",
+        Status.RUNNING);
+    // flow nodes that are just wrappers are immediately started even if there would be something
+    // to block basically
+    assertStatus(pipelineFlow, "pipelineEmbeddedFlow4", Status.RUNNING);
+    // this should still be queued because some jobs are still running in previousFlow
+    assertStatus(pipelineFlow, "pipelineEmbeddedFlow4:innerJobA", Status.QUEUED);
+
+    // succeed prev until pipeline4
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobA").succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobB").succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobC").succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerFlow").succeedJob();
+
+    // check that pipeline job is still queued
+    assertStatus(pipelineFlow, "pipelineEmbeddedFlow4:innerJobA", Status.QUEUED);
+
+    // now finish the last pending job
+    InteractiveTestJob.getTestJob("prev:pipeline4").succeedJob();
+
+    // pipelineFlow was disabled, so nothing to do manually
+    // InteractiveTestJob.getTestJob("prev:pipelineFlow").succeedJob();
+
+    assertStatus(previousFlow, "pipelineFlow", Status.SKIPPED);
+    assertFlowStatus(previousFlow, Status.SUCCEEDED);
+    assertThreadShutDown(previousRunner);
+
+    // now this job should've been unblocked
+    assertStatus(pipelineFlow, "pipelineEmbeddedFlow4:innerJobA", Status.RUNNING);
+
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerJobA").succeedJob();
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerFlow2").succeedJob();
+    InteractiveTestJob.getTestJob("pipe:pipeline4").succeedJob();
+    InteractiveTestJob.getTestJob("pipe:pipelineFlow").succeedJob();
+    assertStatus(pipelineFlow, "pipelineFlow", Status.SUCCEEDED);
+    assertFlowStatus(pipelineFlow, Status.SUCCEEDED);
+    assertThreadShutDown(pipelineRunner);
+  }
+
+  @Test
   public void testBasicPipelineLevel3Run() throws Exception {
     final FlowRunner previousRunner = this.testUtil.createFromFlowMap("pipelineFlow", "prev");
 
@@ -518,12 +634,14 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
 
     InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobA")
         .succeedJob();
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow4:innerJobA").succeedJob();
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobA",
         Status.SUCCEEDED);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobB",
         Status.RUNNING);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerJobC",
         Status.RUNNING);
+    assertStatus(previousFlow, "pipelineEmbeddedFlow4:innerJobA", Status.SUCCEEDED);
 
     InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow3:innerJobB")
         .succeedJob();
@@ -543,6 +661,7 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
     assertStatus(previousFlow, "pipelineEmbeddedFlow3:innerFlow",
         Status.SUCCEEDED);
     assertStatus(previousFlow, "pipelineEmbeddedFlow3", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("prev:pipelineEmbeddedFlow4:innerFlow2").succeedJob();
     assertStatus(previousFlow, "pipeline4", Status.RUNNING);
     InteractiveTestJob.getTestJob("prev:pipeline4").succeedJob();
     assertStatus(previousFlow, "pipeline4", Status.SUCCEEDED);
@@ -593,6 +712,8 @@ public class FlowRunnerPipelineTest extends FlowRunnerTestBase {
     assertStatus(pipelineFlow, "pipelineEmbeddedFlow3:innerFlow",
         Status.SUCCEEDED);
     assertStatus(pipelineFlow, "pipelineEmbeddedFlow3", Status.SUCCEEDED);
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerJobA").succeedJob();
+    InteractiveTestJob.getTestJob("pipe:pipelineEmbeddedFlow4:innerFlow2").succeedJob();
     assertStatus(pipelineFlow, "pipeline4", Status.RUNNING);
 
     InteractiveTestJob.getTestJob("pipe:pipeline4").succeedJob();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -33,6 +33,7 @@ import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.MockExecutorLoader;
 import azkaban.executor.Status;
 import azkaban.flow.Flow;
+import azkaban.flow.FlowUtils;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
 import azkaban.metrics.CommonMetrics;
@@ -258,6 +259,7 @@ public class FlowRunnerTestUtil {
     exFlow.setExecutionId(exId);
     if (options != null) {
       exFlow.setExecutionOptions(options);
+      FlowUtils.applyDisabledJobs(options.getDisabledJobs(), exFlow);
     }
     exFlow.getExecutionOptions().addAllFlowParameters(flowParams);
     this.executorLoader.uploadExecutableFlow(exFlow);

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -162,12 +162,14 @@
                         class="form-control form-control-auto input-sm">
                   <option value="1">Level 1</option>
                   <option value="2">Level 2</option>
+                  <option value="3">Level 3</option>
                 </select>
                 <span class="help-block">
                         Pipeline the flow, so the current execution will not be overrun.
                         <ul>
                           <li>Level 1: block job A until the previous flow job A has completed.</li>
-                          <li>Level 2: block job A until the previous flow job A's children have completed.</li>
+                          <li>Level 2: block job A until the previous flow job A's immediate children have completed.</li>
+                          <li>Level 3: block all jobs until the previous flow has completed.</li>
                           </li>
                       </span>
               </div>

--- a/docs/useAzkaban.rst
+++ b/docs/useAzkaban.rst
@@ -234,12 +234,14 @@ executing, several options can be set.
 + **Pipeline** runs the the flow in a manner that the new execution will
   not overrun the concurrent execution.
 
-    + Level 1: blocks executing **job A** until the the previous flow's **job A**
+    + Level 1: blocks executing **job A** until the previous flow's **job A**
       has completed.
-    + Level 2: blocks executing **job A** until the the children of the
-      previous flow's **job A** has completed. This is useful if you need to run
-      your flows a few steps behind an already executin flow.
-
+    + Level 2: blocks executing **job A** until the immediate children of the
+      previous flow's **job A** have completed. This is useful if you need to run
+      your flows two steps behind an already executing flow, as opposed to Level 1 which executes
+      one step behind. If the child node is a sub-flow, Level 2 only blocks on the immediate
+      start node(s) inside the sub-flow. This does **not** wait for the entire sub-flow.
+    + Level 3: blocks all jobs until the previous flow has completed.
 
 .. image:: figures/executeflowconcurrent.png
 

--- a/test/execution-test-data/embedded2/pipeline4.job
+++ b/test/execution-test-data/embedded2/pipeline4.job
@@ -1,2 +1,2 @@
 type=test
-dependencies=pipelineEmbeddedFlow3
+dependencies=pipelineEmbeddedFlow3,pipelineEmbeddedFlow4

--- a/test/execution-test-data/embedded2/pipelineEmbeddedFlow4.job
+++ b/test/execution-test-data/embedded2/pipelineEmbeddedFlow4.job
@@ -1,0 +1,5 @@
+type=flow
+flow.name=innerFlow2
+dependencies=pipeline2
+testprops=moo
+output.override=jobb


### PR DESCRIPTION
2 first commits taken from https://github.com/azkaban/azkaban/pull/2246 & rebased.

From the original PR by @toby-allsopp:

> Sometimes it is not acceptable for any nodes in the flow to run concurrently with any nodes in another execution of that flow. For example, exclusive access to some shared resource, such as a staging table in a database, might be required.

> This PR introduces a third level for the pipeline concurrency option in which none of the nodes in a flow can start until the end nodes in the concurrent execution have finished.

There was a bug that parent flow was not resolved recursively, which I have fixed. Without it blocking didn't work in this scenario:
- Two parallel executions, say ex-1 & ex-2
- In ex-1 sub-flow A is disabled
- In ex-2 sub-flow B is disabled
- Before the fix also jobs inside B in ex-2 started RUNNING without waiting for ex-1 to complete