### PR TITLE
Add job props to uniquely identify a job in mapreduce tags

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -63,7 +63,7 @@ public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implem
         CommonJobProperties.EXEC_ID,
         CommonJobProperties.FLOW_ID,
         CommonJobProperties.PROJECT_NAME,
-        CommonJobProperties.AZKABAN_HOST,
+        CommonJobProperties.AZKABAN_WEBSERVERHOST,
         CommonJobProperties.JOB_ID,
         CommonJobProperties.JOB_ATTEMPT
     };

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -62,7 +62,10 @@ public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implem
     String[] tagKeys = new String[]{
         CommonJobProperties.EXEC_ID,
         CommonJobProperties.FLOW_ID,
-        CommonJobProperties.PROJECT_NAME
+        CommonJobProperties.PROJECT_NAME,
+        CommonJobProperties.AZKABAN_HOST,
+        CommonJobProperties.JOB_ID,
+        CommonJobProperties.JOB_ATTEMPT
     };
     Props jobProps = getJobProps();
     String tagList = HadoopJobUtils.constructHadoopTags(jobProps, tagKeys);

--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -70,6 +70,11 @@ public class CommonJobProperties {
   public static final String AZKABAN_URL = "azkaban.url";
 
   /**
+   * Azkaban host name
+   */
+  public static final String AZKABAN_WEBSERVERHOST = "azkaban.webserverhost";
+
+  /**
    * The attempt number of the executing job.
    */
   public static final String JOB_ATTEMPT = "azkaban.job.attempt";

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -43,6 +43,8 @@ import azkaban.utils.UndefinedPropertyException;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -814,10 +816,18 @@ public class JobRunner extends EventHandler implements Runnable {
   private void insertJobMetadata() {
     final String baseURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);
     if (baseURL != null) {
+      URL webserverURL = null;
+      try {
+        webserverURL = new URL(baseURL);
+      } catch (MalformedURLException e) {
+        logger.error(String.format("Exception in parsing url: %s", baseURL), e);
+      }
+      String azkabanWebserverHost = webserverURL.getHost();
       final String flowName = this.node.getParentFlow().getFlowId();
       final String projectName = this.node.getParentFlow().getProjectName();
 
       this.props.put(CommonJobProperties.AZKABAN_URL, baseURL);
+      this.props.put(CommonJobProperties.AZKABAN_WEBSERVERHOST, azkabanWebserverHost);
       this.props.put(CommonJobProperties.EXECUTION_LINK,
           String.format("%s/executor?execid=%d", baseURL, this.executionId));
       this.props.put(CommonJobProperties.JOBEXEC_LINK, String.format(

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -822,7 +822,7 @@ public class JobRunner extends EventHandler implements Runnable {
       } catch (MalformedURLException e) {
         logger.error(String.format("Exception in parsing url: %s", baseURL), e);
       }
-      String azkabanWebserverHost = webserverURL.getHost();
+      final String azkabanWebserverHost = (webserverURL != null) ? webserverURL.getHost() : null;
       final String flowName = this.node.getParentFlow().getFlowId();
       final String projectName = this.node.getParentFlow().getProjectName();
 


### PR DESCRIPTION
Added **azkaban.webserverhost**, **azkaban.job.id**, **azkaban.job.attempt** to mapreduce tags

ApplicationTags from RM webpage:
azkaban.flow.projectname:az_acceptance_test_new,azkaban.host:ltx1-holdemaz04.grid.linkedin.com,azkaban.flow.execid:417785,azkaban.flow.flowid:hadoopyarnflows,azkaban.job.attempt:0,workflowid:az_acceptance_test_new$hadoopyarnflows,azkaban.job.id:hadoopyarnflows_pigwordcount1