### PR TITLE
Remove dependency on JavaFX: use Pair class from azkaban-common

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/dag/DagServiceTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/DagServiceTest.java
@@ -29,7 +29,8 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import javafx.util.Pair;
+
+import azkaban.utils.Pair;
 import org.junit.After;
 import org.junit.Test;
 

--- a/azkaban-exec-server/src/test/java/azkaban/dag/StatusChangeRecorder.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/StatusChangeRecorder.java
@@ -16,12 +16,12 @@
 
 package azkaban.dag;
 
+import azkaban.utils.Pair;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import javafx.util.Pair;
 
 /**
  * Records the sequence of nodes and dag status change.


### PR DESCRIPTION
Not all JDKs have JavaFX, and there's no reason to use the Pair class from JavaFX over the one from `azkaban-common`.