### PR TITLE
Add support for multiple external links on the Flow Execution page

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -146,7 +146,6 @@ public class Constants {
   // AZ_HOME in containerized execution
   public static final String AZ_HOME = "AZ_HOME";
 
-
   public static class ConfigurationKeys {
 
     public static final String AZKABAN_CLUSTER_NAME = "azkaban.cluster.name";
@@ -176,15 +175,32 @@ public class Constants {
     // These properties are configurable through azkaban.properties
     public static final String AZKABAN_PID_FILENAME = "azkaban.pid.filename";
 
-    // Defines a list of external links, each referred to as a topic
-    public static final String AZKABAN_SERVER_EXTERNAL_TOPICS = "azkaban.server.external.topics";
-
     // External URL template of a given topic, specified in the list defined above
+    //Deprecated, it is replaced by AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_URL
     public static final String AZKABAN_SERVER_EXTERNAL_TOPIC_URL = "azkaban.server.external.${topic}.url";
 
     // Designates one of the external link topics to correspond to an execution analyzer
+    //Deprecated, replaced by AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS
     public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC = "azkaban.server.external.analyzer.topic";
+    //Deprecated, it is replaced by AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL
     public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_LABEL = "azkaban.server.external.analyzer.label";
+
+    // Defines a list of external links, each referred to as a topic
+    // external links defined here will be translated into buttons and rendered in the Flow Execution page
+    public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS = "azkaban.server.external.analyzer.topics";
+
+    // Defines timeout in milliseconds for azkaban to validate exernal links
+    // If this config is missing, azkaban will use default 3000 milliseconds as timeout.
+    // If validation fails, buttons is disabled in Flow Execution page.
+    // external links defined here will be translated into buttons and rendered in the Flow Execution page
+    public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_TIMEOUT_MS = "azkaban.server.external.analyzer.timeout.ms";
+
+    // Designates one of the external link topics to correspond to an execution analyzer
+    public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL = "azkaban.server"
+        + ".external.analyzer.${topic}.label";
+    // External URL template of a given topic, specified in the list defined above
+    public static final String AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_URL = "azkaban.server"
+        + ".external.analyzer.${topic}.url";
 
     // Designates one of the external link topics to correspond to a job log viewer
     public static final String AZKABAN_SERVER_EXTERNAL_LOGVIEWER_TOPIC = "azkaban.server.external.logviewer.topic";

--- a/azkaban-common/src/main/java/azkaban/utils/ExternalLink.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExternalLink.java
@@ -1,0 +1,47 @@
+package azkaban.utils;
+
+/**
+ * This is Object for external analyzer.
+ * It stores analyzer topic, label, linkUrl, isValid, used by web server to render external link.
+ * It is used by AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS right now, and it can be reuseed
+ * by AZKABAN_SERVER_EXTERNAL_LOGVIEWER_TOPIC later.
+ */
+public class ExternalLink {
+
+  private final String topic;
+  private final String label;
+  private final String linkUrl;
+  private final boolean linkUrlValid;
+
+  public ExternalLink(final String topic, final String label,
+      final String linkUrl, final boolean isLinkValid) {
+    this.topic = topic;
+    this.label = label;
+    this.linkUrl = linkUrl;
+    this.linkUrlValid = isLinkValid;
+  }
+
+  @Override
+  public String toString() {
+    return "ExternalAnalyzer{" +
+        ", topic='" + this.topic + '\'' +
+        ", label='" + this.label + '\'' +
+        ", linkUrl='" + this.linkUrl + '\'' +
+        ", linkUrlValid='" + this.linkUrlValid + '\'' +
+        '}';
+  }
+
+  public String getTopic() {
+    return this.topic;
+  }
+  public String getLabel() {
+    return this.label;
+  }
+  public String getLinkUrl() {
+    return this.linkUrl;
+  }
+  public boolean isLinkUrlValid() {
+    return this.linkUrlValid;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/utils/ExternalLinkUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExternalLinkUtils.java
@@ -17,25 +17,40 @@
 package azkaban.utils;
 
 import azkaban.Constants;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.Logger;
+import org.apache.http.HttpStatus;
 
 public class ExternalLinkUtils {
+  private static final int DEFAULT_AZKABAN_SERVER_EXTERNAL_TIMEOUT_MS = 3000; //3 seconds
 
   private static final Logger logger = Logger.getLogger(ExternalLinkUtils.class);
 
-  public static String getExternalAnalyzerOnReq(final Props azkProps,
+  public static String getExternalAnalyzerLinkOnReq(final String topic, final Props azkProps,
       final HttpServletRequest req) {
     // If no topic was configured to be an external analyzer, return empty
-    if (!azkProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC)) {
-      return "";
+    return topic.isEmpty() ? "" : getLinkFromRequest(topic, azkProps, req);
+  }
+
+  static List<String> getExternalAnalyzerTopics(final Props azkProps) {
+    if (azkProps.containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS)) {
+      return azkProps.getStringList(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS);
     }
-    // Find out which external link we should use to lead to our analyzer
-    final String topic = azkProps
-        .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC);
-    return getLinkFromRequest(topic, azkProps, req);
+    // If no AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS defined, use legacy config
+    //AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC
+    return Arrays.asList(azkProps.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC, ""));
   }
 
   public static String getExternalLogViewer(final Props azkProps, final String jobId,
@@ -80,16 +95,34 @@ public class ExternalLinkUtils {
     flowExecutionURL += "?";
     flowExecutionURL += req.getQueryString();
     flowExecutionURL = encodeToUTF8(flowExecutionURL);
-
     urlTemplate = urlTemplate.replace("${url}", flowExecutionURL);
     logger.info("Creating link: " + urlTemplate);
     return urlTemplate;
   }
 
   static String getURLForTopic(final String topic, final Props azkProps) {
-    return azkProps.getString(
-        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_TOPIC_URL.replace("${topic}", topic),
-        "");
+    String externalUrlConfKeyToUse =
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_URL.replace("${topic"
+            + "}", topic);
+    // If no AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_URL defined, use legacy config
+    //AZKABAN_SERVER_EXTERNAL_TOPIC_URL
+    externalUrlConfKeyToUse = azkProps.containsKey(externalUrlConfKeyToUse) ?
+        externalUrlConfKeyToUse :
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_TOPIC_URL.replace("$"
+            + "{topic}", topic);
+    return azkProps.getString(externalUrlConfKeyToUse, "");
+  }
+
+  static String getExternalLabelForTopic(final String topic, final Props azkProps) {
+    String externalLabelConfKeyToUse =
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL.replace("${topic"
+            + "}", topic);
+    // If no AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL defined, use legacy config
+    //AZKABAN_SERVER_EXTERNAL_ANALYZER_LABEL
+    externalLabelConfKeyToUse = azkProps.containsKey(externalLabelConfKeyToUse) ?
+        externalLabelConfKeyToUse :
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_LABEL;
+    return azkProps.getString(externalLabelConfKeyToUse, "External Analyzer");
   }
 
   static String encodeToUTF8(final String url) {
@@ -99,5 +132,66 @@ public class ExternalLinkUtils {
       logger.error("Specified encoding is not supported", e);
     }
     return "";
+  }
+
+  /**
+   * Return list of external analyzers based on configs and current web request to web server
+   * to render the execution page.
+   * @param azkProps azkaban configs
+   * @param req current web request
+   * @return list of external analyzers
+   */
+  public static List<ExternalLink> getExternalAnalyzers( final Props azkProps, final HttpServletRequest req) {
+    final List<String> externalTopics = getExternalAnalyzerTopics(azkProps);
+    return externalTopics.stream().map(topic -> {
+      String externalLinkUrl = getExternalAnalyzerLinkOnReq(topic, azkProps, req);
+      if (!externalLinkUrl.isEmpty()) {
+        logger.debug("Adding an External analyzer to the page");
+        final String execExternalLinkLabel = getExternalLabelForTopic(topic, azkProps);
+        logger.debug("External analyzer label set to : " + execExternalLinkLabel);
+        int timeout =
+            azkProps.getInt(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TIMEOUT_MS,
+            DEFAULT_AZKABAN_SERVER_EXTERNAL_TIMEOUT_MS);
+        return new ExternalLink(topic, execExternalLinkLabel, externalLinkUrl,
+            validExternalLink(externalLinkUrl, timeout));
+      }
+      return null;
+    }).filter(Objects::nonNull).collect(Collectors.toList());
+  }
+
+  /**
+   * check if external link is reachable or not.
+   * It will send http request to target url, and check the status code from response,
+   * If the page returns 200x or 300x status, returns true, and external link is enabled,
+   * otherwise returns false, and external link is disabled.
+   * @param externalLinkUrl azkaban configs
+   * @param timeout timeout for httpClient in milliseconds
+   * @return true if target link is reachable, otherwise false.
+   */
+  private static boolean validExternalLink(final String externalLinkUrl, final int timeout) {
+    final RequestConfig config = RequestConfig.custom()
+        .setConnectTimeout(timeout)
+        .setConnectionRequestTimeout(timeout)
+        .setSocketTimeout(timeout).build();
+    final CloseableHttpClient client = HttpClients.custom()
+        .setDefaultRequestConfig(config)
+        .setSSLSocketFactory(null).disableRedirectHandling().build();
+    try {
+      HttpResponse httpResponse = client.execute(new HttpGet(externalLinkUrl));
+      int responseCode = httpResponse.getStatusLine().getStatusCode();
+      if (responseCode >= HttpStatus.SC_BAD_REQUEST) {
+        logger.warn("validExternalLink url " + externalLinkUrl + " not reachable, response code " + responseCode);
+        return false;
+      }
+      logger.debug("validExternalLink url " + externalLinkUrl + " is reachable.");
+      client.close();
+      return true;
+    } catch (IOException e) {
+      logger.error("validExternalLink url " + externalLinkUrl + " CONNECT IO ERROR " + e);
+      return false;
+    } catch (Exception e) {
+      logger.error("validExternalLink url " + externalLinkUrl + " CONNECT ERROR " + e);
+      return false;
+    }
   }
 }

--- a/azkaban-common/src/test/java/azkaban/utils/ExternalLinkUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/ExternalLinkUtilsTest.java
@@ -21,7 +21,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,11 +33,25 @@ public class ExternalLinkUtilsTest {
   private static final String EXEC_URL = "http://localhost:8081/executor";
   private static final String EXEC_QUERY_STRING = "execid=1";
   private static final String EXTERNAL_ANALYZER_TOPIC = "elephant";
+  private static final String EXTERNAL_ANALYZER_TOPICS = "topic1,topic2";
+  private static final String EXTERNAL_ANALYZER_TOPIC1 = "topic1";
+  private static final String EXTERNAL_ANALYZER_TOPIC2 = "topic2";
+
+  private static final String EXTERNAL_ANALYZER_LABEL1 = "topic1";
+  private static final String EXTERNAL_ANALYZER_LABEL2 = "topic2";
+
   private static final String EXTERNAL_ANALYZER_URL_VALID_FORMAT =
       "http://elephant.linkedin.com/search?q=${url}";
   private static final String EXTERNAL_ANALYZER_EXPECTED_URL =
       "http://elephant.linkedin.com/search?q="
           + "http%3A%2F%2Flocalhost%3A8081%2Fexecutor%3Fexecid%3D1";
+
+  private static final String EXTERNAL_ANALYZER_URL_VALID_FORMAT2 =
+      "http://elephant2.linkedin.com/search?q=${url}";
+  private static final String EXTERNAL_ANALYZER_EXPECTED_URL2 =
+      "http://elephant2.linkedin.com/search?q="
+          + "http%3A%2F%2Flocalhost%3A8081%2Fexecutor%3Fexecid%3D1";
+
   private static final String EXTERNAL_LOGVIEWER_TOPIC = "kibana";
   private static final String EXTERNAL_LOGVIEWER_URL_VALID_FORMAT =
       "http://kibana.linkedin.com/search?jobid=${jobid}&&execid=${execid}";
@@ -59,27 +76,6 @@ public class ExternalLinkUtilsTest {
   }
 
   /**
-   * Test validates the happy path when an external analyzer is configured with '${url}' as the
-   * format in 'azkaban.properties'.
-   */
-  @Test
-  public void testGetExternalAnalyzerValidFormat() {
-    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC,
-        EXTERNAL_ANALYZER_TOPIC);
-    this.azkProps.put(
-        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_TOPIC_URL
-            .replace("${topic}", EXTERNAL_ANALYZER_TOPIC),
-        EXTERNAL_ANALYZER_URL_VALID_FORMAT);
-
-    when(this.mockRequest.getRequestURL()).thenReturn(new StringBuffer(EXEC_URL));
-    when(this.mockRequest.getQueryString()).thenReturn(EXEC_QUERY_STRING);
-
-    final String externalURL =
-        ExternalLinkUtils.getExternalAnalyzerOnReq(this.azkProps, this.mockRequest);
-    assertTrue(externalURL.equals(EXTERNAL_ANALYZER_EXPECTED_URL));
-  }
-
-  /**
    * Test validates the happy path when an log viewer is configured with '${execid}'  and '${jobid}
    * as the format in 'azkaban.properties'.
    */
@@ -95,17 +91,6 @@ public class ExternalLinkUtilsTest {
     final String externalURL =
         ExternalLinkUtils.getExternalLogViewer(this.azkProps, this.jobId, this.jobProps);
     assertTrue(externalURL.equals(EXTERNAL_LOGVIEWER_EXPECTED_URL));
-  }
-
-  /**
-   * Test validates the condition when an external analyzer is not configured in
-   * 'azkaban.properties'.
-   */
-  @Test
-  public void testGetExternalAnalyzerNotConfigured() {
-    final String executionExternalLinkURL =
-        ExternalLinkUtils.getExternalAnalyzerOnReq(this.azkProps, this.mockRequest);
-    assertTrue(executionExternalLinkURL.equals(""));
   }
 
   /**
@@ -142,5 +127,102 @@ public class ExternalLinkUtilsTest {
         .replace("${topic}", "someTopic"), "This is a link");
     assertTrue(
         ExternalLinkUtils.getURLForTopic("someTopic", this.azkProps).equals("This is a link"));
+  }
+  /**
+   * Test validates the GetExternalAnalyzerTopics
+   * format in 'azkaban.properties'. it should work with both
+   * azkaban.server.external.analyzer.topic and azkaban.server.external.analyzer.topics
+   */
+  @Test
+  public void testGetExternalAnalyzerTopics() {
+    List<String> topicsExpected = Arrays.asList(EXTERNAL_ANALYZER_TOPIC1);
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC,
+        EXTERNAL_ANALYZER_TOPIC1);
+
+    List<String> topicsReturned = ExternalLinkUtils.getExternalAnalyzerTopics(this.azkProps);
+    Assert.assertArrayEquals(topicsExpected.toArray(), topicsReturned.toArray());
+
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS,
+        EXTERNAL_ANALYZER_TOPIC1);
+    topicsReturned = ExternalLinkUtils.getExternalAnalyzerTopics(this.azkProps);
+    Assert.assertArrayEquals(topicsExpected.toArray(), topicsReturned.toArray());
+
+
+    topicsExpected = Arrays.asList(EXTERNAL_ANALYZER_TOPIC1, EXTERNAL_ANALYZER_TOPIC2);
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPICS,
+        EXTERNAL_ANALYZER_TOPICS);
+    topicsReturned = ExternalLinkUtils.getExternalAnalyzerTopics(this.azkProps);
+    Assert.assertArrayEquals(topicsExpected.toArray(), topicsReturned.toArray());
+  }
+  /**
+   * Test validates the getExternalLabelForTopic
+   * format in 'azkaban.properties'. it should work with both
+   * azkaban.server.external.analyzer.topic and azkaban.server.external.analyzer.topics
+   */
+  @Test
+  public void testGetExternalLabelForTopic() {
+    String topicLabelExpected = EXTERNAL_ANALYZER_LABEL1;
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_LABEL,
+        EXTERNAL_ANALYZER_LABEL1);
+    String topicLabelReturned =
+        ExternalLinkUtils.getExternalLabelForTopic(EXTERNAL_ANALYZER_TOPIC, this.azkProps);
+    Assert.assertEquals(topicLabelExpected, topicLabelReturned);
+
+
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL
+        .replace("${topic}", EXTERNAL_ANALYZER_TOPIC1), EXTERNAL_ANALYZER_LABEL1);
+    topicLabelReturned =
+        ExternalLinkUtils.getExternalLabelForTopic(EXTERNAL_ANALYZER_TOPIC1, this.azkProps);
+    Assert.assertEquals(topicLabelExpected, topicLabelReturned);
+
+    topicLabelExpected = EXTERNAL_ANALYZER_LABEL2;
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_LABEL
+        .replace("${topic}", EXTERNAL_ANALYZER_TOPIC2), EXTERNAL_ANALYZER_LABEL2);
+    topicLabelReturned =
+        ExternalLinkUtils.getExternalLabelForTopic(EXTERNAL_ANALYZER_TOPIC2, this.azkProps);
+    Assert.assertEquals(topicLabelExpected, topicLabelReturned);
+  }
+
+  /**
+   * Test validates the happy path when an external analyzer is configured with '${url}' as the
+   * format in 'azkaban.properties'.
+   */
+  @Test
+  public void testGetExternalAnalyzerValidFormat() {
+    this.azkProps.put(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC,
+        EXTERNAL_ANALYZER_TOPIC);
+    this.azkProps.put(
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_TOPIC_URL
+            .replace("${topic}", EXTERNAL_ANALYZER_TOPIC1),
+        EXTERNAL_ANALYZER_URL_VALID_FORMAT);
+
+    when(this.mockRequest.getRequestURL()).thenReturn(new StringBuffer(EXEC_URL));
+    when(this.mockRequest.getQueryString()).thenReturn(EXEC_QUERY_STRING);
+
+    String externalURL =
+        ExternalLinkUtils.getExternalAnalyzerLinkOnReq(EXTERNAL_ANALYZER_TOPIC1, this.azkProps,
+            this.mockRequest);
+    assertTrue(externalURL.equals(EXTERNAL_ANALYZER_EXPECTED_URL));
+
+    this.azkProps.put(
+        Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_TOPIC_URL
+            .replace("${topic}", EXTERNAL_ANALYZER_TOPIC1),
+        EXTERNAL_ANALYZER_URL_VALID_FORMAT2);
+
+    externalURL =
+        ExternalLinkUtils.getExternalAnalyzerLinkOnReq(EXTERNAL_ANALYZER_TOPIC1, this.azkProps,
+            this.mockRequest);
+    assertTrue(externalURL.equals(EXTERNAL_ANALYZER_EXPECTED_URL2));
+  }
+  /**
+   * Test validates the condition when an external analyzer is not configured in
+   * 'azkaban.properties'.
+   */
+  @Test
+  public void testGetExternalAnalyzerNotConfigured() {
+    final String executionExternalLinkURL =
+        ExternalLinkUtils.getExternalAnalyzerLinkOnReq(EXTERNAL_ANALYZER_TOPIC1, this.azkProps,
+            this.mockRequest);
+    assertTrue(executionExternalLinkURL.equals(""));
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -43,6 +43,7 @@ import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.user.UserManager;
+import azkaban.utils.ExternalLink;
 import azkaban.utils.ExternalLinkUtils;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
@@ -434,7 +435,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
-    addExternalLinkLabel(req, page);
+    addExternalAnalyzers(req, page);
 
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
@@ -443,20 +444,13 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.render();
   }
 
