### PR TITLE
Fix exception handling of executor health checker

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
@@ -18,18 +18,19 @@ package azkaban.executor;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +72,13 @@ public class ExecutorHealthChecker {
 
   public void start() {
     logger.info("Starting executor health checker.");
-    this.scheduler.scheduleAtFixedRate(() -> checkExecutorHealth(), 0L, this.healthCheckIntervalMin,
+    this.scheduler.scheduleAtFixedRate(this::checkExecutorHealthQuietly, 0L,
+        this.healthCheckIntervalMin,
         TimeUnit.MINUTES);
   }
 
   public void shutdown() {
+    logger.info("Terminating executor health checker.");
     this.scheduler.shutdown();
     try {
       if (!this.scheduler.awaitTermination(60, TimeUnit.SECONDS)) {
@@ -88,10 +91,26 @@ public class ExecutorHealthChecker {
   }
 
   /**
+   * Wrapper for capturing and logging errors and exceptions thrown during healthcheck.
+   * {@code ScheduledExecutorService} stops the scheduled invocations of a given method in
+   * case it throws an exception.
+   * Any exceptions are not expected at this stage however in case any errors and unchecked
+   * exceptions do occur, we still don't want subsequent healthchecks to stop.
+   */
+  public void checkExecutorHealthQuietly() {
+    try {
+      checkExecutorHealth();
+    } catch (Throwable t) {
+      logger.error("Unexepected error during executor healthcheck. Cause: " + ExceptionUtils.getStackTrace(t));
+    }
+  }
+
+  /**
    * Checks executor health. Finalizes the flow if its executor is already removed from DB or
    * sends alert emails if the executor isn't alive any more.
    */
-  public void checkExecutorHealth() {
+  @VisibleForTesting
+  void checkExecutorHealth() {
     final Map<Optional<Executor>, List<ExecutableFlow>> exFlowMap = getFlowToExecutorMap();
     for (final Map.Entry<Optional<Executor>, List<ExecutableFlow>> entry : exFlowMap.entrySet()) {
       final Optional<Executor> executorOption = entry.getKey();
@@ -130,12 +149,18 @@ public class ExecutorHealthChecker {
    * @param flows
    * @param finalizeReason
    */
-  private void finalizeFlows(List<ExecutableFlow> flows, String finalizeReason) {
+  @VisibleForTesting
+  void finalizeFlows(List<ExecutableFlow> flows, String finalizeReason) {
     for (ExecutableFlow flow: flows) {
       logger.warn(
           String.format("Finalizing execution %s, %s", flow.getExecutionId(), finalizeReason));
-      ExecutionControllerUtils
-          .finalizeFlow(this.executorLoader, this.alerterHolder, flow, finalizeReason, null);
+      try {
+        ExecutionControllerUtils
+            .finalizeFlow(this.executorLoader, this.alerterHolder, flow, finalizeReason, null);
+      } catch (RuntimeException e) {
+        logger.error(String.format("Unchecked exception while finalizing execution: %d. "
+            + "Exception: %s", flow.getExecutionId(), ExceptionUtils.getStackTrace(e)));
+      }
     }
   }
 
@@ -158,14 +183,15 @@ public class ExecutorHealthChecker {
         flows.add(runningFlow.getSecond());
       }
     } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get flow to executor map");
+      logger.error("Failed to get flow to executor map. Exception reported: " + ExceptionUtils
+          .getStackTrace(e));
     }
     return exFlowMap;
   }
 
   /**
    * Increments executor failure count. If it reaches max failure count, sends alert emails to AZ
-   * admin and executes any cleanup actions for flows on that executors.
+   * admin and executes any cleanup actions for flows on those executors.
    *
    * @param executor the executor
    * @param flows flows assigned to the executor

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
@@ -78,7 +78,7 @@ public class ExecutorHealthChecker {
   }
 
   public void shutdown() {
-    logger.info("Terminating executor health checker.");
+    logger.info("Shutting down executor health checker.");
     this.scheduler.shutdown();
     try {
       if (!this.scheduler.awaitTermination(60, TimeUnit.SECONDS)) {
@@ -91,17 +91,18 @@ public class ExecutorHealthChecker {
   }
 
   /**
-   * Wrapper for capturing and logging errors and exceptions thrown during healthcheck.
+   * Wrapper for capturing and logging any exceptions thrown during healthcheck.
    * {@code ScheduledExecutorService} stops the scheduled invocations of a given method in
    * case it throws an exception.
-   * Any exceptions are not expected at this stage however in case any errors and unchecked
-   * exceptions do occur, we still don't want subsequent healthchecks to stop.
+   * Any exceptions are not expected at this stage however in case any unchecked exceptions
+   * do occur, we still don't want subsequent healthchecks to stop.
    */
   public void checkExecutorHealthQuietly() {
     try {
       checkExecutorHealth();
-    } catch (Throwable t) {
-      logger.error("Unexepected error during executor healthcheck. Cause: " + ExceptionUtils.getStackTrace(t));
+    } catch (final RuntimeException e) {
+      logger.error("Unexepected error during executor healthcheck. Cause: "
+          + ExceptionUtils.getStackTrace(e));
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
@@ -155,9 +155,9 @@ public class ExecutorHealthCheckerTest {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
         new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenThrow(new Error("test error"));
+        ConnectorParams.PING_ACTION, null, null)).thenThrow(new RuntimeException("test exception"));
 
-    // this will throw causing the test to fail in case the error is not caught correctly
+    // this will throw, causing the test to fail in case the error is not caught correctly
     this.executorHealthChecker.checkExecutorHealthQuietly();
     verifyZeroInteractions(this.alerterHolder);
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
@@ -28,6 +28,7 @@ import azkaban.alert.Alerter;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -144,5 +145,47 @@ public class ExecutorHealthCheckerTest {
     String expectedReason = "Executor was unreachable, executor-id: 1, executor-host: localhost, "
         + "executor-port: 12345";
     verify((this.alerterHolder).get("email")).alertOnError(eq(flow1), eq(expectedReason));
+  }
+
+  /**
+   * Test that the wrapper routine swallows any exceptions reported by underlying health checker.
+   */
+  @Test
+  public void testCheckExecutorHealthWrapperExceptionHandling() throws Exception {
+    this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
+        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+    when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
+        ConnectorParams.PING_ACTION, null, null)).thenThrow(new Error("test error"));
+
+    // this will throw causing the test to fail in case the error is not caught correctly
+    this.executorHealthChecker.checkExecutorHealthQuietly();
+    verifyZeroInteractions(this.alerterHolder);
+  }
+
+  /**
+   * Test that exceptions during flow finalization do not block finalization of subsequent flow
+   * for an executor.
+   */
+  @Test
+  public void testFailureDuringFinalization() throws Exception {
+    final int executionId12 = 12;
+    this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
+        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+
+    ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    this.activeFlows.put(executionId12, new Pair<>(
+        new ExecutionReference(executionId12, this.executor1), flow2));
+    flow2.setExecutionId(executionId12);
+    flow2.setStatus(Status.RUNNING);
+
+    when(this.loader.fetchExecutableFlow(EXECUTION_ID_11)).thenThrow(new RuntimeException(
+        "test runtime exception"));
+    when(this.loader.fetchExecutableFlow(executionId12)).thenThrow(new RuntimeException(
+        "test runtime exception"));
+
+    this.executorHealthChecker.finalizeFlows(ImmutableList.of(this.flow1, flow2),
+        "test finalize reason");
+    verify(this.loader).fetchExecutableFlow(flow1.getExecutionId());
+    verify(this.loader).fetchExecutableFlow(flow2.getExecutionId());
   }
 }


### PR DESCRIPTION
Currently in case of any uncaught exceptions during executor health check
the health checking stops and the exception is never reported.
This is fixed by introducing a wrapper routine for catching and reporting any
uncaught exceptions.
Includes additional exception handling when finalizing flows for an
unreachable executor.