### PR TITLE
Fixed the broken link in the schedule panel page

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/schedulepanel.vm
@@ -129,7 +129,7 @@
                   </tbody>
                 </table>
                 <p><u><span style="color:Indigo"><a
-                    href="http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html" target="_blank">Detailed instructions</a></span>.</u>
+                    href="http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html#examples" target="_blank">Detailed instructions</a></span>.</u>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
The current link we are pointing doesn't exist anymore. Pointed to the right link. Tested if it's taking me to the correct page by running the Azkaban WS locally. 