### PR TITLE
use POST instead of GET for executing flow

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -83,6 +83,8 @@ public class Constants {
 
   public static final Duration MIN_FLOW_TRIGGER_WAIT_TIME = Duration.ofMinutes(1);
 
+  public static final int DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = 20;
+
   // The flow exec id for a flow trigger instance which hasn't started a flow yet
   public static final int UNASSIGNED_EXEC_ID = -1;
 
@@ -182,6 +184,8 @@ public class Constants {
     public static final String METRICS_SERVER_URL = "azkaban.metrics.server.url";
 
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
+    public static final String MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = "azkaban.metrics"
+        + ".min_age_for_classifying_a_flow_aged_minutes";
 
     // User facing web server configurations used to construct the user facing server URLs. They are useful when there is a reverse proxy between Azkaban web servers and users.
     // enduser -> myazkabanhost:443 -> proxy -> localhost:8081
@@ -240,6 +244,7 @@ public class Constants {
         "azkaban.event.reporting.kafka.topic";
     public static final String AZKABAN_EVENT_REPORTING_KAFKA_SCHEMA_REGISTRY_URL =
         "azkaban.event.reporting.kafka.schema.registry.url";
+
 
     /*
      * The max number of artifacts retained per project.

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -113,6 +113,16 @@ public class ExecutionFlowDao {
     }
   }
 
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(FetchExecutableFlows.FETCH_FLOWS_QUEUED_FOR_LONG_TIME,
+          new FetchExecutableFlows(), System.currentTimeMillis() - minAge.toMillis());
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching aged queued flows", e);
+    }
+  }
+
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException {
     try {
@@ -461,6 +471,11 @@ public class ExecutionFlowDao {
         "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE project_id=? AND flow_id=? AND status=? "
             + "ORDER BY exec_id DESC LIMIT ?, ?";
+    // Fetch flows that are in preparing state for more than a certain duration.
+    private static final String FETCH_FLOWS_QUEUED_FOR_LONG_TIME =
+        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows"
+            + " WHERE submit_time < ? AND status = "
+            + Status.PREPARING.getNumVal();
 
     @Override
     public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -228,6 +228,9 @@ public interface ExecutorLoader {
   List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException;
 
+  public List<ExecutableFlow> fetchAgedQueuedFlows(
+      final Duration minAge) throws ExecutorManagerException;
+
   boolean updateExecutableReference(int execId, long updateTime)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -549,6 +549,13 @@ public class ExecutorManager extends EventHandler implements
     return this.queuedFlows.size();
   }
 
+  @Override
+  public long getAgedQueuedFlowSize() {
+    logger.error("Unsupported Function: getAgedQueuedFlowSize() - Retrieving of Aged flows that are"
+        + " waiting in queue");
+    return 0;
+  }
+
   /* Helper method to flow ids of all running flows */
   private void getRunningFlowsIdsHelper(final List<Integer> allIds,
       final Collection<Pair<ExecutionReference, ExecutableFlow>> collection) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -42,6 +42,8 @@ public interface ExecutorManagerAdapter {
 
   public long getQueuedFlowSize();
 
+  public long getAgedQueuedFlowSize();
+
   /**
    * <pre>
    * Returns All running with executors and queued flows

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -87,6 +87,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
     return this.executionFlowDao.fetchQueuedFlows();
   }
 
+  @Override
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    return this.executionFlowDao.fetchAgedQueuedFlows(minAge);
+  }
+
   /**
    * maxAge indicates how long finished flows are shown in Recently Finished flow page.
    */

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -441,6 +441,26 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  // TODO(anish-mal) To be used in a future unit test, once System calls to obtain
+  // current time have been replaced by Clocks. Clocks are needed in order to write
+  // unit tests for duration based features. Without it, the tests end up being flaky.
+  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+      throws ExecutorManagerException {
+    final List<ExecutableFlow> agedQueuedFlows = new ArrayList<>();
+
+    long timeThreshoold = System.currentTimeMillis() - minAge.toMillis();
+    for (final int execId : this.refs.keySet()) {
+      if (!this.executionExecutorMapping.containsKey(execId)) {
+        ExecutableFlow agedFlow = this.flows.get(execId);
+        if (agedFlow.getSubmitTime() < timeThreshoold) {
+          agedQueuedFlows.add(agedFlow);
+        }
+      }
+    }
+    return agedQueuedFlows;
+  }
+
+  @Override
   public void unassignExecutor(final int executionId) throws ExecutorManagerException {
     this.executionExecutorMapping.remove(executionId);
   }

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -70,7 +70,7 @@ function executeFlow(executingData) {
     }
   };
 
-  $.get(executeURL, executingData, successHandler, "json");
+  $.post(executeURL, executingData, successHandler, "json");
 }
 
 function fetchFlowInfo(model, projectName, flowId, execId) {

--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -622,7 +622,7 @@ This API executes a flow via an ajax call, supporting a rich selection
 of different options. Running an individual job can also be achieved via
 this API by disabling all other jobs in the same flow.
 
--  **Method:** GET
+-  **Method:** POST
 -  **Request URL:** /executor?ajax=executeFlow
 -  **Parameter Location:** Request Query String
 


### PR DESCRIPTION
because GET has url length limitation, this will cause problem when we have a large flow, and we disable a lot of the job inside, as the disabled jobs list will need to be included in the request param.