### PR TITLE
ApiGateway support for ramp-up mechanism from POLL to CONTANERIZED dispatch

### DIFF
--- a/azkaban-common/src/main/java/azkaban/DispatchMethod.java
+++ b/azkaban-common/src/main/java/azkaban/DispatchMethod.java
@@ -36,6 +36,15 @@ public enum DispatchMethod {
     return this.numVal;
   }
 
+  public static DispatchMethod fromNumVal(final int numVal) {
+    for (DispatchMethod dispatchMethod : DispatchMethod.values()) {
+      if (dispatchMethod.getNumVal() == numVal) {
+        return dispatchMethod;
+      }
+    }
+    throw new IllegalArgumentException("No Dispatch Method corresponding to num value " + numVal);
+  }
+
   public static DispatchMethod getDispatchMethod(String value) {
     try {
       logger.info("Value of dispatch method is : " + value);

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -197,7 +197,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
 
     final String[] hostPortSplit = hostPort.split(":");
     return this.apiGateway.callForJsonObjectMap(hostPortSplit[0],
-        Integer.valueOf(hostPortSplit[1]), "/jmx", paramList);
+        Integer.valueOf(hostPortSplit[1]), "/jmx", null, paramList);
   }
 
   /**
@@ -223,7 +223,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
         .add(new Pair<>(ConnectorParams.ACTION_PARAM, action));
 
     return this.apiGateway.callForJsonObjectMap(executor.getHost(), executor.getPort(),
-        "/stats", paramList);
+        "/stats", null, paramList);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -52,6 +52,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String IS_LOCKED_PARAM = "isLocked";
   public static final String FLOW_LOCK_ERROR_MESSAGE_PARAM = "flowLockErrorMessage";
   public static final String EXECUTION_SOURCE = "executionSource";
+  public static final String FLOW_DISPATCH_METHOD = "dispatch_method";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
@@ -306,6 +307,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
     flowObj.put(IS_LOCKED_PARAM, this.isLocked);
     flowObj.put(FLOW_LOCK_ERROR_MESSAGE_PARAM, this.flowLockErrorMessage);
+    flowObj.put(FLOW_DISPATCH_METHOD, getDispatchMethod().getNumVal());
 
     return flowObj;
   }
@@ -359,6 +361,9 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
     this.setLocked(flowObj.getBool(IS_LOCKED_PARAM, false));
     this.setFlowLockErrorMessage(flowObj.getString(FLOW_LOCK_ERROR_MESSAGE_PARAM, null));
+    // Dispatch Method default is POLL
+    this.setDispatchMethod(DispatchMethod.fromNumVal(flowObj.getInt(FLOW_DISPATCH_METHOD,
+        DispatchMethod.POLL.getNumVal())));
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -680,7 +680,7 @@ public class ExecutionFlowDao {
             final ExecutableFlow exFlow =
                 ExecutableFlow.createExecutableFlow(
                     GZIPUtils.transformBytesToObject(data, encType), status);
-            final ExecutionReference ref = new ExecutionReference(id);
+            final ExecutionReference ref = new ExecutionReference(id, exFlow.getDispatchMethod());
             execFlows.add(new Pair<>(ref, exFlow));
           } catch (final IOException e) {
             throw new SQLException("Error retrieving flow data " + id, e);

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionReference.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionReference.java
@@ -16,12 +16,15 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
+
 import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class ExecutionReference {
 
   private final int execId;
+  private final DispatchMethod dispatchMethod;
   private Executor executor;
   //Todo jamiesjc: deprecate updateTime in ExecutionReference class gradually.
   private long updateTime;
@@ -29,13 +32,15 @@ public class ExecutionReference {
   private int numErrors = 0;
 
 
-  public ExecutionReference(final int execId) {
+  public ExecutionReference(final int execId, final DispatchMethod dispatchMethod) {
     this.execId = execId;
+    this.dispatchMethod = dispatchMethod;
   }
 
-  public ExecutionReference(final int execId, @Nullable final Executor executor) {
+  public ExecutionReference(final int execId, @Nullable final Executor executor, final DispatchMethod dispatchMethod) {
     this.execId = execId;
     this.executor = executor;
+    this.dispatchMethod = dispatchMethod;
   }
 
   public long getUpdateTime() {
@@ -72,5 +77,9 @@ public class ExecutionReference {
 
   public void setExecutor(final @Nullable Executor executor) {
     this.executor = executor;
+  }
+
+  public DispatchMethod getDispatchMethod() {
+    return this.dispatchMethod;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
@@ -138,7 +138,7 @@ public class ExecutorHealthChecker {
         // Todo jamiesjc: add metrics to monitor the http call return time
         results = this.apiGateway
             .callWithExecutionId(executor.getHost(), executor.getPort(),
-                ConnectorParams.PING_ACTION, null, null);
+                ConnectorParams.PING_ACTION, null, null, null);
       } catch (final ExecutorManagerException e) {
         healthcheckException = Optional.of(e);
       } catch (final RuntimeException re) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -204,7 +204,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final Future<ExecutorInfo> fetchExecutionInfo =
           this.executorInfoRefresherService.submit(
               () -> this.apiGateway.callForJsonType(executor.getHost(),
-                  executor.getPort(), "/serverStatistics", null, ExecutorInfo.class));
+                  executor.getPort(), "/serverStatistics", DispatchMethod.PUSH, null, ExecutorInfo.class));
       futures.add(new Pair<>(executor,
           fetchExecutionInfo));
     }
@@ -644,7 +644,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
         // We create an active flow reference in the datastore. If the upload
         // fails, we remove the reference.
         final ExecutionReference reference =
-            new ExecutionReference(exflow.getExecutionId());
+            new ExecutionReference(exflow.getExecutionId(), exflow.getDispatchMethod());
 
         this.executorLoader.addActiveExecutableReference(reference);
         this.queuedFlows.enqueue(exflow, reference);

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -85,7 +85,7 @@ public class FetchActiveFlowDao {
       final boolean executorStatus = rs.getBoolean("executorStatus");
       executor = new Executor(executorId, host, port, executorStatus);
     }
-    final ExecutionReference ref = new ExecutionReference(exFlow.getExecutionId(), executor);
+    final ExecutionReference ref = new ExecutionReference(exFlow.getExecutionId(), executor, exFlow.getDispatchMethod());
     return new Pair<>(ref, exFlow);
   }
 

--- a/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
+++ b/azkaban-common/src/main/java/azkaban/utils/RestfulApiClient.java
@@ -83,7 +83,7 @@ public abstract class RestfulApiClient<T> {
   /**
    * helper function to fill  the request with header entries and posting body .
    */
