### PR TITLE
Added mechanism to rampup Containerized from POLL dispatch

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -524,6 +524,8 @@ public class Constants {
         AZKABAN_CONTAINERIZED_PREFIX + "execution.processing.thread.pool.size";
     public static final String CONTAINERIZED_CREATION_RATE_LIMIT =
         AZKABAN_CONTAINERIZED_PREFIX + "creation.rate.limit";
+    public static final String CONTAINERIZED_RAMPUP =
+        AZKABAN_CONTAINERIZED_PREFIX + "rampup";
 
     // Kubernetes related properties
     public static final String AZKABAN_KUBERNETES_PREFIX = "azkaban.kubernetes.";

--- a/azkaban-common/src/main/java/azkaban/DispatchMethod.java
+++ b/azkaban-common/src/main/java/azkaban/DispatchMethod.java
@@ -22,10 +22,19 @@ import org.slf4j.LoggerFactory;
  * This enum contains list of dispatch types implemented in Azkaban.
  */
 public enum DispatchMethod {
-  PUSH,
-  POLL,
-  CONTAINERIZED;
+  PUSH(0),
+  POLL(1),
+  CONTAINERIZED(2);
   private static final Logger logger = LoggerFactory.getLogger(DispatchMethod.class);
+  private final int numVal;
+
+  DispatchMethod(final int numVal) {
+    this.numVal = numVal;
+  }
+
+  public int getNumVal() {
+    return this.numVal;
+  }
 
   public static DispatchMethod getDispatchMethod(String value) {
     try {

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -280,6 +280,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     exflow.setSubmitUser(userId);
     exflow.setStatus(getStartStatus());
     exflow.setSubmitTime(System.currentTimeMillis());
+    exflow.setDispatchMethod(getDispatchMethod());
 
     // Get collection of running flows given a project and a specific flow name
     final List<Integer> running = getRunningFlows(projectId, flowId);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.flow.Flow;
 import azkaban.project.Project;
 import azkaban.sla.SlaOption;
@@ -72,6 +73,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   // For Flow_Status_Changed event
   private String failedJobId = "unknown";
   private String modifiedBy = "unknown";
+  private DispatchMethod dispatchMethod;
 
   // For slaOption information
   private String slaOptionStr = "null";
@@ -99,6 +101,14 @@ public class ExecutableFlow extends ExecutableFlowBase {
     // overwrite status from the flow data blob as that one should NOT be used
     exFlow.setStatus(status);
     return exFlow;
+  }
+
+  public DispatchMethod getDispatchMethod() {
+    return this.dispatchMethod;
+  }
+
+  public void setDispatchMethod(final DispatchMethod dispatchMethod) {
+    this.dispatchMethod = dispatchMethod;
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -45,7 +45,7 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
 
 
   @Inject
-  protected ExecutionController(final Props azkProps, final ExecutorLoader executorLoader,
+  public ExecutionController(final Props azkProps, final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final AlerterHolder alerterHolder, final
   ExecutorHealthChecker executorHealthChecker) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
 import azkaban.db.EncodingType;
 import azkaban.db.SQLTransaction;
@@ -71,9 +72,11 @@ public class ExecutionFlowDao {
 
     final String INSERT_EXECUTABLE_FLOW = "INSERT INTO execution_flows "
         + "(project_id, flow_id, version, status, submit_time, submit_user, update_time, "
-        + "use_executor, flow_priority, execution_source) values (?,?,?,?,?,?,?,?,?,?)";
+        + "use_executor, flow_priority, execution_source, dispatch_method) values (?,?,?,?,?,?,?,"
+        + "?,?,?,?)";
     final long submitTime = flow.getSubmitTime();
     final String executionSource = flow.getExecutionSource();
+    final DispatchMethod dispatchMethod = flow.getDispatchMethod();
 
     /**
      * Why we need a transaction to get last insert ID?
@@ -84,7 +87,8 @@ public class ExecutionFlowDao {
     final SQLTransaction<Long> insertAndGetLastID = transOperator -> {
       transOperator.update(INSERT_EXECUTABLE_FLOW, flow.getProjectId(),
           flow.getFlowId(), flow.getVersion(), flow.getStatus().getNumVal(),
-          submitTime, flow.getSubmitUser(), submitTime, executorId, flowPriority, executionSource);
+          submitTime, flow.getSubmitUser(), submitTime, executorId, flowPriority, executionSource
+          , dispatchMethod.getNumVal());
       transOperator.getConnection().commit();
       return transOperator.getLastInsertId();
     };
@@ -380,7 +384,8 @@ public class ExecutionFlowDao {
     }
   }
 
-  public int selectAndUpdateExecution(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecution(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
     final String UPDATE_EXECUTION = "UPDATE execution_flows SET executor_id = ?, update_time = ?, status=? "
         + "where exec_id = ?";
@@ -392,7 +397,7 @@ public class ExecutionFlowDao {
       transOperator.getConnection().setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
 
       final List<Integer> execIds = transOperator.query(selectExecutionForUpdate,
-          new SelectFromExecutionFlows(), Status.READY.getNumVal(), executorId);
+          new SelectFromExecutionFlows(), Status.READY.getNumVal(), dispatchMethod.getNumVal(), executorId);
 
       int execId = -1;
       if (!execIds.isEmpty()) {
@@ -412,7 +417,8 @@ public class ExecutionFlowDao {
     }
   }
 
-  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
     final String UPDATE_EXECUTION = "UPDATE execution_flows SET executor_id = ?, update_time = ?, status=? "
         + "where exec_id = ?";
@@ -427,7 +433,8 @@ public class ExecutionFlowDao {
       if (hasLocked) {
         try {
           final List<Integer> execIds = transOperator.query(selectExecutionForUpdate,
-              new SelectFromExecutionFlows(), Status.READY.getNumVal(), executorId);
+              new SelectFromExecutionFlows(), Status.READY.getNumVal(), dispatchMethod.getNumVal(),
+              executorId);
           if (CollectionUtils.isNotEmpty(execIds)) {
             execId = execIds.get(0);
             transOperator.update(UPDATE_EXECUTION, executorId, System.currentTimeMillis(),
@@ -464,7 +471,8 @@ public class ExecutionFlowDao {
    */
   public Set<Integer> selectAndUpdateExecutionWithLocking(final boolean batchEnabled,
       final int limit,
-      final Status updatedStatus)
+      final Status updatedStatus,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
     final String UPDATE_EXECUTION = "UPDATE execution_flows SET status = ?, update_time = ? "
         + "where exec_id = ?";
@@ -479,11 +487,11 @@ public class ExecutionFlowDao {
           if (batchEnabled) {
             execIds = transOperator.query(String
                     .format(SelectFromExecutionFlows.SELECT_EXECUTION_IN_BATCH_FOR_UPDATE_FORMAT, ""),
-                new SelectFromExecutionFlows(), Status.READY.getNumVal(), limit);
+                new SelectFromExecutionFlows(), Status.READY.getNumVal(), dispatchMethod.getNumVal(), limit);
           } else {
             execIds = transOperator.query(
                 String.format(SelectFromExecutionFlows.SELECT_EXECUTION_FOR_UPDATE_FORMAT, ""),
-                new SelectFromExecutionFlows(), Status.READY.getNumVal());
+                new SelectFromExecutionFlows(), Status.READY.getNumVal(), dispatchMethod.getNumVal());
           }
           if (CollectionUtils.isNotEmpty(execIds)) {
             executions.addAll(execIds);
@@ -544,14 +552,14 @@ public class ExecutionFlowDao {
 
     private static final String SELECT_EXECUTION_FOR_UPDATE_FORMAT =
         "SELECT exec_id from execution_flows WHERE exec_id = (SELECT exec_id from execution_flows"
-            + " WHERE status = ?"
+            + " WHERE status = ? and dispatch_method = ?"
             + " and executor_id is NULL and flow_data is NOT NULL %s"
             + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC LIMIT 1) and "
             + "executor_id is NULL FOR UPDATE";
 
     private static final String SELECT_EXECUTION_IN_BATCH_FOR_UPDATE_FORMAT =
         "SELECT exec_id from execution_flows WHERE exec_id in (SELECT exec_id from execution_flows"
-            + " WHERE status = ?"
+            + " WHERE status = ? and dispatch_method = ?"
             + " and executor_id is NULL and flow_data is NOT NULL %s ) "
             + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC "
             + " LIMIT ? FOR UPDATE";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
@@ -309,10 +310,10 @@ public interface ExecutorLoader {
 
   void unsetExecutorIdForExecution(final int executionId) throws ExecutorManagerException;
 
-  int selectAndUpdateExecution(final int executorId, boolean isActive)
+  int selectAndUpdateExecution(final int executorId, boolean isActive, final DispatchMethod dispatchMethod)
       throws ExecutorManagerException;
 
-  int selectAndUpdateExecutionWithLocking(final int executorId, boolean isActive)
+  int selectAndUpdateExecutionWithLocking(final int executorId, boolean isActive, final DispatchMethod dispatchMethod)
       throws ExecutorManagerException;
 
   /**
@@ -328,7 +329,7 @@ public interface ExecutorLoader {
    * @throws ExecutorManagerException
    */
   Set<Integer> selectAndUpdateExecutionWithLocking(final boolean batchEnabled, final int limit,
-      Status updatedStatus) throws ExecutorManagerException;
+      Status updatedStatus, final DispatchMethod dispatchMethod) throws ExecutorManagerException;
 
   ExecutableRampMap fetchExecutableRampMap()
       throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
@@ -368,22 +369,24 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public int selectAndUpdateExecution(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecution(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
-    return this.executionFlowDao.selectAndUpdateExecution(executorId, isActive);
+    return this.executionFlowDao.selectAndUpdateExecution(executorId, isActive, dispatchMethod);
   }
 
   @Override
-  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
-    return this.executionFlowDao.selectAndUpdateExecutionWithLocking(executorId, isActive);
+    return this.executionFlowDao.selectAndUpdateExecutionWithLocking(executorId, isActive, dispatchMethod);
   }
 
   @Override
   public Set<Integer> selectAndUpdateExecutionWithLocking(final boolean batchEnabled, int limit,
-      Status updatedStatus) throws ExecutorManagerException {
+      Status updatedStatus, final DispatchMethod dispatchMethod) throws ExecutorManagerException {
     return this.executionFlowDao.selectAndUpdateExecutionWithLocking(batchEnabled, limit,
-        updatedStatus);
+        updatedStatus, dispatchMethod);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -117,6 +117,21 @@ public class ContainerizedDispatchManagerTest {
   }
 
   @Test
+  public void testRampUpDispatchMethod() throws Exception {
+    initializeContainerizedDispatchImpl();
+    this.containerizedDispatchManager.setRampUp(0);
+    for (int i = 0; i < 100; i++) {
+      DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
+      assertThat(dispatchMethod).isEqualTo(DispatchMethod.POLL);
+    }
+    this.containerizedDispatchManager.setRampUp(100);
+    for (int i = 0; i < 100; i++) {
+      DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
+      assertThat(dispatchMethod).isEqualTo(DispatchMethod.CONTAINERIZED);
+    }
+  }
+
+  @Test
   public void testFetchAllActiveFlows() throws Exception {
     initializeContainerizedDispatchImpl();
     initializeUnfinishedFlows();

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.flow.Flow;
 import azkaban.project.Project;
@@ -486,13 +487,15 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public int selectAndUpdateExecution(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecution(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
     return 1;
   }
 
   @Override
-  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive)
+  public int selectAndUpdateExecutionWithLocking(final int executorId, final boolean isActive,
+      final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {
     return 1;
   }
@@ -500,7 +503,8 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public Set<Integer> selectAndUpdateExecutionWithLocking(final boolean batchEnabled,
       final int limit,
-      final Status updatedStatus) throws ExecutorManagerException {
+      final Status updatedStatus,
+      final DispatchMethod dispatchMethod) throws ExecutorManagerException {
     final Set<Integer> executions = new HashSet<>();
     executions.add(1);
     return executions;

--- a/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
+++ b/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
@@ -16,6 +16,7 @@
 
 package azkaban.utils;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutableFlow;
 import azkaban.flow.Flow;
 import azkaban.project.DirectoryYamlFlowLoader;
@@ -53,7 +54,7 @@ public class TestUtils {
     flowMap.put(flow.getId(), flow);
     project.setFlows(flowMap);
     final ExecutableFlow execFlow = new ExecutableFlow(project, flow);
-
+    execFlow.setDispatchMethod(DispatchMethod.POLL);
     return execFlow;
   }
 

--- a/azkaban-db/src/main/sql/create.containerization-tables-all.sql
+++ b/azkaban-db/src/main/sql/create.containerization-tables-all.sql
@@ -107,3 +107,9 @@ CREATE TABLE IF NOT EXISTS version_set (
 -- TODO: Add the alter table script in the specific release
 -- Adding version_set_id column in execution_flows
 -- alter table execution_flows add column version_set_id INT default null;
+
+-- TODO: Add the alter table script in the specific release
+-- Adding dispatch_method column in execution_flows
+-- alter table execution_flows add column dispatch_method TINYINT default 1;
+-- CREATE INDEX ex_flows_dispatch_method ON execution_flows (dispatch_method);
+

--- a/azkaban-db/src/main/sql/create.execution_flows.sql
+++ b/azkaban-db/src/main/sql/create.execution_flows.sql
@@ -15,6 +15,7 @@ CREATE TABLE execution_flows (
   use_executor INT                  DEFAULT NULL,
   flow_priority TINYINT    NOT NULL DEFAULT 5,
   execution_source VARCHAR(32)        DEFAULT NULL,
+  dispatch_method TINYINT        DEFAULT 1,
   PRIMARY KEY (exec_id)
 );
 
@@ -30,3 +31,5 @@ CREATE INDEX executor_id
   ON execution_flows (executor_id);
 CREATE INDEX ex_flows_staus
   ON execution_flows (status);
+CREATE INDEX ex_flows_dispatch_method
+  ON execution_flows (dispatch_method);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -1150,10 +1150,10 @@ public class FlowRunnerManager implements EventListener<Event>,
           if (FlowRunnerManager.this.azkabanProps
               .getBoolean(ConfigurationKeys.AZKABAN_POLLING_LOCK_ENABLED, false)) {
             execId = FlowRunnerManager.this.executorLoader.selectAndUpdateExecutionWithLocking(
-                this.executorId, FlowRunnerManager.this.active);
+                this.executorId, FlowRunnerManager.this.active, DispatchMethod.POLL);
           } else {
             execId = FlowRunnerManager.this.executorLoader.selectAndUpdateExecution(this.executorId,
-                FlowRunnerManager.this.active);
+                FlowRunnerManager.this.active, DispatchMethod.POLL);
           }
           FlowRunnerManager.this.execMetrics.markOnePoll();
           if (execId == -1) {


### PR DESCRIPTION
This ramp-up mechanism requires that containerization be enabled and ramp-up percentages are set appropriately. Setting it to 100 will make all the executions use Containerization and setting it to 0 implies they will be polled by the executor server.

This allows ContainerizedDispatchManager to submit/upload some flows to the execution_flows table based on the ramp percentage with an additional column value dispatch_method. Whenever executions are pulled from the execution_flows table, respective dispatch managers will query by filtering the dispatch_method. Any future changes to the ContainerizedDispatchManager will automatically be honored as there is no new DispatchManager.

If this mechanism needs to removed then the only change will be required in the class azkaban.executor.container.ContainerizedDispatchManager where getDispatchMethod will be changed to always return DispatchMethod.CONTAINERIZED

Following is the summary of the change:

1) Added a new column dispatch_method in the table exectuion_flows 
2) Modified the getDispatchMethod() in the azkaban.executor.container.ContainerizedDispatchManager to determine the dispatch based on the ramp-up value set in the constructor.
3) getDispatchMethod() is used while the flow is submitted by azkaban.executor.AbstractExecutorManagerAdapter#uploadExecutableFlow
4) Modified the azkaban.executor.ExecutionFlowDao to make sure that dispatch_method value is also added to the execution_flows table while invoking uploadExecutableFlow()
5) Modified the azkaban.executor.ExecutionFlowDao to make sure that all selectAndUpdateExecution methods will require DispatchMethod as a parameter for querying.
6) Whenever selectAndUpdateExecution methods are used respective DispatchManagers will pass the appropriate DispatchMethod and hence only the corresponding executions are polled. 