### PR TITLE
create-all-sql-*.sql is missing in some distributions

### DIFF
--- a/azkaban-db/build.gradle
+++ b/azkaban-db/build.gradle
@@ -48,7 +48,7 @@ dependencies {
  */
 task concat() {
     doLast {
-        ext.destFile = 'build/sql/create-all-sql-' + version + '.sql';
+        ext.destFile = "$buildDir/sql/create-all-sql-" + version + '.sql';
         ant.concat(destfile: destFile, fixlastline: 'yes') {
             logger.info('Concating create scripts to ' + destFile)
             fileset(dir: 'src/main/sql') {


### PR DESCRIPTION
Note how `distributions` below collects from "$buildDir/sql" -- *not* from 'build/sql'.
Turns out that $buildDir can be azkaban/build/azkaban-db *or* azkaban/azkaban-db/build,
depending on the build configuration. So it's important to be consistent about (1) where
the create-all-sql-*.sql is created and (2) where it is picked up from into distributions.