### PR TITLE
Merge FlowContainer and flow logs into one so that they can be viewed as flow logs in UI.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -16,6 +16,9 @@
 
 package azkaban;
 
+import org.apache.log4j.Layout;
+import org.apache.log4j.PatternLayout;
+
 import java.time.Duration;
 
 /**
@@ -145,6 +148,9 @@ public class Constants {
 
   // AZ_HOME in containerized execution
   public static final String AZ_HOME = "AZ_HOME";
+
+  public static final Layout DEFAULT_FLOWRUNNER_LAYOUT = new PatternLayout(
+          "%d{dd-MM-yyyy HH:mm:ss z} %c{1} %p - %m\n");
 
 
   public static class ConfigurationKeys {

--- a/azkaban-exec-server/src/main/java/azkaban/container/ContainerizedFlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/ContainerizedFlowPreparer.java
@@ -51,6 +51,11 @@ public class ContainerizedFlowPreparer extends AbstractFlowPreparer {
     return Paths.get(azHome).toAbsolutePath();
   }
 
+  public static Path getExecutionDir() {
+    return Paths.get(getCurrentDir().toString(), PROJECT_DIR);
+  }
+
+
   /**
    * Constructor
    * @param projectStorageManager ProjectStorageManager
@@ -93,22 +98,15 @@ public class ContainerizedFlowPreparer extends AbstractFlowPreparer {
   @Override
   protected File setupExecutionDir(final Path dir, final ExecutableFlow flow)
           throws ExecutorManagerException {
-    // Create project dir
+    // Create project dir path
     final Path projectDirPath = Paths.get(dir.toString(), PROJECT_DIR);
-    // A directory of name projectDirPath cannot pre-exist.
-    if (Files.exists(projectDirPath)) {
-      final String msg = "A project directory of name " + projectDirPath + " already exists";
+    // A directory of name projectDirPath must be there by now.
+    if (!Files.exists(projectDirPath)) {
+      final String msg = "A project directory of name " + projectDirPath + " does not exist";
       LOGGER.error(msg);
       throw new ExecutorManagerException(msg);
     }
 
-    LOGGER.info("Creating execution dir");
-    try {
-      Files.createDirectory(projectDirPath);
-    } catch (final IOException e) {
-      LOGGER.error("Error creating directory :" + projectDirPath, e);
-      throw new ExecutorManagerException(e);
-    }
     flow.setExecutionPath(projectDirPath.toString());
     return projectDirPath.toFile();
   }

--- a/azkaban-exec-server/src/test/java/azkaban/container/ContainerizedFlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/container/ContainerizedFlowPreparerTest.java
@@ -27,6 +27,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -51,6 +54,11 @@ public class ContainerizedFlowPreparerTest extends FlowPreparerTestBase {
     when(executableFlow.getProjectId()).thenReturn(FAT_PROJECT_ID);
     when(executableFlow.getVersion()).thenReturn(34);
 
+    try {
+      Files.createDirectory(execDir.toPath());
+    } catch (final IOException e) {
+     throw new ExecutorManagerException(e);
+    }
     this.instance.setup(executableFlow);
     assertTrue(new File(execDir, SAMPLE_FLOW_01).exists());
   }


### PR DESCRIPTION
Merge FlowContainer and flow logs into one so that they can be viewed as flow logs in UI.

- Moved the logger to FlowContainer from FlowRunner for containeriazed
  execution.
- Use log4j instead of slf4j to use appender in FlowContainer.
- Reformatted logging messages in FlowContainer compliant with log4j.