-  private void addExternalLinkLabel(final HttpServletRequest req, final Page page) {
+  private void addExternalAnalyzers(final HttpServletRequest req, final Page page) {
     final Props props = getApplication().getServerProps();
-    final String execExternalLinkURL = ExternalLinkUtils.getExternalAnalyzerOnReq(props, req);
+    List<ExternalLink> externalLinks = ExternalLinkUtils.getExternalAnalyzers(props, req);
 
-    if (execExternalLinkURL.length() > 0) {
-      page.add("executionExternalLinkURL", execExternalLinkURL);
-      logger.debug("Added an External analyzer to the page");
-      logger.debug("External analyzer url: " + execExternalLinkURL);
-
-      final String execExternalLinkLabel =
-          props.getString(Constants.ConfigurationKeys.AZKABAN_SERVER_EXTERNAL_ANALYZER_LABEL,
-              "External Analyzer");
-      page.add("executionExternalLinkLabel", execExternalLinkLabel);
-      logger.debug("External analyzer label set to : " + execExternalLinkLabel);
+    if (!externalLinks.isEmpty()) {
+      logger.debug("addExternalLinkLabels");
+      page.add("externalAnalyzers", externalLinks);
     }
   }
 
@@ -494,7 +488,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       return;
     }
 
-    addExternalLinkLabel(req, page);
+    addExternalAnalyzers(req, page);
 
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -20,6 +20,28 @@
   -khtml-user-select: none;
   -webkit-user-select: none;
   user-select: none;
+
+
+  .btn-external {
+    margin: 2px 20px 5px;
+    word-break: break-all;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px;
+    &:hover, &:focus {
+      color: #ffffff;
+      text-decoration: none;
+      border-color: #39b3d7;
+      background-color: #269abc;
+    }
+  }
+
+  .btn-external.disabled,
+  .btn-external[disabled],
+  fieldset[disabled] .btn-external {
+    pointer-events: auto;
+    cursor: not-allowed;
+  }
 }
 
 #flow-executing-graph {
