### PR TITLE
Fix handling of null executionId in ExecutorApiGateway

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java
@@ -34,9 +34,12 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import javax.inject.Singleton;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class ExecutorApiGateway {
+  private final static Logger logger = LoggerFactory.getLogger(ExecutorApiGateway.class);
   public final static String DEFAULT_EXECUTION_RESOURCE = "executor";
   public final static String CONTAINERIZED_EXECUTION_RESOURCE = "container";
 
@@ -92,14 +95,15 @@ public class ExecutorApiGateway {
   }
 
   @VisibleForTesting
-  String createExecutionPath(Optional<Integer> executionId) throws ExecutorManagerException {
+  String createExecutionPath(final Optional<Integer> executionId) throws ExecutorManagerException {
     if (!isReverseProxyEnabled) {
       return "/" + executionResourceName;
     }
 
     if(!executionId.isPresent()) {
-      throw new ExecutorManagerException(
-          "Execution Id must be provided when reverse-proxy is enabled");
+      final String errorMessage = "Execution Id must be provided when reverse-proxy is enabled";
+      logger.error(errorMessage);
+      throw new ExecutorManagerException(errorMessage);
     }
     return "/" + executionResourceNameModifier.apply(executionId.get(), executionResourceName);
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
@@ -16,11 +16,12 @@
 
 package azkaban.executor;
 
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTOR_REVERSE_PROXY_HOSTNAME;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTOR_REVERSE_PROXY_PORT;
+import static azkaban.executor.ExecutorApiClientTest.REVERSE_PROXY_HOST;
+import static azkaban.executor.ExecutorApiClientTest.REVERSE_PROXY_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -29,11 +30,15 @@ import azkaban.DispatchMethod;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,23 +90,100 @@ public class ExecutorApiGatewayTest {
   }
 
   @Test
-  public void testPathWithDefaultConfigs() {
+  public void testPathWithDefaultConfigs() throws Exception {
     int executionId = 12345;
-    String path = gateway.createExecutionPath(12345);
+    String path = gateway.createExecutionPath(Optional.of(12345));
     Assert.assertEquals("/"+ExecutorApiGateway.DEFAULT_EXECUTION_RESOURCE, path);
   }
 
   @Test
-  public void testPathWithContainerizedConfigs() {
-    Props containerizedConfigs = new Props();
-    containerizedConfigs.put(ConfigurationKeys.AZKABAN_EXECUTOR_REVERSE_PROXY_ENABLED, "true");
-    containerizedConfigs.put(ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD,
-        DispatchMethod.CONTAINERIZED.name());
-    ExecutorApiGateway gateway = new ExecutorApiGateway(client, containerizedConfigs);
+  public void testPathWithContainerizedConfigs() throws Exception {
+    final ExecutorApiGateway gateway = gatewayWithConfigs(this.client, containerizationEnabledProps());
     int executionId = 12345;
-    String path = gateway.createExecutionPath(12345);
+    String path = gateway.createExecutionPath(Optional.of(12345));
     Assert.assertEquals("/" + executionId + "/" +
             ExecutorApiGateway.CONTAINERIZED_EXECUTION_RESOURCE,
         path);
+  }
+
+  private Props containerizationEnabledProps() {
+    Props containerizedProps = new Props();
+    containerizedProps.put(ConfigurationKeys.AZKABAN_EXECUTOR_REVERSE_PROXY_ENABLED, "true");
+    containerizedProps.put(AZKABAN_EXECUTOR_REVERSE_PROXY_HOSTNAME, REVERSE_PROXY_HOST);
+    containerizedProps.put(AZKABAN_EXECUTOR_REVERSE_PROXY_PORT, REVERSE_PROXY_PORT);
+    containerizedProps.put(ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD,
+        DispatchMethod.CONTAINERIZED.name());
+    return containerizedProps;
+  }
+
+  private ExecutorApiGateway gatewayWithConfigs(ExecutorApiClient client, Props props) {
+    return new ExecutorApiGateway(client, props);
+  }
+
+  @Test
+  public void testPingWithDefaultConfigs() throws Exception {
+    Props props = new Props();
+    final ExecutorApiClient clientSpy = Mockito.spy(new SendDisabledExecutorApiClient(props));
+
+    final ExecutorApiGateway gateway = gatewayWithConfigs(clientSpy, props);
+    final String apiAction = ConnectorParams.PING_ACTION;
+    final String apiHost = "host1";
+    final int apiPort = 1234;
+    final Map<String, Object> response = gateway.callWithExecutionId(apiHost, apiPort, apiAction,
+        null, null);
+    final URI expectedUri = new URI("http://host1:1234/executor");
+    final List<Pair<String, String>> expectedParams = ImmutableList.of(
+        new Pair<>("action", "ping"),
+        new Pair<>("execid", "null"), // this is "null" (string) due to application of String.valueOf()
+        new Pair<>("user", null));
+    Mockito.verify(clientSpy).httpPost(eq(expectedUri), eq(expectedParams));
+  }
+
+  @Test
+  public void testPingWithContainerization() throws Exception {
+    Props props = new Props();
+    props.put(ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD, DispatchMethod.CONTAINERIZED.name());
+    final ExecutorApiClient clientSpy = Mockito.spy(new SendDisabledExecutorApiClient(props));
+    final ExecutorApiGateway gateway = gatewayWithConfigs(clientSpy, props);
+    final String apiAction = ConnectorParams.PING_ACTION;
+    final String apiHost = "host1";
+    final int apiPort = 1234;
+    final Map<String, Object> response = gateway.callWithExecutionId(apiHost, apiPort, apiAction,
+        null, null);
+
+    final URI expectedUri = new URI("http://host1:1234/container");
+    final List<Pair<String, String>> expectedParams = ImmutableList.of(
+        new Pair<>("action", "ping"),
+        new Pair<>("execid", "null"),
+        new Pair<>("user", null));
+    Mockito.verify(clientSpy).httpPost(eq(expectedUri), eq(expectedParams));
+  }
+
+  @Test(expected = ExecutorManagerException.class)
+  public void testPingWithReverseProxy() throws Exception {
+    Props props = containerizationEnabledProps();
+    final ExecutorApiClient client = new SendDisabledExecutorApiClient(props);
+    final ExecutorApiGateway gateway = gatewayWithConfigs(client, props);
+    final String apiAction = ConnectorParams.PING_ACTION;
+    final String apiHost = "host1";
+    final int apiPort = 1234;
+
+    // this should throw an exception as the properties have reverse-proxy enabled.
+    final Map<String, Object> response = gateway.callWithExecutionId(apiHost, apiPort, apiAction,
+        null, null);
+    Assert.fail();
+  }
+
+  private static class SendDisabledExecutorApiClient extends ExecutorApiClient {
+    private static String SUCCESS_JSON = "{\"status\":\"success\"}";
+
+    public SendDisabledExecutorApiClient(Props azkProps) {
+      super(azkProps);
+    }
+
+    @Override
+    protected String sendAndReturn(HttpUriRequest request) throws IOException {
+      return SUCCESS_JSON;
+    }
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
@@ -91,23 +91,23 @@ public class ExecutorApiGatewayTest {
 
   @Test
   public void testPathWithDefaultConfigs() throws Exception {
-    int executionId = 12345;
-    String path = gateway.createExecutionPath(Optional.of(12345));
+    final int executionId = 12345;
+    final String path = gateway.createExecutionPath(Optional.of(executionId));
     Assert.assertEquals("/"+ExecutorApiGateway.DEFAULT_EXECUTION_RESOURCE, path);
   }
 
   @Test
   public void testPathWithContainerizedConfigs() throws Exception {
     final ExecutorApiGateway gateway = gatewayWithConfigs(this.client, containerizationEnabledProps());
-    int executionId = 12345;
-    String path = gateway.createExecutionPath(Optional.of(12345));
+    final int executionId = 12345;
+    final String path = gateway.createExecutionPath(Optional.of(executionId));
     Assert.assertEquals("/" + executionId + "/" +
             ExecutorApiGateway.CONTAINERIZED_EXECUTION_RESOURCE,
         path);
   }
 
   private Props containerizationEnabledProps() {
-    Props containerizedProps = new Props();
+    final Props containerizedProps = new Props();
     containerizedProps.put(ConfigurationKeys.AZKABAN_EXECUTOR_REVERSE_PROXY_ENABLED, "true");
     containerizedProps.put(AZKABAN_EXECUTOR_REVERSE_PROXY_HOSTNAME, REVERSE_PROXY_HOST);
     containerizedProps.put(AZKABAN_EXECUTOR_REVERSE_PROXY_PORT, REVERSE_PROXY_PORT);
@@ -116,13 +116,13 @@ public class ExecutorApiGatewayTest {
     return containerizedProps;
   }
 
-  private ExecutorApiGateway gatewayWithConfigs(ExecutorApiClient client, Props props) {
+  private ExecutorApiGateway gatewayWithConfigs(final ExecutorApiClient client, final Props props) {
     return new ExecutorApiGateway(client, props);
   }
 
   @Test
   public void testPingWithDefaultConfigs() throws Exception {
-    Props props = new Props();
+    final Props props = new Props();
     final ExecutorApiClient clientSpy = Mockito.spy(new SendDisabledExecutorApiClient(props));
 
     final ExecutorApiGateway gateway = gatewayWithConfigs(clientSpy, props);
@@ -131,6 +131,7 @@ public class ExecutorApiGatewayTest {
     final int apiPort = 1234;
     final Map<String, Object> response = gateway.callWithExecutionId(apiHost, apiPort, apiAction,
         null, null);
+
     final URI expectedUri = new URI("http://host1:1234/executor");
     final List<Pair<String, String>> expectedParams = ImmutableList.of(
         new Pair<>("action", "ping"),
@@ -141,7 +142,7 @@ public class ExecutorApiGatewayTest {
 
   @Test
   public void testPingWithContainerization() throws Exception {
-    Props props = new Props();
+    final Props props = new Props();
     props.put(ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD, DispatchMethod.CONTAINERIZED.name());
     final ExecutorApiClient clientSpy = Mockito.spy(new SendDisabledExecutorApiClient(props));
     final ExecutorApiGateway gateway = gatewayWithConfigs(clientSpy, props);
@@ -161,7 +162,7 @@ public class ExecutorApiGatewayTest {
 
   @Test(expected = ExecutorManagerException.class)
   public void testPingWithReverseProxy() throws Exception {
-    Props props = containerizationEnabledProps();
+    final Props props = containerizationEnabledProps();
     final ExecutorApiClient client = new SendDisabledExecutorApiClient(props);
     final ExecutorApiGateway gateway = gatewayWithConfigs(client, props);
     final String apiAction = ConnectorParams.PING_ACTION;


### PR DESCRIPTION
Handling of `null` execution-id in ExecutorApiGateway.callWithExecutionId() was broken by commit
https://github.com/azkaban/azkaban/pull/2715/commits/38f3c103b771d1cf4687f9e97a0e0537dea1a1e4