### PR TITLE
Support sla settings in execute & schedule API actions

### DIFF
--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -19,6 +19,7 @@ import azkaban.executor.DisabledJob;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutionOptions.FailureAction;
 import azkaban.executor.ExecutorManagerException;
+import azkaban.sla.SlaOption;
 import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.Role;
@@ -38,7 +39,11 @@ import org.apache.commons.lang.StringUtils;
 
 public class HttpRequestUtils {
 
-  public static ExecutionOptions parseFlowOptions(final HttpServletRequest req)
+  public static final String PARAM_SLA_EMAILS = "slaEmails";
+  public static final String PARAM_SLA_SETTINGS = "slaSettings";
+
+  public static ExecutionOptions parseFlowOptions(final HttpServletRequest req,
+      final String flowName)
       throws ServletException {
     final ExecutionOptions execOptions = new ExecutionOptions();
 
@@ -99,6 +104,15 @@ public class HttpRequestUtils {
     if (hasParam(req, "mailCreator")) {
       final String mailCreator = getParam(req, "mailCreator");
       execOptions.setMailCreator(mailCreator);
+    }
+
+    final Map<String, String> slaSettings = getParamGroup(req, PARAM_SLA_SETTINGS);
+    // emails param is optional
+    final String emailStr = getParam(req, PARAM_SLA_EMAILS, null);
+    final List<SlaOption> slaOptions = SlaRequestUtils.parseSlaOptions(flowName, emailStr,
+        slaSettings);
+    if (!slaOptions.isEmpty()) {
+      execOptions.setSlaOptions(slaOptions);
     }
 
     final Map<String, String> flowParamGroup = getParamGroup(req, "flowOverride");

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -21,8 +21,13 @@ public class SlaRequestUtils {
 
   public static List<SlaOption> parseSlaOptions(final String flowName, final String emailStr,
       final Map<String, String> settings) throws ServletException {
-    final String[] emailSplit = emailStr.split("\\s*,\\s*|\\s*;\\s*|\\s+");
-    final List<String> slaEmails = Arrays.asList(emailSplit);
+    final List<String> slaEmails;
+    if (emailStr == null) {
+      slaEmails = Arrays.asList();
+    } else {
+      final String[] emailSplit = emailStr.split("\\s*,\\s*|\\s*;\\s*|\\s+");
+      slaEmails = Arrays.asList(emailSplit);
+    }
 
     final List<SlaOption> slaOptions = new ArrayList<>();
     for (final String set : settings.keySet()) {

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.server;
 
 import azkaban.sla.SlaAction;

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -49,7 +49,8 @@ public class SlaRequestUtils {
       try {
         slaOption = parseSlaSetting(settings.get(set), flowName, slaEmails);
       } catch (final Exception e) {
-        throw new ServletException(e);
+        throw new ServletException(
+            "Error parsing SLA setting '" + settings.get(set) + "': " + e.toString(), e);
       }
       slaOptions.add(slaOption);
     }

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -1,6 +1,5 @@
 package azkaban.server;
 
-import azkaban.scheduler.ScheduleManagerException;
 import azkaban.sla.SlaAction;
 import azkaban.sla.SlaOption;
 import azkaban.sla.SlaOption.SlaOptionBuilder;
@@ -43,7 +42,7 @@ public class SlaRequestUtils {
   }
 
   private static SlaOption parseSlaSetting(final String set, final String flowName,
-      final List<String> emails) throws ScheduleManagerException {
+      final List<String> emails) throws ServletException {
     logger.info("Trying to parse sla with the following set: " + set);
 
     final String[] parts = set.split(",", -1);
@@ -79,12 +78,12 @@ public class SlaRequestUtils {
     try {
       dur = parseDuration(duration);
     } catch (final Exception e) {
-      throw new ScheduleManagerException(
+      throw new ServletException(
           "Unable to parse duration for a SLA that needs to take actions!", e);
     }
 
     if (actions.isEmpty()) {
-      throw new ScheduleManagerException("Unable to create SLA as there is no action set");
+      throw new ServletException("Unable to create SLA as there is no action set");
     }
     logger.info("Parsing sla as id:" + id + " type:" + type + " sla:"
         + rule + " Duration:" + duration + " actions:" + actions);

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.joda.time.DateTime;
@@ -341,6 +342,40 @@ public class SlaOption {
     return options.stream()
         .filter(option -> option.isComponentType(componentType))
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public String toString() {
+    return "SlaOption{" +
+        "type=" + type +
+        ", flowName='" + flowName + '\'' +
+        ", jobName='" + jobName + '\'' +
+        ", duration=" + duration +
+        ", actions=" + actions +
+        ", emails=" + emails +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SlaOption slaOption = (SlaOption) o;
+    return type == slaOption.type &&
+        Objects.equals(flowName, slaOption.flowName) &&
+        Objects.equals(jobName, slaOption.jobName) &&
+        Objects.equals(duration, slaOption.duration) &&
+        Objects.equals(actions, slaOption.actions) &&
+        Objects.equals(emails, slaOption.emails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, flowName, jobName, duration, actions, emails);
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -946,7 +946,14 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final ExecutableFlow exflow = FlowUtils.createExecutableFlow(project, flow);
     exflow.setSubmitUser(user.getUserId());
 
-    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, flowId);
+    final ExecutionOptions options;
+    try {
+      options = HttpRequestUtils.parseFlowOptions(req, flowId);
+    } catch (final ServletException e) {
+      logger.info("parseFlowOptions failed", e);
+      ret.put("error", "Error parsing flow options: " + e.getMessage());
+      return;
+    }
     exflow.setExecutionOptions(options);
     if (!options.isFailureEmailsOverridden()) {
       options.setFailureEmails(flow.getFailureEmails());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -946,7 +946,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final ExecutableFlow exflow = FlowUtils.createExecutableFlow(project, flow);
     exflow.setSubmitUser(user.getUserId());
 
-    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req);
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, flowId);
     exflow.setExecutionOptions(options);
     if (!options.isFailureEmailsOverridden()) {
       options.setFailureEmails(flow.getFailureEmails());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -458,7 +458,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
     ExecutionOptions flowOptions = null;
     try {
-      flowOptions = HttpRequestUtils.parseFlowOptions(req);
+      flowOptions = HttpRequestUtils.parseFlowOptions(req, flowName);
       HttpRequestUtils.filterAdminOnlyFlowParams(this.userManager, flowOptions, user);
     } catch (final Exception e) {
       ret.put(PARAM_ERROR, e.getMessage());
@@ -569,7 +569,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
     ExecutionOptions flowOptions = null;
     try {
-      flowOptions = HttpRequestUtils.parseFlowOptions(req);
+      flowOptions = HttpRequestUtils.parseFlowOptions(req, flowName);
       HttpRequestUtils.filterAdminOnlyFlowParams(this.userManager, flowOptions, user);
     } catch (final Exception e) {
       ret.put(PARAM_ERROR, e.getMessage());

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.webapp.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import azkaban.sla.SlaAction;
+import azkaban.sla.SlaOption;
+import azkaban.sla.SlaType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.ServletException;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
+
+  private ExecutorServlet executorServlet;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    this.executorServlet = new ExecutorServlet();
+    this.executorServlet.init(this.servletConfig);
+  }
+
+  /**
+   * When executeFlow is called with SLA options, a new execution should be submitted with SLA.
+   */
+  @Test
+  public void postAjaxExecuteFlowWithSlaSettings() throws Exception {
+    mockTestProjectAndFlow();
+    mockSubmitExecution();
+    this.req.addParameter("ajax", "executeFlow");
+    this.req.addParameter("project", "testProject");
+    this.req.addParameter("flow", "testFlow");
+    this.req.addParameter("slaSettings[1]", ",FINISH,2:30,true,false");
+    this.req.addParameter("slaEmails", "sla1@example.com,sla2@example.com");
+
+    this.executorServlet.handlePost(this.req, this.res, this.session);
+
+    assertEquals(200, this.res.getStatus());
+
+    final JsonNode json = this.res.getResponseJson();
+    assertEquals("testProject", json.path("project").asText());
+    assertEquals("testFlow", json.path("flow").asText());
+    assertEquals("Submitted (mocked)", json.path("message").asText());
+    assertEquals(99, json.path("execid").asInt());
+
+    final List<SlaOption> slaOptions = this.exFlow.getValue().getExecutionOptions().getSlaOptions();
+    final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "testFlow",
+        "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
+        ImmutableList.of("sla1@example.com", "sla2@example.com")));
+    Assert.assertEquals(expected, slaOptions);
+  }
+
+  /**
+   * When SLA options can't be parsed, API is expected to return 200 OK with JSON that has "error".
+   */
+  @Test
+  public void postAjaxExecuteFlowWithInvalidSlaSettings() throws Exception {
+    mockTestProjectAndFlow();
+    mockSubmitExecution();
+    this.req.addParameter("ajax", "executeFlow");
+    this.req.addParameter("project", "testProject");
+    this.req.addParameter("flow", "testFlow");
+    this.req.addParameter("slaSettings[1]", "broken-syntax-for-sla");
+
+    this.executorServlet.handlePost(this.req, this.res, this.session);
+
+    assertEquals(200, this.res.getStatus());
+    assertEquals("Error parsing flow options: Error parsing SLA setting 'broken-syntax-for-sla': "
+            + "java.lang.ArrayIndexOutOfBoundsException: 1",
+        this.res.getResponseJson().path("error").asText());
+  }
+
+  /**
+   * When executeFlow is called without project param, API is expected to raise an exception.
+   */
+  @Test
+  public void postAjaxExecuteFlowWithMissingProjectParameter() throws Exception {
+    this.req.addParameter("ajax", "executeFlow");
+    try {
+      this.executorServlet.handlePost(this.req, this.res, this.session);
+      fail("Expected exception was not thrown");
+    } catch (final ServletException e) {
+      assertEquals("Missing required parameter 'project'.", e.getMessage());
+    }
+  }
+
+  /**
+   * When execution is not found, API is expected to return 200 OK with JSON that has "error".
+   */
+  @Test
+  public void postAjaxFlowInfoErrorFetching() throws Exception {
+    this.req.addParameter("ajax", "flowInfo");
+    this.req.addParameter("execid", "123");
+
+    this.executorServlet.handlePost(this.req, this.res, this.session);
+
+    assertEquals(200, this.res.getStatus());
+    assertEquals("Cannot find execution '123'", this.res.getResponseJson().path("error").asText());
+  }
+
+}

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTestBase.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTestBase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.webapp.servlet;
+
+import azkaban.ServiceProvider;
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutorManagerAdapter;
+import azkaban.executor.ExecutorManagerException;
+import azkaban.flow.Flow;
+import azkaban.flowtrigger.FlowTriggerService;
+import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import azkaban.scheduler.ScheduleManager;
+import azkaban.server.session.Session;
+import azkaban.user.Permission;
+import azkaban.user.Permission.Type;
+import azkaban.user.Role;
+import azkaban.user.User;
+import azkaban.user.UserManager;
+import azkaban.utils.Props;
+import azkaban.webapp.AzkabanWebServer;
+import azkaban.webapp.WebMetrics;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import java.io.IOException;
+import javax.servlet.ServletConfig;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public abstract class LoginAbstractAzkabanServletTestBase {
+
+  protected static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Mock
+  protected Injector injector;
+
+  @Mock
+  protected AzkabanWebServer azkabanWebServer;
+  @Mock
+  protected WebMetrics webMetrics;
+
+  @Mock
+  protected ProjectManager projectManager;
+  @Mock
+  protected UserManager userManager;
+  @Mock
+  protected ExecutorManagerAdapter executorManager;
+  @Mock
+  protected ScheduleManager scheduleManager;
+  @Mock
+  protected FlowTriggerService flowTriggerService;
+
+  @Mock
+  protected ServletConfig servletConfig;
+  @Mock
+  protected Session session;
+  protected AzkabanMockHttpServletRequest req;
+  protected AzkabanMockHttpServletResponse res;
+
+  @Captor
+  protected ArgumentCaptor<ExecutableFlow> exFlow;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    ServiceProvider.SERVICE_PROVIDER.unsetInjector();
+    ServiceProvider.SERVICE_PROVIDER.setInjector(this.injector);
+    Mockito.when(this.injector.getInstance(AzkabanWebServer.class))
+        .thenReturn(this.azkabanWebServer);
+    Mockito.when(this.injector.getInstance(WebMetrics.class))
+        .thenReturn(this.webMetrics);
+
+    // This could possibly load
+    // azkaban-public/azkaban-web-server/src/main/resources/conf/azkaban.properties
+    // , but so far not needed
+    Mockito.when(this.azkabanWebServer.getServerProps()).thenReturn(Props.of());
+    Mockito.when(this.azkabanWebServer.getProjectManager()).thenReturn(this.projectManager);
+    Mockito.when(this.azkabanWebServer.getUserManager()).thenReturn(this.userManager);
+    Mockito.when(this.azkabanWebServer.getExecutorManager()).thenReturn(this.executorManager);
+    Mockito.when(this.azkabanWebServer.getScheduleManager()).thenReturn(this.scheduleManager);
+    Mockito.when(this.azkabanWebServer.getFlowTriggerService()).thenReturn(this.flowTriggerService);
+
+    mockTesUserWithAdminRole();
+
+    this.req = new AzkabanMockHttpServletRequest();
+    this.res = new AzkabanMockHttpServletResponse();
+  }
+
+  private void mockTesUserWithAdminRole() {
+    final User testAdminUser = new User("testAdminUser");
+    testAdminUser.addRole("adminRole");
+    final Role adminRole = new Role("adminRole", new Permission(Type.ADMIN));
+    Mockito.when(this.userManager.getRole("adminRole")).thenReturn(adminRole);
+    Mockito.when(this.session.getUser()).thenReturn(testAdminUser);
+  }
+
+  protected void mockTestProjectAndFlow() {
+    final Project project = new Project(11, "testProject");
+    Mockito.when(this.projectManager.getProject("testProject")).thenReturn(project);
+    final Flow flow = new Flow("testFlow");
+    project.setFlows(ImmutableMap.of(flow.getId(), flow));
+  }
+
+  protected void mockSubmitExecution() throws ExecutorManagerException {
+    Mockito.doAnswer(invocation -> {
+      final ExecutableFlow exFlow = invocation.getArgument(0, ExecutableFlow.class);
+      // Mock the behavior of ExecutorLoader#uploadExecutableFlow: assign an execution id.
+      exFlow.setExecutionId(99);
+      return "Submitted (mocked)";
+    }).when(this.executorManager).submitExecutableFlow(this.exFlow.capture(), Mockito.anyString());
+  }
+
+  public static class AzkabanMockHttpServletRequest extends MockHttpServletRequest {
+
+  }
+
+  public static class AzkabanMockHttpServletResponse extends MockHttpServletResponse {
+
+    protected JsonNode getResponseJson() throws IOException {
+      return LoginAbstractAzkabanServletTestBase.MAPPER.readTree(this.getContentAsString());
+    }
+
+  }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ ext.deps = [
     slf4j                : 'org.slf4j:slf4j-api:' + versions.slf4j,
     slf4jLog4j           : 'org.slf4j:slf4j-log4j12:' + versions.slf4j,
     sparkCore            : 'org.apache.spark:spark-core_2.10:1.4.0',
+    springTest           : 'org.springframework:spring-test:3.2.18.RELEASE',
     snakeyaml            : 'org.yaml:snakeyaml:1.18',
     velocity             : 'org.apache.velocity:velocity:1.7',
     velocityTools        : 'org.apache.velocity:velocity-tools:2.0',
@@ -176,6 +177,7 @@ subprojects {
       testCompile deps.powermockmodulejunit4
       testCompile deps.jsonassert
       testCompile deps.awaitility
+      testCompile deps.springTest
     }
 
     test {


### PR DESCRIPTION
This implements https://github.com/azkaban/azkaban/issues/2509 _Support SLA options in execute API_.

As a bonus SLA options are now supported also in the schedule call because it's using the same HttpRequestUtils. This is nice because if using the API directly to add schedules (like many users do), the API now allows ensuring that a scheduled execution doesn't start running before SLA has been set for it.

The separate set sla API for schedules remains as well.