### PR TITLE
Resolve symbolic links for jar files added to HadoopSecurityManagerClassloader

### DIFF
--- a/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/Cluster.java
@@ -106,7 +106,7 @@ public class Cluster {
           final List<URL> clusterUrls;
           try {
             clusterUrls = getClusterComponentURLs(hadoopSecurityManagerDependencyComponents);
-          } catch (IOException e) {
+          } catch (final IOException e) {
             throw new IllegalArgumentException(
                 String.format("Invalid dependency components for " +
                     HadoopSecurityManagerClassLoader.class.getName() + " of cluster %s", clusterId));
@@ -184,6 +184,12 @@ public class Cluster {
       return resources;
     }
 
+    // The syntax of a library path follows the pattern allowed by java's -cp option
+    // (e.g. /export/apps/A/*:/export/apps/A/conf:/export/apps/B/x.jar). Paths to
+    // individual jar files (e.g. /export/apps/B/x.jar) are resolved if they are symlinks.
+    // Paths to directories (e.g. /export/apps/A/conf, /export/apps/A/*) are expanded
+    // to include every jars files directly underneath the directory (not recursively
+    // expanded) and resolved from symlinks.
     for (String path : clusterLibraryPath.split(PATH_DELIMITER)) {
       // strip the trailing * character from the path, if any
       path = path.replaceAll("\\*$", "");

--- a/azkaban-common/src/test/java/azkaban/cluster/ClusterTest.java
+++ b/azkaban-common/src/test/java/azkaban/cluster/ClusterTest.java
@@ -61,8 +61,8 @@ public class ClusterTest {
       clusterUrlFiles.add(url.getFile());
     }
 
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getPath()));
-    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getCanonicalPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getCanonicalPath()));
     Assert.assertTrue(clusterUrls.size() == 2);
   }
 
@@ -84,10 +84,10 @@ public class ClusterTest {
       clusterUrlFiles.add(url.getFile());
     }
 
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getPath() + "/"));
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getPath()));
-    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getParentFile().getPath() + "/"));
-    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getCanonicalPath() + "/"));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getCanonicalPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getParentFile().getCanonicalPath() + "/"));
+    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getCanonicalPath()));
     Assert.assertTrue(clusterUrls.size() == 4);
   }
 
@@ -111,10 +111,10 @@ public class ClusterTest {
       clusterUrlFiles.add(url.getFile());
     }
 
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getPath() + "/"));
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getPath()));
-    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getParentFile().getPath() + "/"));
-    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getCanonicalPath() + "/"));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getCanonicalPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getParentFile().getCanonicalPath() + "/"));
+    Assert.assertTrue(clusterUrlFiles.contains(hadoopJar.getCanonicalPath()));
     Assert.assertTrue(clusterUrls.size() == 4);
   }
 
@@ -139,8 +139,8 @@ public class ClusterTest {
       clusterUrlFiles.add(url.getFile());
     }
 
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getPath() + "/"));
-    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getPath()));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getParentFile().getCanonicalPath() + "/"));
+    Assert.assertTrue(clusterUrlFiles.contains(hiveJar.getCanonicalPath()));
     Assert.assertTrue(clusterUrls.size() == 2);
   }
   @Test (expected = IllegalArgumentException.class)


### PR DESCRIPTION
Jar files added to HadoopSecurityManagerClassloader as search paths could be located under symbolic links.

For example, let's say there are two jars, `A-0.0.1.jar` and `B-0.0.1.jar` under a symbolic link `/export/apps/hadoop/latest`
When these jars are added, effectively two paths are added to HadoopSecurityManagerClassloader,
`/export/apps/hadoop/latest/A-0.0.1.jar` and `/export/apps/hadoop/latest/B-0.0.1.jar`

When the symbolic link moves, HadoopSecurityManagerClassloader breaks. Let's say the symbolic link `/export/apps/hadoop/latest` is updated to point to a newer version of hadoop that contains newer version of A and B, `A-0.0.2.jar` and `B-0.0.2.jar` respectively. Once the symlink is updated, there are no longer `/export/apps/hadoop/latest/A-0.0.1.jar` and `/export/apps/hadoop/latest/B-0.0.1.jar`, but existing HadoopSecurityManagerClassloader instances continue to load classes from them, therefore may fail all jobs launch post the Hadoop upgrade.

Note an instance of HadoopSecurityManagerClassloader is created per Hadoop cluster, and shared by every job that's submitted to that cluster.   
