### PR TITLE
Add probes from the podTemplate to the podSpec

### DIFF
--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
@@ -19,6 +19,7 @@ package azkaban.container.models;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.util.Yaml;
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
  * Volumes and VolumeMounts for the application-container/flow-container will be extracted from the
  * POD created from this template file.
  * <p>
- * Extracted Items are later merged via {@link azkaban.executor.container.KubernetesContainerizedImpl#mergePodSpec(V1PodSpec,
+ * Extracted Items are later merged via {@link PodTemplateMergeUtils#mergePodSpec(V1PodSpec, AzKubernetesV1PodTemplate)} (V1PodSpec,
  * AzKubernetesV1PodTemplate)} with the pod-spec created using {@link AzKubernetesV1SpecBuilder}
  * <p>
  * Merging criteria is such that, if the item in the already created pod-spec has the same name as
@@ -165,5 +166,37 @@ public class AzKubernetesV1PodTemplate {
     List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
     return containers.isEmpty() ? Collections.emptyList() :
         containers.get(FLOW_CONTAINER_INDEX).getVolumeMounts();
+  }
+
+  /**
+   * @return The Liveliness probe for the appContainer derived form the POD specified in the
+   * template.
+   */
+  public V1Probe getContainerLivelinessProbe() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
+    return containers.isEmpty() ? null :
+        containers.get(FLOW_CONTAINER_INDEX).getLivenessProbe();
+  }
+
+  /**
+   * @return The Readiness probe for the appContainer derived form the POD specified in the
+   * template.
+   */
+  public V1Probe getContainerReadinessProbe() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
+    return containers.isEmpty() ? null :
+        containers.get(FLOW_CONTAINER_INDEX).getReadinessProbe();
+  }
+
+  /**
+   * @return The Startup probe for the appContainer derived form the POD specified in the template.
+   */
+  public V1Probe getContainerStartupProbe() {
+    V1PodSpec spec = this.podFromTemplate.getSpec();
+    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
+    return containers.isEmpty() ? null :
+        containers.get(FLOW_CONTAINER_INDEX).getStartupProbe();
   }
 }

