### PR TITLE
Fix flaky queue duration condition in JobRunnerTest

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -88,7 +88,7 @@ public class JobRunnerTest {
   }
 
   @Test
-  public void testBasicRun() throws IOException {
+  public void testBasicRun() throws Exception {
     final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
@@ -96,6 +96,8 @@ public class JobRunnerTest {
     final ExecutableNode node = runner.getNode();
     // Job starts to queue
     runner.setTimeInQueue(System.currentTimeMillis());
+    // ensure that queue duration should be > 0
+    Thread.sleep(1L);
 
     eventCollector.handleEvent(Event.create(null, EventType.JOB_STARTED, new EventData(node)));
     Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED


### PR DESCRIPTION
Fixes test failure like this:
```
azkaban.execapp.JobRunnerTest > testBasicRun FAILED
    java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:86)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.junit.Assert.assertTrue(Assert.java:52)
        at azkaban.execapp.JobRunnerTest.testBasicRun(JobRunnerTest.java:112)
```

Which points to this line:
https://github.com/azkaban/azkaban/blob/783f88d490a65ecbc1283c317eb9f662056f4fba/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java#L112

At least locally this test was often executed so fast that time in queue was set to 0. That must mean that `System.currentTimeMillis()` had not advanced between the times when job was queued and executed. Add 1 ms sleep to ensure that queue time is always at least 1.