### PR TITLE
Remove duplication in embedded flow name.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -389,8 +389,7 @@ public class ExecutableFlowBase extends ExecutableNode {
     if (this.getParentFlow() == null) {
       return this.getFlowId();
     } else {
-      return this.getParentFlow().getFlowPath() + "," + this.getId() + ":"
-          + this.getFlowId();
+      return this.getId() + ":" + this.getFlowId();
     }
   }
 }


### PR DESCRIPTION
Current logic to resolve an embedded flow name adds fully qualified name for each
flow name in the path, leading to a lot of duplication. This change removes the
duplication so the FQN's are shorter, more readable and most importantly take
less space in the DB.

Example:

Before the change, a nested flow id FQN for dag_4:
----------------------------------------
Flow Id FQN: dag_2,dag_3:dag_2:dag_3,dag_4:dag_2:dag_3:dag_4

After the change:
----------------------------------------
Flow Id FQN: dag_4:dag_2:dag_3:dag_4

Verified the change by execution nested flows, accessing flow and job logs and
by running internal acceptance tests.