### PR TITLE
Allow multiple copies of the same dependency file in Thin Zips.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/ThinArchiveUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ThinArchiveUtils.java
@@ -53,7 +53,7 @@ public class ThinArchiveUtils {
     }
 
     List<Map<String, String>> rawParseResult =
-        ((HashMap<String, List<Map<String, String>>>) JSONUtils.parseJSONFromString(rawJson)).get("dependencies");
+        ((Map<String, List<Map<String, String>>>) JSONUtils.parseJSONFromString(rawJson)).get("dependencies");
 
     if (rawParseResult == null) {
       throw new IOException("Could not find 'dependencies' key in startup-dependencies.json file.");

--- a/azkaban-spi/src/main/java/azkaban/spi/Dependency.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/Dependency.java
@@ -24,19 +24,20 @@ import java.util.Objects;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
- * Representation of startup dependency. Maps 1:1 to an entry in startup-dependencies.json for thin archives.
- * Will automatically validate SHA1 checksum upon instantiation to avoid SQL injection when this checksum is used
- * for DB queries, as well as mitigating other issues down the road.
+ * Representation of startup dependency. Maps 1:1 to an entry in startup-dependencies.json for thin
+ * archives. Will automatically validate SHA1 checksum upon instantiation to avoid SQL injection
+ * when this checksum is used for DB queries, as well as mitigating other issues down the road.
  */
 public class Dependency {
+
   private final String fileName;
   private final String destination;
   private final String type;
   private final String ivyCoordinates;
   private final String sha1;
 
-  public Dependency(final String fileName, final String destination, final String type, final String ivyCoordinates,
-      final String sha1) throws InvalidHashException {
+  public Dependency(final String fileName, final String destination, final String type,
+      final String ivyCoordinates, final String sha1) throws InvalidHashException {
     this.fileName = fileName;
     this.destination = destination;
     this.type = type;
@@ -45,8 +46,8 @@ public class Dependency {
   }
 
   public Dependency(final Map<String, String> fieldMap) throws InvalidHashException {
-    this(fieldMap.get("file"), fieldMap.get("destination"), fieldMap.get("type"), fieldMap.get("ivyCoordinates"),
-        fieldMap.get("sha1"));
+    this(fieldMap.get("file"), fieldMap.get("destination"), fieldMap.get("type"),
+        fieldMap.get("ivyCoordinates"), fieldMap.get("sha1"));
   }
 
   /**
@@ -56,8 +57,9 @@ public class Dependency {
    */
   public Dependency copy() {
     try {
-      return new Dependency(getFileName(), getDestination(), getType(), getIvyCoordinates(), getSHA1());
-    } catch (InvalidHashException e) {
+      return new Dependency(getFileName(), getDestination(), getType(), getIvyCoordinates(),
+          getSHA1());
+    } catch (final InvalidHashException e) {
       // This should never happen because we already validated the hash when creating this dependency
       throw new RuntimeException("InvalidHashException when copying dependency.");
     }
@@ -71,8 +73,9 @@ public class Dependency {
    */
   public DependencyFile makeDependencyFile(final File file) {
     try {
-      return new DependencyFile(file, getFileName(), getDestination(), getType(), getIvyCoordinates(), getSHA1());
-    } catch (InvalidHashException e) {
+      return new DependencyFile(file, getFileName(), getDestination(), getType(),
+          getIvyCoordinates(), getSHA1());
+    } catch (final InvalidHashException e) {
       // This should never happen because we already validated the hash when creating this dependency
       throw new RuntimeException("InvalidHashException when copying dependency.");
     }
@@ -82,12 +85,25 @@ public class Dependency {
   // spec we expect the property to be "file" not "fileName" so we have to annotate this to tell the JSON serializer
   // to insert it with "file", instead of assuming the name based on the name of the getter like it usually does.
   @JsonProperty("file")
-  public String getFileName() { return this.fileName; }
+  public String getFileName() {
+    return this.fileName;
+  }
 
-  public String getDestination() { return this.destination; }
-  public String getType() { return this.type; }
-  public String getIvyCoordinates() { return this.ivyCoordinates; }
-  public String getSHA1() { return this.sha1; }
+  public String getDestination() {
+    return this.destination;
+  }
+
+  public String getType() {
+    return this.type;
+  }
+
+  public String getIvyCoordinates() {
+    return this.ivyCoordinates;
+  }
+
+  public String getSHA1() {
+    return this.sha1;
+  }
 
   @Override
   public boolean equals(final Object o) {
@@ -97,9 +113,12 @@ public class Dependency {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Dependency that = (Dependency) o;
-    return this.fileName.equals(that.fileName) && this.type.equals(that.type) && this.ivyCoordinates.equals(that.ivyCoordinates)
-        && this.sha1.equals(that.sha1);
+    final Dependency that = (Dependency) o;
+    return this.fileName.equals(that.fileName) &&
+        this.destination.equals(that.destination) &&
+        this.type.equals(that.type) &&
+        this.ivyCoordinates.equals(that.ivyCoordinates) &&
+        this.sha1.equals(that.sha1);
   }
 
   @Override


### PR DESCRIPTION
Sometimes, to isolate dependencies and avoid conflicts the same dependency jar file is required in different paths in a project. For example:
```
common-libs
 |-jackson-annotations-2.6.0.jar
 |-….jar
 |-….jar
 |-other-libs
     |-jackson-annotations-2.6.0.jar
     |-….jar
```
To allow this we need to take into consideration dependency `destination` when building the _Set_ of dependencies to download.