### PR TITLE
Added template based design to add items to the pod-spec

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -560,6 +560,8 @@ public class Constants {
         KUBERNETES_FLOW_CONTAINER_PREFIX + "init.jobtypes.mount.path";
     public static final String KUBERNETES_MOUNT_PATH_FOR_JOBTYPES =
         KUBERNETES_FLOW_CONTAINER_PREFIX + "jobtypes.mount.path";
+    public static final String KUBERNETES_POD_TEMPLATE_PATH =
+        KUBERNETES_POD_PREFIX + "template.path";
 
     // Kubernetes service related properties
     public static final String KUBERNETES_SERVICE_PREFIX = AZKABAN_KUBERNETES_PREFIX + "service.";

--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.container.models;
+
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.util.Yaml;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * A singleton class which reads a k8s pod-spec yaml file as template. Items like InitContainers,
+ * Volumes and VolumeMounts for the application-container/flow-container will be extracted from the
+ * POD created from this template file.
+ * <p>
+ * Extracted Items are later merged via {@link azkaban.executor.container.KubernetesContainerizedImpl#mergePodSpec(V1PodSpec,
+ * AzKubernetesV1PodTemplate)} with the pod-spec created using {@link AzKubernetesV1SpecBuilder}
+ * <p>
+ * Merging criteria is such that, if the item in the already created pod-spec has the same name as
+ * of the item extracted from the template, then it will be retained.
+ * <p>
+ * This template design enables declaration of static initContainers, volumes, volumeMounts, etc.
+ * which are not job-types but are useful. For example: init container which will fetch the required
+ * certificates/tokens etc. writes to a volume and then that volume will be mounted to the
+ * application-container/flow-container.
+ *
+ * The template must have only one non-init container. Azkaban k8s design is such that
+ * flow-container will be the only non-init container.
+ */
+public class AzKubernetesV1PodTemplate {
+
+  public static final int FLOW_CONTAINER_INDEX = 0;
+  private V1Pod podFromTemplate;
+  private static AzKubernetesV1PodTemplate instance;
+
+  /**
+   * Private constructor to make this class singleton
+   *
+   * @param templatePath th where the template file is located.
+   * @throws IOException If unable to read the template file.
+   */
+  private AzKubernetesV1PodTemplate(String templatePath) throws IOException {
+    File templateFile = Paths.get(templatePath).toFile();
+    this.podFromTemplate = (V1Pod) Yaml.load(templateFile);
+  }
+
+  /**
+   * @param templatePath Path where the template file is located.
+   * @return Singleton instance of this class.
+   * @throws IOException If unable to read the template file.
+   */
+  public static synchronized AzKubernetesV1PodTemplate getInstance(String templatePath)
+      throws IOException {
+    if (null == instance) {
+      instance = new AzKubernetesV1PodTemplate(templatePath);
+    }
+    return instance;
+  }
+
+  /**
+   * @return the {@link V1Pod} POD generated from the template.
+   */
+  public V1Pod getPodFromTemplate() {
+    return this.podFromTemplate;
+  }
+
+  /**
+   * @param filterPredicate Predicate to filter the init containers.
+   * @return The list of filtered init Containers derived from the POD specified in the template.
+   */
+  public List<V1Container> getInitContainers(Predicate<? super V1Container> filterPredicate) {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    if (null == spec) {
+      return Collections.emptyList();
+    }
+    List<V1Container> initContainers = spec.getInitContainers();
+    return initContainers == null ? Collections.emptyList() :
+        initContainers.stream().filter(filterPredicate).collect(Collectors.toList());
+  }
+
+  /**
+   * @return The list of init Containers derived from the POD specified in the template.
+   */
+  public List<V1Container> getInitContainers() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    return spec == null ? Collections.emptyList() : spec.getInitContainers();
+  }
+
+  /**
+   * @param filterPredicate Predicate to filter the volumes.
+   * @return The list of filtered Volumes derived from the POD specified in the template.
+   */
+  public List<V1Volume> getVolumes(Predicate<? super V1Volume> filterPredicate) {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    if (null == spec) {
+      return Collections.emptyList();
+    }
+    List<V1Volume> volumes = spec.getVolumes();
+    return volumes == null ?
+        Collections.emptyList() :
+        volumes.stream().filter(filterPredicate).collect(Collectors.toList());
+  }
+
+  /**
+   * @return The list of filtered Volumes derived from the POD specified in the template.
+   */
+  public List<V1Volume> getVolumes() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    return spec == null ? Collections.emptyList() : spec.getVolumes();
+  }
+
+  /**
+   * This method returns volume mounts only for the first container.
+   *
+   * @param filterPredicate Predicate to filter the Volume Mounts.
+   * @return The list of filtered Volume Mounts to the appContainer derived from the POD specified
+   * in the template.
+   */
+  public List<V1VolumeMount> getContainerVolumeMounts(
+      Predicate<? super V1VolumeMount> filterPredicate) {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    if (null == spec) {
+      return Collections.emptyList();
+    }
+    List<V1Container> containers = spec.getContainers();
+    if (null == containers || containers.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<V1VolumeMount> volumeMounts =
+        spec.getContainers().get(FLOW_CONTAINER_INDEX).getVolumeMounts();
+    return null == volumeMounts ? Collections.emptyList()
+        : volumeMounts.stream().filter(filterPredicate).collect(Collectors.toList());
+  }
+
+  /**
+   * This method returns volume mounts only for the first container.
+   *
+   * @return The list of Volume Mounts to the appContainer derived from the POD specified in the
+   * template.
+   */
+  public List<V1VolumeMount> getContainerVolumeMounts() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
+    return containers.isEmpty() ? Collections.emptyList() :
+        containers.get(FLOW_CONTAINER_INDEX).getVolumeMounts();
+  }
+}

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    akey1: aval1
+  labels:
+    lkey1: lvalue1
+  name: az-example
+  namespace: az-team
+spec:
+  containers:
+  - env:
+    - name: AZ_CLUSTER
+      value: mycluster
+    - name: AZ_CONF_VERSION
+      value: 0.0.3
+    - name: envKey
+      value: envValue
+    image: path/azkaban-base-image:0.0.5
+    imagePullPolicy: IfNotPresent
+    name: az-flow-container
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 500m
+        memory: 500Mi
+    volumeMounts:
+    - mountPath: azBasePath/plugins/jobtypes/spark
+      name: jobtype-volume-spark
+    - mountPath: /var/run/nscd/socket
+      name: nscd-socket
+    - mountPath: /var/azkaban/private/conf
+      name: azkaban-private-properties
+    - mountPath: /var/run/kubelet
+      name: kubelet
+  initContainers:
+  - env:
+    - name: AZ_CLUSTER
+      value: mycluster
+    - name: JOBTYPE_MOUNT_PATH
+      value: /data/jobtypes/spark
+    image: path/spark-jobtype:0.0.5
+    imagePullPolicy: IfNotPresent
+    name: jobtype-init-spark
+    volumeMounts:
+    - mountPath: /data/jobtypes/spark
+      name: jobtype-volume-spark
+  - command:
+    - chown
+    - -R
+    - '1000'
+    - /var/run/kubelet/
+    image: path/my-image:0.0.5
+    name: chown-kubelet
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/run/kubelet
+      name: kubelet
+  restartPolicy: Never
+  volumes:
+  - emptyDir: {}
+    name: jobtype-volume-spark
+  - hostPath:
+      type: Socket
+      path: /var/run/nscd/socket
+    name: nscd-socket
+  - name: azkaban-private-properties
+    secret:
+      defaultMode: 256
+      secretName: azkaban-private-properties
+  - hostPath:
+      type: Directory
+      path: /export/content/lid/apps/kubelet/i002/var
+    name: kubelet

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
@@ -1,0 +1,33 @@
+apiVersion: "v1"
+kind: "Pod"
+metadata:
+  name: "az-template-example"
+  namespace: "az-team"
+spec:
+  initContainers:
+    - name: chown-kubelet
+      image: path/my-image:0.0.5
+      command:
+        - chown
+        - "-R"
+        - '1000'
+        - "/var/run/kubelet/"
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: kubelet
+          mountPath: "/var/run/kubelet"
+  containers:
+    - image: "path/azkaban-base-image:0.0.5"
+      imagePullPolicy: "IfNotPresent"
+      name: "az-flow-container"
+      volumeMounts:
+        - name: kubelet
+          mountPath: "/var/run/kubelet"
+  volumes:
+    - emptyDir: {}
+      name: jobtype-volume-spark
+    - name: kubelet
+      hostPath:
+        path: /export/content/lid/apps/kubelet/i002/var
+        type: Directory


### PR DESCRIPTION
This template design enables the declaration of static initContainers, volumes, volumeMounts, etc. which are not job-types but are useful. For example: init container which will fetch the required certificates/tokens etc. writes to a volume and then that volume will be mounted to the application-container/flow-container.

Items like InitContainers, Volumes, and VolumeMounts for the application-container/flow-container will be extracted from the POD created from this template file. Extracted Items are later merged with the already created pod-spec(builder based approach).
Merging criterion is such that, if the item in the already created pod-spec has the same name as of the item extracted from the template, then it will be retained.