--- a/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.container.models;
+
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1Probe;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import java.util.List;
+
+/**
+ * This class consists of various methods to merge pod-spec with the pod template
+ */
+public class PodTemplateMergeUtils {
+
+  private PodTemplateMergeUtils() {
+    // Not to be instantiated
+  }
+
+  /**
+   * Items extracted from the podTemplate will be merged with the pod-spec. Merging criteria is such
+   * that, if the item, in the already created pod-spec, has the same name as of the item extracted
+   * from the template, then it will retained.
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  public static void mergePodSpec(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
+    mergeVolumes(podSpec, podTemplate);
+    mergeInitContainers(podSpec, podTemplate);
+    mergeContainerVolumes(podSpec, podTemplate);
+    mergeReadinessProbe(podSpec, podTemplate);
+    mergeLivelinessProbe(podSpec, podTemplate);
+    mergeStartupProbe(podSpec, podTemplate);
+  }
+
+  /**
+   * Set the StartupProbe for flowContainer derived from the podTemplate to the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeStartupProbe(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
+    V1Probe containerStartupProbe = podTemplate.getContainerStartupProbe();
+    if (null != containerStartupProbe) {
+      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
+          .setStartupProbe(containerStartupProbe);
+    }
+  }
+
+  /**
+   * Set the LivelinessProbe for flowContainer derived from the podTemplate to the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeLivelinessProbe(V1PodSpec podSpec,
+      AzKubernetesV1PodTemplate podTemplate) {
+    V1Probe containerLivelinessProbe = podTemplate.getContainerLivelinessProbe();
+    if (null != containerLivelinessProbe) {
+      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
+          .setLivenessProbe(containerLivelinessProbe);
+    }
+  }
+
+  /**
+   * Set the ReadinessProbe for flowContainer derived from the podTemplate to the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeReadinessProbe(V1PodSpec podSpec,
+      AzKubernetesV1PodTemplate podTemplate) {
+    V1Probe containerReadinessProbe = podTemplate.getContainerReadinessProbe();
+    if (null != containerReadinessProbe) {
+      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
+          .setReadinessProbe(containerReadinessProbe);
+    }
+  }
+
+  /**
+   * Add those container volumes which are not already available in the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeContainerVolumes(V1PodSpec podSpec,
+      AzKubernetesV1PodTemplate podTemplate) {
+    List<V1VolumeMount> podContainerVolumeMounts =
+        podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
+            .getVolumeMounts();
+    if (null != podContainerVolumeMounts) {
+      List<V1VolumeMount> templateContainerVolumeMounts = podTemplate.getContainerVolumeMounts(
+          tempVolMount -> podContainerVolumeMounts.stream().map(V1VolumeMount::getName)
+              .noneMatch(name -> name.equals(tempVolMount.getName())));
+      for (V1VolumeMount volumeMountItem : templateContainerVolumeMounts) {
+        podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
+            .addVolumeMountsItem(volumeMountItem);
+      }
+    }
+  }
+
+  /**
+   * Add those initContainers which are not already available in the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeInitContainers(V1PodSpec podSpec,
+      AzKubernetesV1PodTemplate podTemplate) {
+    List<V1Container> podSpecInitContainers = podSpec.getInitContainers();
+    if (null != podSpecInitContainers) {
+      List<V1Container> templateInitContainers = podTemplate.getInitContainers(
+          tempInitContainer -> podSpecInitContainers.stream().map(V1Container::getName)
+              .noneMatch(name -> name.equals(tempInitContainer.getName())));
+      for (V1Container containerItem : templateInitContainers) {
+        podSpec.addInitContainersItem(containerItem);
+      }
+    }
+  }
+
+  /**
+   * Add those volumes which are not already available in the podSpec
+   *
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
+   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   */
+  private static void mergeVolumes(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
+    List<V1Volume> podSpecVolumes = podSpec.getVolumes();
+    if (null != podSpecVolumes) {
+      List<V1Volume> templateVolumes = podTemplate.getVolumes(
+          tempVol -> podSpecVolumes.stream().map(V1Volume::getName)
+              .noneMatch(name -> name.equals(tempVol.getName())));
+      for (V1Volume volumeItem : templateVolumes) {
+        podSpec.addVolumesItem(volumeItem);
+      }
+    }
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
+++ b/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
@@ -66,7 +66,7 @@ public class AzKubernetesV1PodBuilderTest {
         // Merge the podSpec created earlier with the pod from the template
         AzKubernetesV1PodTemplate podTemplate = AzKubernetesV1PodTemplate.getInstance(
             this.getClass().getResource("v1PodTestTemplate1.yaml").getFile());
-        KubernetesContainerizedImpl.mergePodSpec(podSpec, podTemplate);
+        PodTemplateMergeUtils.mergePodSpec(podSpec, podTemplate);
         V1Pod pod2 = new AzKubernetesV1PodBuilder(podName, podNameSpace, podSpec)
             .withPodLabels(labels)
             .withPodAnnotations(annotations)

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
@@ -18,7 +18,21 @@ spec:
       value: envValue
     image: path/azkaban-base-image:0.0.5
     imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+        - cat
+        - /tmp/liveProbe
+      initialDelaySeconds: 5
+      periodSeconds: 5
     name: az-flow-container
+    readinessProbe:
+      exec:
+        command:
+        - cat
+        - /tmp/readyProbe
+      initialDelaySeconds: 5
+      periodSeconds: 5
     resources:
       limits:
         cpu: 500m

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
@@ -21,6 +21,20 @@ spec:
     - image: "path/azkaban-base-image:0.0.5"
       imagePullPolicy: "IfNotPresent"
       name: "az-flow-container"
+      livenessProbe:
+        exec:
+          command:
+            - cat
+            - /tmp/liveProbe
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      readinessProbe:
+        exec:
+          command:
+            - cat
+            - /tmp/readyProbe
+        initialDelaySeconds: 5
+        periodSeconds: 5
       volumeMounts:
         - name: kubelet
           mountPath: "/var/run/kubelet"


### PR DESCRIPTION
Probes are static in nature and hence if they are present in the pod template, they should be added to the actual pod spec during dispatch.