### PR TITLE
Updaing dependency jopt-simple to 5.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ ext.deps = [
     jettyUtil            : 'org.mortbay.jetty:jetty-util:6.1.26',
     jexl                 : 'org.apache.commons:commons-jexl:2.1.1',
     jodaTime             : 'joda-time:joda-time:2.0',
-    jopt                 : 'net.sf.jopt-simple:jopt-simple:4.3',
+    jopt                 : 'net.sf.jopt-simple:jopt-simple:5.0.3',
     jsr305               : 'com.google.code.findbugs:jsr305:3.0.2',
     junit                : 'junit:junit:4.12',
     kafkaLog4jAppender   : 'org.apache.kafka:kafka-log4j-appender:0.10.0.0',


### PR DESCRIPTION
joptsimple.OptionParser#acceptsAll(java.util.Collection<java.lang.String>, java.lang.String) 
method singnature has changed to 
joptsimple.OptionParser#acceptsAll(java.util.List<java.lang.String>, java.lang.String)

from 4.3 to 5.0.3 for net.sf.jopt-simple:jopt-simple jar