### PR TITLE
Prevent kill action from leaving executions stuck in KILLING status.

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1268,7 +1268,9 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
   public void kill() {
     synchronized (this.mainSyncObj) {
-      if (isKilled()) {
+      if (isKilled() || this.flowFinished) {
+        this.logger.info(
+            "Dropping Kill action as execution " + this.execId + " is already finished.");
         return;
       }
       this.logger.info("Kill has been called on execution " + this.execId);


### PR DESCRIPTION
When a user requests to kill an execution a check that it's still running is made several times however the execution may finish before the kill action is processed after those checks causing it to stay in KILLING status forever. 