### PR TITLE
Add metric NumAgedQueuedFlows: Counts flows submitted long ago, but n…

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -83,6 +83,8 @@ public class Constants {
 
   public static final Duration MIN_FLOW_TRIGGER_WAIT_TIME = Duration.ofMinutes(1);
 
+  public static final Duration MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED = Duration.ofMinutes(20);
+
   // The flow exec id for a flow trigger instance which hasn't started a flow yet
   public static final int UNASSIGNED_EXEC_ID = -1;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.event.EventHandler;
 import azkaban.flow.FlowUtils;
@@ -317,6 +318,18 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     long size = 0L;
     try {
       size = this.executorLoader.fetchQueuedFlows().size();
+    } catch (final ExecutorManagerException e) {
+      this.logger.error("Failed to get queued flow size.", e);
+    }
+    return size;
+  }
+
+  @Override
+  public long getAgedQueuedFlowSize() {
+    long size = 0L;
+    try {
+      size = this.executorLoader.fetchAgedQueuedFlows(
+          Constants.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED).size();
     } catch (final ExecutorManagerException e) {
       this.logger.error("Failed to get queued flow size.", e);
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -228,6 +228,9 @@ public interface ExecutorLoader {
   List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException;
 
+  public List<Pair<ExecutionReference, ExecutableFlow>> fetchAgedQueuedFlows(
+      final Duration minAge) throws ExecutorManagerException;
+
   boolean updateExecutableReference(int execId, long updateTime)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -549,6 +549,13 @@ public class ExecutorManager extends EventHandler implements
     return this.queuedFlows.size();
   }
 
+  @Override
+  public long getAgedQueuedFlowSize() {
+    logger.error("Unsupported Function: getQueuedFlowSize() - Retrieving of Aged flows that are "
+        + "waiting in queue");
+    return 0;
+  }
+
   /* Helper method to flow ids of all running flows */
   private void getRunningFlowsIdsHelper(final List<Integer> allIds,
       final Collection<Pair<ExecutionReference, ExecutableFlow>> collection) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -42,6 +42,8 @@ public interface ExecutorManagerAdapter {
 
   public long getQueuedFlowSize();
 
+  public long getAgedQueuedFlowSize();
+
   /**
    * <pre>
    * Returns All running with executors and queued flows

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -87,6 +87,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
     return this.executionFlowDao.fetchQueuedFlows();
   }
 
+  @Override
+  public List<Pair<ExecutionReference, ExecutableFlow>> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    return this.executionFlowDao.fetchAgedQueuedFlows(minAge);
+  }
+
   /**
    * maxAge indicates how long finished flows are shown in Recently Finished flow page.
    */

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -441,6 +441,24 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public List<Pair<ExecutionReference, ExecutableFlow>> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    final List<Pair<ExecutionReference, ExecutableFlow>> agedQueuedFlows =
+        new ArrayList<>();
+
+    long timeThreshoold = System.currentTimeMillis() - minAge.toMillis();
+    for (final int execId : this.refs.keySet()) {
+      if (!this.executionExecutorMapping.containsKey(execId)) {
+        ExecutableFlow agedFlow = this.flows.get(execId);
+        if (agedFlow.getSubmitTime() < timeThreshoold) {
+          agedQueuedFlows.add(new Pair<>(this.refs.get(execId), this.flows.get(execId)));
+        }
+      }
+    }
+    return agedQueuedFlows;
+  }
+
+  @Override
   public void unassignExecutor(final int executionId) throws ExecutorManagerException {
     this.executionExecutorMapping.remove(executionId);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -93,6 +93,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.jmx.HierarchyDynamicMBean;
 import org.apache.velocity.app.VelocityEngine;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.DefaultServlet;
@@ -510,6 +511,13 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   private void startWebMetrics() throws Exception {
     this.metricsManager
         .addGauge("WEB-NumQueuedFlows", this.executorManagerAdapter::getQueuedFlowSize);
+
+    // Metric for flows that have been submitted, but haven't started for more than 20 minutes.
+    if (this.props.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
+      this.metricsManager
+          .addGauge("WEB-NumAgedQueuedFlows", this.executorManagerAdapter::getAgedQueuedFlowSize);
+    }
+
     /*
      * TODO: Currently {@link ExecutorManager#getRunningFlows()} includes both running and non-dispatched flows.
      * Originally we would like to do a subtraction between getRunningFlows and {@link ExecutorManager#getQueuedFlowSize()},


### PR DESCRIPTION
This introduces a metric to track number of flows that have not started running for more than 20 minutes after the web server put those in the queue.

Unit-Test
=======
Writing unit test for duration-dependent functionality is flaky if the underlying code is using System.currentTimeMillis() calls, which the existing code was already doing. So I will be following this up with another change to restructure the existing code and add a unit test.

The follow on change will also make the definition of age configurable through property file. Right now minimum age is hard coded to 20 minutes.