### PR TITLE
use POST instead of GET for executing flow

### DIFF
--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -71,7 +71,7 @@ function executeFlow(executingData) {
     }
   };
 
-  $.get(executeURL, executingData, successHandler, "json");
+  $.post(executeURL, executingData, successHandler, "json");
 }
 
 function fetchFlowInfo(model, projectName, flowId, execId) {

--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -622,7 +622,7 @@ This API executes a flow via an ajax call, supporting a rich selection
 of different options. Running an individual job can also be achieved via
 this API by disabling all other jobs in the same flow.
 
--  **Method:** GET
+-  **Method:** POST
 -  **Request URL:** /executor?ajax=executeFlow
 -  **Parameter Location:** Request Query String
 
@@ -742,7 +742,7 @@ Here is a curl command example:
 
 .. code-block:: guess
 
-   curl -k --get --data 'session.id=189b956b-f39f-421e-9a95-e3117e7543c9' --data 'ajax=executeFlow' --data 'project=azkaban-test-project' --data 'flow=test' https://localhost:8443/executor
+   curl -k -X POST --data "session.id=189b956b-f39f-421e-9a95-e3117e7543c9&ajax=executeFlow&project=azkaban-test-project&flow=test" https://localhost:8443/executor
 
 Sample response:
 

--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -27,7 +27,7 @@ Authenticate
 
 -  **Method:** POST
 -  **Request URL:** /?action=login
--  **Parameter Location:** Request Query String
+-  **Parameter Location:** Request body
 
 This API helps authenticate a user and provides a ``session.id`` in
 response.


### PR DESCRIPTION
because GET has url length limitation, this will cause problem when we have a large flow, and we disable a lot of the job inside, as the disabled jobs list will need to be included in the request param.

