### PR TITLE
Fixing the name of Property class for Containerized Dispatch. Earlier it was ContainerizedExecutionManagerProperties.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -486,8 +486,7 @@ public class Constants {
     public static final String COMMONSYSCONFFILE = "commonprivate.properties";
   }
 
-  public static class ContainerizedExecutionManagerProperties {
-
+  public static class ContainerizedDispatchManagerProperties {
     public static final String AZKABAN_CONTAINERIZED_PREFIX = "azkaban.containerized.";
     public static final String CONTAINERIZED_IMPL_TYPE = AZKABAN_CONTAINERIZED_PREFIX + "impl.type";
     public static final String CONTAINERIZED_EXECUTION_BATCH_ENABLED =

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -15,7 +15,7 @@
  */
 package azkaban.executor.container;
 
-import static azkaban.Constants.ContainerizedExecutionManagerProperties;
+import static azkaban.Constants.ContainerizedDispatchManagerProperties;
 
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.executor.ExecutableFlow;
@@ -59,7 +59,7 @@ public class ContainerCleanupManager {
       final ContainerizedImpl containerizedImpl) {
     this.cleanupIntervalMin = azkProps
         .getLong(
-            ContainerizedExecutionManagerProperties.CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN,
+            ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN,
             DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL.toMinutes());
     this.staleContainerAgeMins = azkProps.getLong(ConfigurationKeys.AZKABAN_MAX_FLOW_RUNNING_MINS,
         DEFAULT_STALE_CONTAINER_AGE_MINS.toMinutes());

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -16,7 +16,7 @@
 package azkaban.executor.container;
 
 import azkaban.Constants;
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
 import azkaban.executor.AbstractExecutorManagerAdapter;
 import azkaban.executor.ExecutableFlow;
@@ -69,7 +69,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
     super(azkProps, executorLoader, commonMetrics, apiGateway);
     rateLimiter =
         RateLimiter.create(azkProps
-            .getInt(ContainerizedExecutionManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));
+            .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));
     this.containerizedImpl = containerizedImpl;
   }
 
@@ -208,14 +208,14 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       setActive(
           this.azkProps.getBoolean(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, true));
       this.executionsBatchProcessingEnabled = azkProps
-          .getBoolean(ContainerizedExecutionManagerProperties.CONTAINERIZED_EXECUTION_BATCH_ENABLED,
+          .getBoolean(ContainerizedDispatchManagerProperties.CONTAINERIZED_EXECUTION_BATCH_ENABLED,
               false);
       this.executionsBatchSize =
           azkProps
-              .getInt(ContainerizedExecutionManagerProperties.CONTAINERIZED_EXECUTION_BATCH_SIZE,
+              .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_EXECUTION_BATCH_SIZE,
                   10);
       this.executorService = Executors.newFixedThreadPool(azkProps.getInt(
-          ContainerizedExecutionManagerProperties.CONTAINERIZED_EXECUTION_PROCESSING_THREAD_POOL_SIZE,
+          ContainerizedDispatchManagerProperties.CONTAINERIZED_EXECUTION_PROCESSING_THREAD_POOL_SIZE,
           10));
       this.setName("Containerized-QueueProcessor-Thread");
     }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -16,7 +16,7 @@
 package azkaban.executor.container;
 
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.container.models.AzKubernetesV1PodBuilder;
 import azkaban.container.models.AzKubernetesV1ServiceBuilder;
 import azkaban.container.models.AzKubernetesV1SpecBuilder;
@@ -97,44 +97,44 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
     this.azkProps = azkProps;
     this.executorLoader = executorLoader;
     this.namespace = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_NAMESPACE);
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_NAMESPACE);
     this.flowContainerName =
         this.azkProps
-            .getString(ContainerizedExecutionManagerProperties.KUBERNETES_FLOW_CONTAINER_NAME
+            .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_NAME
                 , DEFAULT_FLOW_CONTAINER_NAME_PREFIX);
     this.podPrefix =
-        this.azkProps.getString(ContainerizedExecutionManagerProperties.KUBERNETES_POD_NAME_PREFIX,
+        this.azkProps.getString(ContainerizedDispatchManagerProperties.KUBERNETES_POD_NAME_PREFIX,
             DEFAULT_POD_NAME_PREFIX);
     this.servicePrefix = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_SERVICE_NAME_PREFIX,
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_NAME_PREFIX,
             DEFAULT_SERVICE_NAME_PREFIX);
     this.clusterName = this.azkProps.getString(ConfigurationKeys.AZKABAN_CLUSTER_NAME,
         DEFAULT_CLUSTER_NAME);
     this.cpuLimit = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_FLOW_CONTAINER_CPU_LIMIT,
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_CPU_LIMIT,
             CPU_LIMIT);
     this.cpuRequest = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_FLOW_CONTAINER_CPU_REQUEST,
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_CPU_REQUEST,
             DEFAULT_CPU_REQUEST);
     this.memoryLimit = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_FLOW_CONTAINER_MEMORY_LIMIT,
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_MEMORY_LIMIT,
             MEMORY_LIMIT);
     this.memoryRequest = this.azkProps
