### PR TITLE
Make MetricsManager more robust to changes in metrics reporter Ctor

### DIFF
--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -120,10 +120,11 @@ public class MetricsManager {
     if (metricsReporterClassName != null && metricsServerURL != null) {
       try {
         log.info("metricsReporterClassName: " + metricsReporterClassName);
-        final Class metricsClass = Class.forName(metricsReporterClassName);
+        final Class<?> metricsClass = Class.forName(metricsReporterClassName);
 
-        final Constructor[] constructors = metricsClass.getConstructors();
-        constructors[0].newInstance(reporterName, this.registry, metricsServerURL);
+        final Constructor<?> ctor = metricsClass.getConstructor(reporterName.getClass(),
+            this.registry.getClass(), metricsServerURL.getClass(), boolean.class);
+        ctor.newInstance(reporterName, this.registry, metricsServerURL, true);
 
       } catch (final Exception e) {
         log.error("Encountered error while loading and instantiating "


### PR DESCRIPTION
When we added second public Ctor with a different signature
to the reporter class, MetricsManager started failing sporadically
depending on which Ctor was the [0]-th in the list.
Tested on local soloserver:
2020-10-23 01:33:28,768 INFO [azkaban.metrics.MetricsManager main] metricsReporterClassName: com.linkedin.amf.reporter.AmfReporter
2020-10-23 01:33:28,771 INFO [com.linkedin.amf.reporter.AmfReporter main] AmfReporter Initializing. serverUrl: ltx1-amf.prod.linkedin.com