### PR TITLE
increase solo server Xmx to 3G

### DIFF
--- a/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
+++ b/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh
@@ -53,7 +53,7 @@ echo "CLASSPATH: ${CLASSPATH}";
 executorport=$(grep executor.port "${conf}/azkaban.properties" | cut -d = -f 2)
 serverpath=$(pwd)
 
-AZKABAN_OPTS=" -Xmx512M -server -Djava.io.tmpdir=$tmpdir -Dexecutorport=${executorport} \
+AZKABAN_OPTS=" -Xmx3G -server -Djava.io.tmpdir=$tmpdir -Dexecutorport=${executorport} \
     -Dserverpath=${serverpath} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 
 if [[ -f "${conf}/log4j.properties" ]]; then


### PR DESCRIPTION
Fixes Out of memory issue with solo server, somehow start script has low max memory set, compared to web and executor servers

https://github.com/azkaban/azkaban/blob/f49d865417c202ebaa14ef102060cf44f9af3179/azkaban-solo-server/src/main/bash/internal/internal-start-solo-server.sh#L56

https://github.com/azkaban/azkaban/blob/f49d865417c202ebaa14ef102060cf44f9af3179/azkaban-web-server/src/main/bash/internal/internal-start-web.sh#L48

https://github.com/azkaban/azkaban/blob/f49d865417c202ebaa14ef102060cf44f9af3179/azkaban-exec-server/src/main/bash/internal/internal-start-executor.sh#L49

Resolves #2769 

