### PR TITLE
Fetching all the hadoop tokens from single method and moving call to specific method as responsibility of each implementation

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
@@ -204,6 +204,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * Get file system as User passed in parameter.
+   *
    * @param user
    * @return
    * @throws HadoopSecurityManagerException
@@ -238,6 +239,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * This method will verify whether proxy is allowed or not.
+   *
    * @return
    */
   public boolean shouldProxy() {
@@ -246,6 +248,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * This method is used to get custom credential provider.
+   *
    * @param props
    * @param hadoopCred
    * @param jobLogger
@@ -277,8 +280,9 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
   }
 
   /**
-   * This method is used to register custom credentials which will be used when doPrefetch method
-   * is called.
+   * This method is used to register custom credentials which will be used when doPrefetch method is
+   * called.
+   *
    * @param props
    * @param hadoopCred
    * @param userToProxy
@@ -333,6 +337,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * This method is used to verify whether Hadoop security is enabled or not.
+   *
    * @return
    */
   @Override
@@ -353,6 +358,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * This method is used to prefetch all required tokens for a job.
+   *
    * @param tokenFile
    * @param props
    * @param logger
@@ -373,23 +379,10 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
     try {
       fetchAllHadoopTokens(userToProxyFQN, userToProxy, props, logger, cred);
-
-      getProxiedUser(userToProxyFQN).doAs(new PrivilegedExceptionAction<Void>() {
-        @Override
-        public Void run() throws Exception {
-          getCustomTokens(userToProxyFQN, userToProxy);
-          return null;
-        }
-
-        private void getCustomTokens(final String userToProxyFQN, final String userToProxy)
-            throws InterruptedException, IOException, HadoopSecurityManagerException {
-          logger.info("Here is the props for " + HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN +
-              ": " + props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN));
-
-          registerAllCustomCredentials(userToProxy, props, cred, logger);
-        }
+      getProxiedUser(userToProxyFQN).doAs((PrivilegedExceptionAction<Void>) () -> {
+        registerAllCustomCredentials(userToProxy, props, cred, logger);
+        return null;
       });
-
       logger.info("Preparing token file " + tokenFile.getAbsolutePath());
       prepareTokenFile(userToProxy, cred, tokenFile, logger,
           props.getString(Constants.ConfigurationKeys.SECURITY_USER_GROUP, "azkaban"));
@@ -433,8 +426,9 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
   }
 
   /**
-   * This method is used to write all the credentials into file so that the file can be shared
-   * with user job process.
+   * This method is used to write all the credentials into file so that the file can be shared with
+   * user job process.
+   *
    * @param credentials
    * @param tokenFile
    * @param logger
@@ -548,6 +542,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
 
   /**
    * This method is used to cancel token.
+   *
    * @param tokenFile
    * @param userToProxy
    * @param logger
@@ -632,8 +627,9 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
   }
 
   /**
-   * This method is used to fetch all Hadoop tokens which includes NameNode, JHS, JT and
-   * Metastore and add it in cred object.
+   * This method is used to fetch all Hadoop tokens which includes NameNode, JHS, JT and Metastore
+   * and add it in cred object.
+   *
    * @param userToProxyFQN
    * @param userToProxy
    * @param props
@@ -642,7 +638,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
    * @throws HadoopSecurityManagerException
    * @throws IOException
    */
-  protected abstract void fetchAllHadoopTokens(final String userToProxyFQN, final String userToProxy,
-      final Props props, final Logger logger, final Credentials cred)
+  protected abstract void fetchAllHadoopTokens(final String userToProxyFQN,
+      final String userToProxy, final Props props, final Logger logger, final Credentials cred)
       throws HadoopSecurityManagerException, IOException, InterruptedException;
 }

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
@@ -370,27 +370,23 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
     logger.info("Getting hadoop tokens based on props for " + userToProxyFQN);
 
     final Credentials cred = new Credentials();
