### PR TITLE
Introduce a per-cluster HadoopSecurityManagerClassLoader to reduce the classloading workload on the JVM.

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -23,6 +23,7 @@ import azkaban.utils.Props;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
 
@@ -32,6 +33,19 @@ import org.apache.log4j.Logger;
 public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implements IHadoopJob {
 
   private final HadoopProxy hadoopProxy;
+
+  // when jobtype runs in a classloader that is different than that of HadoopSecurityManager
+  // any call to new Configuration() in jobtype will not add the following files as default
+  // resources. This is not a problem when HadoopSecurityManager_H_2_0 and jobtype plugin code
+  // runs within the same classloader because HadoopSecurityManager_H_2_0 does it already.
+  static {
+    Configuration.addDefaultResource("mapred-default.xml");
+    Configuration.addDefaultResource("mapred-site.xml");
+    Configuration.addDefaultResource("yarn-default.xml");
+    Configuration.addDefaultResource("yarn-site.xml");
+    Configuration.addDefaultResource("hdfs-default.xml");
+    Configuration.addDefaultResource("hdfs-site.xml");
+  }
 
   public AbstractHadoopJavaProcessJob(String jobid, Props sysProps, Props jobProps, Logger logger) {
     super(jobid, sysProps, jobProps, logger);

--- a/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
@@ -287,7 +287,7 @@ public class Cluster {
     private final static Logger LOG = LoggerFactory.getLogger(HadoopSecurityManagerClassLoader.class);
 
     private static final String LOG4J_CLASS_PREFIX =
-        Logger.class.getPackage().getName();
+        org.apache.log4j.Logger.class.getPackage().getName();
 
     private final ClassLoader parent;
 

--- a/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import joptsimple.internal.Strings;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A in-memory representation of a Hadoop cluster loaded by {@link ClusterLoader} for each directory
@@ -51,7 +52,7 @@ import org.apache.log4j.Logger;
  * as part of their job properties.
  */
 public class Cluster {
-  private static final Logger LOGGER = Logger.getLogger(Cluster.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Cluster.class);
 
   public static final Cluster UNKNOWN = new Cluster("UNKNOWN", new Props());
   public static final String DEFAULT_CLUSTER = "default";
@@ -283,7 +284,7 @@ public class Cluster {
    * A per-cluster classloader for HadoopSecurityManager.
    */
   public static class HadoopSecurityManagerClassLoader extends URLClassLoader {
-    private final static Logger LOG = Logger.getLogger(HadoopSecurityManagerClassLoader.class);
+    private final static Logger LOG = LoggerFactory.getLogger(HadoopSecurityManagerClassLoader.class);
 
     private static final String LOG4J_CLASS_PREFIX =
         Logger.class.getPackage().getName();

--- a/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
@@ -16,9 +16,11 @@
 package azkaban.cluster;
 
 import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,7 +28,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import joptsimple.internal.Strings;
+import org.apache.log4j.Logger;
 
 /**
  * A in-memory representation of a Hadoop cluster loaded by {@link ClusterLoader} for each directory
@@ -47,6 +51,7 @@ import joptsimple.internal.Strings;
  * as part of their job properties.
  */
 public class Cluster {
+  private static final Logger LOGGER = Logger.getLogger(Cluster.class);
 
   public static final Cluster UNKNOWN = new Cluster("UNKNOWN", new Props());
   public static final String DEFAULT_CLUSTER = "default";
@@ -62,10 +67,14 @@ public class Cluster {
   // org.apache.xalan.processor.TransformerFactoryImpl, a behavior conflicts with JDK.
   public static final String EXCLUDED_LIBRARY_PATTERNS = "library.excluded.patterns";
 
+  public static final String HADOOP_SECURITY_MANAGER_DEPENDENCY_COMPONENTS =
+      "hadoop.security.manager.dependency.components";
+
   public final String clusterId;
-  public final Props properties;
+  private final Props properties;
   private final List<Pattern> excludedLibraryPatterns;
   private final Map<String, List<URL>> componentURLs = new ConcurrentHashMap<>();
+  private volatile HadoopSecurityManagerClassLoader securityManagerClassLoader;
 
   public Cluster(final String clusterId, final Props properties) {
     this.clusterId = clusterId;
@@ -76,6 +85,42 @@ public class Cluster {
     for (final String exclusion : exclusionPatterns) {
       this.excludedLibraryPatterns.add(Pattern.compile(exclusion));
     }
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public Props getProperties() {
+    return properties;
+  }
+
+  public HadoopSecurityManagerClassLoader getSecurityManagerClassLoader() {
+    if (this.securityManagerClassLoader == null) {
+      synchronized(this) {
+        if (this.securityManagerClassLoader == null) {
+          final List<String> hadoopSecurityManagerDependencyComponents = this.properties.getStringList(
+              HADOOP_SECURITY_MANAGER_DEPENDENCY_COMPONENTS);
+          final List<URL> clusterUrls;
+          try {
+            clusterUrls = getClusterComponentURLs(hadoopSecurityManagerDependencyComponents);
+          } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(
+                String.format("Invalid dependency components for " +
+                    HadoopSecurityManagerClassLoader.class.getName() + " of cluster %s", clusterId));
+          }
+          final URL[] urls = new URL[clusterUrls.size()];
+          clusterUrls.toArray(urls);
+          this.securityManagerClassLoader =
+              new HadoopSecurityManagerClassLoader(urls, Cluster.class.getClassLoader(), clusterId);
+          LOGGER.info(String.format(HadoopSecurityManagerClassLoader.class.getName() + " for "
+                  + "cluster %s is loaded with URLs:  %s", clusterId,
+              clusterUrls.stream().map(URL::toString).collect(Collectors.joining(", "))));
+        }
+      }
+    }
+
+    return this.securityManagerClassLoader;
   }
 
   @Override
@@ -226,7 +271,113 @@ public class Cluster {
       if (libPath != null) {
         classpaths.add(libPath);
       }
+      if (libPath == null) {
+        throw new IllegalArgumentException(
+            String.format("Could not find libraries for component: %s ", component));
+      }
     }
     return classpaths.isEmpty() ? Strings.EMPTY : String.join(PATH_DELIMITER, classpaths);
+  }
+
+  /**
+   * A per-cluster classloader for HadoopSecurityManager.
+   */
+  public static class HadoopSecurityManagerClassLoader extends URLClassLoader {
+    private final static Logger LOG = Logger.getLogger(HadoopSecurityManagerClassLoader.class);
+
+    private static final String LOG4J_CLASS_PREFIX =
+        Logger.class.getPackage().getName();
+
+    private final ClassLoader parent;
+
+    static {
+       if (!ClassLoader.registerAsParallelCapable()) {
+          LOG.warn("HadoopSecurityManagerClassLoader's request of registering as parallel capable"
+              + " failed.");
+       }
+    }
+
+    public HadoopSecurityManagerClassLoader(URL[] urls, ClassLoader parent, String clusterId) {
+      super(urls, Cluster.class.getClassLoader());
+      this.parent = Cluster.class.getClassLoader();
+    }
+
+    /**
+     * Try to load resources from this classloader's URLs. Note that this is like the servlet spec,
+     * not the usual Java behaviour where we ask the parent classloader to attempt to load first.
+     */
+    @Override
+    public URL getResource(final String name) {
+      URL url = findResource(name);
+      // borrowed from Hadoop, if the resource that starts with '/' is not found, and tries again
+      // with the leading '/' removed, in case the resource name was incorrectly specified
+      if (url == null && name.startsWith("/")) {
+        LOG.debug("Remove leading / off " + name);
+        url = findResource(name.substring(1));
+      }
+
+      if (url == null) {
+        url = this.parent.getResource(name);
+      }
+
+      if (url != null) {
+        LOG.debug("getResource(" + name + ")=" + url);
+      }
+
+      return url;
+    }
+
+    /**
+     * Try to load class from this classloader's URLs. Note that this is like servlet, not the
+     * standard behaviour where we ask the parent to attempt to load first.
+     */
+    @Override
+    protected Class<?> loadClass(final String name, final boolean resolve)
+        throws ClassNotFoundException {
+
+      synchronized (getClassLoadingLock(name)) {
+        Class<?> c = findLoadedClass(name);
+        ClassNotFoundException ex = null;
+
+        if (c == null && !name.startsWith(LOG4J_CLASS_PREFIX) && !name.equals(Props.class.getName())) {
+          // if this class has not been loaded before
+          try {
+            c = findClass(name);
+            if (c != null) {
+              LOG.debug("Loaded class: " + name);
+            }
+          } catch (final ClassNotFoundException e) {
+            LOG.debug(e.toString());
+            ex = e;
+          }
+        }
+
+
+        // try parent
+        if (c == null) {
+          c = this.parent.loadClass(name);
+          if (c != null) {
+            LOG.debug("Loaded class from parent: " + name);
+          }
+        }
+
+        if (c == null) {
+          throw ex != null ? ex : new ClassNotFoundException(name);
+        }
+
+        if (resolve) {
+          // link the specified class as described in the "Execution" chapter of
+          // "The Java Language Specification"
+          resolveClass(c);
+        }
+        return c;
+      }
+
+    }
+
+    @VisibleForTesting
+    void addURL(Class clazz) {
+      super.addURL(clazz.getProtectionDomain().getCodeSource().getLocation());
+    }
   }
 }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JobClassLoader.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JobClassLoader.java
@@ -24,14 +24,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The classloader associated with a job being executed. It is set to the context classloader of the
- * JobRunner thread executing the job.
+ * A per-job classloader in which only jobtype plugin classes are loaded.
+ * NOTE classes in package azkaban.security and its dependencies, log4j
+ * classes and {@link Props} are loaded from its parent classloader.
  */
 public class JobClassLoader extends URLClassLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(JobClassLoader.class);
   private static final String LOG4J_CLASS_PREFIX =
       org.apache.log4j.Logger.class.getPackage().getName();
+  private static final String AZKABAN_SECURITY_CLASS = "azkaban.security";
   private final String jobId;
   private final ClassLoader parent;
 
@@ -86,7 +88,8 @@ public class JobClassLoader extends URLClassLoader {
 
     // A Job instance is instantiated with an instance of Logger and Props loaded from the parent class
     // in JobTypeManager. We must delegate loading of them both to the parent class as such.
-    if (c == null && !name.startsWith(LOG4J_CLASS_PREFIX) && !name.equals(Props.class.getName())) {
+    if (c == null && !name.startsWith(LOG4J_CLASS_PREFIX) && !name.equals(Props.class.getName())
+        && !name.startsWith(AZKABAN_SECURITY_CLASS)) {
       // if this class has not been loaded before
       try {
         c = findClass(name);

--- a/azkaban-common/src/test/java/azkaban/cluster/HadoopSecurityManagerClassLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/cluster/HadoopSecurityManagerClassLoaderTest.java
@@ -74,7 +74,7 @@ public class HadoopSecurityManagerClassLoaderTest {
    * Test the case where the define job class does not exist.
    */
   @Test(expected = ClassNotFoundException.class)
-  public void testNonexistClass() throws ClassNotFoundException {
+  public void testNonExistClass() throws ClassNotFoundException {
     final ClassLoader currentClassLoader = getClass().getClassLoader();
     final ClassLoader hadoopSecurityManagerClassLoader =
         new HadoopSecurityManagerClassLoader(

--- a/azkaban-common/src/test/java/azkaban/cluster/HadoopSecurityManagerClassLoaderTest.java
+++ b/azkaban-common/src/test/java/azkaban/cluster/HadoopSecurityManagerClassLoaderTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.cluster;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+import azkaban.cluster.Cluster.HadoopSecurityManagerClassLoader;
+import azkaban.utils.Props;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for {@link azkaban.cluster.Cluster.HadoopSecurityManagerClassLoader}.
+ */
+public class HadoopSecurityManagerClassLoaderTest {
+
+  private final static String RESOURCE_FILE = "resource.txt";
+  private static final String SAMPLE_JAR = "helloworld.jar";
+  @Rule
+  public final TemporaryFolder testDir = new TemporaryFolder();
+
+  /**
+   * Test the case where a resource file exists in the HadoopSecurityManager classloader.
+   */
+  @Test
+  public void testGetResource() throws IOException {
+    final URL testJar = makeTestJar().toURI().toURL();
+
+    final ClassLoader currentClassLoader = getClass().getClassLoader();
+    final ClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[]{testJar}, currentClassLoader, "testCluster");
+
+    Assert.assertNull("Resource should not be found in the parent classloader",
+        currentClassLoader.getResource(RESOURCE_FILE));
+    Assert.assertNotNull("Resource should be found in HadoopSecurityManagerClassLoader",
+        hadoopSecurityManagerClassLoader.getResource(RESOURCE_FILE));
+  }
+
+  private File makeTestJar() throws IOException {
+    final File jarFile = this.testDir.newFile("test.jar");
+    try (final JarOutputStream out = new JarOutputStream(new FileOutputStream(jarFile))) {
+      final ZipEntry entry = new ZipEntry(RESOURCE_FILE);
+      out.putNextEntry(entry);
+      out.write("hello".getBytes(UTF_8));
+      out.closeEntry();
+    }
+    return jarFile;
+  }
+
+  /**
+   * Test the case where the define job class does not exist.
+   */
+  @Test(expected = ClassNotFoundException.class)
+  public void testNonexistClass() throws ClassNotFoundException {
+    final ClassLoader currentClassLoader = getClass().getClassLoader();
+    final ClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[]{}, currentClassLoader, "testCluster");
+
+    Assert.assertNull("This class does not exist",
+        hadoopSecurityManagerClassLoader.loadClass("nonexistent.class.name"));
+  }
+
+  /**
+   * Test class loading of a class that is available only in the parent classloader.
+   */
+  @Test
+  public void testClassAvailableInParentClassLoader() throws ClassNotFoundException {
+    final ClassLoader currentClassLoader = getClass().getClassLoader();
+    final ClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[]{}, currentClassLoader, "testCluster");
+    final Class clazz = hadoopSecurityManagerClassLoader.loadClass(
+        HadoopSecurityManagerClassLoaderTest.class.getName());
+    Assert.assertEquals(currentClassLoader, clazz.getClassLoader());
+  }
+
+  /**
+   * Test class loading of a class that is available only in the HadoopSecurityManagerClassLoader.
+   * The class is provided in 'helloworld.jar'.
+   */
+  @Test
+  public void testClassAvailableInHadoopSecurityManagerClassLoader()
+      throws MalformedURLException, ClassNotFoundException {
+    final ClassLoader currentClassLoader = getClass().getClassLoader();
+
+    final File helloworldJar = new File(currentClassLoader.getResource(SAMPLE_JAR).getFile());
+    final URL helloworlURL = helloworldJar.toURI().toURL();
+
+    final ClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[]{helloworlURL}, currentClassLoader, "testCluster");
+
+    final Class clazz = hadoopSecurityManagerClassLoader.loadClass(
+        "org.hello.world.HelloWorld");
+    Assert.assertEquals(hadoopSecurityManagerClassLoader, clazz.getClassLoader());
+  }
+
+  /**
+   * Check {@link org.apache.log4j.Logger} is always loaded by its parent classloader.
+   */
+  @Test
+  public void testLog4JClass() throws ClassNotFoundException {
+    ClassLoader currentClassLoader = getClass().getClassLoader();
+    HadoopSecurityManagerClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[] {}, currentClassLoader, "testCluster");
+    // make org.apache.log4j.Logger class available to the HadoopSecurityManagerClassLoader
+    hadoopSecurityManagerClassLoader.addURL(org.apache.log4j.Logger.class);
+
+    Class clazz = hadoopSecurityManagerClassLoader.loadClass(
+        org.apache.log4j.Logger.class.getName());
+    Assert.assertEquals(currentClassLoader, clazz.getClassLoader());
+  }
+
+  /**
+   * Check {@link azkaban.utils.Props} is always loaded by its parent classloader.
+   */
+  @Test
+  public void testPropsClass() throws ClassNotFoundException {
+    ClassLoader currentClassLoader = getClass().getClassLoader();
+    HadoopSecurityManagerClassLoader hadoopSecurityManagerClassLoader =
+        new HadoopSecurityManagerClassLoader(
+            new URL[] {}, currentClassLoader, "testCluster");
+    // make azkaban.utils.Props class available to the HadoopSecurityManagerClassLoader
+    hadoopSecurityManagerClassLoader.addURL(Props.class);
+
+    Class clazz = hadoopSecurityManagerClassLoader.loadClass(Props.class.getName());
+    Assert.assertEquals(currentClassLoader, clazz.getClassLoader());
+  }
+}

--- a/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/anothertestjob/private.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/anothertestjob/private.properties
@@ -1,2 +1,3 @@
 jobtype.classpath=lib/*
 jobtype.class=azkaban.jobtype.FakeJavaJob
+jobtype.dependency.components=hadoop

--- a/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/common.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/common.properties
@@ -1,0 +1,3 @@
+commonprop1=commonprop1
+commonprop2=commonprop2
+commonprop3=commonprop3

--- a/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/commonprivate.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/commonprivate.properties
@@ -1,0 +1,3 @@
+commonprivate1=commonprivate1
+commonprivate2=commonprivate2
+commonprivate3=commonprivate3

--- a/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/testjob/plugin.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/testjob/plugin.properties
@@ -1,0 +1,4 @@
+pluginprops1=1
+pluginprops2=2
+pluginprops3=3
+commonprop3=pluginprops

--- a/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/testjob/private.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypeswithrouting/testjob/private.properties
@@ -1,0 +1,3 @@
+jobtype.class=azkaban.jobtype.FakeJavaJob2
+commonprivate3=private3
+testprivate=0

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -748,7 +748,7 @@ public class JobRunner extends EventHandler implements Runnable {
       try {
         final JobTypeManager.JobParams jobParams = this.jobtypeManager
             .createJobParams(this.jobId, this.props, this.logger);
-        Thread.currentThread().setContextClassLoader(jobParams.jobClassLoader);
+        Thread.currentThread().setContextClassLoader(jobParams.contextClassLoader);
         this.job = JobTypeManager.createJob(this.jobId, jobParams, this.logger);
 
         if (jobParams.jobProps.containsKey(CommonJobProperties.TARGET_CLUSTER_ID)) {


### PR DESCRIPTION
Right now, the per-job ClassLoader takes care of loading the HadoopSecurityManager class and its dependencies. 

Because each job creates its own ClassLoader instance, we are essentially doing loading HadoopSecurityManager class and its large dependencies over and over for each job. This triggers a bottleneck in the JVM under the classloader subsystem when many threads are doing classloading at the same time, contending for a global lock.

By introducing a HadoopSecurityManager ClassLoader per cluster, we only load HadoopSecurityManager class and its dependencies once per cluster, avoiding hitting the JVM classloader subsystem bottleneck.

NOTE we still create an instance of HadoopSecurityManager per job, which we don't see any issue with, in the current stress testing.