### PR TITLE
Fix startup errors in some environments

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
@@ -47,7 +47,7 @@ public class WebUtils {
     try {
       azkabanEventReporter = ServiceProvider.SERVICE_PROVIDER
           .getInstance(AzkabanEventReporter.class);
-    } catch (NullPointerException | ConfigurationException e) {
+    } catch (Exception e) {
       Logger.getLogger(WebUtils.class.getName()).warn("AzkabanEventReporter not configured", e);
     }
   }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/javascript.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/javascript.vm
@@ -29,7 +29,8 @@
      * used by all the views whenever APIs need to be called. Those wrapper functions should
      * apply application related parameters common to all requests such as this header.
     *#
-  $.ajaxSetup({
+  #set ( $d = "$" )
+  ${d}.ajaxSetup({
     headers: {'Azkaban-Trace-Origin': 'webapp'}
   });
 </script>


### PR DESCRIPTION
1. Some configuration errors resulted in uncaught exceptions from WebUtils that prevented WS from starting.
2. In some environments Velocity template engine failed to process unescaped dollar sign resulting in 500 error to UI.

Tested (1) on local soloserver, (2) on Pokemon and (3) in "certain" environment (where it failed before) by patching `javascript.vm`, splicing patched file into WS JAR file in `lib/, restarting WS and observing the final rendered templates via Dev Tools in Chrome. In all environments the template rendered successfully and correctly.