### PR TITLE
Add metric NumAgedQueuedFlows: Count flows that are in queue for a long time

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -83,6 +83,8 @@ public class Constants {
 
   public static final Duration MIN_FLOW_TRIGGER_WAIT_TIME = Duration.ofMinutes(1);
 
+  public static final int MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = 20;
+
   // The flow exec id for a flow trigger instance which hasn't started a flow yet
   public static final int UNASSIGNED_EXEC_ID = -1;
 
@@ -182,6 +184,8 @@ public class Constants {
     public static final String METRICS_SERVER_URL = "azkaban.metrics.server.url";
 
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
+    public static final String MIN_AGE_FOR_CLASSIFYING_A_JOB_AGED_MINUTES = "azkaban.metrics"
+        + ".min_age_for_classifying_a_job_aged_minutes";
 
     // User facing web server configurations used to construct the user facing server URLs. They are useful when there is a reverse proxy between Azkaban web servers and users.
     // enduser -> myazkabanhost:443 -> proxy -> localhost:8081
@@ -240,6 +244,7 @@ public class Constants {
         "azkaban.event.reporting.kafka.topic";
     public static final String AZKABAN_EVENT_REPORTING_KAFKA_SCHEMA_REGISTRY_URL =
         "azkaban.event.reporting.kafka.schema.registry.url";
+
 
     /*
      * The max number of artifacts retained per project.

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -83,7 +83,7 @@ public class Constants {
 
   public static final Duration MIN_FLOW_TRIGGER_WAIT_TIME = Duration.ofMinutes(1);
 
-  public static final int MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = 20;
+  public static final int DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = 20;
 
   // The flow exec id for a flow trigger instance which hasn't started a flow yet
   public static final int UNASSIGNED_EXEC_ID = -1;

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -184,8 +184,8 @@ public class Constants {
     public static final String METRICS_SERVER_URL = "azkaban.metrics.server.url";
 
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
-    public static final String MIN_AGE_FOR_CLASSIFYING_A_JOB_AGED_MINUTES = "azkaban.metrics"
-        + ".min_age_for_classifying_a_job_aged_minutes";
+    public static final String MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = "azkaban.metrics"
+        + ".min_age_for_classifying_a_flow_aged_minutes";
 
     // User facing web server configurations used to construct the user facing server URLs. They are useful when there is a reverse proxy between Azkaban web servers and users.
     // enduser -> myazkabanhost:443 -> proxy -> localhost:8081

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.event.EventHandler;
 import azkaban.flow.FlowUtils;
@@ -319,6 +320,21 @@ public class ExecutionController extends EventHandler implements ExecutorManager
       size = this.executorLoader.fetchQueuedFlows().size();
     } catch (final ExecutorManagerException e) {
       this.logger.error("Failed to get queued flow size.", e);
+    }
+    return size;
+  }
+
+  @Override
+  public long getAgedQueuedFlowSize() {
+    long size = 0L;
+    int minimum_age_minutes = this.azkProps.getInt(
+        ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_JOB_AGED_MINUTES,
+        Constants.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
+    try {
+      size = this.executorLoader.fetchAgedQueuedFlows(Duration.ofMinutes(minimum_age_minutes))
+          .size();
+    } catch (final ExecutorManagerException e) {
+      this.logger.error("Failed to get flows queued for a long time.", e);
     }
     return size;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -329,7 +328,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     long size = 0L;
     int minimum_age_minutes = this.azkProps.getInt(
         ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_JOB_AGED_MINUTES,
-        Constants.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
+        Constants.DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
     try {
       size = this.executorLoader.fetchAgedQueuedFlows(Duration.ofMinutes(minimum_age_minutes))
           .size();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -327,7 +327,7 @@ public class ExecutionController extends EventHandler implements ExecutorManager
   public long getAgedQueuedFlowSize() {
     long size = 0L;
     int minimum_age_minutes = this.azkProps.getInt(
-        ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_JOB_AGED_MINUTES,
+        ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES,
         Constants.DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
     try {
       size = this.executorLoader.fetchAgedQueuedFlows(Duration.ofMinutes(minimum_age_minutes))

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -315,6 +315,9 @@ public class ExecutionController extends EventHandler implements ExecutorManager
   @Override
   public long getQueuedFlowSize() {
     long size = 0L;
+    // TODO(anish-mal) FetchQueuedExecutableFlows does a lot of processing that is redundant, since
+    // all we care about is the count. Write a new class that's more performant and can be used for
+    // metrics. this.executorLoader.fetchQueuedFlows internally calls FetchQueuedExecutableFlows.
     try {
       size = this.executorLoader.fetchQueuedFlows().size();
     } catch (final ExecutorManagerException e) {
@@ -329,6 +332,10 @@ public class ExecutionController extends EventHandler implements ExecutorManager
     int minimum_age_minutes = this.azkProps.getInt(
         ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES,
         Constants.DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
+
+    // TODO(anish-mal) FetchQueuedExecutableFlows does a lot of processing that is redundant, since
+    // all we care about is the count. Write a new class that's more performant and can be used for
+    // metrics. this.executorLoader.fetchAgedQueuedFlows internally calls FetchQueuedExecutableFlows.
     try {
       size = this.executorLoader.fetchAgedQueuedFlows(Duration.ofMinutes(minimum_age_minutes))
           .size();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -113,6 +113,16 @@ public class ExecutionFlowDao {
     }
   }
 
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_FLOWS_QUEUED_FOR_LONG_TIME,
+          new FetchExecutableFlows(), System.currentTimeMillis() - minAge.toMillis());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching aged queued flows", e);
+    }
+  }
+
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException {
     try {
@@ -461,6 +471,11 @@ public class ExecutionFlowDao {
         "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? AND status=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
+    // Fetch flows that are in preparing state for more than a certain duration.
+    private static final String FETCH_FLOWS_QUEUED_FOR_LONG_TIME =
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows"
+            + " WHERE submit_time < ? AND status = "
+            + Status.PREPARING.getNumVal();
 
     @Override
     public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -228,6 +228,9 @@ public interface ExecutorLoader {
   List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException;
 
+  public List<ExecutableFlow> fetchAgedQueuedFlows(
+      final Duration minAge) throws ExecutorManagerException;
+
   boolean updateExecutableReference(int execId, long updateTime)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -551,8 +551,8 @@ public class ExecutorManager extends EventHandler implements
 
   @Override
   public long getAgedQueuedFlowSize() {
-    logger.error("Unsupported Function: getQueuedFlowSize() - Retrieving of Aged flows that are "
-        + "waiting in queue");
+    logger.error("Unsupported Function: getAgedQueuedFlowSize() - Retrieving of Aged flows that are"
+        + " waiting in queue");
     return 0;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -549,6 +549,13 @@ public class ExecutorManager extends EventHandler implements
     return this.queuedFlows.size();
   }
 
+  @Override
+  public long getAgedQueuedFlowSize() {
+    logger.error("Unsupported Function: getQueuedFlowSize() - Retrieving of Aged flows that are "
+        + "waiting in queue");
+    return 0;
+  }
+
   /* Helper method to flow ids of all running flows */
   private void getRunningFlowsIdsHelper(final List<Integer> allIds,
       final Collection<Pair<ExecutionReference, ExecutableFlow>> collection) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -42,6 +42,8 @@ public interface ExecutorManagerAdapter {
 
   public long getQueuedFlowSize();
 
+  public long getAgedQueuedFlowSize();
+
   /**
    * <pre>
    * Returns All running with executors and queued flows

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -87,6 +87,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
     return this.executionFlowDao.fetchQueuedFlows();
   }
 
+  @Override
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    return this.executionFlowDao.fetchAgedQueuedFlows(minAge);
+  }
+
   /**
    * maxAge indicates how long finished flows are shown in Recently Finished flow page.
    */

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -441,6 +441,26 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  // TODO(anish-mal) To be used in a future unit test, once System calls to obtain
+  // current time have been replaced by Clocks. Clocks are needed in order to write
+  // unit tests for duration based features. Without it, the tests end up being flaky.
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    final List<ExecutableFlow> agedQueuedFlows = new ArrayList<>();
+
+    long timeThreshoold = System.currentTimeMillis() - minAge.toMillis();
+    for (final int execId : this.refs.keySet()) {
+      if (!this.executionExecutorMapping.containsKey(execId)) {
+        ExecutableFlow agedFlow = this.flows.get(execId);
+        if (agedFlow.getSubmitTime() < timeThreshoold) {
+          agedQueuedFlows.add(agedFlow);
+        }
+      }
+    }
+    return agedQueuedFlows;
+  }
+
+  @Override
   public void unassignExecutor(final int executionId) throws ExecutorManagerException {
     this.executionExecutorMapping.remove(executionId);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -93,6 +93,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.jmx.HierarchyDynamicMBean;
 import org.apache.velocity.app.VelocityEngine;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.DefaultServlet;
@@ -510,6 +511,15 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   private void startWebMetrics() throws Exception {
     this.metricsManager
         .addGauge("WEB-NumQueuedFlows", this.executorManagerAdapter::getQueuedFlowSize);
+
+    // Metric for flows that have been submitted, but haven't started for more than N minutes
+    // (N is configurable by MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES).
+    // ToDo(anish-mal) Enable this for push based dispatch logic.
+    if (this.props.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
+      this.metricsManager
+          .addGauge("WEB-NumAgedQueuedFlows", this.executorManagerAdapter::getAgedQueuedFlowSize);
+    }
+
     /*
      * TODO: Currently {@link ExecutorManager#getRunningFlows()} includes both running and non-dispatched flows.
      * Originally we would like to do a subtraction between getRunningFlows and {@link ExecutorManager#getQueuedFlowSize()},

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -515,8 +515,17 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     // (N is configurable by MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES).
     // ToDo(anish-mal) Enable this for push based dispatch logic.
     if (this.props.getBoolean(ConfigurationKeys.AZKABAN_POLL_MODEL, false)) {
-      this.metricsManager
-          .addGauge("WEB-NumAgedQueuedFlows", this.executorManagerAdapter::getAgedQueuedFlowSize);
+      int minAge =
+          this.props.getInt(ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES,
+              Constants.DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
+      if (minAge >= 0) {
+        this.metricsManager
+            .addGauge("WEB-NumAgedQueuedFlows", this.executorManagerAdapter::getAgedQueuedFlowSize);
+      } else {
+        logger.error(String.format("Property config file contains a value of %d for %s. "
+                + "Metric NumAgedQueuedFlows is emitted only when this value is non-negative.",
+            minAge, ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES));
+      }
     }
 
     /*

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -93,7 +93,6 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.jmx.HierarchyDynamicMBean;
 import org.apache.velocity.app.VelocityEngine;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.DefaultServlet;


### PR DESCRIPTION
Add a metric to track number of flows that have not started running for more than 20 minutes (configurable) after the web server put those in the queue.

The metric provides a strong signal that an underlying problem (system overload or sluggish/overworked executors) have started impacting the overall performance of the system.

This is different from:

- The state where large number of flows are in the queue, but all the flows in there are young.
- Measuring polling interval of executors, which does not indicate whether a slowed down polling has impacted the intake from the queue (Please note there could be multiple executors) 

Unit-Test
Writing unit test for duration-dependent functionality is flaky if the underlying code is using System.currentTimeMillis() calls, which the existing code was already doing. So I will be following this up with another change to restructure the existing code and add a unit test.