-        .getString(ContainerizedExecutionManagerProperties.KUBERNETES_FLOW_CONTAINER_MEMORY_REQUEST,
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_MEMORY_REQUEST,
             DEFAULT_MEMORY_REQUEST);
     this.servicePort =
-        this.azkProps.getInt(ContainerizedExecutionManagerProperties.KUBERNETES_SERVICE_PORT,
+        this.azkProps.getInt(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_PORT,
             54343);
     this.serviceTimeout =
         this.azkProps
-            .getLong(ContainerizedExecutionManagerProperties.KUBERNETES_SERVICE_CREATION_TIMEOUT_MS,
+            .getLong(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_CREATION_TIMEOUT_MS,
                 60000);
 
     try {
       // Path to the configuration file for Kubernetes which contains information about
       // Kubernetes API Server and identity for authentication
       final String kubeConfigPath = this.azkProps
-          .getString(ContainerizedExecutionManagerProperties.KUBERNETES_KUBE_CONFIG_PATH);
+          .getString(ContainerizedDispatchManagerProperties.KUBERNETES_KUBE_CONFIG_PATH);
       logger.info("Kube config path is : {}", kubeConfigPath);
       this.client =
           ClientBuilder.kubeconfig(KubeConfig.loadKubeConfig(
@@ -381,7 +381,7 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
    */
   private boolean isServiceRequired() {
     return this.azkProps
-        .getBoolean(ContainerizedExecutionManagerProperties.KUBERNETES_SERVICE_REQUIRED, false);
+        .getBoolean(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_REQUIRED, false);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.executor.container.ContainerizedImpl;
 import azkaban.executor.container.ContainerizedImplType;
@@ -76,7 +76,7 @@ public class ContainerizedDispatchManagerTest {
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.containerizedImpl = mock(ContainerizedImpl.class);
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
-    this.props.put(ContainerizedExecutionManagerProperties.CONTAINERIZED_IMPL_TYPE,
+    this.props.put(ContainerizedDispatchManagerProperties.CONTAINERIZED_IMPL_TYPE,
         ContainerizedImplType.KUBERNETES.name());
     this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
     this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -18,7 +18,7 @@ package azkaban.executor.container;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.Status;
@@ -39,8 +39,8 @@ public class KubernetesContainerizedImplTest {
 
   @Before
   public void setup() throws Exception {
-    this.props.put(ContainerizedExecutionManagerProperties.KUBERNETES_NAMESPACE, "dev-namespace");
-    this.props.put(ContainerizedExecutionManagerProperties.KUBERNETES_KUBE_CONFIG_PATH, "src/test"
+    this.props.put(ContainerizedDispatchManagerProperties.KUBERNETES_NAMESPACE, "dev-namespace");
+    this.props.put(ContainerizedDispatchManagerProperties.KUBERNETES_KUBE_CONFIG_PATH, "src/test"
         + "/resources/container/kubeconfig");
     this.executorLoader = mock(ExecutorLoader.class);
     this.kubernetesContainerizedImpl = new KubernetesContainerizedImpl(this.props,

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -19,7 +19,7 @@ package azkaban.webapp;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
 import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutorManager;
@@ -39,7 +39,6 @@ import azkaban.utils.Props;
 import azkaban.webapp.metrics.DummyWebMetricsImpl;
 import azkaban.webapp.metrics.WebMetrics;
 import azkaban.webapp.metrics.WebMetricsImpl;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
@@ -95,7 +94,7 @@ public class AzkabanWebServerModule extends AbstractModule {
 
   private Class<? extends ContainerizedImpl> resolveContainerizedImpl() {
     final String containerizedImplProperty =
-        props.getString(ContainerizedExecutionManagerProperties.CONTAINERIZED_IMPL_TYPE,
+        props.getString(ContainerizedDispatchManagerProperties.CONTAINERIZED_IMPL_TYPE,
             ContainerizedImplType.KUBERNETES.name())
             .toUpperCase();
     return ContainerizedImplType.valueOf(containerizedImplProperty).getImplClass();

--- a/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/AzkabanWebServerTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNotNull;
 
 import azkaban.AzkabanCommonModule;
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.Constants.ContainerizedExecutionManagerProperties;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.database.AzkabanDatabaseUpdater;
@@ -202,9 +202,9 @@ public class AzkabanWebServerTest {
 
     // Test for CONTAINERIZED method
     props.put(ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD, "CONTAINERIZED");
-    props.put(ContainerizedExecutionManagerProperties.KUBERNETES_KUBE_CONFIG_PATH, "src/test"
+    props.put(ContainerizedDispatchManagerProperties.KUBERNETES_KUBE_CONFIG_PATH, "src/test"
         + "/resources/container/kubeconfig");
-    props.put(ContainerizedExecutionManagerProperties.KUBERNETES_NAMESPACE, "dev-namespace");
+    props.put(ContainerizedDispatchManagerProperties.KUBERNETES_NAMESPACE, "dev-namespace");
     final Injector containerizedInjector = Guice.createInjector(
         new AzkabanCommonModule(props),
         new AzkabanWebServerModule(props)


### PR DESCRIPTION
Renaming ContainerizedExecutionManagerProperties class to ContainerizedDispatchManagerProperties.