### PR TITLE
Add CSRF token validation for modifying project permissions

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/CSRFTokenUtility.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/CSRFTokenUtility.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.webapp;
+
+import azkaban.server.session.Session;
+import azkaban.utils.StringUtils;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Random;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.log4j.Logger;
+
+
+/**
+ * Singleton Class for generating CSRF token from session-id. This class uses "HmacSHA256" algorithm
+ * and a secret-key to get the hashed value of session-id, which will be used as the CSRF token.
+ */
+public class CSRFTokenUtility {
+
+  private static final Logger logger = Logger.getLogger(AzkabanWebServer.class);
+  private static final String ALGORITHM = "HmacSHA256";
+  private Mac hashFunction;
+  private static CSRFTokenUtility instance;
+
+  private CSRFTokenUtility() {
+    // To be instantiated only by this class
+  }
+
+  /**
+   * @return A singleton instance of CSRFTokenUtility
+   */
+  public static synchronized CSRFTokenUtility getCSRFTokenUtility() {
+    if (null == instance) {
+      CSRFTokenUtility csrfTokenUtility = new CSRFTokenUtility();
+      try {
+        csrfTokenUtility.initHashFunction();
+      } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+        logger.info("Unable to initialize the hash function for creating CSRF Token", e);
+        return null;
+      }
+      instance = csrfTokenUtility;
+    }
+    return instance;
+  }
+
+  /**
+   * @param session containing session-id
+   * @return CSRF token derived from session-id
+   */
+  public String getCSRFTokenFromSession(Session session) {
+    if (null == session || StringUtils.isEmpty(session.getSessionId())) {
+      return null;
+    }
+    String sessionId = session.getSessionId();
+    return getCSRFTokenFromSessionId(sessionId);
+  }
+
+  /**
+   * @param sessionId
+   * @return CSRF token derived from session-id
+   */
+  private String getCSRFTokenFromSessionId(String sessionId) {
+    byte[] bytes;
+    try {
+      bytes = sessionId.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      logger.info("Unable to convert sessionId to bytes", e);
+      return null;
+    }
+    byte[] hashedSessionId = this.hashFunction.doFinal(bytes);
+    return Base64.getEncoder().encodeToString(hashedSessionId);
+  }
+
+  /**
+   * @return Eight bytes SecretKey to be used for initializing HmacSHA256
+   */
+  private static byte[] getSecretKey() {
+    Random randomGen = new Random();
+    byte[] secretKey = new byte[8];
+    randomGen.nextBytes(secretKey);
+    return secretKey;
+  }
+
+  private void initHashFunction() throws NoSuchAlgorithmException, InvalidKeyException {
+    byte[] secretKey = getSecretKey();
+    initHashFunction(secretKey);
+  }
+
+  private void initHashFunction(byte[] secretKey)
+      throws NoSuchAlgorithmException, InvalidKeyException {
+    Mac mac = Mac.getInstance(ALGORITHM);
+    SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey, ALGORITHM);
+    mac.init(secretKeySpec);
+    this.hashFunction = mac;
+  }
+
+  /**
+   * @param sessionId
+   * @param csrfTokenFromRequest
+   * @return True if the csrfTokenFromRequest matches with the CSRFToken generated from session-id,
+   * otherwise false
+   */
+  public boolean validateCSRFToken(String sessionId, String csrfTokenFromRequest) {
+    String csrfTokenFromSessionId = getCSRFTokenFromSessionId(sessionId);
+    if (StringUtils.isEmpty(csrfTokenFromSessionId)) {
+      return false;
+    }
+    return csrfTokenFromRequest.equals(csrfTokenFromSessionId);
+  }
+}

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/permissionspage.vm
@@ -21,7 +21,7 @@
   #parse ("azkaban/webapp/servlet/velocity/style.vm")
   #parse ("azkaban/webapp/servlet/velocity/javascript.vm")
 
-  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js?v=1568065399"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/project-permissions.js?v=1601287289"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
@@ -34,6 +34,13 @@
   </script>
 </head>
 <body>
+
+  <form id="csrf-form">
+    <fieldset>
+      <input type="hidden" name="csrf-token" id="csrf-token"
+             value=${csrfToken}>
+    </fieldset>
+  </form>
 
   #set ($current_page = "all")
   #parse ("azkaban/webapp/servlet/velocity/nav.vm")

