### PR TITLE
Restructuring code for HdfsAuth so that there can be multiple impleme…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/AbstractHdfsAuth.java
+++ b/azkaban-common/src/main/java/azkaban/storage/AbstractHdfsAuth.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package azkaban.storage;
+
+import azkaban.utils.Props;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+
+/**
+ * This class is used as an abstract class for implementation of authentication mechanism for HDFS.
+ */
+public abstract class AbstractHdfsAuth {
+  protected final boolean isSecurityEnabled;
+
+  protected final Props props;
+
+  protected UserGroupInformation loggedInUser = null;
+
+  public AbstractHdfsAuth(final Props props, final Configuration conf) {
+    this.props = props;
+    UserGroupInformation.setConfiguration(conf);
+    this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
+  }
+
+  /**
+   * This method is used to authorize with HDFS.
+   */
+  public abstract void authorize();
+}

--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -58,7 +58,7 @@ public class HdfsStorage implements Storage {
   // value used in FileSystem.copyFromLocalFile().
   private static final int UPLOAD_BUFFER_SIZE_BYTES = 4096;
 
-  private final HdfsAuth hdfsAuth;
+  private final AbstractHdfsAuth hdfsAuth;
   private final URI projectRootUri;
   private final URI dependencyRootUri;
 
@@ -75,7 +75,8 @@ public class HdfsStorage implements Storage {
   private final FileSystem http;
 
   @Inject
-  public HdfsStorage(final AzkabanCommonModuleConfig config, final HdfsAuth hdfsAuth,
+  public HdfsStorage(final AzkabanCommonModuleConfig config,
+      @Named("hdfsAuth") final AbstractHdfsAuth hdfsAuth,
       @Named("hdfsFileContext") final FileContext hdfsFileContext,
       @Named("hdfs_cached_httpFS") @Nullable final FileSystem http) {
     this.hdfsAuth = requireNonNull(hdfsAuth);

--- a/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
+++ b/azkaban-common/src/test/java/azkaban/storage/HdfsStorageTest.java
@@ -56,7 +56,7 @@ public class HdfsStorageTest {
   @Rule
   public final TemporaryFolder TEMP_DIR = new TemporaryFolder();
 
-  private HdfsAuth hdfsAuth;
+  private AbstractHdfsAuth hdfsAuth;
   private HdfsStorage hdfsStorage;
   private FileContext hdfsFileContext;
   private FileContext.Util hdfsFileContextUtil;


### PR DESCRIPTION
…ntations of HdfsAuth and we can have an option to choose any implementation.

Tested it by adding new implementation as a plugin. It is able to use the implementation class provided in azkaban.hdfs.auth.impl.class=com.linkedin.azkaban.NewHdfsAuth.

It is able to download the project zip using any implementation of hdfsAuth.

021/01/08 00:35:20.357 +0000  INFO [HdfsClient] [azk-polling-service] [Azkaban] Acquired token with kind HDFS_DELEGATION_TOKEN and service nn1
2021/01/08 00:35:20.357 +0000  INFO [HdfsClient] [azk-polling-service] [Azkaban] Acquired token with kind HDFS_DELEGATION_TOKEN and service nn1
2021/01/08 00:35:20.357 +0000  INFO [NewHdfsAuth] [azk-polling-service] [Azkaban] Successfully captured tokens from New service for HDFS
2021/01/08 00:35:20.357 +0000  INFO [NewHdfsAuth] [azk-polling-service] [Azkaban] Logged in with user azkdata (auth:KERBEROS) via azkdata (auth:SIMPLE)
2021/01/08 00:35:20.358 +0000  INFO [HdfsStorage] [azk-polling-service] [Azkaban] Opening for reading, project file hdfs://nn:9000/.../6353/6353-fa19cf6926449af954de235976ca790d.zip