### PR TITLE
New feature: node specific flow overrides

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -54,6 +54,9 @@ public class Constants {
   // Job properties override suffix
   public static final String JOB_OVERRIDE_SUFFIX = ".jor";
 
+  // Key for runtime properties that affect the entire flow
+  public static final String ROOT_RUNTIME_PROPERTY = "ROOT";
+
   // Names and paths of various file names to configure Azkaban
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";
   public static final String AZKABAN_PRIVATE_PROPERTIES_FILE = "azkaban.private.properties";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -54,8 +54,8 @@ public class Constants {
   // Job properties override suffix
   public static final String JOB_OVERRIDE_SUFFIX = ".jor";
 
-  // Key for runtime properties that affect the entire flow
-  public static final String ROOT_RUNTIME_PROPERTY = "ROOT";
+  // Key for the root node of the DAG in runtime properties
+  public static final String ROOT_NODE_IDENTIFIER = "ROOT";
 
   // Names and paths of various file names to configure Azkaban
   public static final String AZKABAN_PROPERTIES_FILE = "azkaban.properties";

--- a/az-jobsummary/src/main/resources/azkaban/viewer/jobsummary/velocity/jobsummary.vm
+++ b/az-jobsummary/src/main/resources/azkaban/viewer/jobsummary/velocity/jobsummary.vm
@@ -21,7 +21,7 @@
 #parse ("azkaban/webapp/servlet/velocity/style.vm")
 #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
-    <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+    <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
     <script type="text/javascript" src="${context}/jobsummary/js/azkaban/view/job-summary.js"></script>
     <script type="text/javascript" src="${context}/jobsummary/js/azkaban/model/log-data.js"></script>
     <script type="text/javascript">

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -42,7 +42,7 @@ public class ExecutionOptions {
   public static final int DEFAULT_FLOW_PRIORITY = 5;
 
   private static final String FLOW_PARAMETERS = "flowParameters";
-  private static final String NODE_PARAMETERS = "nodeParameters";
+  private static final String RUNTIME_PROPERTIES = "runtimeProperties";
   private static final String NOTIFY_ON_FIRST_FAILURE = "notifyOnFirstFailure";
   private static final String NOTIFY_ON_LAST_FAILURE = "notifyOnLastFailure";
   private static final String SUCCESS_EMAILS = "successEmails";
@@ -79,7 +79,7 @@ public class ExecutionOptions {
   private String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
   private boolean memoryCheck = true;
   private Map<String, String> flowParameters = new HashMap<>();
-  private Map<String, Map<String, String>> nodeParameters = new HashMap<>();
+  private Map<String, Map<String, String>> runtimeProperties = new HashMap<>();
   private FailureAction failureAction = FailureAction.FINISH_CURRENTLY_RUNNING;
   private List<DisabledJob> initiallyDisabledJobs = new ArrayList<>();
   private List<SlaOption> slaOptions = new ArrayList<>();
@@ -105,9 +105,9 @@ public class ExecutionOptions {
       options.flowParameters.putAll(wrapper
           .<String, String>getMap(FLOW_PARAMETERS));
     }
-    if (optionsMap.containsKey(NODE_PARAMETERS)) {
-      options.nodeParameters = new HashMap<>();
-      options.nodeParameters.putAll(wrapper.getMap(NODE_PARAMETERS));
+    if (optionsMap.containsKey(RUNTIME_PROPERTIES)) {
+      options.runtimeProperties = new HashMap<>();
+      options.runtimeProperties.putAll(wrapper.getMap(RUNTIME_PROPERTIES));
     }
     // Failure notification
     options.notifyOnFirstFailure =
@@ -161,16 +161,16 @@ public class ExecutionOptions {
     this.flowParameters.putAll(flowParam);
   }
 
-  public void addAllNodeParameters(final Map<String, Map<String, String>> nodeParams) {
-    this.nodeParameters.putAll(nodeParams);
+  public void addAllRuntimeProperties(final Map<String, Map<String, String>> runtimeProperties) {
+    this.runtimeProperties.putAll(runtimeProperties);
   }
 
   public Map<String, String> getFlowParameters() {
     return this.flowParameters;
   }
 
-  public Map<String, Map<String, String>> getNodeParameters() {
-    return this.nodeParameters;
+  public Map<String, Map<String, String>> getRuntimeProperties() {
+    return this.runtimeProperties;
   }
 
   public boolean isFailureEmailsOverridden() {
@@ -302,7 +302,7 @@ public class ExecutionOptions {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
     flowOptionObj.put(FLOW_PARAMETERS, this.flowParameters);
-    flowOptionObj.put(NODE_PARAMETERS, this.nodeParameters);
+    flowOptionObj.put(RUNTIME_PROPERTIES, this.runtimeProperties);
     flowOptionObj.put(NOTIFY_ON_FIRST_FAILURE, this.notifyOnFirstFailure);
     flowOptionObj.put(NOTIFY_ON_LAST_FAILURE, this.notifyOnLastFailure);
     flowOptionObj.put(SUCCESS_EMAILS, this.successEmails);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -42,6 +42,7 @@ public class ExecutionOptions {
   public static final int DEFAULT_FLOW_PRIORITY = 5;
 
   private static final String FLOW_PARAMETERS = "flowParameters";
+  private static final String JOB_PARAMETERS = "jobParameters";
   private static final String NOTIFY_ON_FIRST_FAILURE = "notifyOnFirstFailure";
   private static final String NOTIFY_ON_LAST_FAILURE = "notifyOnLastFailure";
   private static final String SUCCESS_EMAILS = "successEmails";
@@ -78,6 +79,7 @@ public class ExecutionOptions {
   private String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
   private boolean memoryCheck = true;
   private Map<String, String> flowParameters = new HashMap<>();
+  private Map<String, Map<String, String>> jobParameters = new HashMap<>();
   private FailureAction failureAction = FailureAction.FINISH_CURRENTLY_RUNNING;
   private List<DisabledJob> initiallyDisabledJobs = new ArrayList<>();
   private List<SlaOption> slaOptions = new ArrayList<>();
@@ -102,6 +104,10 @@ public class ExecutionOptions {
       options.flowParameters = new HashMap<>();
       options.flowParameters.putAll(wrapper
           .<String, String>getMap(FLOW_PARAMETERS));
+    }
+    if (optionsMap.containsKey(JOB_PARAMETERS)) {
+      options.jobParameters = new HashMap<>();
+      options.jobParameters.putAll(wrapper.getMap(JOB_PARAMETERS));
     }
     // Failure notification
     options.notifyOnFirstFailure =
@@ -155,8 +161,16 @@ public class ExecutionOptions {
     this.flowParameters.putAll(flowParam);
   }
 
+  public void addAllJobParameters(final Map<String, Map<String, String>> jobParams) {
+    this.jobParameters.putAll(jobParams);
+  }
+
   public Map<String, String> getFlowParameters() {
     return this.flowParameters;
+  }
+
+  public Map<String, Map<String, String>> getJobParameters() {
+    return this.jobParameters;
   }
 
   public boolean isFailureEmailsOverridden() {
@@ -288,6 +302,7 @@ public class ExecutionOptions {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
     flowOptionObj.put(FLOW_PARAMETERS, this.flowParameters);
+    flowOptionObj.put(JOB_PARAMETERS, this.jobParameters);
     flowOptionObj.put(NOTIFY_ON_FIRST_FAILURE, this.notifyOnFirstFailure);
     flowOptionObj.put(NOTIFY_ON_LAST_FAILURE, this.notifyOnLastFailure);
     flowOptionObj.put(SUCCESS_EMAILS, this.successEmails);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -42,7 +42,7 @@ public class ExecutionOptions {
   public static final int DEFAULT_FLOW_PRIORITY = 5;
 
   private static final String FLOW_PARAMETERS = "flowParameters";
-  private static final String JOB_PARAMETERS = "jobParameters";
+  private static final String NODE_PARAMETERS = "nodeParameters";
   private static final String NOTIFY_ON_FIRST_FAILURE = "notifyOnFirstFailure";
   private static final String NOTIFY_ON_LAST_FAILURE = "notifyOnLastFailure";
   private static final String SUCCESS_EMAILS = "successEmails";
@@ -79,7 +79,7 @@ public class ExecutionOptions {
   private String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
   private boolean memoryCheck = true;
   private Map<String, String> flowParameters = new HashMap<>();
-  private Map<String, Map<String, String>> jobParameters = new HashMap<>();
+  private Map<String, Map<String, String>> nodeParameters = new HashMap<>();
   private FailureAction failureAction = FailureAction.FINISH_CURRENTLY_RUNNING;
   private List<DisabledJob> initiallyDisabledJobs = new ArrayList<>();
   private List<SlaOption> slaOptions = new ArrayList<>();
@@ -105,9 +105,9 @@ public class ExecutionOptions {
       options.flowParameters.putAll(wrapper
           .<String, String>getMap(FLOW_PARAMETERS));
     }
-    if (optionsMap.containsKey(JOB_PARAMETERS)) {
-      options.jobParameters = new HashMap<>();
-      options.jobParameters.putAll(wrapper.getMap(JOB_PARAMETERS));
+    if (optionsMap.containsKey(NODE_PARAMETERS)) {
+      options.nodeParameters = new HashMap<>();
+      options.nodeParameters.putAll(wrapper.getMap(NODE_PARAMETERS));
     }
     // Failure notification
     options.notifyOnFirstFailure =
@@ -161,16 +161,16 @@ public class ExecutionOptions {
     this.flowParameters.putAll(flowParam);
   }
 
-  public void addAllJobParameters(final Map<String, Map<String, String>> jobParams) {
-    this.jobParameters.putAll(jobParams);
+  public void addAllNodeParameters(final Map<String, Map<String, String>> nodeParams) {
+    this.nodeParameters.putAll(nodeParams);
   }
 
   public Map<String, String> getFlowParameters() {
     return this.flowParameters;
   }
 
-  public Map<String, Map<String, String>> getJobParameters() {
-    return this.jobParameters;
+  public Map<String, Map<String, String>> getNodeParameters() {
+    return this.nodeParameters;
   }
 
   public boolean isFailureEmailsOverridden() {
@@ -302,7 +302,7 @@ public class ExecutionOptions {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
     flowOptionObj.put(FLOW_PARAMETERS, this.flowParameters);
-    flowOptionObj.put(JOB_PARAMETERS, this.jobParameters);
+    flowOptionObj.put(NODE_PARAMETERS, this.nodeParameters);
     flowOptionObj.put(NOTIFY_ON_FIRST_FAILURE, this.notifyOnFirstFailure);
     flowOptionObj.put(NOTIFY_ON_LAST_FAILURE, this.notifyOnLastFailure);
     flowOptionObj.put(SUCCESS_EMAILS, this.successEmails);

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryFlowLoader.java
@@ -259,7 +259,7 @@ public class DirectoryFlowLoader implements FlowLoader {
     // Add all the in edges and out edges. Catch bad dependencies and self
     // referrals. Also collect list of nodes who are parents.
     for (final Node node : this.nodeMap.values()) {
-      if (Constants.ROOT_RUNTIME_PROPERTY.equals(node.getId())) {
+      if (Constants.ROOT_NODE_IDENTIFIER.equals(node.getId())) {
         this.errors.add(node.getId() + " is not allowed as a name. Pick some other name.");
       }
 

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2017 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package azkaban.project;
 
@@ -105,7 +105,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
   /**
    * Loads all project flows from the directory.
    *
-   * @param project The project.
+   * @param project    The project.
    * @param projectDir The directory to load flows from.
    * @return the validation report.
    */
@@ -125,7 +125,7 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
         final NodeBean nodeBean = loader.load(file);
         if (!loader.validate(nodeBean)) {
           this.errors.add("Failed to validate nodeBean for " + file.getName()
-              + ". Duplicate nodes found or dependency undefined.");
+              + ". Duplicate nodes found or dependency undefined or ROOT used as a name.");
         } else {
           final AzkabanFlow azkabanFlow = (AzkabanFlow) loader.toAzkabanNode(nodeBean);
           if (this.flowMap.containsKey(azkabanFlow.getName())) {

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -69,7 +69,7 @@ public class NodeBeanLoader {
       }
     }
 
-    if (nodeNames.contains(Constants.ROOT_RUNTIME_PROPERTY)) {
+    if (nodeNames.contains(Constants.ROOT_NODE_IDENTIFIER)) {
       // ROOT is reserved as a special value in runtimeProperties
       return false;
     }

--- a/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/NodeBeanLoader.java
@@ -69,6 +69,11 @@ public class NodeBeanLoader {
       }
     }
 
+    if (nodeNames.contains(Constants.ROOT_RUNTIME_PROPERTY)) {
+      // ROOT is reserved as a special value in runtimeProperties
+      return false;
+    }
+
     return true;
   }
 

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -142,7 +142,7 @@ public class HttpRequestUtils {
 
     // Add all flow-level props – they are accessed via ExecutionOptions#getFlowParameters.
     final Map<String, String> rootProps = runtimePropertiesGroup
-        .remove(Constants.ROOT_RUNTIME_PROPERTY);
+        .remove(Constants.ROOT_NODE_IDENTIFIER);
     if (rootProps != null) {
       flowParamGroup.putAll(rootProps);
     }

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -127,8 +127,8 @@ public class HttpRequestUtils {
     final Map<String, String> flowParamGroup = getParamGroup(req, "flowOverride");
     execOptions.addAllFlowParameters(flowParamGroup);
 
-    final Map<String, Map<String, String>> jobParamGroup = getMapParamGroup(req, "jobOverride");
-    execOptions.addAllJobParameters(jobParamGroup);
+    final Map<String, Map<String, String>> nodeParamGroup = getMapParamGroup(req, "nodeOverride");
+    execOptions.addAllNodeParameters(nodeParamGroup);
 
     if (hasParam(req, "disabled")) {
       final String disabled = getParam(req, "disabled");

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -127,6 +127,9 @@ public class HttpRequestUtils {
     final Map<String, String> flowParamGroup = getParamGroup(req, "flowOverride");
     execOptions.addAllFlowParameters(flowParamGroup);
 
+    final Map<String, Map<String, String>> jobParamGroup = getMapParamGroup(req, "jobOverride");
+    execOptions.addAllJobParameters(jobParamGroup);
+
     if (hasParam(req, "disabled")) {
       final String disabled = getParam(req, "disabled");
       if (!disabled.isEmpty()) {
@@ -315,6 +318,9 @@ public class HttpRequestUtils {
     return defaultVal;
   }
 
+  /**
+   * Read params like groupName[key]: value
+   */
   public static Map<String, String> getParamGroup(final HttpServletRequest request,
       final String groupName) throws ServletException {
     final Enumeration<String> enumerate = request.getParameterNames();
@@ -326,6 +332,31 @@ public class HttpRequestUtils {
       if (str.startsWith(matchString)) {
         groupParam.put(str.substring(matchString.length(), str.length() - 1),
             request.getParameter(str));
+      }
+
+    }
+    return groupParam;
+  }
+
+  /**
+   * Read params like groupName[level1Key][level2Key]: value
+   */
+  public static Map<String, Map<String, String>> getMapParamGroup(final HttpServletRequest request,
+      final String groupName) {
+    final Enumeration<String> enumerate = request.getParameterNames();
+    final String matchString = groupName + "[";
+
+    final Map<String, Map<String, String>> groupParam = new HashMap<>();
+    while (enumerate.hasMoreElements()) {
+      final String str = enumerate.nextElement();
+      if (str.startsWith(matchString)) {
+        final int level1KeyEnd = str.indexOf("]");
+
+        final String level1Key = str.substring(matchString.length(), level1KeyEnd);
+        groupParam.putIfAbsent(level1Key, new HashMap<>());
+
+        final String level2Key = str.substring(level1KeyEnd + 2, str.length() - 1);
+        groupParam.get(level1Key).put(level2Key, request.getParameter(str));
       }
 
     }

--- a/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/DirectoryYamlFlowLoaderTest.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2017 LinkedIn Corp.
-*
-* Licensed under the Apache License, Version 2.0 (the “License”); you may not
-* use this file except in compliance with the License. You may obtain a copy of
-* the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations under
-* the License.
-*/
+ * Copyright 2017 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package azkaban.project;
 
@@ -131,7 +131,7 @@ public class DirectoryYamlFlowLoaderTest {
     checkFlowLoaderProperties(loader, 1, 0, 0);
     assertThat(loader.getErrors()).containsExactly(
         "Failed to validate nodeBean for " + DUPLICATE_NODENAME_FLOW_FILE
-            + ". Duplicate nodes found or dependency undefined.");
+            + ". Duplicate nodes found or dependency undefined or ROOT used as a name.");
   }
 
   @Test
@@ -142,7 +142,7 @@ public class DirectoryYamlFlowLoaderTest {
     checkFlowLoaderProperties(loader, 1, 0, 0);
     assertThat(loader.getErrors()).containsExactly(
         "Failed to validate nodeBean for " + DEPENDENCY_UNDEFINED_FLOW_FILE
-            + ". Duplicate nodes found or dependency undefined.");
+            + ". Duplicate nodes found or dependency undefined or ROOT used as a name.");
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -214,32 +214,32 @@ public final class HttpRequestUtilsTest {
         "flowOverride[key1]", "val1",
         "flowOverride[key.2]", "val.2"));
     final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
-    final Map<String, String> flowParameters = options.getFlowParameters();
     final Map<String, String> expected = ImmutableMap.of(
         "key1", "val1",
         "key.2", "val.2");
-    Assert.assertEquals(expected, flowParameters);
+    Assert.assertEquals(expected, options.getFlowParameters());
   }
 
   @Test
-  public void testParseFlowOptionsNodeOverride() throws Exception {
+  public void testParseFlowOptionsRuntimeProperty() throws Exception {
     final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
-        "flowOverride[key1]", "val1",
-        "flowOverride[key.2]", "val.2",
-        "nodeOverride[job-1][job.key]", "job-val",
-        "nodeOverride[job-1][job.key2]", "job-val2",
-        "nodeOverride[job-2][job.key]", "job-2-val"));
+        "runtimeProperty[ROOT][key1]", "val1",
+        "runtimeProperty[ROOT][key.2]", "val.2",
+        "runtimeProperty[job-1][job.key]", "job-val",
+        "runtimeProperty[job-1][job.key2]", "job-val2",
+        "runtimeProperty[job-2][job.key]", "job-2-val"));
     final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
     Assert.assertEquals(ImmutableMap.of(
         "key1", "val1",
-        "key.2", "val.2"), options.getFlowParameters());
+        "key.2", "val.2"
+    ), options.getFlowParameters());
     Assert.assertEquals(ImmutableMap.of(
         "job-1", ImmutableMap.of(
             "job.key", "job-val",
             "job.key2", "job-val2"),
         "job-2", ImmutableMap.of(
             "job.key", "job-2-val")
-    ), options.getNodeParameters());
+    ), options.getRuntimeProperties());
   }
 
   private static HttpServletRequest mockRequestWithSla(final Map<String, String> params) {

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -208,9 +208,45 @@ public final class HttpRequestUtilsTest {
     Assert.assertEquals(expected, slaOptions);
   }
 
+  @Test
+  public void testParseFlowOptionsFlowOverride() throws Exception {
+    final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
+        "flowOverride[key1]", "val1",
+        "flowOverride[key.2]", "val.2"));
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
+    final Map<String, String> flowParameters = options.getFlowParameters();
+    final Map<String, String> expected = ImmutableMap.of(
+        "key1", "val1",
+        "key.2", "val.2");
+    Assert.assertEquals(expected, flowParameters);
+  }
+
+  @Test
+  public void testParseFlowOptionsJobOverride() throws Exception {
+    final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
+        "flowOverride[key1]", "val1",
+        "flowOverride[key.2]", "val.2",
+        "jobOverride[job-1][job.key]", "job-val",
+        "jobOverride[job-1][job.key2]", "job-val2",
+        "jobOverride[job-2][job.key]", "job-2-val"));
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
+    Assert.assertEquals(ImmutableMap.of(
+        "key1", "val1",
+        "key.2", "val.2"), options.getFlowParameters());
+    Assert.assertEquals(ImmutableMap.of(
+        "job-1", ImmutableMap.of(
+            "job.key", "job-val",
+            "job.key2", "job-val2"),
+        "job-2", ImmutableMap.of(
+            "job.key", "job-2-val")
+    ), options.getJobParameters());
+  }
+
   private static HttpServletRequest mockRequestWithSla(final Map<String, String> params) {
     final HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(req.getParameterNames()).thenReturn(Collections.enumeration(params.keySet()));
+    Mockito.when(req.getParameterNames()).thenAnswer(i ->
+        // Enumeration is "consumed", so must create a new instance on every call
+        Collections.enumeration(params.keySet()));
     Mockito.when(req.getParameter(Mockito.anyString()))
         .thenAnswer(i -> params.get(i.getArgument(0, String.class)));
     return req;

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -222,13 +222,13 @@ public final class HttpRequestUtilsTest {
   }
 
   @Test
-  public void testParseFlowOptionsJobOverride() throws Exception {
+  public void testParseFlowOptionsNodeOverride() throws Exception {
     final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
         "flowOverride[key1]", "val1",
         "flowOverride[key.2]", "val.2",
-        "jobOverride[job-1][job.key]", "job-val",
-        "jobOverride[job-1][job.key2]", "job-val2",
-        "jobOverride[job-2][job.key]", "job-2-val"));
+        "nodeOverride[job-1][job.key]", "job-val",
+        "nodeOverride[job-1][job.key2]", "job-val2",
+        "nodeOverride[job-2][job.key]", "job-2-val"));
     final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
     Assert.assertEquals(ImmutableMap.of(
         "key1", "val1",
@@ -239,7 +239,7 @@ public final class HttpRequestUtilsTest {
             "job.key2", "job-val2"),
         "job-2", ImmutableMap.of(
             "job.key", "job-2-val")
-    ), options.getJobParameters());
+    ), options.getNodeParameters());
   }
 
   private static HttpServletRequest mockRequestWithSla(final Map<String, String> params) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -941,6 +941,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       }
       // 5.2. apply node-specific runtime props
       props = applyRuntimeProperties(node, runtimeProperties, props);
+    } else if (runtimeProperties.containsKey(node.getNestedId())) {
+      props = new Props(props, runtimeProperties.get(node.getNestedId()));
     }
 
     node.setInputProps(props);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -883,12 +883,6 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       return;
     }
 
-    Map<String, Map<String, String>> runtimeProperties = this.flow.getExecutionOptions()
-        .getRuntimeProperties();
-    if (runtimeProperties == null) {
-      runtimeProperties = new HashMap<>();
-    }
-
     Props props = null;
 
     if (!FlowLoaderUtils.isAzkabanFlowVersion20(this.flow.getAzkabanFlowVersion())) {
@@ -927,18 +921,23 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       props = jobSource;
     }
 
-    // 5. If configured, runtime properties override also existing .job props & output props
+    // 5. Runtime properties
+    Map<String, Map<String, String>> runtimeProperties = this.flow.getExecutionOptions()
+        .getRuntimeProperties();
+    if (runtimeProperties == null) {
+      runtimeProperties = new HashMap<>();
+    }
     if (isOverrideExistingEnabled()) {
-      // 5.1. apply flow level runtime props
+      // 5.a.1. apply flow level runtime props
       final Map<String, String> flowParam =
           this.flow.getExecutionOptions().getFlowParameters();
       if (flowParam != null && !flowParam.isEmpty()) {
         props = new Props(props, flowParam);
       }
-      // 5.2. apply node-specific runtime props recursively
+      // 5.a.2. apply node-specific runtime props recursively
       props = applyRuntimeProperties(node, runtimeProperties, props);
     } else if (runtimeProperties.containsKey(node.getNestedId())) {
-      // apply node-specific runtime props (current node only)
+      // 5.b. apply node-specific runtime props (current node only)
       props = new Props(props, runtimeProperties.get(node.getNestedId()));
     }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -770,7 +770,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * Recursively propagate status to parent flow. Alert on first error of the flow in new AZ dispatching design.
+   * Recursively propagate status to parent flow. Alert on first error of the flow in new AZ
+   * dispatching design.
    *
    * @param base   the base flow
    * @param status the status to be propagated
@@ -970,7 +971,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * @param props This method is to put in any job properties customization before feeding to the job.
+   * @param props This method is to put in any job properties customization before feeding to the
+   *              job.
    */
   private void customizeJobProperties(final Props props) {
     final boolean memoryCheck = this.flow.getExecutionOptions().getMemoryCheck();
@@ -1106,7 +1108,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * Determines what the state of the next node should be. Returns null if the node should not be run.
+   * Determines what the state of the next node should be. Returns null if the node should not be
+   * run.
    */
   public Status getImpliedStatus(final ExecutableNode node) {
     // If it's running or finished with 'SUCCEEDED', than don't even
@@ -1715,13 +1718,15 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       if (executableFlow.getVersionSet() != null) { // Flow version set is set when flow is
         // executed in a container, which also indicates executor type is Kubernetes.
         final VersionInfo versionInfo =
-            executableFlow.getVersionSet().getImageToVersionMap().getOrDefault(node.getType(), null);
+            executableFlow.getVersionSet().getImageToVersionMap()
+                .getOrDefault(node.getType(), null);
         if (versionInfo != null) {
           // Add job type image version number
           metaData.put(EventReporterConstants.VERSION, versionInfo.getVersion());
         }
       }
-      if (executableFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) { // Determine executor type
+      if (executableFlow.getDispatchMethod()
+          == DispatchMethod.CONTAINERIZED) { // Determine executor type
         metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.KUBERNETES));
       } else {
         metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.BAREMETAL));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -908,11 +908,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     final ExecutableFlowBase parentFlow = node.getParentFlow();
     if (parentFlow != null) {
       // flow level runtime props have been already applied on parent input props
-      Props flowProps = Props.clone(parentFlow.getInputProps());
-      if (!isOverrideExistingEnabled()) {
-        // if there are more specific runtime props, those override the flow level props
-        flowProps = applyRuntimeProperties(node, runtimeProperties, flowProps);
-      }
+      final Props flowProps = Props.clone(parentFlow.getInputProps());
       flowProps.setEarliestAncestor(props);
       props = flowProps;
     }
@@ -939,9 +935,10 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       if (flowParam != null && !flowParam.isEmpty()) {
         props = new Props(props, flowParam);
       }
-      // 5.2. apply node-specific runtime props
+      // 5.2. apply node-specific runtime props recursively
       props = applyRuntimeProperties(node, runtimeProperties, props);
     } else if (runtimeProperties.containsKey(node.getNestedId())) {
+      // apply node-specific runtime props (current node only)
       props = new Props(props, runtimeProperties.get(node.getNestedId()));
     }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -770,8 +770,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * Recursively propagate status to parent flow. Alert on first error of the flow in new AZ
-   * dispatching design.
+   * Recursively propagate status to parent flow. Alert on first error of the flow in new AZ dispatching design.
    *
    * @param base   the base flow
    * @param status the status to be propagated
@@ -952,7 +951,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   private Props applyRuntimeProperties(final ExecutableNode node,
       final Map<String, Map<String, String>> runtimeProperties, final Props props) {
     Props propsWithOverides = props;
-    if (node.getParentFlow() != null) {
+    if (node.getParentFlow() != null && !parentIsOnTheSameLevel(node)) {
       // apply recursively top->down
       propsWithOverides = applyRuntimeProperties(node.getParentFlow(), runtimeProperties, props);
     }
@@ -964,8 +963,14 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * @param props This method is to put in any job properties customization before feeding to the
-   *              job.
+   * Detects if the "parent" is actually the root job node.
+   */
+  private boolean parentIsOnTheSameLevel(final ExecutableNode node) {
+    return node.getParentFlow() instanceof ExecutableFlow;
+  }
+
+  /**
+   * @param props This method is to put in any job properties customization before feeding to the job.
    */
   private void customizeJobProperties(final Props props) {
     final boolean memoryCheck = this.flow.getExecutionOptions().getMemoryCheck();
@@ -1101,8 +1106,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   /**
-   * Determines what the state of the next node should be. Returns null if the node should not be
-   * run.
+   * Determines what the state of the next node should be. Returns null if the node should not be run.
    */
   public Status getImpliedStatus(final ExecutableNode node) {
     // If it's running or finished with 'SUCCEEDED', than don't even

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -312,16 +312,6 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       if (!FlowLoaderUtils.isAzkabanFlowVersion20(this.flow.getAzkabanFlowVersion())) {
         loadAllProperties();
       }
-      final Map<String, String> flowParam =
-          this.flow.getExecutionOptions().getFlowParameters();
-      if (flowParam != null && !flowParam.isEmpty()) {
-        this.logger.info("FlowOverride Props: " + flowParam);
-      }
-      final Map<String, Map<String, String>> nodeParams = this.flow.getExecutionOptions()
-          .getNodeParameters();
-      if (nodeParams != null && !nodeParams.isEmpty()) {
-        this.logger.info("nodeOverride Props: " + nodeParams);
-      }
 
       this.fireEventListeners(
           Event.create(this, EventType.FLOW_STARTED, new EventData(this.getExecutableFlow())));
@@ -425,13 +415,21 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       }
     }
 
-    // If there are flow overrides, we apply them now.
+    // If there are flow overrides, we log them & apply them on the flow node.
     final Map<String, String> flowParam =
         this.flow.getExecutionOptions().getFlowParameters();
     if (flowParam != null && !flowParam.isEmpty()) {
+      this.logger.info("FlowOverride Props: " + flowParam);
       commonFlowProps = new Props(commonFlowProps, flowParam);
     }
     this.flow.setInputProps(commonFlowProps);
+
+    // If there are node overrides, we log them now.
+    final Map<String, Map<String, String>> nodeParams = this.flow.getExecutionOptions()
+        .getNodeParameters();
+    if (nodeParams != null && !nodeParams.isEmpty()) {
+      this.logger.info("NodeOverride Props: " + nodeParams);
+    }
 
     if (this.watcher != null) {
       this.watcher.setLogger(this.logger);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -317,10 +317,10 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       if (flowParam != null && !flowParam.isEmpty()) {
         this.logger.info("FlowOverride Props: " + flowParam);
       }
-      final Map<String, Map<String, String>> jobParams = this.flow.getExecutionOptions()
-          .getJobParameters();
-      if (jobParams != null && !jobParams.isEmpty()) {
-        this.logger.info("jobOverride Props: " + jobParams);
+      final Map<String, Map<String, String>> nodeParams = this.flow.getExecutionOptions()
+          .getNodeParameters();
+      if (nodeParams != null && !nodeParams.isEmpty()) {
+        this.logger.info("nodeOverride Props: " + nodeParams);
       }
 
       this.fireEventListeners(
@@ -934,29 +934,29 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       }
     }
 
-    // 6. If there are any job-specific flow overrides, we also apply them
-    final Map<String, Map<String, String>> jobParams = this.flow.getExecutionOptions()
-        .getJobParameters();
-    if (jobParams != null && !jobParams.isEmpty()) {
-      applyJobOverrides(node, jobParams, props);
+    // 6. If there are any node-specific flow overrides, we also apply them
+    final Map<String, Map<String, String>> nodeParams = this.flow.getExecutionOptions()
+        .getNodeParameters();
+    if (nodeParams != null && !nodeParams.isEmpty()) {
+      applyNodeOverrides(node, nodeParams, props);
     }
 
     node.setInputProps(props);
   }
 
-  private void applyJobOverrides(final ExecutableNode node,
-      final Map<String, Map<String, String>> jobParams, final Props props) {
+  private void applyNodeOverrides(final ExecutableNode node,
+      final Map<String, Map<String, String>> nodeParams, final Props props) {
     if (node.getParentFlow() != null) {
       // apply recursively top->down
-      applyJobOverrides(node.getParentFlow(), jobParams, props);
+      applyNodeOverrides(node.getParentFlow(), nodeParams, props);
     }
     // overrides by plain node id
-    if (jobParams.containsKey(node.getId())) {
-      props.putAll(jobParams.get(node.getId()));
+    if (nodeParams.containsKey(node.getId())) {
+      props.putAll(nodeParams.get(node.getId()));
     }
     // full nested id path overrides plain node id
-    if (jobParams.containsKey(node.getNestedId())) {
-      props.putAll(jobParams.get(node.getNestedId()));
+    if (nodeParams.containsKey(node.getNestedId())) {
+      props.putAll(nodeParams.get(node.getNestedId()));
     }
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -951,11 +951,6 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       // apply recursively top->down
       propsWithOverides = applyNodeOverrides(node.getParentFlow(), nodeParams, props);
     }
-    // overrides by plain node id
-    if (nodeParams.containsKey(node.getId())) {
-      propsWithOverides = new Props(propsWithOverides, nodeParams.get(node.getId()));
-    }
-    // full nested id path overrides plain node id
     if (nodeParams.containsKey(node.getNestedId())) {
       propsWithOverides = new Props(propsWithOverides, nodeParams.get(node.getNestedId()));
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -930,7 +930,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       final Map<String, String> flowParam =
           this.flow.getExecutionOptions().getFlowParameters();
       if (flowParam != null && !flowParam.isEmpty()) {
-        props.putAll(flowParam);
+        props = new Props(props, flowParam);
       }
     }
 
@@ -938,26 +938,28 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     final Map<String, Map<String, String>> nodeParams = this.flow.getExecutionOptions()
         .getNodeParameters();
     if (nodeParams != null && !nodeParams.isEmpty()) {
-      applyNodeOverrides(node, nodeParams, props);
+      props = applyNodeOverrides(node, nodeParams, props);
     }
 
     node.setInputProps(props);
   }
 
-  private void applyNodeOverrides(final ExecutableNode node,
+  private Props applyNodeOverrides(final ExecutableNode node,
       final Map<String, Map<String, String>> nodeParams, final Props props) {
+    Props propsWithOverides = props;
     if (node.getParentFlow() != null) {
       // apply recursively top->down
-      applyNodeOverrides(node.getParentFlow(), nodeParams, props);
+      propsWithOverides = applyNodeOverrides(node.getParentFlow(), nodeParams, props);
     }
     // overrides by plain node id
     if (nodeParams.containsKey(node.getId())) {
-      props.putAll(nodeParams.get(node.getId()));
+      propsWithOverides = new Props(propsWithOverides, nodeParams.get(node.getId()));
     }
     // full nested id path overrides plain node id
     if (nodeParams.containsKey(node.getNestedId())) {
-      props.putAll(nodeParams.get(node.getNestedId()));
+      propsWithOverides = new Props(propsWithOverides, nodeParams.get(node.getNestedId()));
     }
+    return propsWithOverides;
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -419,7 +419,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     final Map<String, String> flowParam =
         this.flow.getExecutionOptions().getFlowParameters();
     if (flowParam != null && !flowParam.isEmpty()) {
-      this.logger.info("FlowOverride Props: " + flowParam);
+      this.logger.info("ROOT Runtime Props: " + flowParam);
       commonFlowProps = new Props(commonFlowProps, flowParam);
     }
     this.flow.setInputProps(commonFlowProps);
@@ -428,7 +428,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     final Map<String, Map<String, String>> runtimeProperties = this.flow.getExecutionOptions()
         .getRuntimeProperties();
     if (runtimeProperties != null && !runtimeProperties.isEmpty()) {
-      this.logger.info("Runtime Props: " + runtimeProperties);
+      this.logger.info("Other Runtime Props: " + runtimeProperties);
     }
 
     if (this.watcher != null) {
@@ -1596,7 +1596,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       // or else use jetty.hostname
       metaData.put(EventReporterConstants.AZ_WEBSERVER,
           props.getString(AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME,
-          props.getString("jetty.hostname", "localhost")));
+              props.getString("jetty.hostname", "localhost")));
       metaData.put(EventReporterConstants.PROJECT_NAME, flow.getProjectName());
       metaData.put(EventReporterConstants.SUBMIT_USER, flow.getSubmitUser());
       metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(flow.getExecutionId()));
@@ -1710,7 +1710,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(node.getStartTime()));
       metaData.put(EventReporterConstants.JOB_TYPE, String.valueOf(node.getType()));
       // Add version of the job type
-      if(executableFlow.getVersionSet() != null) { // Flow version set is set when flow is
+      if (executableFlow.getVersionSet() != null) { // Flow version set is set when flow is
         // executed in a container, which also indicates executor type is Kubernetes.
         final VersionInfo versionInfo =
             executableFlow.getVersionSet().getImageToVersionMap().getOrDefault(node.getType(), null);
@@ -1732,7 +1732,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       // or else use jetty.hostname
       metaData.put(EventReporterConstants.AZ_WEBSERVER,
           props.getString(AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME,
-          props.getString("jetty.hostname", "localhost")));
+              props.getString("jetty.hostname", "localhost")));
       metaData.put(EventReporterConstants.JOB_PROXY_USER, jobRunner.getEffectiveUser());
       // attempt id
       metaData.put(EventReporterConstants.ATTEMPT_ID, String.valueOf(node.getAttempt()));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -75,7 +75,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void testNodeOverrides() throws Exception {
+  public void testRuntimeOverrides() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
 
     final HashMap<String, String> flowProps = new HashMap<>();
@@ -85,7 +85,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
     // Set some node-specific overrides
     final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, flowProps);
-    runner.getExecutableFlow().getExecutionOptions().addAllNodeParameters(ImmutableMap.of(
+    runner.getExecutableFlow().getExecutionOptions().addAllRuntimeProperties(ImmutableMap.of(
         "job2", ImmutableMap.of("job-prop-2", "job2-val-2", "props6", "job2-val-6"),
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins
@@ -108,7 +108,8 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("moo3", job2Props.get("props3"));
     Assert.assertEquals("job7", job2Props.get("props7"));
     Assert.assertEquals("execflow5", job2Props.get("props5"));
-    // should've been overridden by nodeOverride
+    // should've been overridden by the most specific runtime property
+    // props6=execflow6 is a flow override, but it's not the most specific one
     Assert.assertEquals("job2-val-6", job2Props.get("props6"));
     Assert.assertEquals("shared4", job2Props.get("props4"));
     Assert.assertEquals("shared8", job2Props.get("props8"));
@@ -141,7 +142,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void testNodeOverridesWithFlowOverridesExisting() throws Exception {
+  public void testRuntimeOverridesWithFlowOverridesExisting() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
 
     final HashMap<String, String> flowProps = new HashMap<>();
@@ -153,7 +154,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, null, flowProps,
         Props.of(ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED, "true"));
     // Set some node-specific overrides
-    runner.getExecutableFlow().getExecutionOptions().addAllNodeParameters(ImmutableMap.of(
+    runner.getExecutableFlow().getExecutionOptions().addAllRuntimeProperties(ImmutableMap.of(
         "job2", ImmutableMap.of("job-prop-2", "job2-val-2", "props6", "job2-val-6"),
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -69,7 +69,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void testJobOverrides() throws Exception {
+  public void testNodeOverrides() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
 
     final HashMap<String, String> flowProps = new HashMap<>();
@@ -80,8 +80,8 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     // enable overriding also for existing job props
     final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, null, flowProps,
         Props.of(ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED, "true"));
-    // Set some job-specific overrides
-    runner.getExecutableFlow().getExecutionOptions().addAllJobParameters(ImmutableMap.of(
+    // Set some node-specific overrides
+    runner.getExecutableFlow().getExecutionOptions().addAllNodeParameters(ImmutableMap.of(
         "job2", ImmutableMap.of("job-prop-2", "job2-val-2", "props6", "job2-val-6"),
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins
@@ -107,18 +107,18 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("moo3", job2Props.get("props3"));
     Assert.assertEquals("execflow7", job2Props.get("props7"));
     Assert.assertEquals("execflow5", job2Props.get("props5"));
-    // should've been overridden by jobOverride
+    // should've been overridden by nodeOverride
     Assert.assertEquals("job2-val-6", job2Props.get("props6"));
     Assert.assertEquals("shared4", job2Props.get("props4"));
     Assert.assertEquals("shared8", job2Props.get("props8"));
-    // entirely new prop via jobOverride
+    // entirely new prop via nodeOverride
     Assert.assertEquals("job2-val-2", job2Props.get("job-prop-2"));
 
     final Props job1Props = nodeMap.get("innerflow:job1").getInputProps();
     Assert.assertEquals("job1", job1Props.get("props1"));
     Assert.assertEquals("job2", job1Props.get("props2"));
     Assert.assertEquals("job8", job1Props.get("props8"));
-    // jobOverride by the sub-flow parent
+    // nodeOverride by the sub-flow parent
     Assert.assertEquals("innerflow-val-6", job1Props.get("props6"));
     Assert.assertEquals("execflow5", job1Props.get("props5"));
     Assert.assertEquals("execflow7", job1Props.get("props7"));
@@ -128,11 +128,11 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
     Assert.assertEquals("job8", job4Props.get("props8"));
     Assert.assertEquals("job9", job4Props.get("props9"));
-    // jobOverride by the sub-flow parent
+    // nodeOverride by the sub-flow parent
     Assert.assertEquals("innerflow-val-6", job4Props.get("props6"));
-    // jobOverride with plain job id
+    // nodeOverride with plain job id
     Assert.assertEquals("job4-val-7", job4Props.get("props7"));
-    // jobOverride with nested id
+    // nodeOverride with nested id
     Assert.assertEquals("innerflow-job4-val-4", job4Props.get("props4"));
     Assert.assertEquals("innerflow-job4-val-5", job4Props.get("props5"));
     Assert.assertEquals("shared1", job4Props.get("props1"));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -90,10 +90,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins
         "innerflow:job4", ImmutableMap.of(
-            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5"),
-        // overrides by plain job id: most specific after full nested id
-        "job4", ImmutableMap.of(
-            "props4", "job4-val-4", "props5", "job4-val-5", "props7", "job4-val-7")
+            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5")
     ));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
@@ -134,8 +131,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("job9", job4Props.get("props9"));
     // nodeOverride by the sub-flow parent
     Assert.assertEquals("innerflow-val-6", job4Props.get("props6"));
-    // nodeOverride with plain job id
-    Assert.assertEquals("job4-val-7", job4Props.get("props7"));
+    Assert.assertEquals("execflow7", job4Props.get("props7"));
     // nodeOverride with nested id
     Assert.assertEquals("innerflow-job4-val-4", job4Props.get("props4"));
     Assert.assertEquals("innerflow-job4-val-5", job4Props.get("props5"));
@@ -162,10 +158,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins
         "innerflow:job4", ImmutableMap.of(
-            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5"),
-        // overrides by plain job id: most specific after full nested id
-        "job4", ImmutableMap.of(
-            "props4", "job4-val-4", "props5", "job4-val-5", "props7", "job4-val-7")
+            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5")
     ));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
@@ -206,9 +199,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("job9", job4Props.get("props9"));
     // nodeOverride by the sub-flow parent
     Assert.assertEquals("innerflow-val-6", job4Props.get("props6"));
-    // nodeOverride with plain job id
-    Assert.assertEquals("job4-val-7", job4Props.get("props7"));
-    // nodeOverride with nested id
+    Assert.assertEquals("execflow7", job4Props.get("props7"));
     Assert.assertEquals("innerflow-job4-val-4", job4Props.get("props4"));
     Assert.assertEquals("innerflow-job4-val-5", job4Props.get("props5"));
     Assert.assertEquals("shared1", job4Props.get("props1"));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -137,7 +137,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         "innerflow:job4", ImmutableMap.of(
             "runtime1", "runtime1-job4",
             "props4", "innerflow-job4-val-4",
-            "props5", "innerflow-job4-val-5")
+            "props5", "innerflow-job4-val-5"),
+        // job3 is a job, but it's also the root node of this flow
+        "job3", ImmutableMap.of("prop-job3", "should-be-set-only-for-job3")
     ));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
@@ -228,6 +230,10 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertNull(job3Props.get("props10"));
     Assert.assertEquals("runtime1-ROOT", job3Props.get("runtime1"));
     Assert.assertEquals("runtime2-ROOT", job3Props.get("runtime2"));
+
+    Assert.assertEquals("should-be-set-only-for-job3", job3Props.get("prop-job3"));
+    Assert.assertNull(job2Props.get("prop-job3"));
+    Assert.assertNull(job4Props.get("prop-job3"));
   }
 
   private void assertPropertiesWithHighestPrecedenceToRuntimePropsEnabled() throws Exception {
@@ -252,7 +258,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         // overrides by nested job id: this is the most specific, so always wins
         "innerflow:job4", ImmutableMap.of(
             "props4", "innerflow-job4-val-4",
-            "props5", "innerflow-job4-val-5")
+            "props5", "innerflow-job4-val-5"),
+        // job3 is a job, but it's also the root node of this flow
+        "job3", ImmutableMap.of("prop-job3", "should-be-set-only-for-job3")
     ));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
@@ -333,6 +341,10 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("shared2", job3Props.get("props2"));
     Assert.assertEquals("moo4", job3Props.get("props4"));
     Assert.assertNull(job3Props.get("props10"));
+
+    Assert.assertEquals("should-be-set-only-for-job3", job3Props.get("prop-job3"));
+    Assert.assertNull(job2Props.get("prop-job3"));
+    Assert.assertNull(job4Props.get("prop-job3"));
   }
 
   private void createNodeMap(final ExecutableFlowBase flow,

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -65,11 +65,87 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
   @Test
   public void testPropertyResolution() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
-    assertProperties();
+    assertProperties(false);
+  }
+
+  @Test
+  public void testPropertyResolutionWithFlowOverridesExisting() throws Exception {
+    this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
+    assertProperties(true);
   }
 
   @Test
   public void testNodeOverrides() throws Exception {
+    this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
+
+    final HashMap<String, String> flowProps = new HashMap<>();
+    flowProps.put("props7", "execflow7");
+    flowProps.put("props6", "execflow6");
+    flowProps.put("props5", "execflow5");
+
+    // Set some node-specific overrides
+    final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, flowProps);
+    runner.getExecutableFlow().getExecutionOptions().addAllNodeParameters(ImmutableMap.of(
+        "job2", ImmutableMap.of("job-prop-2", "job2-val-2", "props6", "job2-val-6"),
+        "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
+        // overrides by nested job id: this is the most specific, so always wins
+        "innerflow:job4", ImmutableMap.of(
+            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5"),
+        // overrides by plain job id: most specific after full nested id
+        "job4", ImmutableMap.of(
+            "props4", "job4-val-4", "props5", "job4-val-5", "props7", "job4-val-7")
+    ));
+    final Map<String, ExecutableNode> nodeMap = new HashMap<>();
+    createNodeMap(runner.getExecutableFlow(), nodeMap);
+    final ExecutableFlow flow = runner.getExecutableFlow();
+
+    // 1. Start flow. Job 2 should start
+    FlowRunnerTestUtil.startThread(runner);
+    InteractiveTestJob.getTestJob("job2").succeedJob();
+    InteractiveTestJob.getTestJob("innerflow:job1").succeedJob();
+    InteractiveTestJob.getTestJob("innerflow:job4").succeedJob();
+
+    final Props job2Props = nodeMap.get("job2").getInputProps();
+    Assert.assertEquals("shared1", job2Props.get("props1"));
+    Assert.assertEquals("job2", job2Props.get("props2"));
+    Assert.assertEquals("moo3", job2Props.get("props3"));
+    Assert.assertEquals("job7", job2Props.get("props7"));
+    Assert.assertEquals("execflow5", job2Props.get("props5"));
+    // should've been overridden by nodeOverride
+    Assert.assertEquals("job2-val-6", job2Props.get("props6"));
+    Assert.assertEquals("shared4", job2Props.get("props4"));
+    Assert.assertEquals("shared8", job2Props.get("props8"));
+    // entirely new prop via nodeOverride
+    Assert.assertEquals("job2-val-2", job2Props.get("job-prop-2"));
+
+    final Props job1Props = nodeMap.get("innerflow:job1").getInputProps();
+    Assert.assertEquals("job1", job1Props.get("props1"));
+    Assert.assertEquals("job2", job1Props.get("props2"));
+    Assert.assertEquals("job8", job1Props.get("props8"));
+    // nodeOverride by the sub-flow parent
+    Assert.assertEquals("innerflow-val-6", job1Props.get("props6"));
+    Assert.assertEquals("innerflow5", job1Props.get("props5"));
+    Assert.assertEquals("execflow7", job1Props.get("props7"));
+    Assert.assertEquals("moo3", job1Props.get("props3"));
+    Assert.assertEquals("innerflow-val-4", job1Props.get("props4"));
+
+    final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
+    Assert.assertEquals("job8", job4Props.get("props8"));
+    Assert.assertEquals("job9", job4Props.get("props9"));
+    // nodeOverride by the sub-flow parent
+    Assert.assertEquals("innerflow-val-6", job4Props.get("props6"));
+    // nodeOverride with plain job id
+    Assert.assertEquals("job4-val-7", job4Props.get("props7"));
+    // nodeOverride with nested id
+    Assert.assertEquals("innerflow-job4-val-4", job4Props.get("props4"));
+    Assert.assertEquals("innerflow-job4-val-5", job4Props.get("props5"));
+    Assert.assertEquals("shared1", job4Props.get("props1"));
+    Assert.assertEquals("shared2", job4Props.get("props2"));
+    Assert.assertEquals("moo3", job4Props.get("props3"));
+  }
+
+  @Test
+  public void testNodeOverridesWithFlowOverridesExisting() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
 
     final HashMap<String, String> flowProps = new HashMap<>();
@@ -155,20 +231,36 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         .getUploadedFlowFile(eq(project.getId()), eq(project.getVersion()), eq(FLOW_YAML_FILE),
             eq(1), any(File.class)))
         .thenReturn(ExecutionsTestUtil.getFlowFile(FLOW_YAML_DIR, FLOW_YAML_FILE));
-    assertProperties();
+    assertProperties(false);
+  }
+
+  @Test
+  public void testYamlFilePropertyResolutionWithFlowOverridesExisting() throws Exception {
+    this.testUtil = new FlowRunnerTestUtil(FLOW_YAML_DIR, this.temporaryFolder);
+    final Project project = this.testUtil.getProject();
+    when(this.testUtil.getProjectLoader().isFlowFileUploaded(project.getId(), project.getVersion()))
+        .thenReturn(true);
+    when(this.testUtil.getProjectLoader()
+        .getLatestFlowVersion(project.getId(), project.getVersion(), FLOW_YAML_FILE)).thenReturn(1);
+    when(this.testUtil.getProjectLoader()
+        .getUploadedFlowFile(eq(project.getId()), eq(project.getVersion()), eq(FLOW_YAML_FILE),
+            eq(1), any(File.class)))
+        .thenReturn(ExecutionsTestUtil.getFlowFile(FLOW_YAML_DIR, FLOW_YAML_FILE));
+    assertProperties(true);
   }
 
   /**
    * Helper method to test the flow property resolution.
    */
-  private void assertProperties() throws Exception {
+  private void assertProperties(final boolean flowOverridesExisting) throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     flowProps.put("props7", "flow7");
     flowProps.put("props6", "flow6");
     flowProps.put("props5", "flow5");
     // enable overriding also for existing job props
     final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, null, flowProps,
-        Props.of(ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED, "true"));
+        Props.of(ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED,
+            Boolean.toString(flowOverridesExisting)));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
     final ExecutableFlow flow = runner.getExecutableFlow();
@@ -183,7 +275,11 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("shared1", job2Props.get("props1"));
     Assert.assertEquals("job2", job2Props.get("props2"));
     Assert.assertEquals("moo3", job2Props.get("props3"));
-    Assert.assertEquals("flow7", job2Props.get("props7"));
+    if (flowOverridesExisting) {
+      Assert.assertEquals("flow7", job2Props.get("props7"));
+    } else {
+      Assert.assertNull(job2Props.get("job7"));
+    }
     Assert.assertEquals("flow5", job2Props.get("props5"));
     Assert.assertEquals("flow6", job2Props.get("props6"));
     Assert.assertEquals("shared4", job2Props.get("props4"));
@@ -205,9 +301,15 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("job8", job1Props.get("props8"));
     Assert.assertEquals("gjob9", job1Props.get("props9"));
     Assert.assertEquals("gjob10", job1Props.get("props10"));
-    Assert.assertEquals("flow6", job1Props.get("props6"));
-    Assert.assertEquals("flow5", job1Props.get("props5"));
-    Assert.assertEquals("flow7", job1Props.get("props7"));
+    if (flowOverridesExisting) {
+      Assert.assertEquals("flow6", job1Props.get("props6"));
+      Assert.assertEquals("flow5", job1Props.get("props5"));
+      Assert.assertEquals("flow7", job1Props.get("props7"));
+    } else {
+      Assert.assertEquals("innerflow6", job1Props.get("props6"));
+      Assert.assertEquals("innerflow5", job1Props.get("props5"));
+      Assert.assertEquals("flow7", job1Props.get("props7"));
+    }
     Assert.assertEquals("moo3", job1Props.get("props3"));
     Assert.assertEquals("moo4", job1Props.get("props4"));
 
@@ -223,9 +325,15 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
     Assert.assertEquals("job8", job4Props.get("props8"));
     Assert.assertEquals("job9", job4Props.get("props9"));
-    Assert.assertEquals("flow7", job4Props.get("props7"));
-    Assert.assertEquals("flow5", job4Props.get("props5"));
-    Assert.assertEquals("flow6", job4Props.get("props6"));
+    if (flowOverridesExisting) {
+      Assert.assertEquals("flow7", job4Props.get("props7"));
+      Assert.assertEquals("flow5", job4Props.get("props5"));
+      Assert.assertEquals("flow6", job4Props.get("props6"));
+    } else {
+      Assert.assertEquals("g2job7", job4Props.get("props7"));
+      Assert.assertEquals("innerflow5", job4Props.get("props5"));
+      Assert.assertEquals("innerflow6", job4Props.get("props6"));
+    }
     Assert.assertEquals("gjob10", job4Props.get("props10"));
     Assert.assertEquals("shared4", job4Props.get("props4"));
     Assert.assertEquals("shared1", job4Props.get("props1"));
@@ -243,7 +351,11 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     assertStatus(flow, FLOW_NAME, Status.RUNNING);
     final Props job3Props = nodeMap.get("job3").getInputProps();
     Assert.assertEquals("job3", job3Props.get("props3"));
-    Assert.assertEquals("flow6", job3Props.get("props6"));
+    if (flowOverridesExisting) {
+      Assert.assertEquals("flow6", job3Props.get("props6"));
+    } else {
+      Assert.assertEquals("g4job6", job3Props.get("props6"));
+    }
     Assert.assertEquals("g4job9", job3Props.get("props9"));
     Assert.assertEquals("flow7", job3Props.get("props7"));
     Assert.assertEquals("flow5", job3Props.get("props5"));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -65,7 +65,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
   @Test
   public void testPropertyResolution() throws Exception {
     this.testUtil = new FlowRunnerTestUtil(EXEC_FLOW_DIR, this.temporaryFolder);
-    assertProperties(false);
+    assertProperties();
   }
 
   @Test
@@ -155,13 +155,13 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         .getUploadedFlowFile(eq(project.getId()), eq(project.getVersion()), eq(FLOW_YAML_FILE),
             eq(1), any(File.class)))
         .thenReturn(ExecutionsTestUtil.getFlowFile(FLOW_YAML_DIR, FLOW_YAML_FILE));
-    assertProperties(true);
+    assertProperties();
   }
 
   /**
    * Helper method to test the flow property resolution.
    */
-  private void assertProperties(final boolean isAzkabanFlowVersion20) throws Exception {
+  private void assertProperties() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     flowProps.put("props7", "flow7");
     flowProps.put("props6", "flow6");

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -82,6 +82,8 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     flowProps.put("props7", "execflow7");
     flowProps.put("props6", "execflow6");
     flowProps.put("props5", "execflow5");
+    flowProps.put("runtime1", "runtime1-ROOT");
+    flowProps.put("runtime2", "runtime2-ROOT");
 
     // Set some node-specific overrides
     final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, flowProps);
@@ -90,7 +92,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
         "innerflow", ImmutableMap.of("props6", "innerflow-val-6", "props4", "innerflow-val-4"),
         // overrides by nested job id: this is the most specific, so always wins
         "innerflow:job4", ImmutableMap.of(
-            "props4", "innerflow-job4-val-4", "props5", "innerflow-job4-val-5")
+            "runtime1", "runtime1-job4",
+            "props4", "innerflow-job4-val-4",
+            "props5", "innerflow-job4-val-5")
     ));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
@@ -139,6 +143,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("shared1", job4Props.get("props1"));
     Assert.assertEquals("shared2", job4Props.get("props2"));
     Assert.assertEquals("moo3", job4Props.get("props3"));
+    // runtime props: these don't exist anywhere in static props. most specific wins.
+    Assert.assertEquals("runtime1-job4", job4Props.get("runtime1"));
+    Assert.assertEquals("runtime2-ROOT", job4Props.get("runtime2"));
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -57,8 +57,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlowRunnerTestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FlowRunnerTestUtil.class);
 
   private static int id = 101;
   private final Map<String, Flow> flowMap;
@@ -84,9 +88,9 @@ public class FlowRunnerTestUtil {
     when(this.executorLoader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
 
     this.projectLoader = mock(ProjectLoader.class);
-    handler = new ProjectFileHandler(1, 1, 1, "testUser", "zip", "test.zip",
-            1, null, null, null, "111.111.111.111");
-    when(this.projectLoader.fetchProjectMetaData(anyInt(), anyInt())).thenReturn(handler);
+    this.handler = new ProjectFileHandler(1, 1, 1, "testUser", "zip", "test.zip",
+        1, null, null, null, "111.111.111.111");
+    when(this.projectLoader.fetchProjectMetaData(anyInt(), anyInt())).thenReturn(this.handler);
 
     Utils.initServiceProvider();
     JmxJobMBeanManager.getInstance().initialize(new Props());
@@ -115,6 +119,7 @@ public class FlowRunnerTestUtil {
     final FlowLoaderFactory loaderFactory = new FlowLoaderFactory(new Props(null));
     final FlowLoader loader = loaderFactory.createFlowLoader(sourceDir);
 
+    LOG.info("Loading project flows from " + sourceDir);
     loader.loadProjectFlow(project, sourceDir);
     if (!loader.getErrors().isEmpty()) {
       for (final String error : loader.getErrors()) {
@@ -126,6 +131,7 @@ public class FlowRunnerTestUtil {
     }
 
     final Map<String, Flow> flowMap = loader.getFlowMap();
+    LOG.info("Loaded flows: " + flowMap.keySet());
     project.setFlows(flowMap);
     FileUtils.copyDirectory(sourceDir, workingDir);
     return flowMap;
@@ -234,6 +240,7 @@ public class FlowRunnerTestUtil {
       final String flowName, final ExecutionOptions options,
       final Map<String, String> flowParams, final Props azkabanProps)
       throws Exception {
+    LOG.info("Creating a FlowRunner for flow '" + flowName + "'");
     final Flow flow = this.flowMap.get(flowName);
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
     return createFromExecutableFlow(eventCollector, exFlow, options, flowParams,
@@ -297,7 +304,7 @@ public class FlowRunnerTestUtil {
     return this.project;
   }
 
-  public VersionSet createVersionSet(){
+  public VersionSet createVersionSet() {
     final String testJsonString1 = "{\"azkaban-base\":{\"version\":\"7.0.4\",\"path\":\"path1\","
         + "\"state\":\"ACTIVE\"},\"azkaban-config\":{\"version\":\"9.1.1\",\"path\":\"path2\","
         + "\"state\":\"ACTIVE\"},\"spark\":{\"version\":\"8.0\",\"path\":\"path3\","

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -729,6 +729,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     ret.put("successEmails", options.getSuccessEmails());
     ret.put("failureEmails", options.getFailureEmails());
     ret.put("flowParam", options.getFlowParameters());
+    ret.put("jobParams", options.getJobParameters());
 
     final FailureAction action = options.getFailureAction();
     String failureAction = null;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -775,7 +775,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final Map<String, Map<String, String>> runtimeProperties = new HashMap<>();
     if (!options.getFlowParameters().isEmpty()) {
       runtimeProperties
-          .put(Constants.ROOT_RUNTIME_PROPERTY, new HashMap<>(options.getFlowParameters()));
+          .put(Constants.ROOT_NODE_IDENTIFIER, new HashMap<>(options.getFlowParameters()));
     }
     for (final Entry<String, Map<String, String>> runtimeProp :
         options.getRuntimeProperties().entrySet()) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -729,7 +729,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     ret.put("successEmails", options.getSuccessEmails());
     ret.put("failureEmails", options.getFailureEmails());
     ret.put("flowParam", options.getFlowParameters());
-    ret.put("jobParams", options.getJobParameters());
+    ret.put("nodeParams", options.getNodeParameters());
 
     final FailureAction action = options.getFailureAction();
     String failureAction = null;
@@ -908,7 +908,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       nodeObj.put("nodes", nodeList);
       nodeObj.put("flowId", base.getFlowId());
     } else {
-      ClusterInfo cluster = node.getClusterInfo();
+      final ClusterInfo cluster = node.getClusterInfo();
       if (cluster != null && cluster.hadoopClusterURL != null) {
         nodeObj.put("cluster", cluster.hadoopClusterURL);
       }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -728,8 +729,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
     ret.put("successEmails", options.getSuccessEmails());
     ret.put("failureEmails", options.getFailureEmails());
+    ret.put("runtimeProperties", mergeRuntimeProperties(options));
+    // For legacy support. This is not used by the Azkaban UI any more.
     ret.put("flowParam", options.getFlowParameters());
-    ret.put("nodeParams", options.getNodeParameters());
 
     final FailureAction action = options.getFailureAction();
     String failureAction = null;
@@ -763,6 +765,23 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     }
     ret.put("nodeStatus", nodeStatus);
     ret.put("disabled", options.getDisabledJobs());
+  }
+
+  /**
+   * Copies flowOverrides under the key "ROOT".
+   */
+  private static Map<String, Map<String, String>> mergeRuntimeProperties(
+      final ExecutionOptions options) {
+    final Map<String, Map<String, String>> runtimeProperties = new HashMap<>();
+    if (!options.getFlowParameters().isEmpty()) {
+      runtimeProperties
+          .put(Constants.ROOT_RUNTIME_PROPERTY, new HashMap<>(options.getFlowParameters()));
+    }
+    for (final Entry<String, Map<String, String>> runtimeProp :
+        options.getRuntimeProperties().entrySet()) {
+      runtimeProperties.put(runtimeProp.getKey(), new HashMap<>(runtimeProp.getValue()));
+    }
+    return runtimeProperties;
   }
 
   private void ajaxCancelFlow(final HttpServletRequest req, final HttpServletResponse resp,

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -33,7 +33,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1579310616"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowtriggerspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executionspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -47,8 +47,11 @@
             </li>
             <li viewpanel="flow-parameters-panel">
               <a href="#">Flow Parameters</a>
-              <div class="menu-caption">Add temporary flow parameters that are used to override
-                global settings for each job.
+              <div class="menu-caption">Add temporary properties: can be used to override existing
+                properties as well as provide new properties.
+                <p><small>Rows with empty Flow/Job are applied
+                to all jobs. Properties can be scoped per sub-flow as well as individual jobs. Most
+                  specific node path takes precedence.</small></p>
               </div>
             </li>
           </ul>
@@ -184,13 +187,14 @@
                 <table class="table table-striped">
                   <thead>
                   <tr>
+                    <th>Flow/Job</th>
                     <th class="property-key">Name</th>
                     <th>Value</th>
                   </tr>
                   </thead>
                   <tbody>
                   <tr id="addRow" class="addRow">
-                    <td id="addRow-col" colspan="2">
+                    <td id="addRow-col" colspan="3">
                       <button type="button" class="btn btn-success btn-xs" id="add-btn">Add Row
                       </button>
                     </td>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -46,12 +46,11 @@
               </div>
             </li>
             <li viewpanel="flow-parameters-panel">
-              <a href="#">Flow Parameters</a>
-              <div class="menu-caption">Add temporary properties: can be used to override existing
-                properties as well as provide new properties.
-                <p><small>Rows with empty Flow/Job are applied
-                to all jobs. Properties can be scoped per sub-flow as well as individual jobs. Most
-                  specific node path takes precedence.</small></p>
+              <a href="#">Runtime Properties</a>
+              <div class="menu-caption">Add temporary properties.
+                <p><small>Rows with "ROOT" Node apply to all jobs. Properties can be scoped per
+                  sub-flow as well as individual jobs. Most specific node path takes precedence.
+                </small></p>
               </div>
             </li>
           </ul>
@@ -178,16 +177,16 @@
               </div>
             </div>
 
-              ## Flow parameters panel
+              ## Runtime properties panel
 
             <div id="flow-parameters-panel" class="side-panel">
-              <h4>Flow Property Override</h4>
+              <h4>Runtime Properties</h4>
               <hr>
               <div id="editTable">
                 <table class="table table-striped">
                   <thead>
                   <tr>
-                    <th>Flow/Job</th>
+                    <th>Node</th>
                     <th class="property-key">Name</th>
                     <th>Value</th>
                   </tr>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -36,7 +36,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1588045179"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow.js?v=1620232349"></script>
   <script type="text/javascript">
     var contextURL = "${context}";

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowtriggerspage.vm
@@ -20,7 +20,7 @@
 
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/executions.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailspage.vm
@@ -23,7 +23,7 @@
 
   <script type="text/javascript" src="${context}/js/jquery.twbsPagination.min.js"></script>
 
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
   <script type="text/javascript" src="${context}/js/azkaban/model/job-log.js?v=1568515440"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/job-details.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectlogpage.vm
@@ -22,7 +22,7 @@
   #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
   <script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-logs.js?v=1576606441"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -23,7 +23,7 @@
   #parse ("azkaban/webapp/servlet/velocity/svgflowincludes.vm")
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -20,7 +20,7 @@
 
 <script type="text/javascript" src="${context}/js/azkaban/util/common.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/date.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1611955192"></script>
 
 <script type="text/javascript" src="${context}/js/azkaban/util/svgutils.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/svg-navigate.js?v=1620232349"></script>
@@ -31,8 +31,8 @@
 
 <script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1623085074"></script>
-<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js?v=1623085074"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1624913123"></script>
+<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js?v=1624913123"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1623085074"></script>
 

--- a/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
@@ -28,24 +28,23 @@ azkaban.GraphModel = Backbone.Model.extend({
   addFlow: function (data) {
     this.processFlowData(data);
     this.set({'data': data});
-    this.set({'nodeIdsAndNestedIds': this.getAllNodeIdsAndNestedIds(data)});
+    this.set({'nestedIds': this.getAllNestedIds(data)});
   },
 
-  getAllNodeIdsAndNestedIds: function (rootNode) {
+  getAllNestedIds: function (rootNode) {
     var nodes = rootNode["nodes"]
-    var nodeIdsAndNestedIds = [];
+    var nestedIds = [];
     for (var i = 0; i < nodes.length; ++i) {
       var node = nodes[i];
-      nodeIdsAndNestedIds.push(node.id);
-      nodeIdsAndNestedIds.push(node.nestedId);
+      nestedIds.push(node.nestedId);
       if (node.type == "flow") {
-        var childIds = this.getAllNodeIdsAndNestedIds(node);
+        var childIds = this.getAllNestedIds(node);
         if (childIds && childIds.length > 0) {
-          nodeIdsAndNestedIds.push(...childIds);
+          nestedIds.push(...childIds);
         }
       }
     }
-    return [...new Set(nodeIdsAndNestedIds)].sort();
+    return [...new Set(nestedIds)].sort();
   },
 
   processFlowData: function (data) {

--- a/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
@@ -28,6 +28,24 @@ azkaban.GraphModel = Backbone.Model.extend({
   addFlow: function (data) {
     this.processFlowData(data);
     this.set({'data': data});
+    this.set({'nodeIdsAndNestedIds': this.getAllNodeIdsAndNestedIds(data)});
+  },
+
+  getAllNodeIdsAndNestedIds: function (rootNode) {
+    var nodes = rootNode["nodes"]
+    var nodeIdsAndNestedIds = [];
+    for (var i = 0; i < nodes.length; ++i) {
+      var node = nodes[i];
+      nodeIdsAndNestedIds.push(node.id);
+      nodeIdsAndNestedIds.push(node.nestedId);
+      if (node.type == "flow") {
+        var childIds = this.getAllNodeIdsAndNestedIds(node);
+        if (childIds && childIds.length > 0) {
+          nodeIdsAndNestedIds.push(...childIds);
+        }
+      }
+    }
+    return [...new Set(nodeIdsAndNestedIds)].sort();
   },
 
   processFlowData: function (data) {

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -93,8 +93,7 @@ function fetchFlowInfo(model, projectName, flowId, execId) {
           "first": data.notifyFailureFirst,
           "last": data.notifyFailureLast
         },
-        "flowParams": data.flowParam,
-        "nodeParams": data.nodeParams,
+        "runtimeProperties": data.runtimeProperties,
         "isRunning": data.running,
         "nodeStatus": data.nodeStatus,
         "concurrentOption": data.concurrentOptions,

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -94,6 +94,7 @@ function fetchFlowInfo(model, projectName, flowId, execId) {
           "last": data.notifyFailureLast
         },
         "flowParams": data.flowParam,
+        "jobParams": data.jobParams,
         "isRunning": data.running,
         "nodeStatus": data.nodeStatus,
         "concurrentOption": data.concurrentOptions,

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -94,7 +94,7 @@ function fetchFlowInfo(model, projectName, flowId, execId) {
           "last": data.notifyFailureLast
         },
         "flowParams": data.flowParam,
-        "jobParams": data.jobParams,
+        "nodeParams": data.nodeParams,
         "isRunning": data.running,
         "nodeStatus": data.nodeStatus,
         "concurrentOption": data.concurrentOptions,

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -55,22 +55,19 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var failureEmailsOverride = $("#override-failure-emails").is(':checked');
     var successEmailsOverride = $("#override-success-emails").is(':checked');
 
-    var flowOverride = {};
-    var nodeOverride = {};
+    var runtimeProperty = {};
     var editRows = $(".editRow");
     for (var i = 0; i < editRows.length; ++i) {
       var row = editRows[i];
-      var jobOrFlow = row.cells[0].firstChild.value;
+      var node = row.cells[0].firstChild.value;
       var td = $(row).find('span');
       var key = $(td[0]).text();
       var val = $(td[1]).text();
 
       if (key && key.length > 0) {
-        if (jobOrFlow && jobOrFlow.length > 0) {
-          nodeOverride[jobOrFlow] = nodeOverride[jobOrFlow] || {}
-          nodeOverride[jobOrFlow][key] = val;
-        } else {
-          flowOverride[key] = val;
+        if (node && node.length > 0) {
+          runtimeProperty[node] = runtimeProperty[node] || {}
+          runtimeProperty[node][key] = val;
         }
       }
     }
@@ -91,8 +88,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
       successEmails: successEmails,
       notifyFailureFirst: notifyFailureFirst,
       notifyFailureLast: notifyFailureLast,
-      flowOverride: flowOverride,
-      nodeOverride: nodeOverride,
+      runtimeProperty: runtimeProperty,
     };
 
     // Set concurrency option, default is skip
@@ -114,8 +110,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var failureEmails = this.model.get("failureEmails");
     var failureActions = this.model.get("failureAction");
     var notifyFailure = this.model.get("notifyFailure");
-    var flowParams = this.model.get("flowParams");
-    var nodeParams = this.model.get("nodeParams");
+    var runtimeProperties = this.model.get("runtimeProperties");
     var isRunning = this.model.get("isRunning");
     var concurrentOption = this.model.get("concurrentOption");
     var pipelineLevel = this.model.get("pipelineLevel");
@@ -167,22 +162,13 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     }
 
     if ($(".editRow").length == 0) {
-      if (flowParams) {
-        for (var key in flowParams) {
-          editTableView.handleAddRow({
-            paramJobOrFlow: '',
-            paramkey: key,
-            paramvalue: flowParams[key]
-          });
-        }
-      }
-      if (nodeParams) {
-        for (var jobOrFlow in nodeParams) {
-          for (var key in nodeParams[jobOrFlow]) {
+      if (runtimeProperties) {
+        for (var jobOrFlow in runtimeProperties) {
+          for (var key in runtimeProperties[jobOrFlow]) {
             editTableView.handleAddRow({
               paramJobOrFlow: jobOrFlow,
               paramkey: key,
-              paramvalue: nodeParams[jobOrFlow][key]
+              paramvalue: runtimeProperties[jobOrFlow][key]
             });
           }
         }
@@ -381,14 +367,13 @@ azkaban.EditTableView = Backbone.View.extend({
     var idSelect = document.createElement("select");
     idSelect.setAttribute("class", "form-control");
 
-    // global option (flowOverride)
-    idSelect.options[0] = new Option("", "");
+    idSelect.options[0] = new Option("ROOT", "ROOT");
 
-    // node-specific options (nodeOverride)
+    // runtime properties
     for (var i = 0; i < nestedIds.length; ++i) {
       var nestedId = nestedIds[i];
       idSelect.options[i + 1] = new Option(nestedId, nestedId);
-      if (jobOrFlow == nestedId) {
+      if (jobOrFlow === nestedId) {
         idSelect.options[i + 1].selected = true;
       }
     }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -206,7 +206,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
 
     var self = this;
     var loadCallback = function () {
-      // loadFlowInfo needs the list of nodeIdsAndNestedIds. that's why loading
+      // loadFlowInfo needs the list of nestedIds. that's why loading
       // it here in the callback.
       self.loadFlowInfo(projectName, flowId, execId);
       if (jobId) {
@@ -342,7 +342,7 @@ azkaban.EditTableView = Backbone.View.extend({
   },
 
   handleAddRow: function (data) {
-    var nodeIdsAndNestedIds = executableGraphModel.get("nodeIdsAndNestedIds");
+    var nestedIds = executableGraphModel.get("nestedIds");
 
     var jobOrFlow = "";
     if (data.paramJobOrFlow) {
@@ -387,10 +387,10 @@ azkaban.EditTableView = Backbone.View.extend({
     idSelect.options[0] = new Option("", "");
 
     // node-specific options (nodeOverride)
-    for (var i = 0; i < nodeIdsAndNestedIds.length; ++i) {
-      var idOrNestedId = nodeIdsAndNestedIds[i];
-      idSelect.options[i + 1] = new Option(idOrNestedId, idOrNestedId);
-      if (jobOrFlow == idOrNestedId) {
+    for (var i = 0; i < nestedIds.length; ++i) {
+      var nestedId = nestedIds[i];
+      idSelect.options[i + 1] = new Option(nestedId, nestedId);
+      if (jobOrFlow == nestedId) {
         idSelect.options[i + 1].selected = true;
       }
     }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -67,9 +67,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
 
       if (key && key.length > 0) {
         if (jobOrFlow && jobOrFlow.length > 0) {
-          if (!nodeOverride.hasOwnProperty(jobOrFlow)) {
-            nodeOverride[jobOrFlow] = {};
-          }
+          nodeOverride[jobOrFlow] = nodeOverride[jobOrFlow] || {}
           nodeOverride[jobOrFlow][key] = val;
         } else {
           flowOverride[key] = val;

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -56,7 +56,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var successEmailsOverride = $("#override-success-emails").is(':checked');
 
     var flowOverride = {};
-    var jobOverride = {};
+    var nodeOverride = {};
     var editRows = $(".editRow");
     for (var i = 0; i < editRows.length; ++i) {
       var row = editRows[i];
@@ -67,10 +67,10 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
 
       if (key && key.length > 0) {
         if (jobOrFlow && jobOrFlow.length > 0) {
-          if (!jobOverride.hasOwnProperty(jobOrFlow)) {
-            jobOverride[jobOrFlow] = {};
+          if (!nodeOverride.hasOwnProperty(jobOrFlow)) {
+            nodeOverride[jobOrFlow] = {};
           }
-          jobOverride[jobOrFlow][key] = val;
+          nodeOverride[jobOrFlow][key] = val;
         } else {
           flowOverride[key] = val;
         }
@@ -94,7 +94,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
       notifyFailureFirst: notifyFailureFirst,
       notifyFailureLast: notifyFailureLast,
       flowOverride: flowOverride,
-      jobOverride: jobOverride,
+      nodeOverride: nodeOverride,
     };
 
     // Set concurrency option, default is skip
@@ -117,7 +117,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var failureActions = this.model.get("failureAction");
     var notifyFailure = this.model.get("notifyFailure");
     var flowParams = this.model.get("flowParams");
-    var jobParams = this.model.get("jobParams");
+    var nodeParams = this.model.get("nodeParams");
     var isRunning = this.model.get("isRunning");
     var concurrentOption = this.model.get("concurrentOption");
     var pipelineLevel = this.model.get("pipelineLevel");
@@ -178,13 +178,13 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
           });
         }
       }
-      if (jobParams) {
-        for (var jobOrFlow in jobParams) {
-          for (var key in jobParams[jobOrFlow]) {
+      if (nodeParams) {
+        for (var jobOrFlow in nodeParams) {
+          for (var key in nodeParams[jobOrFlow]) {
             editTableView.handleAddRow({
               paramJobOrFlow: jobOrFlow,
               paramkey: key,
-              paramvalue: jobParams[jobOrFlow][key]
+              paramvalue: nodeParams[jobOrFlow][key]
             });
           }
         }
@@ -386,7 +386,7 @@ azkaban.EditTableView = Backbone.View.extend({
     // global option (flowOverride)
     idSelect.options[0] = new Option("", "");
 
-    // job-specific options (jobOverride)
+    // node-specific options (nodeOverride)
     for (var i = 0; i < nodeIdsAndNestedIds.length; ++i) {
       var idOrNestedId = nodeIdsAndNestedIds[i];
       idSelect.options[i + 1] = new Option(idOrNestedId, idOrNestedId);


### PR DESCRIPTION
Until now Azkaban has only supported setting flat flowOverride properties that affect all jobs. While keeping that capability, this PR allows additionally overriding properties for specific jobs or sub-flows.

On the UI side the flow override is extended to be similar with job level SLA settings: there's a dropdown picker for the nested id (includes all nodes which means leaf job nodes as well as sub-flows).

----

This change is 100% backward compatible.

----

## UI testing

Some screenshots from the UI below.

I used this kind of flow for manual testing:

<img width="478" alt="Näyttökuva 2020-9-14 kello 23 23 49" src="https://user-images.githubusercontent.com/4446608/93134384-658c7600-f6e1-11ea-9c9f-3b6ddbadb074.png">

The new thing in UI is the Flow/Job dropdown:

<img width="949" alt="Näyttökuva 2021-4-7 kello 20 26 14" src="https://user-images.githubusercontent.com/4446608/113908988-db704000-97df-11eb-937e-81aee2dcf2aa.png">

An example of some rows entered:

<img width="950" alt="Näyttökuva 2021-4-7 kello 20 27 16" src="https://user-images.githubusercontent.com/4446608/113909004-e2974e00-97df-11eb-826e-7eb1ea87d936.png">

And log lines on how that's reflected in the backend: 

<img width="1017" alt="Näyttökuva 2021-4-7 kello 20 27 56" src="https://user-images.githubusercontent.com/4446608/113909043-eb881f80-97df-11eb-8848-cc712bcc2465.png">

----

## TODOs

### Documentation

Should the docs be updated to include this?