-  private static HttpEntityEnclosingRequestBase completeRequest(
+  protected static HttpEntityEnclosingRequestBase completeRequest(
       final HttpEntityEnclosingRequestBase request,
       final List<Pair<String, String>> params) throws UnsupportedEncodingException {
     if (request != null) {

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -87,30 +87,30 @@ public class ContainerizedDispatchManagerTest {
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
     this.props.put(ContainerizedDispatchManagerProperties.CONTAINERIZED_IMPL_TYPE,
         ContainerizedImplType.KUBERNETES.name());
-    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
-    this.flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
-    this.flow4 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
+    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
+    this.flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
+    this.flow4 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
     this.flow1.setExecutionId(1);
     this.flow2.setExecutionId(2);
     this.flow3.setExecutionId(3);
     this.flow4.setExecutionId(4);
-    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), null);
-    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), null);
-    this.ref3 = new ExecutionReference(this.flow3.getExecutionId(), null);
+    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
+    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
+    this.ref3 = new ExecutionReference(this.flow3.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
 
     this.activeFlows = ImmutableMap
         .of(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2),
             this.flow3.getExecutionId(), new Pair<>(this.ref3, this.flow3));
     when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
     when(this.loader.fetchActiveFlowByExecId(flow1.getExecutionId())).thenReturn(
-        new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId()), flow1));
+        new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), DispatchMethod.CONTAINERIZED), flow1));
     this.queuedFlows = ImmutableList.of(new Pair<>(this.ref1, this.flow1));
     when(this.loader.fetchQueuedFlows(Status.READY)).thenReturn(this.queuedFlows);
 
     Pair<ExecutionReference, ExecutableFlow> executionReferencePair =
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(
-            flow1.getExecutionId(), new Executor(1, "host", 2021, true)),
+            flow1.getExecutionId(), new Executor(1, "host", 2021, true), DispatchMethod.CONTAINERIZED),
             flow1);
     when(this.loader.fetchUnfinishedFlows()).thenReturn(ImmutableMap.of(flow1.getExecutionId(),
         executionReferencePair));
@@ -327,7 +327,7 @@ public class ContainerizedDispatchManagerTest {
   public void testCancelFlowWithMissingExecutor() throws Exception {
     // Return a null executor for the unfinished execution
     Pair<ExecutionReference, ExecutableFlow> executionReferencePair =
-        new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), null), flow1);
+        new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), DispatchMethod.CONTAINERIZED), flow1);
     when(this.loader.fetchUnfinishedFlows()).thenReturn(ImmutableMap.of(flow1.getExecutionId(),
         executionReferencePair));
 