-    fetchMetaStoreToken(userToProxyFQN, userToProxy, props, logger, cred);
 
     try {
-      fetchJHSToken(userToProxyFQN, userToProxy, props, logger, cred);
+      fetchAllHadoopTokens(userToProxyFQN, userToProxy, props, logger, cred);
 
       getProxiedUser(userToProxyFQN).doAs(new PrivilegedExceptionAction<Void>() {
         @Override
         public Void run() throws Exception {
-          getToken(userToProxyFQN, userToProxy);
+          getCustomTokens(userToProxyFQN, userToProxy);
           return null;
         }
 
-        private void getToken(final String userToProxyFQN, final String userToProxy)
+        private void getCustomTokens(final String userToProxyFQN, final String userToProxy)
             throws InterruptedException, IOException, HadoopSecurityManagerException {
           logger.info("Here is the props for " + HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN +
               ": " + props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN));
 
           registerAllCustomCredentials(userToProxy, props, cred, logger);
-
-          fetchNameNodeToken(userToProxyFQN, userToProxy, props, logger, cred);
-          fetchJobTrackerToken(userToProxyFQN, userToProxy, props, logger, cred);
         }
       });
 
@@ -636,8 +632,8 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
   }
 
   /**
-   * This method is used to fetch delegation token for JHS and add it in cred object.
-   *
+   * This method is used to fetch all Hadoop tokens which includes NameNode, JHS, JT and
+   * Metastore and add it in cred object.
    * @param userToProxyFQN
    * @param userToProxy
    * @param props
@@ -646,53 +642,7 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
    * @throws HadoopSecurityManagerException
    * @throws IOException
    */
-  protected abstract void fetchJHSToken(final String userToProxyFQN, final String userToProxy,
+  protected abstract void fetchAllHadoopTokens(final String userToProxyFQN, final String userToProxy,
       final Props props, final Logger logger, final Credentials cred)
-      throws HadoopSecurityManagerException, IOException;
-
-  /**
-   * This method is used to fetch delegation token for MetaStore and add it in cred object.
-   *
-   * @param userToProxyFQN
-   * @param userToProxy
-   * @param props
-   * @param logger
-   * @param cred
-   * @throws HadoopSecurityManagerException
-   */
-  protected abstract void fetchMetaStoreToken(final String userToProxyFQN,
-      final String userToProxy, final Props props, final Logger logger,
-      final Credentials cred) throws HadoopSecurityManagerException;
-
-  /**
-   * This method is used to fetch delegation token for NameNode and add it in cred object.
-   *
-   * @param userToProxyFQN
-   * @param userToProxy
-   * @param props
-   * @param logger
-   * @param cred
-   * @throws IOException
-   * @throws HadoopSecurityManagerException
-   */
-  protected abstract void fetchNameNodeToken(final String userToProxyFQN,
-      final String userToProxy, final Props props, final Logger logger,
-      final Credentials cred) throws IOException, HadoopSecurityManagerException;
-
-  /**
-   * This method is used to fetch delegation token for JT and add it in cred object.
-   *
-   * @param userToProxyFQN
-   * @param userToProxy
-   * @param props
-   * @param logger
-   * @param cred
-   * @throws IOException
-   * @throws InterruptedException
-   * @throws HadoopSecurityManagerException
-   */
-  protected abstract void fetchJobTrackerToken(final String userToProxyFQN,
-      final String userToProxy, final Props props,
-      final Logger logger, final Credentials cred)
-      throws IOException, InterruptedException, HadoopSecurityManagerException;
+      throws HadoopSecurityManagerException, IOException, InterruptedException;
 }

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -26,6 +26,7 @@ import azkaban.utils.UndefinedPropertyException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
+import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -182,8 +183,19 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
     return hcatToken;
   }
 
