### PR TITLE
Props.toAllProperties() should not let property settings in the parent take precedence

### DIFF
--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -733,13 +733,14 @@ public class Props {
    */
   public Properties toAllProperties() {
     final Properties allProp = new Properties();
-    // import local properties
-    allProp.putAll(toProperties());
 
     // import parent properties
     if (this._parent != null) {
       allProp.putAll(this._parent.toProperties());
     }
+
+    // import local properties
+    allProp.putAll(toProperties());
 
     return allProp;
   }

--- a/az-core/src/test/java/azkaban/utils/PropsTest.java
+++ b/az-core/src/test/java/azkaban/utils/PropsTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -57,5 +58,21 @@ public class PropsTest {
     Props parent = new Props();
     Props props = new Props(parent, file);
     Assert.assertNull(props.getSource());
+  }
+
+  @Test
+  public void testPropsWithOverriding() {
+    final String property = "property.a";
+
+    final Props parent = new Props();
+    final String valueInParent = "parentValue";
+    parent.put("property.a", valueInParent);
+
+    final Props child = new Props(parent);
+    final String valueInChild = "childValue";
+    child.put(property, valueInChild);
+
+    final Properties merged = child.toAllProperties();
+    Assert.assertEquals(valueInChild, merged.get(property));
   }
 }


### PR DESCRIPTION
When a properties is set both in the parent and child, Props.toAllProperties() takes
the parent's value, which is inconsistent with the behavior of Props.get() method.