@@ -408,18 +430,4 @@ li.tree-list-item {
 .expandallarrow .glyphicon-chevron-down:first-child {
   position: absolute;
   top: -3px;
-}
-
-#analyzerButton {
-  padding: 5px 10px;
-  font-size: 12px;
-  line-height: 1.5;
-  border-radius: 3px;
-
-  &:hover, &:focus {
-    color: #ffffff;
-    text-decoration: none;
-    border-color: #39b3d7;
-    background-color: #269abc;
-  }
 }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -121,10 +121,19 @@
       <li id="jobslistViewLink"><a href="#jobslist">Job List</a></li>
       <li id="flowLogViewLink"><a href="#log">Flow Log</a></li>
       <li id="statsViewLink"><a href="#stats">Stats</a></li>
-      #if ($executionExternalLinkURL)
-        <li><a id="analyzerButton" href="${executionExternalLinkURL}" class="btn btn-info btn-sm"
-               type="button" target="_blank"
-               title="Analyze job in ${executionExternalLinkLabel}">${executionExternalLinkLabel}</a>
+      #foreach ($analyzer in $externalAnalyzers)
+        #if (!${analyzer.isLinkUrlValid()})
+          #set($title = "Execution is not analyzable in ${analyzer.getLabel()} at the moment. "
+          + "If ${analyzer.getLabel()} is applicable for this execution, you can try again later.")
+          #set($isDisabled = "disabled")
+        #else
+          #set($title = "Analyze execution in ${analyzer.getLabel()}")
+          #set($isDisabled = "")
+        #end
+        #set($id = "analyzerButton${analyzer.getTopic()}")
+        <li><a id="${id}" href="${analyzer.getLinkUrl()}" class="btn btn-info btn-sm btn-external"
+               type="button" ${isDisabled} target="_blank"
+               title="${title}">${analyzer.getLabel()}</a>
         </li>
       #end
       <li class="nav-button pull-right">

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutionFlowViewTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutionFlowViewTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertTrue;
 
 import azkaban.fixture.VelocityContextTestUtil;
 import azkaban.fixture.VelocityTemplateTestUtil;
