### PR TITLE
Bring back "Flow override properties to also override job properties"

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -399,6 +399,11 @@ public class Constants {
     public static final String OAUTH_REDIRECT_URI_KEY = "oauth.redirect_uri";  // how OAuth calls us back, e.g.:
     //    oauth.redirect_uri=http://localhost:8081/?action=oauth_callback
 
+    // By default job props always win over flow override props.
+    // If this flag is set to true, then override props override also override existing job props.
+    public static final String EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED =
+        "executor.props.resolve.overrideExisting.enabled";
+
     public static final String EXECUTOR_CONNECTION_TLS_ENABLED = "executor.connection.tls.enabled";
 
     public static final String AZKABAN_EXECUTOR_REVERSE_PROXY_ENABLED =

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -253,9 +253,13 @@ public class ExecutionOptions {
     this.memoryCheck = memoryCheck;
   }
 
-  public List<SlaOption> getSlaOptions() { return slaOptions; }
+  public List<SlaOption> getSlaOptions() {
+    return this.slaOptions;
+  }
 
-  public void setSlaOptions(final List<SlaOption> slaOptions) { this.slaOptions = slaOptions; }
+  public void setSlaOptions(final List<SlaOption> slaOptions) {
+    this.slaOptions = slaOptions;
+  }
 
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -161,11 +161,12 @@ public final class HttpRequestUtilsTest {
   @Test
   public void testGetJsonBodyForSingleMapObject() throws IOException, ServletException {
     final HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
-    final String originalString = "  {\n" + "    \"action\": \"update\",\n" + "    \"table\": \"ramp\",\n"
-        + "    \"conditions\" : {\n" + "      \"rampId\" : \"dali\"\n" + "    },\n"
-        + "    \"values\": {\n"
-        + "      \"rampStage\": 2,\n" + "      \"lastUpdatedTime\": 1566259437000\n" + "    }\n"
-        + "  }\n";
+    final String originalString =
+        "  {\n" + "    \"action\": \"update\",\n" + "    \"table\": \"ramp\",\n"
+            + "    \"conditions\" : {\n" + "      \"rampId\" : \"dali\"\n" + "    },\n"
+            + "    \"values\": {\n"
+            + "      \"rampStage\": 2,\n" + "      \"lastUpdatedTime\": 1566259437000\n" + "    }\n"
+            + "  }\n";
     final InputStream inputStream = new ByteArrayInputStream(originalString.getBytes(UTF_8));
     final InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
     final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
@@ -185,13 +186,13 @@ public final class HttpRequestUtilsTest {
 
   @Test
   public void testParseFlowOptionsSla() throws Exception {
-    HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
+    final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
         // job_name, status, duration, is_email, is_kill
         "slaSettings[1]", ",FINISH,2:30,true,false",
         "slaSettings[2]", "test_job,SUCCESS,12:00,false,true",
         "slaSettings[3]", ",SUCCESS,12:00,true,true"));
-    ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
-    List<SlaOption> slaOptions = options.getSlaOptions();
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
+    final List<SlaOption> slaOptions = options.getSlaOptions();
     final List<SlaOption> expected = Arrays.asList(
         new SlaOption(SlaType.FLOW_FINISH, "test-flow", "", Duration.ofMinutes(150),
             ImmutableSet.of(SlaAction.ALERT), ImmutableList.of()),
@@ -205,19 +206,19 @@ public final class HttpRequestUtilsTest {
 
   @Test
   public void testParseFlowOptionsSlaWithEmail() throws Exception {
-    HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
+    final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
         "slaSettings[1]", ",FINISH,2:30,true,false",
         "slaEmails", "sla1@example.com,sla2@example.com"));
-    ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
-    List<SlaOption> slaOptions = options.getSlaOptions();
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
+    final List<SlaOption> slaOptions = options.getSlaOptions();
     final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "test-flow",
         "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
         ImmutableList.of("sla1@example.com", "sla2@example.com")));
     Assert.assertEquals(expected, slaOptions);
   }
 
-  private static HttpServletRequest mockRequestWithSla(Map<String, String> params) {
-    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+  private static HttpServletRequest mockRequestWithSla(final Map<String, String> params) {
+    final HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
     Mockito.when(req.getParameterNames()).thenReturn(Collections.enumeration(params.keySet()));
     Mockito.when(req.getParameter(Mockito.anyString()))
         .thenAnswer(i -> params.get(i.getArgument(0, String.class)));

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -135,12 +135,7 @@ public final class HttpRequestUtilsTest {
   @Test
   public void testGetJsonBodyForListOfMapObject() throws IOException, ServletException {
     final HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
-    final String originalString =
-        "[\n" + "  {\n" + "    \"action\": \"update\",\n" + "    \"table\": \"ramp\",\n"
-            + "    \"conditions\" : {\n" + "      \"rampId\" : \"dali\"\n" + "    },\n"
-            + "    \"values\": {\n"
-            + "      \"rampStage\": 2,\n" + "      \"lastUpdatedTime\": 1566259437000\n" + "    }\n"
-            + "  }\n" + "]";
+    final String originalString = TestUtils.readResource("list_map_object.json", this);
     final InputStream inputStream = new ByteArrayInputStream(originalString.getBytes(UTF_8));
     final InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
     final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
@@ -161,12 +156,7 @@ public final class HttpRequestUtilsTest {
   @Test
   public void testGetJsonBodyForSingleMapObject() throws IOException, ServletException {
     final HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
-    final String originalString =
-        "  {\n" + "    \"action\": \"update\",\n" + "    \"table\": \"ramp\",\n"
-            + "    \"conditions\" : {\n" + "      \"rampId\" : \"dali\"\n" + "    },\n"
-            + "    \"values\": {\n"
-            + "      \"rampStage\": 2,\n" + "      \"lastUpdatedTime\": 1566259437000\n" + "    }\n"
-            + "  }\n";
+    final String originalString = TestUtils.readResource("single_map_object.json", this);
     final InputStream inputStream = new ByteArrayInputStream(originalString.getBytes(UTF_8));
     final InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
     final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);

--- a/azkaban-common/src/test/resources/azkaban/server/list_map_object.json
+++ b/azkaban-common/src/test/resources/azkaban/server/list_map_object.json
@@ -1,0 +1,13 @@
+[
+  {
+    "action": "update",
+    "table": "ramp",
+    "conditions" : {
+      "rampId" : "dali"
+    },
+    "values": {
+      "rampStage": 2,
+      "lastUpdatedTime": 1566259437000
+    }
+  }
+]

--- a/azkaban-common/src/test/resources/azkaban/server/single_map_object.json
+++ b/azkaban-common/src/test/resources/azkaban/server/single_map_object.json
@@ -1,0 +1,11 @@
+{
+  "action": "update",
+  "table": "ramp",
+  "conditions" : {
+    "rampId" : "dali"
+  },
+  "values": {
+    "rampStage": 2,
+    "lastUpdatedTime": 1566259437000
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -100,7 +100,6 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 
-
 /**
  * Class that handles the running of a ExecutableFlow DAG
  */
@@ -155,25 +154,37 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   private volatile boolean flowKilled = false;
   private volatile boolean flowIsRamping = false;
 
-  public long getFlowKillTime() { return this.flowKillTime; }
+  public long getFlowKillTime() {
+    return this.flowKillTime;
+  }
 
   private volatile long flowKillTime = -1;
 
   private volatile long flowKillDuration = 0;
 
-  public long getFlowKillDuration() { return this.flowKillDuration; }
+  public long getFlowKillDuration() {
+    return this.flowKillDuration;
+  }
 
-  public long getFlowPauseTime() { return this.flowPauseTime; }
+  public long getFlowPauseTime() {
+    return this.flowPauseTime;
+  }
 
-  public void setFlowCreateTime(long flowCreateTime) { this.flowCreateTime = flowCreateTime; }
+  public void setFlowCreateTime(final long flowCreateTime) {
+    this.flowCreateTime = flowCreateTime;
+  }
 
   private volatile long flowPauseTime = -1;
 
   private volatile long flowPauseDuration = 0;
 
-  public long getFlowPauseDuration() { return this.flowPauseDuration; }
+  public long getFlowPauseDuration() {
+    return this.flowPauseDuration;
+  }
 
-  public long getFlowCreateTime() { return this.flowCreateTime; }
+  public long getFlowCreateTime() {
+    return this.flowCreateTime;
+  }
 
   private volatile long flowCreateTime = -1;
 
@@ -192,6 +203,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
   // Project upload data for events
   private final ProjectFileHandler projectFileHandler;
+
   /**
    * Constructor. This will create its own ExecutorService for thread pools
    */
@@ -243,8 +255,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     createLogger(this.flow.getFlowId());
     this.azkabanEventReporter = azkabanEventReporter;
 
-    projectFileHandler =
-            this.projectLoader.fetchProjectMetaData(this.flow.getProjectId(), this.flow.getVersion());
+    this.projectFileHandler =
+        this.projectLoader.fetchProjectMetaData(this.flow.getProjectId(), this.flow.getVersion());
   }
 
   public FlowRunner setFlowWatcher(final FlowWatcher watcher) {
@@ -328,7 +340,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         this.fireEventListeners(
             Event.create(this, EventType.FLOW_FINISHED, new EventData(this.flow)));
         this.logger
-            .info("Created " + EventType.FLOW_FINISHED + " event for " + flow.getExecutionId());
+            .info("Created " + EventType.FLOW_FINISHED + " event for " + this.flow.getExecutionId());
         // In polling model, executor will be responsible for sending alerting emails when a flow
         // finishes.
         // Todo jamiesjc: switch to event driven model and alert on FLOW_FINISHED event.
@@ -358,10 +370,10 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       case KILLED:
         this.execMetrics.markFlowKilled();
         // Compute the duration to kill a flow
-        if (this.flowKillDuration == 0 && flowKillTime != -1) {
+        if (this.flowKillDuration == 0 && this.flowKillTime != -1) {
           this.flowKillDuration = System.currentTimeMillis() - this.flowKillTime;
         }
-        this.execMetrics.addFlowTimeToKill( this.flowKillDuration );
+        this.execMetrics.addFlowTimeToKill(this.flowKillDuration);
         break;
       default:
         break;
@@ -576,7 +588,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
           setFlowFailed(node);
           // Report FLOW_STATUS_CHANGED EVENT when status changes from running to failed
           this.fireEventListeners(
-              Event.create(this, EventType.FLOW_STATUS_CHANGED, new EventData(this.getExecutableFlow())));
+              Event.create(this, EventType.FLOW_STATUS_CHANGED,
+                  new EventData(this.getExecutableFlow())));
         } else {
           nodesToCheck.add(node);
           continue;
@@ -671,7 +684,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
     if (nextNodeStatus == Status.CANCELLED) {
       // if node is root flow
-      if (node instanceof ExecutableFlow && node.getParentFlow() == null)  {
+      if (node instanceof ExecutableFlow && node.getParentFlow() == null) {
         this.logger.info(String.format("Flow '%s' was cancelled before execution had started.",
             node.getId()));
         finalizeFlow((ExecutableFlow) node);
@@ -732,7 +745,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
    * Recursively propagate status to parent flow. Alert on first error of the flow in new AZ
    * dispatching design.
    *
-   * @param base the base flow
+   * @param base   the base flow
    * @param status the status to be propagated
    */
   private void propagateStatusAndAlert(final ExecutableFlowBase base, final Status status) {
@@ -879,12 +892,19 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       props = jobSource;
     }
 
+    // 5. If there are any runtime flow overrides, we apply them now.
+    final Map<String, String> flowParam =
+        this.flow.getExecutionOptions().getFlowParameters();
+    if (flowParam != null && !flowParam.isEmpty()) {
+      props.putAll(flowParam);
+    }
+
     node.setInputProps(props);
   }
 
   /**
    * @param props This method is to put in any job properties customization before feeding to the
-   * job.
+   *              job.
    */
   private void customizeJobProperties(final Props props) {
     final boolean memoryCheck = this.flow.getExecutionOptions().getMemoryCheck();
@@ -987,19 +1007,21 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     node.setStatus(Status.QUEUED);
 
     // Attach Ramp Props if there is any desired properties
-    String jobId = node.getId();
-    String jobType = Optional.ofNullable(node.getInputProps()).map(props -> props.getString("type")).orElse(null);
+    final String jobId = node.getId();
+    final String jobType = Optional.ofNullable(node.getInputProps()).map(props -> props.getString("type"))
+        .orElse(null);
     if (jobType != null && jobId != null) {
-      Props rampProps = this.flow.getRampPropsForJob(jobId, jobType);
+      final Props rampProps = this.flow.getRampPropsForJob(jobId, jobType);
       if (rampProps != null) {
         this.flowIsRamping = true;
-        logger.info(String.format(
+        this.logger.info(String.format(
             "RAMP_FLOW_ATTACH_PROPS_FOR_JOB : (flow.ExecId = %d, flow.Id = %s, flow.flowName = %s, job.id = %s, job.type = %s, props = %s)",
-            this.flow.getExecutionId(), this.flow.getId(), this.flow.getFlowName(), jobId, jobType, rampProps.toString()));
+            this.flow.getExecutionId(), this.flow.getId(), this.flow.getFlowName(), jobId, jobType,
+            rampProps.toString()));
         node.setRampProps(rampProps);
       }
     } else {
-      logger.warn(String.format(
+      this.logger.warn(String.format(
           "RAMP_FLOW_ATTACH_PROPS_FOR_JOB : (flow.ExecId = %d, flow.Id = %s, flow.flowName = %s) does not have Job Type or Id",
           this.flow.getExecutionId(), this.flow.getId(), this.flow.getFlowName()));
     }
@@ -1291,7 +1313,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
       // Report FLOW_STATUS_CHANGED EVENT when status changes from running to killing
       this.fireEventListeners(
-          Event.create(this, EventType.FLOW_STATUS_CHANGED, new EventData(this.getExecutableFlow())));
+          Event.create(this, EventType.FLOW_STATUS_CHANGED,
+              new EventData(this.getExecutableFlow())));
 
       this.logger.info("Killing " + this.activeJobRunners.size() + " jobs.");
       for (final JobRunner runner : this.activeJobRunners) {
@@ -1412,7 +1435,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
   }
 
   private void interrupt() {
-    if(this.flowRunnerThread != null) {
+    if (this.flowRunnerThread != null) {
       this.flowRunnerThread.interrupt();
     }
   }
@@ -1566,11 +1589,12 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         final ExecutableFlow flow = flowRunner.getExecutableFlow();
         FlowRunner.this.logger.info("Flow started: " + flow.getId());
         FlowRunner.this.azkabanEventReporter.report(event.getType(), getFlowMetadata(flowRunner));
-      } else if (event.getType() == EventType.FLOW_STATUS_CHANGED){
+      } else if (event.getType() == EventType.FLOW_STATUS_CHANGED) {
         final FlowRunner flowRunner = (FlowRunner) event.getRunner();
         final ExecutableFlow flow = flowRunner.getExecutableFlow();
         if (flow.getStatus() == Status.KILLING || flow.getStatus() == Status.KILLED) {
-          FlowRunner.this.logger.info("Flow is killed by " + flow.getModifiedBy() + ": " + flow.getId());
+          FlowRunner.this.logger
+              .info("Flow is killed by " + flow.getModifiedBy() + ": " + flow.getId());
         }
         final Map<String, String> flowMetadata = getFlowMetadata(flowRunner);
         flowMetadata.put("flowStatus", flow.getStatus().name());

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -25,6 +25,7 @@ import static azkaban.project.DirectoryYamlFlowLoader.CONDITION_ON_JOB_STATUS_PA
 import static azkaban.project.DirectoryYamlFlowLoader.CONDITION_VARIABLE_REPLACEMENT_PATTERN;
 
 import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.ServiceProvider;
 import azkaban.event.Event;
@@ -892,11 +893,16 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       props = jobSource;
     }
 
-    // 5. If there are any runtime flow overrides, we apply them now.
-    final Map<String, String> flowParam =
-        this.flow.getExecutionOptions().getFlowParameters();
-    if (flowParam != null && !flowParam.isEmpty()) {
-      props.putAll(flowParam);
+    if (this.azkabanProps.getBoolean(
+        ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED, false)) {
+      // Flow override props are configured to also override existing job props
+      // =>
+      // 5. If there are any runtime flow overrides, we apply them now.
+      final Map<String, String> flowParam =
+          this.flow.getExecutionOptions().getFlowParameters();
+      if (flowParam != null && !flowParam.isEmpty()) {
+        props.putAll(flowParam);
+      }
     }
 
     node.setInputProps(props);

--- a/azkaban-exec-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-exec-server/src/main/resources/conf/azkaban.properties
@@ -49,4 +49,4 @@ mysql.numconnections=100
 # Azkaban Executor settings
 executor.maxThreads=50
 executor.flow.threads=30
-
+executor.props.resolve.overrideExisting.enabled=false

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -36,17 +36,17 @@ import org.junit.Test;
 
 /**
  * Test the property resolution of jobs in a flow.
- *
+ * <p>
  * The tests are contained in execpropstest, and should be resolved in the following fashion, where
  * the later props take precedence over the previous ones.
- *
- * 1. Global props (set in the FlowRunner) 2. Shared job props (depends on job directory) 3. Flow
- * Override properties 4. Previous job outputs to the embedded flow (Only if contained in embedded
- * flow) 5. Embedded flow properties (Only if contained in embedded flow) 6. Previous job outputs
- * (if exists) 7. Job Props
- *
+ * <p>
+ * 1. Global props (set in the FlowRunner) 2. Shared job props (depends on job directory) 3.
+ * Previous job outputs to the embedded flow (Only if contained in embedded flow) 4. Embedded flow
+ * properties (Only if contained in embedded flow) 5. Previous job outputs (if exists) 6. Job Props
+ * 7. Flow Override properties
+ * <p>
  * The test contains the following structure: job2 -> innerFlow (job1 -> job4 ) -> job3
- *
+ * <p>
  * job2 and 4 are in nested directories so should have different shared properties than other jobs.
  */
 public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
@@ -107,7 +107,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("shared1", job2Props.get("props1"));
     Assert.assertEquals("job2", job2Props.get("props2"));
     Assert.assertEquals("moo3", job2Props.get("props3"));
-    Assert.assertEquals("job7", job2Props.get("props7"));
+    Assert.assertEquals("flow7", job2Props.get("props7"));
     Assert.assertEquals("flow5", job2Props.get("props5"));
     Assert.assertEquals("flow6", job2Props.get("props6"));
     Assert.assertEquals("shared4", job2Props.get("props4"));
@@ -115,7 +115,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
     // Job 1 is inside another flow, and is nested in a different directory
     // The priority order should be:
-    // job1->innerflow->job2.output->flow.overrides->job1 shared props
+    // job1->innerflow->job2.output->job1.sharedprops->flow.overrides
     final Props job2Generated = new Props();
     job2Generated.put("props6", "gjob6");
     job2Generated.put("props9", "gjob9");
@@ -129,16 +129,15 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     Assert.assertEquals("job8", job1Props.get("props8"));
     Assert.assertEquals("gjob9", job1Props.get("props9"));
     Assert.assertEquals("gjob10", job1Props.get("props10"));
-    Assert.assertEquals("innerflow6", job1Props.get("props6"));
-    Assert.assertEquals("innerflow5", job1Props.get("props5"));
+    Assert.assertEquals("flow6", job1Props.get("props6"));
+    Assert.assertEquals("flow5", job1Props.get("props5"));
     Assert.assertEquals("flow7", job1Props.get("props7"));
     Assert.assertEquals("moo3", job1Props.get("props3"));
     Assert.assertEquals("moo4", job1Props.get("props4"));
 
     // Job 4 is inside another flow and takes output from job 1
     // The priority order should be:
-    // job4->job1.output->innerflow->job2.output->flow.overrides->job4 shared
-    // props
+    // job4->job1.output->innerflow->job2.output->job4.sharedprops->flow.overrides
     final Props job1GeneratedProps = new Props();
     job1GeneratedProps.put("props9", "g2job9");
     job1GeneratedProps.put("props7", "g2job7");
@@ -148,9 +147,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     final Props job4Props = nodeMap.get("innerflow:job4").getInputProps();
     Assert.assertEquals("job8", job4Props.get("props8"));
     Assert.assertEquals("job9", job4Props.get("props9"));
-    Assert.assertEquals("g2job7", job4Props.get("props7"));
-    Assert.assertEquals("innerflow5", job4Props.get("props5"));
-    Assert.assertEquals("innerflow6", job4Props.get("props6"));
+    Assert.assertEquals("flow7", job4Props.get("props7"));
+    Assert.assertEquals("flow5", job4Props.get("props5"));
+    Assert.assertEquals("flow6", job4Props.get("props6"));
     Assert.assertEquals("gjob10", job4Props.get("props10"));
     Assert.assertEquals("shared4", job4Props.get("props4"));
     Assert.assertEquals("shared1", job4Props.get("props1"));
@@ -159,7 +158,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
 
     // Job 3 is a normal job taking props from an embedded flow
     // The priority order should be:
-    // job3->innerflow.output->flow.overrides->job3.sharedprops
+    // job3->innerflow.output->job3.sharedprops->flow.overrides
     final Props job4GeneratedProps = new Props();
     job4GeneratedProps.put("props9", "g4job9");
     job4GeneratedProps.put("props6", "g4job6");
@@ -168,7 +167,7 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     assertStatus(flow, FLOW_NAME, Status.RUNNING);
     final Props job3Props = nodeMap.get("job3").getInputProps();
     Assert.assertEquals("job3", job3Props.get("props3"));
-    Assert.assertEquals("g4job6", job3Props.get("props6"));
+    Assert.assertEquals("flow6", job3Props.get("props6"));
     Assert.assertEquals("g4job9", job3Props.get("props9"));
     Assert.assertEquals("flow7", job3Props.get("props7"));
     Assert.assertEquals("flow5", job3Props.get("props5"));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerPropertyResolutionTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import azkaban.Constants.ConfigurationKeys;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
@@ -92,7 +93,9 @@ public class FlowRunnerPropertyResolutionTest extends FlowRunnerTestBase {
     flowProps.put("props7", "flow7");
     flowProps.put("props6", "flow6");
     flowProps.put("props5", "flow5");
-    final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, flowProps);
+    // enable overriding also for existing job props
+    final FlowRunner runner = this.testUtil.createFromFlowMap(FLOW_NAME, null, flowProps,
+        Props.of(ConfigurationKeys.EXECUTOR_PROPS_RESOLVE_OVERRIDE_EXISTING_ENABLED, "true"));
     final Map<String, ExecutableNode> nodeMap = new HashMap<>();
     createNodeMap(runner.getExecutableFlow(), nodeMap);
     final ExecutableFlow flow = runner.getExecutableFlow();

--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -44,6 +44,7 @@ azkaban.jobtype.plugin.dir=plugins/jobtypes
 # Number of executions to be displayed
 azkaban.display.execution_page_size=16
 azkaban.use.multiple.executors=true
+executor.props.resolve.overrideExisting.enabled=false
 # Azkaban Ramp Feature Configuration
 #Ramp Feature Related
 azkaban.ramp.enabled=true

--- a/azkaban-web-server/src/web/js/azkaban/util/ajax.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/ajax.js
@@ -14,7 +14,8 @@
  * the License.
  */
 
-function ajaxCall(requestURL, data, successCallback, beforeSendCallback, requestType) {
+function ajaxCall(requestURL, data, successCallback, beforeSendCallback,
+    requestType) {
   var successHandler = function (data) {
     if (data.error == "session") {
       // We need to relogin.

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -29,8 +29,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     $("#override-success-emails").click(function (evt) {
       if ($(this).is(':checked')) {
         $('#success-emails').attr('disabled', null);
-      }
-      else {
+      } else {
         $('#success-emails').attr('disabled', "disabled");
       }
     });
@@ -38,8 +37,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     $("#override-failure-emails").click(function (evt) {
       if ($(this).is(':checked')) {
         $('#failure-emails').attr('disabled', null);
-      }
-      else {
+      } else {
         $('#failure-emails').attr('disabled', "disabled");
       }
     });
@@ -96,8 +94,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     if (concurrentOption == "pipeline") {
       var pipelineLevel = $("#pipeline-level").val();
       executingData.pipelineLevel = pipelineLevel;
-    }
-    else if (concurrentOption == "queue") {
+    } else if (concurrentOption == "queue") {
       executingData.queueLevel = $("#queueLevel").val();
     }
 
@@ -121,14 +118,12 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
 
     if (overrideSuccessEmails) {
       $('#override-success-emails').prop('checked', true);
-    }
-    else {
+    } else {
       $('#success-emails').attr('disabled', 'disabled');
     }
     if (overrideFailureEmails) {
       $('#override-failure-emails').prop('checked', true);
-    }
-    else {
+    } else {
       $('#failure-emails').attr('disabled', 'disabled');
     }
 
@@ -188,8 +183,7 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
     var loadCallback = function () {
       if (jobId) {
         self.showExecuteJob(projectName, flowId, jobId, data.withDep);
-      }
-      else {
+      } else {
         self.showExecuteFlow(projectName, flowId);
       }
     }
@@ -484,8 +478,7 @@ var handleJobMenuClick = function (action, el, pos) {
       + flowName + "&job=" + jobid;
   if (action == "open") {
     window.location.href = requestURL;
-  }
-  else if (action == "openwindow") {
+  } else if (action == "openwindow") {
     window.open(requestURL);
   }
 }
@@ -502,11 +495,9 @@ var disableFinishedJobs = function (data) {
     if (node.status == "DISABLED" || node.status == "SKIPPED") {
       node.status = "READY";
       node.disabled = true;
-    }
-    else if (node.status == "SUCCEEDED" || node.noInitialStatus) {
+    } else if (node.status == "SUCCEEDED" || node.noInitialStatus) {
       node.disabled = true;
-    }
-    else {
+    } else {
       node.disabled = false;
     }
     if (node.type == "flow") {
@@ -588,8 +579,7 @@ var gatherDisabledNodes = function (data) {
     var node = nodes[i];
     if (node.disabled) {
       disabled.push(node.id);
-    }
-    else {
+    } else {
       if (node.type == "flow") {
         var array = gatherDisabledNodes(node);
         if (array && array.length > 0) {
@@ -650,8 +640,7 @@ var expanelNodeClickCallback = function (event, model, node) {
         }
       ];
 
-    }
-    else {
+    } else {
       menu = [
         {
           title: "Expand Flow...", callback: function () {
@@ -670,8 +659,7 @@ var expanelNodeClickCallback = function (event, model, node) {
         }
       ];
     }
-  }
-  else {
+  } else {
     var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
         + flowId + "&job=" + jobId;
     menu = [
@@ -757,7 +745,8 @@ var expanelNodeClickCallback = function (event, model, node) {
   contextMenuView.show(event, menu);
 }
 
-var expanelEdgeClickCallback = function (event) {}
+var expanelEdgeClickCallback = function (event) {
+}
 
 var expanelGraphClickCallback = function (event, model) {
   var data = model.get("data");

--- a/azkaban-web-server/src/web/js/azkaban/view/schedule-options.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/schedule-options.js
@@ -64,8 +64,7 @@ azkaban.ScheduleContextMenu = Backbone.View.extend({
       evt.currentTarget.expanded = false;
       $('#scheduleEnableArrow').removeClass('collapse');
       $('#scheduleEnableSub').hide();
-    }
-    else {
+    } else {
       evt.currentTarget.expanded = true;
       $('#scheduleEnableArrow').addClass('collapse');
       $('#scheduleEnableSub').show();
@@ -81,8 +80,7 @@ azkaban.ScheduleContextMenu = Backbone.View.extend({
       evt.currentTarget.expanded = false;
       $('#scheduleDisableArrow').removeClass('collapse');
       $('#scheduleDisableSub').hide();
-    }
-    else {
+    } else {
       evt.currentTarget.expanded = true;
       $('#scheduleDisableArrow').addClass('collapse');
       $('#scheduleDisableSub').show();
@@ -145,19 +143,16 @@ azkaban.ScheduleFlowView = Backbone.View.extend({
           if (data.action == "redirect") {
             window.location = contextURL + "/manager?project=" + projectName
                 + "&flow=" + flowName;
-          }
-          else {
+          } else {
             $("#success_message").text("Flow " + projectName + "." + flowName
                 + " scheduled!");
             window.location = contextURL + "/manager?project=" + projectName
                 + "&flow=" + flowName;
           }
-        }
-        else {
+        } else {
           if (data.action == "login") {
             window.location = "";
-          }
-          else {
+          } else {
             $("#errorMsg").text("ERROR: " + data.message);
             $("#errorMsg").slideDown("fast");
           }
@@ -253,8 +248,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
         function (data) {
           if (data.error) {
             alert(data.error);
-          }
-          else {
+          } else {
             if (data.successEmails) {
               $('#scheduleSuccessEmails').val(data.successEmails.join());
             }
@@ -392,8 +386,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
         function (data) {
           if (data.error) {
             alert(data.error);
-          }
-          else {
+          } else {
             window.location = scheduleURL;
           }
         },
@@ -481,18 +474,15 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
         + flowName + "&job=" + jobid;
     if (action == "open") {
       window.location.href = requestURL;
-    }
-    else if (action == "openwindow") {
+    } else if (action == "openwindow") {
       window.open(requestURL);
-    }
-    else if (action == "disable") {
+    } else if (action == "disable") {
       var disabled = flowData.get("disabled");
 
       disabled[jobid] = true;
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "disableAll") {
+    } else if (action == "disableAll") {
       var disabled = flowData.get("disabled");
 
       var nodes = flowData.get("nodes");
@@ -502,8 +492,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "disableParents") {
+    } else if (action == "disableParents") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
       var inNodes = nodes[jobid].inNodes;
@@ -516,8 +505,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "disableChildren") {
+    } else if (action == "disableChildren") {
       var disabledMap = flowData.get("disabled");
       var nodes = flowData.get("nodes");
       var outNodes = nodes[jobid].outNodes;
@@ -530,8 +518,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabledMap});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "disableAncestors") {
+    } else if (action == "disableAncestors") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
 
@@ -539,8 +526,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "disableDescendents") {
+    } else if (action == "disableDescendents") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
 
@@ -548,20 +534,17 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enable") {
+    } else if (action == "enable") {
       var disabled = flowData.get("disabled");
 
       disabled[jobid] = false;
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enableAll") {
+    } else if (action == "enableAll") {
       disabled = {};
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enableParents") {
+    } else if (action == "enableParents") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
       var inNodes = nodes[jobid].inNodes;
@@ -574,8 +557,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enableChildren") {
+    } else if (action == "enableChildren") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
       var outNodes = nodes[jobid].outNodes;
@@ -588,8 +570,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enableAncestors") {
+    } else if (action == "enableAncestors") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
 
@@ -597,8 +578,7 @@ azkaban.AdvancedScheduleView = Backbone.View.extend({
 
       flowData.set({disabled: disabled});
       flowData.trigger("change:disabled");
-    }
-    else if (action == "enableDescendents") {
+    } else if (action == "enableDescendents") {
       var disabled = flowData.get("disabled");
       var nodes = flowData.get("nodes");
 

--- a/test/local-conf-templates/conf/azkaban.properties
+++ b/test/local-conf-templates/conf/azkaban.properties
@@ -55,3 +55,4 @@ executor.connector.stats=true
 executor.metric.reports=true
 executor.metric.milisecinterval.default=60000
 azkaban.use.multiple.executors=true
+executor.props.resolve.overrideExisting.enabled=false


### PR DESCRIPTION
This feature was reverted by @djaiswal83 in https://github.com/azkaban/azkaban/pull/2620.

Now adding it back as [requested](https://github.com/azkaban/azkaban/pull/2241#issuecomment-713893621):

> Can you please make it configurable and disabled by default?

See the PR description of https://github.com/azkaban/azkaban/pull/2241 for the background/rationale of this change.

Content of this PR:

- First, revert commit 21d33f0812c22df0883a3e56fc508ddd5abdc621 ie. PR https://github.com/azkaban/azkaban/pull/2620 to add back the code changes of https://github.com/azkaban/azkaban/pull/2241
- Then, make it configurable with a new property `executor.props.resolve.overrideExisting.enabled`

So, by default there is no change in behavior. That is to **not** override existing job props.