### PR TITLE
Added jobtype based filtering for containerization ramp-up

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -526,6 +526,8 @@ public class Constants {
         AZKABAN_CONTAINERIZED_PREFIX + "creation.rate.limit";
     public static final String CONTAINERIZED_RAMPUP =
         AZKABAN_CONTAINERIZED_PREFIX + "rampup";
+    public static final String CONTAINERIZED_JOBTYPE_ALLOWLIST =
+        AZKABAN_CONTAINERIZED_PREFIX + "jobtype.allowlist";
 
     // Kubernetes related properties
     public static final String AZKABAN_KUBERNETES_PREFIX = "azkaban.kubernetes.";

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -273,6 +273,11 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     }
   }
 
+  @Override
+  public DispatchMethod getDispatchMethod(final ExecutableFlow flow) {
+    return getDispatchMethod();
+  }
+
   protected String uploadExecutableFlow(
       final ExecutableFlow exflow, final String userId, final String flowId,
       String message) throws ExecutorManagerException {
@@ -280,7 +285,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     exflow.setSubmitUser(userId);
     exflow.setStatus(getStartStatus());
     exflow.setSubmitTime(System.currentTimeMillis());
-    exflow.setDispatchMethod(getDispatchMethod());
+    exflow.setDispatchMethod(getDispatchMethod(exflow));
 
     // Get collection of running flows given a project and a specific flow name
     final List<Integer> running = getRunningFlows(projectId, flowId);

--- a/azkaban-common/src/main/java/azkaban/executor/Executor.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Executor.java
@@ -18,17 +18,24 @@ package azkaban.executor;
 
 import azkaban.utils.Utils;
 import java.util.Date;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 /**
  * Class to represent an AzkabanExecutorServer details for ExecutorManager
  *
  * @author gaggarwa
  */
+@JsonPropertyOrder({"id", "host", "port", "isActive"})
 public class Executor implements Comparable<Executor> {
 
+  @JsonProperty("id")
   private final int id;
+  @JsonProperty("host")
   private final String host;
+  @JsonProperty("port")
   private final int port;
+  @JsonProperty("isActive")
   private boolean isActive;
   // cached copy of the latest statistics from  the executor.
   private ExecutorInfo cachedExecutorStats;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -46,6 +46,11 @@ public interface ExecutorManagerAdapter {
   public DispatchMethod getDispatchMethod();
 
   /**
+   * Compute {@link DispatchMethod} based on the {@link ExecutableFlow}
+   */
+  public DispatchMethod getDispatchMethod(ExecutableFlow flow);
+
+  /**
    * <pre>
    * Returns All running with executors and queued flows
    * Note, returns empty list if there isn't any running or queued flows

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerImplUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerImplUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.executor.container;
+
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
+import azkaban.executor.ExecutableNode;
+import azkaban.executor.ExecutorManagerException;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Utility class containing static methods to be used during Containerized Dispatch
+ */
+public class ContainerImplUtils {
+
+  private ContainerImplUtils() {
+    // Not to be instantiated
+  }
+
+  /**
+   * This method is used to get jobTypes for a flow. This method is going to call
+   * populateJobTypeForFlow which has recursive method call to traverse the DAG for a flow.
+   *
+   * @param flow Executable flow object
+   * @return
+   * @throws ExecutorManagerException
+   */
+  public static TreeSet<String> getJobTypesForFlow(final ExecutableFlow flow) {
+    final TreeSet<String> jobTypes = new TreeSet<>();
+    populateJobTypeForFlow(flow, jobTypes);
+    return jobTypes;
+  }
+
+  /**
+   * This method is used to populate jobTypes for ExecutableNode.
+   *
+   * @param node
+   * @param jobTypes
+   */
+  private static void populateJobTypeForFlow(final ExecutableNode node, Set<String> jobTypes) {
+    if (node instanceof ExecutableFlowBase) {
+      final ExecutableFlowBase base = (ExecutableFlowBase) node;
+      for (ExecutableNode subNode : base.getExecutableNodes()) {
+        populateJobTypeForFlow(subNode, jobTypes);
+      }
+    } else {
+      jobTypes.add(node.getType());
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerJobTypeCriteria.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerJobTypeCriteria.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.executor.container;
+
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
+import azkaban.DispatchMethod;
+import azkaban.executor.ExecutableFlow;
+import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Class for determining {@link DispatchMethod} based on allowList.
+ */
+public class ContainerJobTypeCriteria {
+
+  public static final String ALL = "ALL";
+  private Set<String> allowList;
+
+  public ContainerJobTypeCriteria(final Props azkProps) {
+    this.allowList = new HashSet<>(azkProps
+        .getStringList(ContainerizedDispatchManagerProperties.CONTAINERIZED_JOBTYPE_ALLOWLIST));
+  }
+
+  @VisibleForTesting
+  public void updateAllowList(Set<String> allowList) {
+    this.allowList = allowList;
+  }
+
+  @VisibleForTesting
+  public void appendAllowList(Set<String> allowList) {
+    this.allowList.addAll(allowList);
+  }
+
+  @VisibleForTesting
+  public void removeFromAllowList(Set<String> allowList) {
+    this.allowList.removeAll(allowList);
+  }
+
+  @VisibleForTesting
+  public Set<String> getAllowList() {
+    return this.allowList;
+  }
+
+  @VisibleForTesting
+  public String getAllowListAsString() {
+    return String.join(",", this.allowList);
+  }
+
+  /**
+   * If the set of JobTypes extracted from the flow is not allowed, the return DispatchMethod.POLL
+   * other DispatchMethod.CONTAINERIZED. If the allowList contains "ALL", then
+   * DispatchMethod.CONTAINERIZED is returned.
+   */
+  public DispatchMethod getDispatchMethod(final ExecutableFlow flow) {
+    if (this.allowList.contains(ALL)) {
+      return DispatchMethod.CONTAINERIZED;
+    }
+    Set<String> jobTypesForFlow = ContainerImplUtils.getJobTypesForFlow(flow);
+    for (String jobType : jobTypesForFlow) {
+      if (!this.allowList.contains(jobType)) {
+        return DispatchMethod.POLL;
+      }
+    }
+    return DispatchMethod.CONTAINERIZED;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerRampUpCriteria.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerRampUpCriteria.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.executor.container;
+
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
+import azkaban.DispatchMethod;
+import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class for determining {@link DispatchMethod} based on rampUp.
+ */
+public class ContainerRampUpCriteria {
+
+  private int rampUp;
+  private static final Logger logger = LoggerFactory.getLogger(ContainerRampUpCriteria.class);
+
+  public ContainerRampUpCriteria(final Props azkProps) {
+    int rampUp = azkProps.getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_RAMPUP, 100);
+    if (rampUp > 100 || rampUp < 0) {
+      String errorMessage = "RampUp must be an integer between [0, 100]: " + rampUp;
+      logger.error(errorMessage);
+      throw new IllegalArgumentException(errorMessage);
+    } else {
+      this.rampUp = rampUp;
+    }
+  }
+
+  /**
+   * Return DispatchMethod based on the rampUp percentage.
+   */
+  public DispatchMethod getDispatchMethod() {
+    if (this.rampUp == 0) {
+      return DispatchMethod.POLL;
+    } else if (this.rampUp == 100) {
+      return DispatchMethod.CONTAINERIZED;
+    }
+    ThreadLocalRandom rand = ThreadLocalRandom.current();
+    int randomInt = rand.nextInt(100);
+    if (randomInt < this.rampUp) {
+      return DispatchMethod.CONTAINERIZED;
+    } else {
+      return DispatchMethod.POLL;
+    }
+  }
+
+  @VisibleForTesting
+  public void setRampUp(int rampUp) {
+    this.rampUp = rampUp;
+  }
+
+  @VisibleForTesting
+  public int getRampUp() {
+    return this.rampUp;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -22,7 +22,6 @@ import azkaban.executor.AbstractExecutorManagerAdapter;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlow;
-import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutionReference;
 import azkaban.executor.Executor;
 import azkaban.executor.ExecutorApiGateway;
@@ -30,7 +29,6 @@ import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.metrics.CommonMetrics;
-import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
@@ -62,11 +60,12 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter {
-  private int rampUp;
   private final ContainerizedImpl containerizedImpl;
   private QueueProcessorThread queueProcessor;
   private final RateLimiter rateLimiter;
   private static final Logger logger = LoggerFactory.getLogger(ContainerizedDispatchManager.class);
+  private final ContainerJobTypeCriteria containerJobTypeCriteria;
+  private final ContainerRampUpCriteria containerRampUpCriteria;
 
   @Inject
   public ContainerizedDispatchManager(final Props azkProps, final ExecutorLoader executorLoader,
@@ -78,19 +77,16 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
         RateLimiter.create(azkProps
             .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));
     this.containerizedImpl = containerizedImpl;
-    int rampUp = azkProps.getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_RAMPUP, 100);
-    if (rampUp > 100 || rampUp < 0) {
-      String errorMessage = "RampUp must be an integer between [0, 100]: " + rampUp;
-      logger.error(errorMessage);
-      throw new ExecutorManagerException(errorMessage);
-    } else {
-      this.rampUp = rampUp;
-    }
+    this.containerJobTypeCriteria = new ContainerJobTypeCriteria(azkProps);
+    this.containerRampUpCriteria = new ContainerRampUpCriteria(azkProps);
   }
 
-  @VisibleForTesting
-  public void setRampUp(int rampUp) {
-    this.rampUp = rampUp;
+  public ContainerJobTypeCriteria getContainerJobTypeCriteria() {
+    return this.containerJobTypeCriteria;
+  }
+
+  public ContainerRampUpCriteria getContainerRampUpCriteria() {
+    return this.containerRampUpCriteria;
   }
 
   /**
@@ -138,18 +134,16 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
    */
   @Override
   public DispatchMethod getDispatchMethod() {
-    if (this.rampUp == 0) {
-      return DispatchMethod.POLL;
-    } else if (this.rampUp == 100) {
-      return DispatchMethod.CONTAINERIZED;
+    return this.containerRampUpCriteria.getDispatchMethod();
+  }
+
+  @Override
+  public DispatchMethod getDispatchMethod(final ExecutableFlow flow) {
+    DispatchMethod dispatchMethod = getDispatchMethod();
+    if (dispatchMethod != DispatchMethod.CONTAINERIZED) {
+      return dispatchMethod;
     }
-    Random rand = new Random();
-    int randomInt = rand.nextInt(100);
-    if (randomInt < this.rampUp) {
-      return DispatchMethod.CONTAINERIZED;
-    } else {
-      return DispatchMethod.POLL;
-    }
+    return this.containerJobTypeCriteria.getDispatchMethod(flow);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -29,8 +29,6 @@ import azkaban.container.models.AzKubernetesV1SpecBuilder;
 import azkaban.container.models.ImagePullPolicy;
 import azkaban.container.models.PodTemplateMergeUtils;
 import azkaban.executor.ExecutableFlow;
-import azkaban.executor.ExecutableFlowBase;
-import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
@@ -582,7 +580,7 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
     // Fetch execution flow from execution Id.
     final ExecutableFlow flow = this.executorLoader.fetchExecutableFlow(executionId);
     // Step 1: Fetch set of jobTypes for a flow from executionId
-    final TreeSet<String> jobTypes = getJobTypesForFlow(flow);
+    final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     logger.info("ExecId: {}, Jobtypes for flow {} are: {}", executionId, flow.getFlowId(), jobTypes);
 
     final Map<String, String> flowParam =
@@ -704,37 +702,6 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
 
   private void addSecretVolume(final AzKubernetesV1SpecBuilder v1SpecBuilder) {
     v1SpecBuilder.addSecretVolume(secretVolume, secretName, secretMountpath);
-  }
-
-  /**
-   * This method is used to get jobTypes for a flow. This method is going to call
-   * populateJobTypeForFlow which has recursive method call to traverse the DAG for a flow.
-   *
-   * @param flow Executable flow object
-   * @return
-   * @throws ExecutorManagerException
-   */
-  public TreeSet<String> getJobTypesForFlow(final ExecutableFlow flow) {
-    final TreeSet<String> jobTypes = new TreeSet<>();
-    populateJobTypeForFlow(flow, jobTypes);
-    return jobTypes;
-  }
-
-  /**
-   * This method is used to populate jobTypes for ExecutableNode.
-   *
-   * @param node
-   * @param jobTypes
-   */
-  private void populateJobTypeForFlow(final ExecutableNode node, Set<String> jobTypes) {
-    if (node instanceof ExecutableFlowBase) {
-      final ExecutableFlowBase base = (ExecutableFlowBase) node;
-      for (ExecutableNode subNode : base.getExecutableNodes()) {
-        populateJobTypeForFlow(subNode, jobTypes);
-      }
-    } else {
-      jobTypes.add(node.getType());
-    }
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
@@ -19,10 +19,12 @@ import azkaban.imagemgmt.models.ImageRampup.StabilityTag;
 import azkaban.imagemgmt.models.ImageVersion.State;
 import java.util.List;
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 /**
  * This DTO class represents API specific image version metadata response.
  */
+@JsonPropertyOrder({"version", "state", "path", "message", "rampups"})
 public class ImageVersionMetadataResponseDTO {
 
   // Represents version for an image type selected based on random rampup or current active version.
@@ -73,6 +75,7 @@ public class ImageVersionMetadataResponseDTO {
   /**
    * Represents rampup metadata for an image type.
    */
+  @JsonPropertyOrder({"version", "stabilityTag", "rampupPercentage"})
   public static class RampupMetadata {
 
     @JsonProperty("version")

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -42,6 +42,7 @@ import azkaban.utils.TestUtils;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -73,6 +74,7 @@ public class ContainerizedDispatchManagerTest {
   private ExecutableFlow flow2;
   private ExecutableFlow flow3;
   private ExecutableFlow flow4;
+  private ExecutableFlow flow5;
   private ExecutionReference ref1;
   private ExecutionReference ref2;
   private ExecutionReference ref3;
@@ -91,10 +93,13 @@ public class ContainerizedDispatchManagerTest {
     this.flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
     this.flow3 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
     this.flow4 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.CONTAINERIZED);
+    this.flow5 = TestUtils.createTestExecutableFlowFromYaml("basicflowyamltest", "basic_flow");
     this.flow1.setExecutionId(1);
     this.flow2.setExecutionId(2);
     this.flow3.setExecutionId(3);
     this.flow4.setExecutionId(4);
+    this.flow5.setExecutionId(5);
+    this.flow5.setDispatchMethod(DispatchMethod.CONTAINERIZED);
     this.ref1 = new ExecutionReference(this.flow1.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
     this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
     this.ref3 = new ExecutionReference(this.flow3.getExecutionId(), null, DispatchMethod.CONTAINERIZED);
@@ -119,16 +124,39 @@ public class ContainerizedDispatchManagerTest {
   @Test
   public void testRampUpDispatchMethod() throws Exception {
     initializeContainerizedDispatchImpl();
-    this.containerizedDispatchManager.setRampUp(0);
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
     for (int i = 0; i < 100; i++) {
       DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
       assertThat(dispatchMethod).isEqualTo(DispatchMethod.POLL);
     }
-    this.containerizedDispatchManager.setRampUp(100);
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(100);
     for (int i = 0; i < 100; i++) {
       DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
       assertThat(dispatchMethod).isEqualTo(DispatchMethod.CONTAINERIZED);
     }
+  }
+
+  @Test
+  public void testAllowAndDenyList() throws Exception {
+    // Flow 5 comprises of "command" and "noop" jobtypes
+    initializeContainerizedDispatchImpl();
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
+    DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    Assert.assertEquals(DispatchMethod.POLL, dispatchMethod);
+
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(100);
+    this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of("java", "command",
+        "noop"));
+    dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    Assert.assertEquals(DispatchMethod.CONTAINERIZED, dispatchMethod);
+
+    this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of("java", "command"));
+    dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    Assert.assertEquals(DispatchMethod.POLL, dispatchMethod);
+
+    this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of());
+    dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    Assert.assertEquals(DispatchMethod.POLL, dispatchMethod);
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -179,7 +179,7 @@ public class KubernetesContainerizedImplTest {
     flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(System.currentTimeMillis());
     flow.setExecutionId(0);
-    TreeSet<String> jobTypes = this.kubernetesContainerizedImpl.getJobTypesForFlow(flow);
+    TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     assertThat(jobTypes.size()).isEqualTo(1);
   }
 
@@ -189,7 +189,7 @@ public class KubernetesContainerizedImplTest {
     flow.setExecutionId(1);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
     when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
-    final TreeSet<String> jobTypes = this.kubernetesContainerizedImpl.getJobTypesForFlow(flow);
+    final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     assert(jobTypes.contains("command"));
     assert(jobTypes.contains("hadoopJava"));
     assert(jobTypes.contains("spark"));
@@ -221,7 +221,7 @@ public class KubernetesContainerizedImplTest {
     when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
     when(imageRampupManager.getVersionInfo(any(String.class), any(String.class)))
         .thenReturn(new VersionInfo("7.0.4", "path1", State.ACTIVE));
-    final TreeSet<String> jobTypes = this.kubernetesContainerizedImpl.getJobTypesForFlow(flow);
+    final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     // Add included job types
     jobTypes.add("hadoopJava");
     jobTypes.add("pig");
@@ -287,7 +287,7 @@ public class KubernetesContainerizedImplTest {
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
     when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
-    final TreeSet<String> jobTypes = this.kubernetesContainerizedImpl.getJobTypesForFlow(flow);
+    final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     // Add included job types
     jobTypes.add("hadoopJava");
     jobTypes.add("pig");

--- a/azkaban-web-server/src/main/java/azkaban/webapp/ContainerizedClusterStatus.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/ContainerizedClusterStatus.java
@@ -17,8 +17,8 @@
 
 package azkaban.webapp;
 
+import azkaban.executor.Executor;
 import azkaban.imagemgmt.dto.ImageVersionMetadataResponseDTO;
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
@@ -27,11 +27,19 @@ import org.codehaus.jackson.annotate.JsonPropertyOrder;
  * This POJO is used by GSON library to create a status JSON object. This class represents status
  * for containerized cluster.
  */
-@JsonPropertyOrder({"version", "pid", "installationPath", "usedMemory", "xmx", "isDatabaseUp", "imageTypeVersionMap"})
+@JsonPropertyOrder({"version", "pid", "installationPath", "usedMemory", "xmx", "isDatabaseUp",
+    "containerizationRampUp", "containerizationJobTypeFilter", "executorStatusMap",
+    "imageTypeVersionMap"})
 public class ContainerizedClusterStatus extends Status {
 
   @JsonProperty("imageTypeVersionMap")
   private final Map<String, ImageVersionMetadataResponseDTO> imageTypeVersionMap;
+  @JsonProperty("executorStatusMap")
+  private final Map<Integer, Executor> executorStatusMap;
+  @JsonProperty("containerizationRampUp")
+  private final int containerizationRampUp;
+  @JsonProperty("containerizationJobTypeFilter")
+  private final String containerizationJobTypeFilter;
 
   public ContainerizedClusterStatus(final String version,
       final String pid,
@@ -39,9 +47,15 @@ public class ContainerizedClusterStatus extends Status {
       final long usedMemory,
       final long xmx,
       final boolean isDatabaseUp,
-      final Map<String, ImageVersionMetadataResponseDTO> imageTypeVersionMap) {
+      final Map<String, ImageVersionMetadataResponseDTO> imageTypeVersionMap,
+      final Map<Integer, Executor> executorStatusMap,
+      final int containerizationRampUp,
+      final String containerizationJobTypeFilter) {
     super(version, pid, installationPath, usedMemory, xmx, isDatabaseUp);
     this.imageTypeVersionMap = imageTypeVersionMap;
+    this.executorStatusMap = executorStatusMap;
+    this.containerizationRampUp = containerizationRampUp;
+    this.containerizationJobTypeFilter = containerizationJobTypeFilter;
   }
 
   public Map<String, ImageVersionMetadataResponseDTO> getImageTypeVersionMap() {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ServletUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ServletUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.webapp.servlet;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility class containing static methods to be used by various Servlets
+ */
+public class ServletUtils {
+
+  /**
+   * Returns the Set of String from the comma-separated val
+   */
+  public static Set<String> getSetFromString(final String val) {
+    if (val == null || val.trim().length() == 0) {
+      return Collections.emptySet();
+    }
+    return new HashSet<>(Arrays.asList(val.split("\\s*,\\s*")));
+  }
+}

--- a/azkaban-web-server/src/test/java/azkaban/webapp/StatusServiceTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/StatusServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package azkaban.webapp;
+
+import azkaban.Constants;
+import azkaban.Constants.ContainerizedDispatchManagerProperties;
+import azkaban.DispatchMethod;
+import azkaban.ServiceProvider;
+import azkaban.db.DatabaseOperator;
+import azkaban.executor.Executor;
+import azkaban.executor.ExecutorLoader;
+import azkaban.executor.ExecutorManagerAdapter;
+import azkaban.executor.container.ContainerJobTypeCriteria;
+import azkaban.executor.container.ContainerRampUpCriteria;
+import azkaban.executor.container.ContainerizedDispatchManager;
+import azkaban.imagemgmt.dto.ImageVersionMetadataResponseDTO;
+import azkaban.imagemgmt.dto.ImageVersionMetadataResponseDTO.RampupMetadata;
+import azkaban.imagemgmt.models.ImageRampup.StabilityTag;
+import azkaban.imagemgmt.models.ImageVersion.State;
+import azkaban.imagemgmt.services.ImageVersionMetadataService;
+import azkaban.utils.Props;
+import azkaban.utils.TestUtils;
+import azkaban.webapp.servlet.StatusServlet;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import java.io.IOException;
+import java.util.Collections;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class StatusServiceTest {
+
+  @Mock
+  private ContainerizedDispatchManager executorManager;
+  @Mock
+  private Injector injector;
+  @Mock
+  private ExecutorLoader executorLoader;
+  @Mock
+  private DatabaseOperator dbOperator;
+  @Mock
+  private ImageVersionMetadataService imageVersionMetadataService;
+  private final Props props = new Props();
+  private StatusService statusService;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    ServiceProvider.SERVICE_PROVIDER.unsetInjector();
+    ServiceProvider.SERVICE_PROVIDER.setInjector(this.injector);
+    Mockito.when(this.injector.getInstance(ImageVersionMetadataService.class))
+        .thenReturn(this.imageVersionMetadataService);
+    Mockito.when(this.injector.getInstance(ExecutorManagerAdapter.class))
+        .thenReturn(this.executorManager);
+
+    this.props.put(ContainerizedDispatchManagerProperties.CONTAINERIZED_JOBTYPE_ALLOWLIST,
+        "jobType1, jobType2");
+    this.props.put(ContainerizedDispatchManagerProperties.CONTAINERIZED_RAMPUP,
+        "50");
+    ImageVersionMetadataResponseDTO imageVersionMetadataResponseDTO = new ImageVersionMetadataResponseDTO(
+        "0.0.7", State.ACTIVE, "registry/myPath",
+        Collections.singletonList(new RampupMetadata("0.0.7", 100, StabilityTag.STABLE)), "");
+
+    Mockito.when(this.dbOperator.query(Mockito.any(), Mockito.any())).thenReturn(true);
+    Mockito.when(this.imageVersionMetadataService.getVersionMetadataForAllImageTypes())
+        .thenReturn(ImmutableMap.of("myJobType", imageVersionMetadataResponseDTO));
+    Mockito.when(this.executorManager.getContainerRampUpCriteria())
+        .thenReturn(new ContainerRampUpCriteria(this.props));
+    Mockito.when(this.executorManager.getContainerJobTypeCriteria())
+        .thenReturn(new ContainerJobTypeCriteria(this.props));
+    Mockito.when(this.executorLoader.fetchActiveExecutors()).thenReturn(
+        Collections.singletonList(new Executor(7, "0.0.0.0", 12345, true)));
+    this.statusService = Mockito.spy(new StatusService(this.props, this.executorLoader,
+        this.dbOperator));
+    Mockito.doReturn("0.0.7").when(this.statusService).getVersion();
+    Mockito.doReturn("123").when(this.statusService).getPid();
+    Mockito.doReturn("/myDir").when(this.statusService).getInstallationPath();
+    Mockito.doReturn(12345L).when(this.statusService).getUsedMemory();
+    Mockito.doReturn(12345L).when(this.statusService).getMaxMemory();
+  }
+
+  @Test
+  public void testClusterStatus() throws IOException {
+    ObjectMapper objectMapper = StatusServlet.getObjectMapper();
+    String clusterStatusString = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(this.statusService.getStatus());
+    String expectedClusterStatusString = TestUtils
+        .readResource("cluster_status", this).trim();
+    Assert.assertEquals(expectedClusterStatusString, clusterStatusString);
+
+    this.props.put(Constants.ConfigurationKeys.AZKABAN_EXECUTION_DISPATCH_METHOD,
+        DispatchMethod.CONTAINERIZED.name());
+    String containerizedClusterStatusString = objectMapper.writerWithDefaultPrettyPrinter()
+        .writeValueAsString(this.statusService.getStatus());
+    String expectedContainerizedClusterStatusString = TestUtils
+        .readResource("containerized_cluster_status", this).trim();
+    Assert.assertEquals(expectedContainerizedClusterStatusString, containerizedClusterStatusString);
+  }
+}

--- a/azkaban-web-server/src/test/resources/azkaban/webapp/cluster_status
+++ b/azkaban-web-server/src/test/resources/azkaban/webapp/cluster_status
@@ -1,0 +1,16 @@
+{
+  "version" : "0.0.7",
+  "pid" : "123",
+  "installationPath" : "/myDir",
+  "usedMemory" : 12345,
+  "xmx" : 12345,
+  "isDatabaseUp" : true,
+  "executorStatusMap" : {
+    "7" : {
+      "id" : 7,
+      "host" : "0.0.0.0",
+      "port" : 12345,
+      "isActive" : true
+    }
+  }
+}

--- a/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
+++ b/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
@@ -1,0 +1,31 @@
+{
+  "version" : "0.0.7",
+  "pid" : "123",
+  "installationPath" : "/myDir",
+  "usedMemory" : 12345,
+  "xmx" : 12345,
+  "isDatabaseUp" : true,
+  "containerizationRampUp" : 50,
+  "containerizationJobTypeFilter" : "jobType2,jobType1",
+  "executorStatusMap" : {
+    "7" : {
+      "id" : 7,
+      "host" : "0.0.0.0",
+      "port" : 12345,
+      "isActive" : true
+    }
+  },
+  "imageTypeVersionMap" : {
+    "myJobType" : {
+      "version" : "0.0.7",
+      "state" : "ACTIVE",
+      "path" : "registry/myPath",
+      "message" : "",
+      "rampups" : [ {
+        "version" : "0.0.7",
+        "stabilityTag" : "STABLE",
+        "rampupPercentage" : 100
+      } ]
+    }
+  }
+}


### PR DESCRIPTION
- Changed the dispatch method to use ExecutableFlow to determine the job types set for the flow.
- Introduced AllowList for the containerized executions, i.e., if a job-type in a flow is not part of allowList, then it won't be executed as part of Containerization but will be polled by the executor-server.
- Introduced the API to update the property for overwriting, appending to, and removing from the allowlist. It will also allow updating ramp-up percentages.
- Fixed the changes in the status page to show both executors and image statuses.
- Added containerizationRampUp and containerizationJobTypeFilter to the status page.
- Added visibilityChecker to the ObjectMapper in StatusServlet to use only the fields which are specifically marked as JsonProperty as part of converting the object to JSON.
- Refactored the containerization ramp-up logic to ContainerRampUpCriteria.java 