### PR TITLE
Implemented Project Cache Abstraction

### DIFF
--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -23,6 +23,8 @@ import azkaban.db.MySQLDataSource;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.JdbcExecutorLoader;
 import azkaban.project.JdbcProjectImpl;
+import azkaban.project.ProjectCache;
+import azkaban.project.ProjectCacheInMem;
 import azkaban.project.ProjectLoader;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageException;
@@ -63,6 +65,7 @@ public class AzkabanCommonModule extends AbstractModule {
     bind(TriggerLoader.class).to(JdbcTriggerImpl.class);
     bind(ProjectLoader.class).to(JdbcProjectImpl.class);
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class);
+    bind(ProjectCache.class).to(ProjectCacheInMem.class);
     bind(OsCpuUtil.class).toProvider(() -> {
       final int cpuLoadPeriodSec = this.props
           .getInt(ConfigurationKeys.AZKABAN_POLLING_CRITERIA_CPU_LOAD_PERIOD_SEC,

--- a/azkaban-common/src/main/java/azkaban/project/AbstractProjectCache.java
+++ b/azkaban-common/src/main/java/azkaban/project/AbstractProjectCache.java
@@ -1,0 +1,64 @@
+package azkaban.project;
+
+import azkaban.flow.Flow;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract Class implementing common methods for Project Cache Implementation
+ */
+
+public abstract class AbstractProjectCache implements ProjectCache {
+
+  private final ProjectLoader loader;
+
+  public AbstractProjectCache(final ProjectLoader loader) {
+    this.loader = loader;
+  }
+
+  /**
+   * loadAllFlowsForAllProjects  : To load all flows corresponding to projects from the database
+   *
+   * @param projects list of Projects to fetch flows for.
+   */
+  public void loadAllFlowsForAllProjects(final List<Project> projects) {
+    try {
+      final Map<Project, List<Flow>> projectToFlows = this.loader
+          .fetchAllFlowsForProjects(projects);
+
+      // Load the flows into the project objects
+      for (final Map.Entry<Project, List<Flow>> entry : projectToFlows.entrySet()) {
+        final Project project = entry.getKey();
+        final List<Flow> flows = entry.getValue();
+
+        final Map<String, Flow> flowMap = new HashMap<>();
+        for (final Flow flow : flows) {
+          flowMap.put(flow.getId(), flow);
+        }
+
+        project.setFlows(flowMap);
+      }
+    } catch (final ProjectManagerException e) {
+      throw new RuntimeException("Could not load projects flows from store.", e);
+    }
+  }
+
+  /**
+   * get all active projects from database.
+   *
+   * @return List of projects;
+   */
+  @Override
+  public Collection<Project> getAllProjects() {
+    final List<Project> result;
+    try {
+      result = this.loader.fetchAllActiveProjects();
+    } catch (final ProjectManagerException e) {
+      throw new RuntimeException("Could not load projects from store.", e);
+    }
+    return result;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
@@ -49,19 +49,22 @@ class JdbcProjectHandlerSet {
   public static class ProjectResultHandler implements ResultSetHandler<List<Project>> {
 
     private static final String BASE_QUERY = "SELECT "
-      + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj.last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
-      + "prm.name, prm.permissions, prm.isGroup "
-      + "FROM projects prj ";
+        + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj.last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
+        + "prm.name, prm.permissions, prm.isGroup "
+        + "FROM projects prj ";
 
     // Still return the project if it has no associated permissions
-    public static final String SELECT_PROJECT_BY_ID = BASE_QUERY + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.id=?";
+    public static final String SELECT_PROJECT_BY_ID =
+        BASE_QUERY + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.id=?";
 
     // Still return the project if it has no associated permissions
-    public static final String SELECT_ACTIVE_PROJECT_BY_NAME = BASE_QUERY + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.name=? AND prj.active=true";
+    public static final String SELECT_ACTIVE_PROJECT_BY_NAME = BASE_QUERY
+        + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.name=? AND prj.active=true";
 
     // ONLY return projects that have at least one associated permission, this is for performance reasons.
     // (JOIN is way faster than LEFT JOIN)
-    public static final String SELECT_ALL_ACTIVE_PROJECTS = BASE_QUERY + "JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.active=true";
+    public static final String SELECT_ALL_ACTIVE_PROJECTS = BASE_QUERY
+        + "JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.active=true";
 
     @Override
     public List<Project> handle(final ResultSet rs) throws SQLException {
@@ -132,7 +135,7 @@ class JdbcProjectHandlerSet {
         // If username is null, we can assume that this row was returned without any associated permission
         // i.e. this project had no associated permissions.
         if (username != null) {
-          Permission perm = new Permission(permissionFlag);
+          final Permission perm = new Permission(permissionFlag);
           if (isGroup) {
             projects.get(id).setGroupPermission(username, perm);
           } else {
@@ -295,9 +298,10 @@ class JdbcProjectHandlerSet {
       ResultSetHandler<List<ProjectFileHandler>> {
 
     public static String SELECT_PROJECT_VERSION =
-        "SELECT project_id, version, upload_time, uploader, file_type, file_name, md5, num_chunks," +
-                " resource_id, startup_dependencies, uploader_ip_addr " +
-                " FROM project_versions WHERE project_id=? AND version=?";
+        "SELECT project_id, version, upload_time, uploader, file_type, file_name, md5, num_chunks,"
+            +
+            " resource_id, startup_dependencies, uploader_ip_addr " +
+            " FROM project_versions WHERE project_id=? AND version=?";
 
     @Override
     public List<ProjectFileHandler> handle(final ResultSet rs) throws SQLException {
@@ -323,8 +327,9 @@ class JdbcProjectHandlerSet {
         if (startupDependenciesBlob != null) {
           try {
             startupDependencies = ThinArchiveUtils.parseStartupDependencies(
-                IOUtils.toString(startupDependenciesBlob.getBinaryStream(), StandardCharsets.UTF_8));
-          } catch (IOException | InvalidHashException e) {
+                IOUtils
+                    .toString(startupDependenciesBlob.getBinaryStream(), StandardCharsets.UTF_8));
+          } catch (final IOException | InvalidHashException e) {
             // This should never happen unless the file is malformed in the database.
             // The file was already validated when the project was uploaded.
             throw new SQLException(e);
@@ -332,7 +337,8 @@ class JdbcProjectHandlerSet {
         }
 
         final ProjectFileHandler handler =
-            new ProjectFileHandler(projectId, version, uploadTime, uploader, fileType, fileName, numChunks, md5,
+            new ProjectFileHandler(projectId, version, uploadTime, uploader, fileType, fileName,
+                numChunks, md5,
                 startupDependencies, resourceId, uploaderIpAddr);
 
         handlers.add(handler);
@@ -383,4 +389,5 @@ class JdbcProjectHandlerSet {
       return data;
     }
   }
+  
 }

--- a/azkaban-common/src/main/java/azkaban/project/ProjectCache.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectCache.java
@@ -1,0 +1,59 @@
+package azkaban.project;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface ProjectCache {
+
+  /**
+   * Initialize the cache with projects and their corresponding flows fetched from DB.
+   */
+  void init();
+
+  /**
+   * Put the project in cache
+   *
+   * @param project Project
+   */
+  void putProject(Project project);
+
+  /**
+   * Gets the active project from cache if present else queries DB
+   *
+   * @param key name of the project
+   * @return Project for it
+   */
+  Project getProjectByName(final String key);
+
+  /**
+   * Returns project corresponding to id if present in cache else queries DB to get it
+   *
+   * @param id Project id
+   * @return Project
+   */
+  Project getProjectById(final Integer id);
+
+  /**
+   * invalidates the project from the cache
+   *
+   * @param project
+   */
+  void removeProject(Project project);
+
+  /**
+   * Queries DB to get all active projects present.
+   *
+   * @return list of all active projects;
+   */
+  public Collection<Project> getAllProjects();
+
+  /**
+   * @return list of names of all active projects
+   */
+  List<String> getAllProjectNames();
+
+  /**
+   * returns id corresponding to name;
+   */
+  Integer getProjectId(String name);
+}

--- a/azkaban-common/src/main/java/azkaban/project/ProjectCacheInMem.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectCacheInMem.java
@@ -1,0 +1,137 @@
+package azkaban.project;
+
+import azkaban.utils.CaseInsensitiveConcurrentHashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements ProjectCache and extends AbstractProjectCache to implement a in-memory
+ * implementation of project cache where all the active projects are loaded into the main-memory
+ * when the web-server starts. This would be replaced in future by guava cache implementation.
+ */
+@Singleton
+public class ProjectCacheInMem extends AbstractProjectCache implements ProjectCache {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProjectCacheInMem.class);
+
+  private final ConcurrentHashMap<Integer, Project> projectsById;
+
+  private final CaseInsensitiveConcurrentHashMap<Project> projectsByName;
+
+  private final ProjectLoader projectLoader;
+
+  @Inject
+  public ProjectCacheInMem(final ProjectLoader loader) {
+    super(loader);
+    this.projectLoader = loader;
+    this.projectsById = new ConcurrentHashMap<>();
+    this.projectsByName = new CaseInsensitiveConcurrentHashMap<>();
+    final long startTime = System.currentTimeMillis();
+    init();
+    final long elapsedTime = System.currentTimeMillis() - startTime;
+    logger.info("Time taken to initalize and load cache in milliseconds: " + elapsedTime);
+  }
+
+  /**
+   * load all active projects and their corresponding flows into memory.
+   */
+  @Override
+  public void init() {
+
+    final List<Project> projects;
+    logger.info("Loading active projects.");
+    try {
+      projects = this.projectLoader.fetchAllActiveProjects();
+    } catch (final ProjectManagerException e) {
+      throw new RuntimeException("Could not load projects from store.", e);
+    }
+    for (final Project proj : projects) {
+      putProject(proj);
+    }
+    logger.info("Loading flows from active projects.");
+
+    loadAllFlowsForAllProjects(projects);
+  }
+
+  /**
+   * Inserts given project into the cache.
+   *
+   * @param project Project
+   */
+  @Override
+  public void putProject(final Project project) {
+    this.projectsByName.put(project.getName(), project);
+    this.projectsById.put(project.getId(), project);
+  }
+
+  /**
+   * queries an active project by name
+   *
+   * @param key name of the project
+   * @return Project
+   */
+  @Override
+  public Project getProjectByName(final String key) {
+    Project project = this.projectsByName.get(key);
+    if (project == null) {
+      logger.info("No active project with name {} exists in cache or DB.", key);
+      try {
+        project = this.projectLoader.fetchProjectByName(key);
+      } catch (final ProjectManagerException e) {
+        logger.error("Could not load project from store.", e);
+      }
+    } else {
+      logger.info("Project {} not found in cache, fetched from DB.", key);
+    }
+    return project;
+  }
+
+  /**
+   * Queries any project active/inactive by project id
+   *
+   * @param key Project id
+   * @return Project
+   */
+  @Override
+  public Project getProjectById(final Integer key) {
+    Project project = this.projectsById.get(key);
+    if (project == null) {
+      try {
+        project = this.projectLoader.fetchProjectById(key);
+      } catch (final ProjectManagerException e) {
+        logger.error("Could not load project from store.", e);
+      }
+    }
+    return project;
+  }
+
+  /**
+   * Invlidated the given project from cache.
+   */
+  @Override
+  public void removeProject(final Project project) {
+    this.projectsByName.remove(project.getName());
+    this.projectsById.remove(project.getId());
+  }
+
+  /**
+   * fetches names for all the active projects;
+   */
+  @Override
+  public List<String> getAllProjectNames() {
+    return this.projectsByName.getKeys();
+  }
+
+  /**
+   * returns id by querying the project name map
+   */
+  @Override
+  public Integer getProjectId(final String name) {
+    return this.projectsByName.get(name).getId();
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -21,7 +21,6 @@ import azkaban.project.ProjectLogEvent.EventType;
 import azkaban.user.Permission;
 import azkaban.user.User;
 import azkaban.utils.Props;
-import azkaban.utils.Triple;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -48,7 +47,7 @@ public interface ProjectLoader {
   /**
    * Should create an empty project with the given name and user and adds it to the data store. It
    * will auto assign a unique id for this project if successful.
-   *
+   * <p>
    * If an active project of the same name exists, it will throw an exception. If the name and
    * description of the project exceeds the store's constraints, it will throw an exception.
    *
@@ -112,7 +111,7 @@ public interface ProjectLoader {
    * Fetch project metadata from project_versions table
    *
    * @param projectId project ID
-   * @param version version
+   * @param version   version
    * @return ProjectFileHandler object containing the metadata
    */
   ProjectFileHandler fetchProjectMetaData(int projectId, int version);
@@ -231,5 +230,10 @@ public interface ProjectLoader {
    */
   boolean isFlowFileUploaded(int projectId, int projectVersion)
       throws ProjectManagerException;
+
+  /**
+   * Retrieve projects corresponding to ids specified in a list.
+   */
+  List<Project> fetchProjectById(List<Integer> ids) throws ProjectManagerException;
 
 }

--- a/azkaban-common/src/main/java/azkaban/utils/CaseInsensitiveConcurrentHashMap.java
+++ b/azkaban-common/src/main/java/azkaban/utils/CaseInsensitiveConcurrentHashMap.java
@@ -1,20 +1,22 @@
 /*
-* Copyright 2018 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2018 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -42,4 +44,7 @@ public class CaseInsensitiveConcurrentHashMap<V> {
     return this.map.remove(key.toLowerCase());
   }
 
+  public List<String> getKeys() {
+    return new ArrayList<>(this.map.keySet());
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -31,6 +31,7 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -226,12 +227,16 @@ public class JdbcProjectImplTest {
   public void testGetPermissionsOnAllActiveProjects() throws Exception {
     createThreeProjects();
     final Project project1 = this.loader.fetchProjectByName("mytestProject");
-    this.loader.updatePermission(project1, "testUser1", new Permission(Permission.Type.ADMIN), false);
-    this.loader.updatePermission(project1, "testUser2", new Permission(Permission.Type.EXECUTE), false);
-    this.loader.updatePermission(project1, "testGroup1", new Permission(Permission.Type.ADMIN), true);
+    this.loader
+        .updatePermission(project1, "testUser1", new Permission(Permission.Type.ADMIN), false);
+    this.loader
+        .updatePermission(project1, "testUser2", new Permission(Permission.Type.EXECUTE), false);
+    this.loader
+        .updatePermission(project1, "testGroup1", new Permission(Permission.Type.ADMIN), true);
 
     final Project project2 = this.loader.fetchProjectByName("mytestProject2");
-    this.loader.updatePermission(project2, "testGroup2", new Permission(Permission.Type.READ), true);
+    this.loader
+        .updatePermission(project2, "testGroup2", new Permission(Permission.Type.READ), true);
 
     final List<Project> projectList = this.loader.fetchAllActiveProjects();
     final Project returnedProject1 = findProjectWithName(projectList, "mytestProject");
@@ -245,16 +250,20 @@ public class JdbcProjectImplTest {
     Assert.assertNull(returnedProject3);
 
     // Make sure proper permissions were returned for project1
-    Assert.assertTrue(returnedProject1.getUserPermission("testUser1").isPermissionSet(Permission.Type.ADMIN));
-    Assert.assertTrue(returnedProject1.getUserPermission("testUser2").isPermissionSet(Permission.Type.EXECUTE));
-    Assert.assertTrue(returnedProject1.getGroupPermission("testGroup1").isPermissionSet(Permission.Type.ADMIN));
+    Assert.assertTrue(
+        returnedProject1.getUserPermission("testUser1").isPermissionSet(Permission.Type.ADMIN));
+    Assert.assertTrue(
+        returnedProject1.getUserPermission("testUser2").isPermissionSet(Permission.Type.EXECUTE));
+    Assert.assertTrue(
+        returnedProject1.getGroupPermission("testGroup1").isPermissionSet(Permission.Type.ADMIN));
 
     // Make sure proper permissions were returned for project2
     Assert.assertEquals(returnedProject2.getUserPermissions().size(), 0);
-    Assert.assertTrue(returnedProject2.getGroupPermission("testGroup2").isPermissionSet(Permission.Type.READ));
+    Assert.assertTrue(
+        returnedProject2.getGroupPermission("testGroup2").isPermissionSet(Permission.Type.READ));
   }
 
-  private Project findProjectWithName(List<Project> projects, String name) {
+  private Project findProjectWithName(final List<Project> projects, final String name) {
     return projects.stream().filter(p -> p.getName().equals(name)).findFirst().orElse(null);
   }
 
@@ -329,9 +338,10 @@ public class JdbcProjectImplTest {
     // Don't upload any flows for project3
     final Project project3 = this.loader.fetchProjectByName("mytestProject3");
 
-    List<Project> projectList = Arrays.asList(project1, project2, project3);
+    final List<Project> projectList = Arrays.asList(project1, project2, project3);
 
-    final Map<Project, List<Flow>> projectToFlows = this.loader.fetchAllFlowsForProjects(projectList);
+    final Map<Project, List<Flow>> projectToFlows = this.loader
+        .fetchAllFlowsForProjects(projectList);
     Assert.assertEquals(projectToFlows.size(), 3);
     Assert.assertEquals(projectToFlows.get(project1).size(), 2);
     Assert.assertEquals(projectToFlows.get(project2).size(), 1);
@@ -515,5 +525,18 @@ public class JdbcProjectImplTest {
     } catch (final SQLException e) {
       e.printStackTrace();
     }
+  }
+
+  @Test
+  public void testFetchProjectByIds() throws Exception {
+    createThreeProjects();
+    final Project project1 = this.loader.fetchProjectByName("mytestProject");
+    final List<Integer> exp = new ArrayList<>();
+    exp.add(project1.getId());
+    final List<Project> project2 = this.loader.fetchProjectById(exp);
+    Assert.assertNotNull(project2);
+    Assert.assertEquals(project1.getName(), project1.getName());
+    Assert.assertEquals(project1.getDescription(), project2.get(0).getDescription());
+    Assert.assertEquals(project1.getLastModifiedUser(), project2.get(0).getLastModifiedUser());
   }
 }


### PR DESCRIPTION
1. First set of changes for Web-server side Project Cache. These changes follow the current in-memory caching scheme but with a project cache abstraction. It will help plugin any cache implementation in future for caching project entities. 
2. This change should not result in any functional change, it is a preparatory step for guava cache implementation.
3. The code was tested on existing unit tests. The server was run and existing functionalities like searching for projects, access, creating, deleting, uploading flows, execute were checked manually.