### PR TITLE
add a common property "azkaban.flow.start.epochsecond"

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -165,6 +165,7 @@ public class CommonJobProperties {
   /**
    * Properties for passing the flow start time to the jobs.
    */
+  public static final String FLOW_START_EPOCHSECOND = "azkaban.flow.start.epochsecond";
   public static final String FLOW_START_TIMESTAMP =
       "azkaban.flow.start.timestamp";
   public static final String FLOW_START_YEAR = "azkaban.flow.start.year";

--- a/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowUtils.java
@@ -27,6 +27,8 @@ import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.utils.Props;
 import com.google.gson.Gson;
+
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,7 +52,9 @@ public class FlowUtils {
     props.put(CommonJobProperties.EXECUTION_SOURCE, flow.getExecutionSource());
 
     final DateTime loadTime = new DateTime();
+    final long epochSecond = Instant.now().getEpochSecond();
 
+    props.put(CommonJobProperties.FLOW_START_EPOCHSECOND,epochSecond);
     props.put(CommonJobProperties.FLOW_START_TIMESTAMP, loadTime.toString());
     props.put(CommonJobProperties.FLOW_START_YEAR, loadTime.toString("yyyy"));
     props.put(CommonJobProperties.FLOW_START_MONTH, loadTime.toString("MM"));


### PR DESCRIPTION
# 2682 In CommonJobProperties.java add a proterty "azkaban.flow.start.epochsecond" to record the number of seconds from the Java epoch of this workflow