+import azkaban.utils.ExternalLink;
+import java.util.Arrays;
 import org.apache.velocity.VelocityContext;
 import org.junit.Test;
 
@@ -12,30 +14,46 @@ import org.junit.Test;
  */
 public class ExecutionFlowViewTest {
 
-  private static final String EXTERNAL_ANALYZER_ELEMENT =
-      "<li><a id=\"analyzerButton\" href=\"http://elephant.linkedin.com/\" "
-          + "class=\"btn btn-info btn-sm\" type=\"button\" target=\"_blank\" "
-          + "title=\"Analyze job in Dr. Elephant\">Dr. Elephant</a></li>";
-
+  private static final String EXTERNAL_ANALYZER_ELEMENT1 =
+      "<li><a id=\"analyzerButtontopic1\" href=\"http://topic1.linkedin.com/\" "
+          + "class=\"btn btn-info btn-sm btn-external\" type=\"button\" target=\"_blank\" "
+          + "title=\"Analyze execution in Label1\">Label1</a></li>";
+  private static final String EXTERNAL_ANALYZER_ELEMENT2 =
+      "<li><a id=\"analyzerButtontopic2\" href=\"http://topic2.linkedin.com/\" "
+          + "class=\"btn btn-info btn-sm btn-external\" type=\"button\" disabled target=\"_blank\" "
+          + "title=\"Execution is not analyzable in Label2 at the moment. If Label2"
+          + " is applicable for this execution, you can try again later.\">Label2</a></li>";
   /**
    * Test aims to check that the external analyzer button is displayed in the page.
    *
    * @throws Exception the exception
    */
-  @Test
-  public void testExternalAnalyzerButton() throws Exception {
-    final VelocityContext context = VelocityContextTestUtil.getInstance();
+    @Test
+    public void testExternalAnalyzerButton() throws Exception {
+      final VelocityContext context = VelocityContextTestUtil.getInstance();
 
-    context.put("execid", 1);
-    context.put("executionExternalLinkURL", "http://elephant.linkedin.com/");
-    context.put("executionExternalLinkLabel", "Dr. Elephant");
-    context.put("projectId", 1001);
-    context.put("projectName", "user-hello-pig-azkaban");
-    context.put("flowid", 27);
+      ExternalLink externalLink1 = new ExternalLink( "topic1",
+          "Label1",
+          "http://topic1.linkedin.com/", true);
 
-    final String result =
-        VelocityTemplateTestUtil.renderTemplate("executingflowpage", context);
-    assertTrue(VelocityTemplateTestUtil.
-        ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT));
-  }
+      context.put("externalAnalyzers", Arrays.asList(externalLink1));
+
+      String result =
+          VelocityTemplateTestUtil.renderTemplate("executingflowpage", context);
+      assertTrue(VelocityTemplateTestUtil.
+          ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT1));
+
+      ExternalLink externalLink2 = new ExternalLink( "topic2",
+          "Label2",
+          "http://topic2.linkedin.com/", false);
+
+      context.put("externalAnalyzers", Arrays.asList(externalLink1, externalLink2));
+
+      result =
+          VelocityTemplateTestUtil.renderTemplate("executingflowpage", context);
+      assertTrue(VelocityTemplateTestUtil.
+          ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT1));
+      assertTrue(VelocityTemplateTestUtil.
+          ignoreCaseContains(result, EXTERNAL_ANALYZER_ELEMENT2));
+    }
 }


### PR DESCRIPTION
Changes in this PR:
1. Add new Azkaban configs to support multiple external links in the UI. The configs are:
```
azkaban.server.external.analyzer.topics
azkaban.server.external.analyzer.${topic}.label
azkaban.server.external.analyzer.${topic}.url
```
To have 2 external links, for example, following configs should be added to the web server configuration file (azkaban.properties) :
```
azkaban.server.external.analyzer.topics=myAwesomelLink,anotherExternalLink

azkaban.server.external.analyzer.myAwesomelLink.label= My Awesome Link
azkaban.server.external.analyzer.myAwesomelLink.url =https://my-awesome-link.com/

azkaban.server.external.analyzer.anotherExternalLink.label= Another External Link
azkaban.server.external.analyzer.anotherExternalLink.url =https://another-external-link.com/
```
Each link configured will be presented in the UI as a button.

2. Add method to validate external links. If validation fails, the link (a button) will not be clickable in the UI.
An additional property can be set in the azkaban.properties file to essentially configure the max validation time 
`azkaban.server.external.analyzer.timeout.ms `
If not configured, the default value is 3 milliseconds.