--- a/azkaban-web-server/src/test/java/azkaban/webapp/CSRFTokenUtilityTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/CSRFTokenUtilityTest.java
@@ -1,0 +1,39 @@
+package azkaban.webapp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import azkaban.server.session.Session;
+import azkaban.user.User;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CSRFTokenUtilityTest {
+
+  @Test
+  public void assertSingleton() {
+    CSRFTokenUtility csrfTokenUtility1 = CSRFTokenUtility.getCSRFTokenUtility();
+    CSRFTokenUtility csrfTokenUtility2 = CSRFTokenUtility.getCSRFTokenUtility();
+    assertThat(csrfTokenUtility1).isSameAs(csrfTokenUtility2).isNotNull();
+  }
+
+  @Test
+  public void assertConsistentHash() {
+    CSRFTokenUtility csrfTokenUtility = CSRFTokenUtility.getCSRFTokenUtility();
+    Session luke = new Session(UUID.randomUUID().toString(), new User("luke"), "0.0.0.0");
+    String csrfToken1 = csrfTokenUtility.getCSRFTokenFromSession(luke);
+    String csrfToken2 = csrfTokenUtility.getCSRFTokenFromSession(luke);
+    Assert.assertEquals(csrfToken1, csrfToken2);
+  }
+
+  @Test
+  public void assertUniqueHash() {
+    CSRFTokenUtility csrfTokenUtility = CSRFTokenUtility.getCSRFTokenUtility();
+    Session luke = new Session(UUID.randomUUID().toString(), new User("luke"), "0.0.0.0");
+    Session leia = new Session(UUID.randomUUID().toString(), new User("leia"), "0.0.0.0");
+    String csrfTokenLuke = csrfTokenUtility.getCSRFTokenFromSession(luke);
+    String csrfTokenLeia = csrfTokenUtility.getCSRFTokenFromSession(leia);
+    Assert.assertNotEquals(csrfTokenLuke, csrfTokenLeia);
+  }
+
+}

--- a/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-permissions.js
@@ -75,6 +75,7 @@ azkaban.RemoveProxyView = Backbone.View.extend({
   handleRemoveProxy: function () {
     var requestURL = contextURL + "/manager";
     var proxyName = this.el.proxyName;
+    var csrfTokenVal = $('#csrf-token').val().trim();
     var requestData = {
       "project": projectName,
       "name": proxyName,
@@ -91,7 +92,14 @@ azkaban.RemoveProxyView = Backbone.View.extend({
       window.location.replace(replaceURL);
     };
 
-    $.get(requestURL, requestData, successHandler, "json");
+    $.ajax({
+      url: requestURL,
+      data: requestData,
+      type: "POST",
+      headers: { 'X-CSRF-TOKEN': csrfTokenVal },
+      success: successHandler,
+      dataType: "json"
+    });
   }
 });
 
@@ -114,6 +122,7 @@ azkaban.AddProxyView = Backbone.View.extend({
   handleAddProxy: function () {
     var requestURL = contextURL + "/manager";
     var name = $('#proxy-user-box').val().trim();
+    var csrfTokenVal = $('#csrf-token').val().trim();
     var requestData = {
       "project": projectName,
       "name": name,
@@ -131,7 +140,14 @@ azkaban.AddProxyView = Backbone.View.extend({
       var replaceURL = requestURL + "?project=" + projectName + "&permissions";
       window.location.replace(replaceURL);
     };
-    $.get(requestURL, requestData, successHandler, "json");
+    $.ajax({
+      url: requestURL,
+      data: requestData,
+      type: "POST",
+      headers: { 'X-CSRF-TOKEN': csrfTokenVal },
+      success: successHandler,
+      dataType: "json"
+    });
   }
 });
 
@@ -279,6 +295,7 @@ azkaban.ChangePermissionView = Backbone.View.extend({
   handleChangePermissions: function (evt) {
     var requestURL = contextURL + "/manager";
     var name = $('#user-box').val().trim();
+    var csrfTokenVal = $('#csrf-token').val().trim();
     var command = this.newPerm ? "addPermission" : "changePermission";
     var group = this.group;
 
@@ -307,8 +324,14 @@ azkaban.ChangePermissionView = Backbone.View.extend({
       var replaceURL = requestURL + "?project=" + projectName + "&permissions";
       window.location.replace(replaceURL);
     };
-
-    $.get(requestURL, requestData, successHandler, "json");
+    $.ajax({
+      url: requestURL,
+      data: requestData,
+      type: "POST",
+      headers: { 'X-CSRF-TOKEN': csrfTokenVal },
+      success: successHandler,
+      dataType: "json"
+    });
   }
 });
 


### PR DESCRIPTION
CSRF token validation for modifying project permissions
We have used "Synchronizer token pattern" for CSRF validation. This code generates CSRF token by hashing session-id hence csrf tokens are not kept in memory. 
CSRF token will be sent as an HTTP header rather than request parameters, as it is the more recommended approach