-  @Override
-  protected void fetchJobTrackerToken(final String userToProxyFQN,
+  /**
+   * This method is used to fetch delegation token for JT and add it in cred object.
+   *
+   * @param userToProxyFQN
+   * @param userToProxy
+   * @param props
+   * @param logger
+   * @param cred
+   * @throws IOException
+   * @throws InterruptedException
+   * @throws HadoopSecurityManagerException
+   */
+  private void fetchJobTrackerToken(final String userToProxyFQN,
       final String userToProxy, final Props props,
       final Logger logger, final Credentials cred)
       throws IOException, InterruptedException, HadoopSecurityManagerException {
@@ -211,7 +223,33 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
   }
 
   @Override
-  protected void fetchNameNodeToken(final String userToProxyFQN,
+  protected void fetchAllHadoopTokens(final String userToProxyFQN,
+      final String userToProxy, final Props props,
+      final Logger logger,
+      final Credentials cred) throws IOException, InterruptedException,
+      HadoopSecurityManagerException {
+    logger.info("Fetching all hadoop tokens.");
+    fetchMetaStoreToken(userToProxyFQN, userToProxy, props, logger, cred);
+    fetchJHSToken(userToProxyFQN, userToProxy, props, logger, cred);
+    getProxiedUser(userToProxyFQN).doAs((PrivilegedExceptionAction<Void>) () -> {
+      fetchNameNodeToken(userToProxyFQN, userToProxy, props, logger, cred);
+      fetchJobTrackerToken(userToProxyFQN, userToProxy, props, logger, cred);
+      return null;
+    });
+  }
+
+  /**
+   * This method is used to fetch delegation token for NameNode and add it in cred object.
+   *
+   * @param userToProxyFQN
+   * @param userToProxy
+   * @param props
+   * @param logger
+   * @param cred
+   * @throws IOException
+   * @throws HadoopSecurityManagerException
+   */
+  private void fetchNameNodeToken(final String userToProxyFQN,
       final String userToProxy, final Props props,
       final Logger logger,
       final Credentials cred) throws IOException, HadoopSecurityManagerException {
@@ -250,7 +288,6 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
    * @throws IOException
    * @throws HadoopSecurityManagerException
    */
-
   private void fetchNameNodeTokenInternal(final String renewer, final Credentials cred,
       final String userToProxyFQN, final URI uri)
       throws IOException, HadoopSecurityManagerException {
@@ -285,8 +322,18 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
     }
   }
 
-  @Override
-  protected void fetchJHSToken(final String userToProxyFQN,
+  /**
+   * This method is used to fetch delegation token for JHS and add it in cred object.
+   *
+   * @param userToProxyFQN
+   * @param userToProxy
+   * @param props
+   * @param logger
+   * @param cred
+   * @throws HadoopSecurityManagerException
+   * @throws IOException
+   */
+  private void fetchJHSToken(final String userToProxyFQN,
       final String userToProxy, final Props props, final Logger logger, final Credentials cred)
       throws HadoopSecurityManagerException, IOException {
     if (props.getBoolean(OBTAIN_JOBHISTORYSERVER_TOKEN, false)) {
@@ -328,8 +375,17 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
     }
   }
 
-  @Override
-  protected void fetchMetaStoreToken(final String userToProxyFQN,
+  /**
+   * This method is used to fetch delegation token for MetaStore and add it in cred object.
+   *
+   * @param userToProxyFQN
+   * @param userToProxy
+   * @param props
+   * @param logger
+   * @param cred
+   * @throws HadoopSecurityManagerException
+   */
+  private void fetchMetaStoreToken(final String userToProxyFQN,
       final String userToProxy, final Props props, final Logger logger,
       final Credentials cred)
       throws HadoopSecurityManagerException {

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -253,9 +253,10 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
       final String userToProxy, final Props props,
       final Logger logger,
       final Credentials cred) throws IOException, HadoopSecurityManagerException {
+    logger.info("Here is the props for " + HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN +
+        ": " + props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN));
     if (props.getBoolean(HadoopSecurityManager.OBTAIN_NAMENODE_TOKEN, false)) {
       final String renewer = getMRTokenRenewerInternal(new JobConf()).toString();
-
       // Get the tokens name node
       fetchNameNodeTokenInternal(renewer, cred, userToProxyFQN, null);
       Optional<String[]> otherNameNodes = getOtherNameNodes(props);


### PR DESCRIPTION
This will provide us a way to make single call to fetch all the hadoop tokens together if we have different implementation for AbstractHadoopSecurityManager.