@@ -386,13 +386,13 @@ public class ContainerizedDispatchManagerTest {
     }
 
     public URI getExpectedReverseProxyContainerizedURI() throws IOException {
-      return buildExecutorUri(null, 1, "container", false, (Pair<String, String>[]) null);
+      return buildExecutorUri(null, 1, "container", false, DispatchMethod.CONTAINERIZED, (Pair<String, String>[]) null);
     }
 
     @Override
     public URI buildExecutorUri(String host, int port, String path,
-        boolean isHttp, Pair<String, String>... params) throws IOException {
-      this.lastBuildExecutorUriRespone = super.buildExecutorUri(host, port, path, isHttp, params);
+        boolean isHttp, final DispatchMethod dispatchMethod, Pair<String, String>... params) throws IOException {
+      this.lastBuildExecutorUriRespone = super.buildExecutorUri(host, port, path, isHttp, dispatchMethod, params);
       return lastBuildExecutorUriRespone;
     }
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowPriorityComparatorTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowPriorityComparatorTest.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.utils.Pair;
 import azkaban.utils.TestUtils;
 import java.io.IOException;
@@ -34,7 +35,7 @@ public class ExecutableFlowPriorityComparatorTest {
   private ExecutableFlow createExecutableFlow(final String flowName, final int priority,
       final long updateTime, final int executionId) throws IOException {
     final ExecutableFlow execFlow =
-        TestUtils.createTestExecutableFlow("exectest1", flowName);
+        TestUtils.createTestExecutableFlow("exectest1", flowName, DispatchMethod.POLL);
 
     execFlow.setUpdateTime(updateTime);
     execFlow.setExecutionId(executionId);
@@ -52,7 +53,7 @@ public class ExecutableFlowPriorityComparatorTest {
     final ExecutableFlow flow1 = createExecutableFlow("exec1", 5, 3, 1);
     final ExecutableFlow flow2 = createExecutableFlow("exec2", 6, 3, 2);
     final ExecutableFlow flow3 = createExecutableFlow("exec3", 2, 3, 3);
-    final ExecutionReference dummyRef = new ExecutionReference(0);
+    final ExecutionReference dummyRef = new ExecutionReference(0, DispatchMethod.PUSH);
 
     final BlockingQueue<Pair<ExecutionReference, ExecutableFlow>> queue =
         new PriorityBlockingQueue<>(10,
@@ -73,7 +74,7 @@ public class ExecutableFlowPriorityComparatorTest {
     final ExecutableFlow flow1 = createExecutableFlow("exec1", 3, 3, 1);
     final ExecutableFlow flow2 = createExecutableFlow("exec2", 2, 3, 2);
     final ExecutableFlow flow3 = createExecutableFlow("exec3", -2, 3, 3);
-    final ExecutionReference dummyRef = new ExecutionReference(0);
+    final ExecutionReference dummyRef = new ExecutionReference(0, DispatchMethod.PUSH);
 
     final BlockingQueue<Pair<ExecutionReference, ExecutableFlow>> queue =
         new PriorityBlockingQueue<>(10,
@@ -97,7 +98,7 @@ public class ExecutableFlowPriorityComparatorTest {
     final ExecutableFlow flow2 = createExecutableFlow("exec2", 2, 2, 2);
     final ExecutableFlow flow3 = createExecutableFlow("exec3", -2, 3, 3);
     final ExecutableFlow flow4 = createExecutableFlow("exec3", 3, 4, 4);
-    final ExecutionReference dummyRef = new ExecutionReference(0);
+    final ExecutionReference dummyRef = new ExecutionReference(0, DispatchMethod.PUSH);
 
     final BlockingQueue<Pair<ExecutionReference, ExecutableFlow>> queue =
         new PriorityBlockingQueue<>(10,
@@ -125,7 +126,7 @@ public class ExecutableFlowPriorityComparatorTest {
     final ExecutableFlow flow2 = createExecutableFlow("exec2", 2, 2, 2);
     final ExecutableFlow flow3 = createExecutableFlow("exec3", -2, 2, 3);
     final ExecutableFlow flow4 = createExecutableFlow("exec3", 3, 4, 4);
-    final ExecutionReference dummyRef = new ExecutionReference(0);
+    final ExecutionReference dummyRef = new ExecutionReference(0, DispatchMethod.PUSH);
 
     final BlockingQueue<Pair<ExecutionReference, ExecutableFlow>> queue =
         new PriorityBlockingQueue<>(10,

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutionOptions.FailureAction;
 import azkaban.flow.Flow;
 import azkaban.project.DirectoryFlowLoader;
@@ -281,6 +282,7 @@ public class ExecutableFlowTest {
     Assert.assertNotNull(flow);
 
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    exFlow.setDispatchMethod(DispatchMethod.POLL);
 
     final Object obj = exFlow.toObject();
     final String exFlowJSON = JSONUtils.toJSON(obj);
@@ -298,6 +300,7 @@ public class ExecutableFlowTest {
     Assert.assertNotNull(flow);
 
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    exFlow.setDispatchMethod(DispatchMethod.POLL);
     exFlow.setExecutionId(101);
     // reset twice so that attempt = 2
     exFlow.resetForRetry();
@@ -356,6 +359,7 @@ public class ExecutableFlowTest {
     final Flow flow = this.project.getFlow("jobe");
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
     exFlow.setExecutionId(101);
+    exFlow.setDispatchMethod(DispatchMethod.POLL);
 
     // Create copy of flow
     final Object obj = exFlow.toObject();

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
+import azkaban.DispatchMethod;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.user.User;
@@ -91,17 +92,17 @@ public class ExecutionControllerTest {
     this.allExecutors = ImmutableList.of(executor1, executor2, executor3);
     when(this.loader.fetchActiveExecutors()).thenReturn(this.activeExecutors);
 
-    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
-    this.flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
-    this.flow4 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
+    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
+    this.flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
+    this.flow4 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
     this.flow1.setExecutionId(1);
     this.flow2.setExecutionId(2);
     this.flow3.setExecutionId(3);
     this.flow4.setExecutionId(4);
-    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), null);
-    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2);
-    this.ref3 = new ExecutionReference(this.flow3.getExecutionId(), executor3);
+    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), null, DispatchMethod.POLL);
+    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2, DispatchMethod.POLL);
+    this.ref3 = new ExecutionReference(this.flow3.getExecutionId(), executor3, DispatchMethod.POLL);
 
     this.activeFlows = ImmutableMap
         .of(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2),

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -103,7 +103,7 @@ public class ExecutionFlowDaoTest {
   }
 
   private ExecutableFlow createTestFlow() throws Exception {
-    return TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    return TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
   }
 
   private void createTestProject() {
@@ -283,7 +283,7 @@ public class ExecutionFlowDaoTest {
     final String host = "localhost";
     final int port = 12345;
     final Executor executor = this.executorDao.addExecutor(host, port);
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     this.executionFlowDao.uploadExecutableFlow(flow);
     this.assignExecutor.assignExecutor(executor.getId(), flow.getExecutionId());
 
@@ -298,7 +298,7 @@ public class ExecutionFlowDaoTest {
   /* Test exception when assigning a non-existent executor to a flow */
   @Test
   public void testAssignExecutorInvalidExecutor() throws Exception {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     this.executionFlowDao.uploadExecutableFlow(flow);
 
     // Since we haven't inserted any executors, 1 should be non-existent executor id.
@@ -435,7 +435,7 @@ public class ExecutionFlowDaoTest {
 
   private ExecutableFlow createExecution(final long startTime, final Status status)
       throws IOException, ExecutorManagerException {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow.setSubmitUser("testUser");
     flow.setSubmitTime(startTime - 1);
     flow.setStartTime(startTime);
@@ -448,7 +448,7 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testFetchActiveFlowsStatusChanged() throws Exception {
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     this.executionFlowDao.uploadExecutableFlow(flow1);
     final Executor executor = this.executorDao.addExecutor("test", 1);
     this.assignExecutor.assignExecutor(executor.getId(), flow1.getExecutionId());
@@ -478,7 +478,7 @@ public class ExecutionFlowDaoTest {
   @Test
   public void testUploadAndFetchExecutableNode() throws Exception {
 
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow.setExecutionId(10);
 
     final File jobFile = ExecutionsTestUtil.getFlowFile("exectest1", "job10.job");
@@ -517,7 +517,7 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testSelectAndUpdateExecution() throws Exception {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow.setStatus(Status.READY);
     flow.setSubmitTime(System.currentTimeMillis());
     flow.setDispatchMethod(DispatchMethod.POLL);
@@ -531,7 +531,7 @@ public class ExecutionFlowDaoTest {
 
   @Test
   public void testSelectAndUpdateExecutionWithStatusUpdate() throws Exception {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow.setStatus(Status.READY);
     flow.setSubmitTime(System.currentTimeMillis());
     flow.setDispatchMethod(DispatchMethod.POLL);
@@ -964,7 +964,7 @@ public class ExecutionFlowDaoTest {
       final long submitTime, final int flowPriority, final Status status,
       Optional<Long> startTime, DispatchMethod dispatchMethod) throws IOException,
       ExecutorManagerException {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow(projectName, flowName);
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow(projectName, flowName, DispatchMethod.POLL);
     flow.setStatus(status);
     flow.setSubmitTime(submitTime);
     flow.setSubmitUser("testUser");

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewaySystemTest.java
@@ -60,7 +60,7 @@ public class ExecutorApiGatewaySystemTest {
             JSONUtils.toJSON(updateTimesList));
 
     final Map<String, Object> results = this.apiGateway.callWithExecutionId("localhost", 12321,
-        ConnectorParams.UPDATE_ACTION, null, null, executionIds, updateTimes);
+        ConnectorParams.UPDATE_ACTION, null, null, null, executionIds, updateTimes);
 
     Assert.assertTrue(results != null);
     final List<Map<String, Object>> executionUpdates =

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import azkaban.Constants.ConfigurationKeys;
+import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
@@ -69,11 +70,11 @@ public class ExecutorHealthCheckerTest {
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.executorHealthChecker = new ExecutorHealthChecker(this.props, this.loader, this
         .apiGateway, this.alerterHolder);
-    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     this.flow1.getExecutionOptions().setFailureEmails(Arrays.asList(FLOW_ADMIN_EMAIL.split(",")));
     this.flow1.setExecutionId(EXECUTION_ID_11);
     this.flow1.setStatus(Status.RUNNING);
-    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
     this.flow2.setExecutionId(EXECUTION_ID_12);
     this.flow2.setStatus(Status.RUNNING);
 
@@ -89,9 +90,9 @@ public class ExecutorHealthCheckerTest {
   @Test
   public void checkExecutorHealthAlive() throws Exception {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenReturn(ImmutableMap.of(ConnectorParams
+        ConnectorParams.PING_ACTION, null, null, null)).thenReturn(ImmutableMap.of(ConnectorParams
         .STATUS_PARAM, ConnectorParams.RESPONSE_ALIVE));
     this.executorHealthChecker.checkExecutorHealth();
     assertThat(this.flow1.getStatus()).isEqualTo(Status.RUNNING);
@@ -104,7 +105,7 @@ public class ExecutorHealthCheckerTest {
   @Test
   public void checkExecutorHealthExecutorIdRemoved() throws Exception {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, null), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, null, DispatchMethod.POLL), this.flow1));
     when(this.loader.fetchExecutableFlow(EXECUTION_ID_11)).thenReturn(this.flow1);
     this.executorHealthChecker.checkExecutorHealth();
     verify(this.loader).updateExecutableFlow(this.flow1);
@@ -120,23 +121,23 @@ public class ExecutorHealthCheckerTest {
     // Therefore underlying call to apiGateway.callWithExecutionId returns an empty Map for all
     // invocations of executorHealthChecker.checkExecutorHealth() in this test.
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
     // Failed to ping executor. Failure count (=1) < MAX_FAILURE_COUNT (=2). Do not alert.
     this.executorHealthChecker.checkExecutorHealth();
     verify(this.apiGateway).callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null);
+        ConnectorParams.PING_ACTION, null, null, null);
     verifyZeroInteractions(this.alerterHolder);
 
     // Pinged executor successfully. Failure count (=0) < MAX_FAILURE_COUNT (=2). Do not alert.
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenReturn(ImmutableMap.of(ConnectorParams
+        ConnectorParams.PING_ACTION, null, null, null)).thenReturn(ImmutableMap.of(ConnectorParams
         .STATUS_PARAM, ConnectorParams.RESPONSE_ALIVE));
     this.executorHealthChecker.checkExecutorHealth();
     verifyZeroInteractions(this.alerterHolder);
 
     // Failed to ping executor. Failure count (=1) < MAX_FAILURE_COUNT (=2). Do not alert.
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenReturn(null);
+        ConnectorParams.PING_ACTION, null, null, null)).thenReturn(null);
     this.executorHealthChecker.checkExecutorHealth();
     verifyZeroInteractions(this.alerterHolder);
 
@@ -162,9 +163,9 @@ public class ExecutorHealthCheckerTest {
   @Test
   public void testCheckExecutorHealthWrapperExceptionHandling() throws Exception {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenThrow(new RuntimeException("test exception"));
+        ConnectorParams.PING_ACTION, null, null, null)).thenThrow(new RuntimeException("test exception"));
 
     // this will throw, causing the test to fail in case the error is not caught correctly
     this.executorHealthChecker.checkExecutorHealthQuietly();
@@ -178,23 +179,23 @@ public class ExecutorHealthCheckerTest {
   @Test
   public void testFailureDuringExecutorPing() throws Exception {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
     this.activeFlows.put(EXECUTION_ID_12, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_12, this.executor2), this.flow2));
+        new ExecutionReference(EXECUTION_ID_12, this.executor2, DispatchMethod.POLL), this.flow2));
 
     // Throw a runtime exception for both executors.
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenThrow(new RuntimeException("test exception"));
+        ConnectorParams.PING_ACTION, null, null, null)).thenThrow(new RuntimeException("test exception"));
     when(this.apiGateway.callWithExecutionId(this.executor2.getHost(), this.executor2.getPort(),
-        ConnectorParams.PING_ACTION, null, null)).thenThrow(new RuntimeException("test exception"));
+        ConnectorParams.PING_ACTION, null, null, null)).thenThrow(new RuntimeException("test exception"));
     this.executorHealthChecker.checkExecutorHealth();
 
     // Verify ping API is called for both executors. Implying that runtime exception for one of the
     // executors did not prevent the check on other executor.
     verify(this.apiGateway).callWithExecutionId(this.executor1.getHost(),
-        this.executor1.getPort(), ConnectorParams.PING_ACTION, null, null);
+        this.executor1.getPort(), ConnectorParams.PING_ACTION, null, null, null);
     verify(this.apiGateway).callWithExecutionId(this.executor2.getHost(),
-        this.executor2.getPort(), ConnectorParams.PING_ACTION, null, null);
+        this.executor2.getPort(), ConnectorParams.PING_ACTION, null, null, null);
     verifyZeroInteractions(this.alerterHolder);
   }
 
@@ -206,14 +207,14 @@ public class ExecutorHealthCheckerTest {
   public void testFailureDuringAlerting() throws Exception {
     this.activeFlows.clear();
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
 
     // Force a failure of the executor ping API
     ExecutorManagerException healthcheckException = new ExecutorManagerException("test exception");
     when(this.apiGateway.callWithExecutionId(
         this.executor1.getHost(),
         this.executor1.getPort(),
-        ConnectorParams.PING_ACTION, null, null))
+        ConnectorParams.PING_ACTION, null, null, null))
         .thenThrow(healthcheckException);
 
     // Force an unchecked exception when sending alert emails for the healthcheck failure
@@ -249,9 +250,9 @@ public class ExecutorHealthCheckerTest {
   @Test
   public void testFailureDuringFinalization() throws Exception {
     this.activeFlows.put(EXECUTION_ID_11, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_11, this.executor1), this.flow1));
+        new ExecutionReference(EXECUTION_ID_11, this.executor1, DispatchMethod.POLL), this.flow1));
     this.activeFlows.put(EXECUTION_ID_12, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_12, this.executor1), this.flow2));
+        new ExecutionReference(EXECUTION_ID_12, this.executor1, DispatchMethod.POLL), this.flow2));
 
     when(this.loader.fetchExecutableFlow(EXECUTION_ID_11)).thenThrow(new RuntimeException(
         "test runtime exception"));

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
+import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
@@ -231,9 +232,9 @@ public class ExecutorManagerTest {
   @Test
   public void testQueuedFlows() throws Exception {
     final ExecutorManager manager = createMultiExecutorManagerInstance();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.setExecutionId(1);
-    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.PUSH);
     flow2.setExecutionId(2);
 
     final User testUser = TestUtils.getTestUser();
@@ -265,7 +266,7 @@ public class ExecutorManagerTest {
   @Test(expected = ExecutorManagerException.class)
   public void testDuplicateQueuedFlows() throws Exception {
     final ExecutorManager manager = createMultiExecutorManagerInstance();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.getExecutionOptions().setConcurrentOption(
         ExecutionOptions.CONCURRENT_OPTION_SKIP);
 
@@ -281,7 +282,7 @@ public class ExecutorManagerTest {
   @Test
   public void testKillQueuedFlow() throws Exception {
     final ExecutorManager manager = createMultiExecutorManagerInstance();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     final User testUser = TestUtils.getTestUser();
     manager.submitExecutableFlow(flow1, testUser.getUserId());
 
@@ -298,7 +299,7 @@ public class ExecutorManagerTest {
   public void testNotFoundFlows() throws Exception {
     testSetUpForRunningFlows();
     this.manager.start();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
     mockFlowDoesNotExist();
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
@@ -314,7 +315,7 @@ public class ExecutorManagerTest {
   public void testDispatchException() throws Exception {
     testSetUpForRunningFlows();
     this.manager.start();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     doReturn(flow1).when(this.loader).fetchExecutableFlow(-1);
     mockFlowDoesNotExist();
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
@@ -338,7 +339,7 @@ public class ExecutorManagerTest {
   public void testDispatchFailed() throws Exception {
     testSetUpForRunningFlows();
     this.manager.start();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.getExecutionOptions().setFailureEmails(Arrays.asList("test@example.com"));
     when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
@@ -378,7 +379,7 @@ public class ExecutorManagerTest {
   @Test
   public void testSubmitFlows() throws Exception {
     testSetUpForRunningFlows();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
     verify(this.loader).uploadExecutableFlow(flow1);
     verify(this.loader).addActiveExecutableReference(any());
@@ -489,7 +490,7 @@ public class ExecutorManagerTest {
     this.props.put(Constants.ConfigurationKeys.MAX_DISPATCHING_ERRORS_PERMITTED, 4);
     testSetUpForRunningFlows();
     this.manager.start();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.getExecutionOptions().setFailureEmails(Arrays.asList("test@example.com"));
     when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
 
@@ -521,7 +522,7 @@ public class ExecutorManagerTest {
   @Test
   public void testSetFlowLock() throws Exception {
     testSetUpForRunningFlows();
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.setLocked(true);
     final String msg = this.manager.submitExecutableFlow(flow1, this.user.getUserId());
     assertThat(msg).isEqualTo("Flow derived-member-data for project flow is locked.");
@@ -616,12 +617,12 @@ public class ExecutorManagerTest {
     when(this.loader.fetchActiveExecutors()).thenReturn(executors);
     this.manager = createExecutorManager();
 
-    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
-    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
+    this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.PUSH);
     this.flow1.setExecutionId(1);
     this.flow2.setExecutionId(2);
-    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), executor1);
-    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2);
+    this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), executor1, DispatchMethod.PUSH);
+    this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2, DispatchMethod.PUSH);
     this.activeFlows.put(this.flow1.getExecutionId(), new Pair<>(this.ref1, this.flow1));
     this.activeFlows.put(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2));
     when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);

--- a/azkaban-common/src/test/java/azkaban/executor/FetchActiveFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/FetchActiveFlowDaoTest.java
@@ -3,6 +3,7 @@ package azkaban.executor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import azkaban.DispatchMethod;
 import azkaban.db.EncodingType;
 import azkaban.executor.FetchActiveFlowDao.FetchActiveExecutableFlows;
 import azkaban.utils.JSONUtils;
@@ -47,7 +48,7 @@ public class FetchActiveFlowDaoTest {
   }
 
   private void mockResultWithData() throws Exception {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     final String json = JSONUtils.toJSON(flow.toObject());
     final byte[] data = json.getBytes("UTF-8");
     mockExecution(EncodingType.PLAIN.getNumVal(), data);

--- a/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
@@ -18,6 +18,7 @@ package azkaban.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
 import azkaban.test.Utils;
 import azkaban.utils.TestUtils;
@@ -68,15 +69,15 @@ public class NumExecutionsDaoTest {
 
   @Test
   public void testFetchNumExecutableFlows() throws Exception {
-    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow1.setStatus(Status.READY);
     this.executionFlowDao.uploadExecutableFlow(flow1);
 
-    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
     flow2.setStatus(Status.RUNNING);
     this.executionFlowDao.uploadExecutableFlow(flow2);
 
-    final ExecutableFlow flow2b = TestUtils.createTestExecutableFlow("exectest1", "exec2");
+    final ExecutableFlow flow2b = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);
     flow2b.setStatus(Status.FAILED);
     this.executionFlowDao.uploadExecutableFlow(flow2b);
 

--- a/azkaban-common/src/test/java/azkaban/executor/QueuedExecutionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/QueuedExecutionsTest.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.utils.Pair;
 import azkaban.utils.TestUtils;
 import java.io.IOException;
@@ -32,9 +33,9 @@ public class QueuedExecutionsTest {
    */
   private Pair<ExecutionReference, ExecutableFlow> createExecutablePair(
       final String flowName, final int execId) throws IOException {
-    final ExecutableFlow execFlow = TestUtils.createTestExecutableFlow("exectest1", flowName);
+    final ExecutableFlow execFlow = TestUtils.createTestExecutableFlow("exectest1", flowName, DispatchMethod.PUSH);
     execFlow.setExecutionId(execId);
-    final ExecutionReference ref = new ExecutionReference(execId);
+    final ExecutionReference ref = new ExecutionReference(execId, DispatchMethod.PUSH);
     return new Pair<>(ref, execFlow);
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
 import azkaban.metrics.CommonMetrics;
 import azkaban.utils.Pair;
@@ -58,7 +59,7 @@ public class RunningExecutionsUpdaterTest {
     this.activeExecutor = new Executor(1, "activeExecutor-1", 9999, true);
     this.runningExecutions = new RunningExecutions();
     this.runningExecutions.get().put(EXECUTION_ID_77, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_77, this.activeExecutor), this.execution));
+        new ExecutionReference(EXECUTION_ID_77, this.activeExecutor, DispatchMethod.PUSH), this.execution));
     this.updater = new RunningExecutionsUpdater(this.updaterStage, this.alerterHolder,
         this.commonMetrics, this.apiGateway, this.runningExecutions, this.executionFinalizer,
         this.executorLoader);
@@ -153,7 +154,7 @@ public class RunningExecutionsUpdaterTest {
 
   private void mockExecutorDoesNotExist() {
     this.runningExecutions.get().put(EXECUTION_ID_77, new Pair<>(
-        new ExecutionReference(EXECUTION_ID_77, null), this.execution));
+        new ExecutionReference(EXECUTION_ID_77, null, DispatchMethod.PUSH), this.execution));
   }
 
   private void mockUpdateCallFails() throws ExecutorManagerException {

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import azkaban.Constants;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.Constants.FlowParameters;
+import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorLoader;
@@ -315,7 +316,7 @@ public class KubernetesContainerizedImplTest {
   }
 
   private ExecutableFlow createTestFlow() throws Exception {
-    return TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    return TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
   }
 
   private ExecutableFlow createFlowWithMultipleJobtypes() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -17,6 +17,7 @@ package azkaban.server;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import azkaban.DispatchMethod;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorManagerException;
@@ -56,7 +57,7 @@ public final class HttpRequestUtilsTest {
 
   /* Helper method to get a test flow and add required properties */
   public static ExecutableFlow createExecutableFlow() throws IOException {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1");
+    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
     flow.getExecutionOptions().getFlowParameters()
         .put(ExecutionOptions.FLOW_PRIORITY, "1");
     flow.getExecutionOptions().getFlowParameters()

--- a/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
+++ b/azkaban-common/src/test/java/azkaban/utils/TestUtils.java
@@ -43,7 +43,7 @@ public class TestUtils {
 
   /* Helper method to create an ExecutableFlow from serialized description */
   public static ExecutableFlow createTestExecutableFlow(final String projectName,
-      final String flowName) throws IOException {
+      final String flowName, final DispatchMethod dispatchMethod) throws IOException {
     final File jsonFlowFile = ExecutionsTestUtil.getFlowFile(projectName, flowName + ".flow");
     final HashMap<String, Object> flowObj =
         (HashMap<String, Object>) JSONUtils.parseJSONFromFile(jsonFlowFile);
@@ -54,7 +54,7 @@ public class TestUtils {
     flowMap.put(flow.getId(), flow);
     project.setFlows(flowMap);
     final ExecutableFlow execFlow = new ExecutableFlow(project, flow);
-    execFlow.setDispatchMethod(DispatchMethod.POLL);
+    execFlow.setDispatchMethod(dispatchMethod);
     return execFlow;
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import azkaban.DispatchMethod;
 import azkaban.event.Event;
 import azkaban.execapp.event.FlowWatcher;
 import azkaban.execapp.jmx.JmxJobMBeanManager;
@@ -192,6 +193,7 @@ public class FlowRunnerTestUtil {
       throws Exception {
     final ExecutableFlow exFlow = FlowRunnerTestUtil
         .prepareExecDir(this.workingDir, this.projectDir, flowName, 1);
+    exFlow.setDispatchMethod(DispatchMethod.POLL);
     if (watcher != null) {
       options.setPipelineLevel(pipeline);
       options.setPipelineExecutionId(watcher.getExecId());


### PR DESCRIPTION
Ramp-up mechanism is introduced in https://github.com/azkaban/azkaban/pull/2779 allowing some flows to be dispatched as Containerized and others as POLL to have a mechanism of ramping the containerization on the already running POLL based Azkaban cluster.

Hence web server, depending on the execution, may need to send a request to the Container via reverse proxy or to the executor server. Column "flow_data" in the execution_flows is a blob containing information regarding flow execution and it will also contain the dispatch_method for that execution. Based on the dispatch_method derived from "flow_data", we can send the request to the appropriate server.

Key changes:
azkaban-common/src/main/java/azkaban/executor/ExecutorApiClient.java
azkaban-common/src/main/java/azkaban/executor/ExecutorApiGateway.java

This is to make sure that both ExecutorApiGateway and ExecutorApiClient take into account the dispatch_method for every call, and creates & use the appropriate Http/Https client.

