### PR TITLE
Overhaul Project Cache Cleanup Code to fix inefficiencies

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -298,11 +298,11 @@ public class Constants {
         + ".max_number_per_ip_per_user";
 
     // allowed max size of shared project dir (percentage of partition size), e.g 0.8
-    public static final String PROJECT_CACHE_SIZE_PERCENTAGE = "azkaban"
-        + ".project_cache_size_percentage_of_disk";
+    public static final String PROJECT_CACHE_SIZE_PERCENTAGE =
+        "azkaban.project_cache_size_percentage_of_disk";
 
-    public static final String PROJECT_CACHE_THROTTLE_PERCENTAGE = "azkaban"
-        + ".project_cache_throttle_percentage";
+    public static final String PROJECT_CACHE_THROTTLE_PERCENTAGE =
+        "azkaban.project_cache_throttle_percentage";
 
     // how many older versions of project files are kept in DB before deleting them
     public static final String PROJECT_VERSION_RETENTION = "project.version.retention";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -301,6 +301,9 @@ public class Constants {
     public static final String PROJECT_CACHE_SIZE_PERCENTAGE = "azkaban"
         + ".project_cache_size_percentage_of_disk";
 
+    public static final String PROJECT_CACHE_THROTTLE_PERCENTAGE = "azkaban"
+        + ".project_cache_throttle_percentage";
+
     // how many older versions of project files are kept in DB before deleting them
     public static final String PROJECT_VERSION_RETENTION = "project.version.retention";
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -312,4 +312,10 @@ class FlowPreparer {
     execDir.mkdirs();
     return execDir;
   }
+
+  public void shutdown() {
+    if (projectCacheCleaner.isPresent()) {
+      this.projectCacheCleaner.get().shutdown();
+    }
+  }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -228,11 +228,15 @@ public class FlowRunnerManager implements EventListener,
             getClass().getClassLoader());
 
     ProjectCacheCleaner cleaner = null;
+    this.LOGGER.info("Configuring Project Cache");
     try {
       final double projectCacheSizePercentage =
           props.getDouble(ConfigurationKeys.PROJECT_CACHE_SIZE_PERCENTAGE);
+      this.LOGGER.info("Configuring Cache Cleaner with {} % as threshold", projectCacheSizePercentage);
       cleaner = new ProjectCacheCleaner(this.projectDirectory, projectCacheSizePercentage);
+      this.LOGGER.info("ProjectCacheCleaner configured.");
     } catch (final UndefinedPropertyException ex) {
+      ex.printStackTrace();
     }
 
     // Create a flow preparer
@@ -892,6 +896,7 @@ public class FlowRunnerManager implements EventListener,
         LOGGER.error(e.getMessage());
       }
     }
+    flowPreparer.shutdown();
     LOGGER.warn("Shutdown FlowRunnerManager complete.");
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -229,14 +229,27 @@ public class FlowRunnerManager implements EventListener,
 
     ProjectCacheCleaner cleaner = null;
     this.LOGGER.info("Configuring Project Cache");
+    double projectCacheSizePercentage = 0.0;
+    double projectCacheThrottlePercentage = 0.0;
     try {
-      final double projectCacheSizePercentage =
+      projectCacheSizePercentage =
           props.getDouble(ConfigurationKeys.PROJECT_CACHE_SIZE_PERCENTAGE);
+      projectCacheThrottlePercentage =
+          props.getDouble(ConfigurationKeys.PROJECT_CACHE_THROTTLE_PERCENTAGE);
       this.LOGGER.info("Configuring Cache Cleaner with {} % as threshold", projectCacheSizePercentage);
-      cleaner = new ProjectCacheCleaner(this.projectDirectory, projectCacheSizePercentage);
+      cleaner = new ProjectCacheCleaner(this.projectDirectory,
+          projectCacheSizePercentage,
+          projectCacheThrottlePercentage);
       this.LOGGER.info("ProjectCacheCleaner configured.");
     } catch (final UndefinedPropertyException ex) {
-      ex.printStackTrace();
+      if (projectCacheSizePercentage == 0.0) {
+        this.LOGGER.info("Property {} not set. Project Cache directory will not be auto-cleaned as it gets full",
+            ConfigurationKeys.PROJECT_CACHE_SIZE_PERCENTAGE);
+      } else {
+        // Exception must have been fired because Throttle percentage is not set. Initialize the cleaner
+        // with the default throttle value
+        cleaner = new ProjectCacheCleaner(this.projectDirectory, projectCacheSizePercentage);
+      }
     }
 
     // Create a flow preparer

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -248,6 +248,8 @@ public class FlowRunnerManager implements EventListener,
       } else {
         // Exception must have been fired because Throttle percentage is not set. Initialize the cleaner
         // with the default throttle value
+        this.LOGGER.info("Property {} not set. Initializing with default value of Throttle Percentage",
+            ConfigurationKeys.PROJECT_CACHE_THROTTLE_PERCENTAGE);
         cleaner = new ProjectCacheCleaner(this.projectDirectory, projectCacheSizePercentage);
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectCacheCleaner.java
@@ -296,7 +296,7 @@ class ProjectCacheCleaner {
     boolean throttleAfterDeletion = false;
 
     final long highWatermark = (long) (projectCacheDirCapacity * this.percentageOfDisk);
-    final long throttleWatermark = (long) (projectCacheDirCapacity * throttlePercentage);
+    final long throttleWatermark = (long) (projectCacheDirCapacity * this.throttlePercentage);
 
     long projectedCacheSize = currentCacheSize + newProjectSizeInBytes;
 


### PR DESCRIPTION
The previous code in ProjectCacheCleaner class had several deficiencies:
1. When a watermark for cache cleaning hits, the code did LRU evictions by deleting old
   project directories in a *blocking context*. This can cause flows to get stuck in
   preparing state.
2. Every time this class is invoked in response to a cache miss; the code does equivalent
   of a "du" command on the project cache directory. On large clusters this directory tends
   to get huge thereby making the flows get stuck for several seconds. In extreme cases
   for minutes or even hours.
3. The calculation of watermark (deletion thresh-hold) itself was flawed. The thresh-hold
   is getting calculated from the partition size; when other things like execution directories
   share the same partition. So in many cases the commonly used thresh-hold value of 70% is
   impossible to hit as > 30% space is consumed by non-cache directories.

The code changes overhaul the ProjectCacheCleaner class to fix all 3 issues mentioned above:
1. Deletion is now done in a *non-blocking* context. Also a *throttle-watermark* is introduced
   to address extreme scenarios such as 95% cache full when it actually does make sense to block
   till cache is fully clean.
2. A full "du" is done only on first cache miss. Subsequent invocations of this class will
   only calculate directory space for newly added projects since the previous invocation.
3. The watermarks are now made dynamic. They feed off from:
   "Current Cache Space + Available capacity in partition". Hence, if say execution directory
   is taking more space than usual; then cache watermarks will re-adjust automatically.

TESTING:
1. Adjusted existing unit test cases for the non-blocking behavior. Also added a new test case
   to test throttle condition.
2. Tested on a real cluster by artifically setting low thresh-holds to make sure the new code
   is working as expected and all possible conditions are getting fired.