### PR TITLE
Use default 'user.to.proxy' value for JOB_STARTED Kafka event when that property is not defined

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1488,11 +1488,12 @@ public class FlowRunner extends EventHandler implements Runnable {
     @VisibleForTesting
     synchronized Map<String, String> getJobMetadata(final JobRunner jobRunner) {
       final ExecutableNode node = jobRunner.getNode();
+      final ExecutableFlow executableFlow = node.getExecutableFlow();
       final Props props = ServiceProvider.SERVICE_PROVIDER.getInstance(Props.class);
       final Map<String, String> metaData = new HashMap<>();
       metaData.put("jobId", node.getId());
-      metaData.put("executionID", String.valueOf(node.getExecutableFlow().getExecutionId()));
-      metaData.put("flowName", node.getExecutableFlow().getId());
+      metaData.put("executionID", String.valueOf(executableFlow.getExecutionId()));
+      metaData.put("flowName", executableFlow.getId());
       metaData.put("startTime", String.valueOf(node.getStartTime()));
       metaData.put("jobType", String.valueOf(node.getType()));
       // Azkaban executor hostname
@@ -1501,8 +1502,7 @@ public class FlowRunner extends EventHandler implements Runnable {
       // or else use jetty.hostname
       metaData.put("azkabanWebserver", props.getString(AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME,
           props.getString("jetty.hostname", "localhost")));
-      metaData.put("jobProxyUser",
-          jobRunner.getProps().getString(JobProperties.USER_TO_PROXY, null));
+      metaData.put("jobProxyUser", jobRunner.getEffectiveUser());
 
       // Propagate job properties to Event Reporter
       FlowRunner.propagateMetadataFromProps(metaData, node.getInputProps(), "job", node.getId(),

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -178,6 +178,11 @@ public class JobRunner extends EventHandler implements Runnable {
     return this.props;
   }
 
+  public String getEffectiveUser() {
+    return this.props.getString(JobProperties.USER_TO_PROXY,
+        this.getNode().getExecutableFlow().getSubmitUser());
+  }
+
   public void setPipeline(final FlowWatcher watcher, final int pipelineLevel) {
     this.watcher = watcher;
     this.pipelineLevel = pipelineLevel;


### PR DESCRIPTION
When a flow didn't define `user.to.proxy` property it defaulted to NULL when sending the _JOB_STARTED_ Kafka event causing a NullPointerException and a failure to send the event.