### PR TITLE
Add executor api calls for containerized flows

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -400,6 +400,13 @@ public class Constants {
     //    oauth.redirect_uri=http://localhost:8081/?action=oauth_callback
 
     public static final String EXECUTOR_CONNECTION_TLS_ENABLED = "executor.connection.tls.enabled";
+
+    public static final String AZKABAN_EXECUTOR_REVERSE_PROXY_ENABLED =
+        "azkaban.executor.reverse.proxy.enabled";
+    public static final String AZKABAN_EXECUTOR_REVERSE_PROXY_HOSTNAME =
+        "azkaban.executor.reverse.proxy.hostname";
+    public static final String AZKABAN_EXECUTOR_REVERSE_PROXY_PORT =
+        "azkaban.executor.reverse.proxy.port";
   }
 
   public static class FlowProperties {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -89,7 +89,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final ExecutorManagerUpdaterStage updaterStage,
       final ExecutionFinalizer executionFinalizer,
       final RunningExecutionsUpdaterThread updaterThread) {
-    super(azkProps, executorLoader, commonMetrics, apiGateway);
+    super(azkProps, executorLoader, commonMetrics, apiGateway, null);
     this.runningExecutions = runningExecutions;
     this.activeExecutors = activeExecutors;
     this.updaterStage = updaterStage;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -19,6 +19,7 @@ import azkaban.Constants;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
 import azkaban.executor.AbstractExecutorManagerAdapter;
+import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorApiGateway;
@@ -65,8 +66,9 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   @Inject
   public ContainerizedDispatchManager(final Props azkProps, final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics, final ExecutorApiGateway apiGateway,
-      final ContainerizedImpl containerizedImpl) throws ExecutorManagerException {
-    super(azkProps, executorLoader, commonMetrics, apiGateway);
+      final ContainerizedImpl containerizedImpl,
+      final AlerterHolder alerterHolder) throws ExecutorManagerException {
+    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder);
     rateLimiter =
         RateLimiter.create(azkProps
             .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));
@@ -320,106 +322,79 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
 
   //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
   @Override
-  public LogData getExecutableFlowLog(ExecutableFlow exFlow, int offset, int length)
-      throws ExecutorManagerException {
-    return null;
-  }
-
-  //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
-  @Override
-  public LogData getExecutionJobLog(ExecutableFlow exFlow, String jobId, int offset, int length,
-      int attempt) throws ExecutorManagerException {
-    return null;
-  }
-
-  //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
-  @Override
-  public List<Object> getExecutionJobStats(ExecutableFlow exflow, String jobId, int attempt)
-      throws ExecutorManagerException {
-    return null;
-  }
-
-  //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
-  @Override
-  public void cancelFlow(ExecutableFlow exFlow, String userId) throws ExecutorManagerException {
-
-  }
-
-  //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
-  @Override
   public void resumeFlow(ExecutableFlow exFlow, String userId) throws ExecutorManagerException {
-
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
   @Override
   public void pauseFlow(ExecutableFlow exFlow, String userId) throws ExecutorManagerException {
-
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
   @Override
   public void retryFailures(ExecutableFlow exFlow, String userId) throws ExecutorManagerException {
-
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   //TODO: BDP-2567 Add container stats information
   @Override
   public Map<String, Object> callExecutorStats(int executorId, String action,
       Pair<String, String>... param) throws IOException, ExecutorManagerException {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   //TODO: BDP-2567 Add way to call jmx endpoint for flow container
   @Override
   public Map<String, Object> callExecutorJMX(String hostPort, String action, String mBean)
       throws IOException {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public Map<String, String> doRampActions(List<Map<String, Object>> rampAction)
       throws ExecutorManagerException {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public Set<String> getAllActiveExecutorServerHosts() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public State getExecutorManagerThreadState() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public boolean isExecutorManagerThreadActive() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public long getLastExecutorManagerThreadCheckTime() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public Set<? extends String> getPrimaryServerHosts() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public Collection<Executor> getAllActiveExecutors() {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public Executor fetchExecutor(int executorId) throws ExecutorManagerException {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 
   @Override
   public void setupExecutors() throws ExecutorManagerException {
-    throw new UnsupportedOperationException("Invalid Method");
+    throw new UnsupportedOperationException("Unsupported Method");
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
@@ -19,7 +19,7 @@ public class ExecutorApiGatewaySystemTest {
   @Before
   public void setUp() throws Exception {
     final ExecutorApiClient client = new ExecutorApiClient(new Props());
-    this.apiGateway = new ExecutorApiGateway(client);
+    this.apiGateway = new ExecutorApiGateway(client, new Props());
   }
 
   @Test


### PR DESCRIPTION
Modifies ExecutorApiClient and ExecutorApiGateway for
 - Handling Reverse-proxy based access to Executors/FlowContainers
 - Containerized dispatch to FlowContainers

Add executor api call invocations from ContainerizedDispatchManager
 - Done indirectly by adding invocation in base class AbstractDispatchManager
 - Adds getExecutableFlowLog, getExecutionJobLog, getExecutionJobStats, cancelFlow