### PR TITLE
Flow deterministic ramp-ups for imagetype and containerization

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerImplUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerImplUtils.java
@@ -19,8 +19,10 @@ import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutorManagerException;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.codec.digest.MurmurHash3;
 
 /**
  * Utility class containing static methods to be used during Containerized Dispatch
@@ -60,5 +62,19 @@ public class ContainerImplUtils {
     } else {
       jobTypes.add(node.getType());
     }
+  }
+
+  /**
+   * Return the int mapping between 1 to 100 for a given flow name
+   * @param flow
+   * @return
+   */
+  public static int getFlowNameHashValMapping(ExecutableFlow flow) {
+    // Flow name is <projectName>.<flowId>
+    String flowName = flow.getFlowName();
+    byte[] flowNameBytes = flowName.getBytes(StandardCharsets.UTF_8);
+    // To be utilized for flow deterministic ramp-up
+    int flowNameHashVal = MurmurHash3.hash32x86(flowNameBytes);
+    return flowNameHashVal % 100 + 1;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerRampUpCriteria.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerRampUpCriteria.java
@@ -17,9 +17,9 @@ package azkaban.executor.container;
 
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
+import azkaban.executor.ExecutableFlow;
 import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.slf4j.Logger;
@@ -45,7 +45,7 @@ public class ContainerRampUpCriteria {
   }
 
   /**
-   * Return DispatchMethod based on the rampUp percentage.
+   * Return DispatchMethod based on the rampUp percentage and random selection
    */
   public DispatchMethod getDispatchMethod() {
     if (this.rampUp == 0) {
@@ -56,6 +56,25 @@ public class ContainerRampUpCriteria {
     ThreadLocalRandom rand = ThreadLocalRandom.current();
     int randomInt = rand.nextInt(100);
     if (randomInt < this.rampUp) {
+      return DispatchMethod.CONTAINERIZED;
+    } else {
+      return DispatchMethod.POLL;
+    }
+  }
+
+  /**
+   * Return DispatchMethod based on the rampUp percentage and deterministic selection
+   * based on the flow name
+   */
+  public DispatchMethod getDispatchMethod(final ExecutableFlow flow) {
+    if (this.rampUp == 0) {
+      return DispatchMethod.POLL;
+    } else if (this.rampUp == 100) {
+      return DispatchMethod.CONTAINERIZED;
+    }
+    int flowNameHashValMapping = ContainerImplUtils.getFlowNameHashValMapping(flow);
+
+    if (flowNameHashValMapping <= this.rampUp) {
       return DispatchMethod.CONTAINERIZED;
     } else {
       return DispatchMethod.POLL;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -139,7 +139,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
 
   @Override
   public DispatchMethod getDispatchMethod(final ExecutableFlow flow) {
-    DispatchMethod dispatchMethod = getDispatchMethod();
+    DispatchMethod dispatchMethod = this.containerRampUpCriteria.getDispatchMethod(flow);
     if (dispatchMethod != DispatchMethod.CONTAINERIZED) {
       return dispatchMethod;
     }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManager.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManager.java
@@ -15,6 +15,7 @@
  */
 package azkaban.imagemgmt.rampup;
 
+import azkaban.executor.ExecutableFlow;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageVersionMetadata;
 import azkaban.imagemgmt.version.VersionInfo;
@@ -33,15 +34,17 @@ public interface ImageRampupManager {
    * @return Map<String, VersionInfo>
    * @throws ImageMgmtException
    */
-  public Map<String, VersionInfo> getVersionForAllImageTypes() throws ImageMgmtException;
+  public Map<String, VersionInfo> getVersionForAllImageTypes(ExecutableFlow flow)
+      throws ImageMgmtException;
 
   /**
-   * Fetches the version of all the given image types based on rampup
+   * Fetches the version of all the given image types based on rampup and flow
    *
    * @return Map<String, VersionInfo>
    * @throws ImageMgmtException
    */
-  public Map<String, VersionInfo> getVersionByImageTypes(Set<String> imageTypes)
+  public Map<String, VersionInfo> getVersionByImageTypes(ExecutableFlow flow,
+      Set<String> imageTypes)
       throws ImageMgmtException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
@@ -16,6 +16,8 @@
 package azkaban.imagemgmt.rampup;
 
 import azkaban.Constants.ImageMgmtConstants;
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.container.ContainerImplUtils;
 import azkaban.imagemgmt.daos.ImageRampupDao;
 import azkaban.imagemgmt.daos.ImageTypeDao;
 import azkaban.imagemgmt.daos.ImageVersionDao;
@@ -32,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -87,7 +88,8 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
   }
 
   @Override
-  public Map<String, VersionInfo> getVersionForAllImageTypes() throws ImageMgmtException {
+  public Map<String, VersionInfo> getVersionForAllImageTypes(final ExecutableFlow flow)
+      throws ImageMgmtException {
     final Map<String, List<ImageRampup>> imageTypeRampups = this.imageRampupDao
         .getRampupForAllImageTypes();
     final List<ImageType> imageTypeList = this.imageTypeDao.getAllImageTypes();
@@ -97,7 +99,7 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
     }
     final Set<String> remainingImageTypes = new TreeSet<>();
     final Map<String, ImageVersionMetadata> imageTypeVersionMap = this
-        .processAndGetVersionForImageTypes(imageTypes, imageTypeRampups, remainingImageTypes);
+        .processAndGetVersionForImageTypes(flow, imageTypes, imageTypeRampups, remainingImageTypes);
     // Throw exception if there are left over image types
     if (!remainingImageTypes.isEmpty()) {
       throw new ImageMgmtException("Could not fetch version for below image types. Reasons: "
@@ -119,7 +121,8 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
     }
     final Set<String> remainingImageTypes = new TreeSet<>();
     final Map<String, ImageVersionMetadata> imageTypeVersionMap =
-        this.processAndGetVersionForImageTypes(imageTypes, imageTypeRampups, remainingImageTypes);
+        this.processAndGetVersionForImageTypes(null, imageTypes, imageTypeRampups,
+            remainingImageTypes);
     if (!remainingImageTypes.isEmpty()) {
       final Map<String, ImageVersion> imageTypeLatestNonActiveVersionMap =
           this.getLatestNonActiveImageVersion(remainingImageTypes);
@@ -135,13 +138,15 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
   }
 
   @Override
-  public Map<String, VersionInfo> getVersionByImageTypes(final Set<String> imageTypes)
+  public Map<String, VersionInfo> getVersionByImageTypes(final ExecutableFlow flow,
+      final Set<String> imageTypes)
       throws ImageMgmtException {
     final Map<String, List<ImageRampup>> imageTypeRampups = this.imageRampupDao
         .getRampupByImageTypes(imageTypes);
     final Set<String> remainingImageTypes = new TreeSet<>();
     final Map<String, ImageVersionMetadata> imageTypeVersionMap =
-        this.processAndGetVersionForImageTypes(imageTypes, imageTypeRampups, remainingImageTypes);
+        this.processAndGetVersionForImageTypes(flow, imageTypes, imageTypeRampups,
+            remainingImageTypes);
     // Throw exception if there are left over image types
     if (!remainingImageTypes.isEmpty()) {
       throw new ImageMgmtException("Could not fetch version for below image types. Reasons: "
@@ -188,6 +193,7 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
    * @return Map<String, VersionMetadata>
    */
   private Map<String, ImageVersionMetadata> processAndGetVersionForImageTypes(
+      final ExecutableFlow flow,
       final Set<String> imageTypes,
       final Map<String, List<ImageRampup>> imageTypeRampups,
       final Set<String> remainingImageTypes) {
@@ -196,7 +202,7 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
     final Map<String, ImageVersionMetadata> imageTypeVersionMap = new TreeMap<>(
         String.CASE_INSENSITIVE_ORDER);
     final Map<String, ImageVersion> imageTypeRampupVersionMap =
-        this.processAndGetRandomRampupVersion(imageTypeRampups);
+        this.processAndGetRandomRampupVersion(flow, imageTypeRampups);
     imageTypeRampupVersionMap
         .forEach((k, v) -> imageTypeVersionMap.put(k, new ImageVersionMetadata(v,
             imageTypeRampups.get(k), MSG_RANDOM_RAMPUP_VERSION_SELECTION)));
@@ -240,6 +246,7 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
    * @return Map<String, ImageVersion>
    */
   private Map<String, ImageVersion> processAndGetRandomRampupVersion(
+      final ExecutableFlow flow,
       final Map<String, List<ImageRampup>> imageTypeRampups) {
     final Set<String> imageTypeSet = imageTypeRampups.keySet();
     log.info("Found active rampup for the image types {} ", imageTypeSet);
@@ -250,12 +257,23 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
       final String imageTypeName = iterator.next();
       final List<ImageRampup> imageRampupList = imageTypeRampups.get(imageTypeName);
       Collections.sort(imageRampupList, this.getRampupPercentageComparator());
+      if (imageRampupList.isEmpty()) {
+        continue;
+      }
+      if (null == flow) {
+        ImageRampup firstImageRampup = imageRampupList.get(0);
+        imageTypeRampupVersionMap.put(imageTypeName, this.fetchImageVersion(imageTypeName,
+            firstImageRampup.getImageVersion()).orElseThrow(() ->
+          new ImageMgmtException(String.format("Unable to fetch version %s from image "
+              + "versions table.", firstImageRampup.getImageVersion()))));
+        continue;
+      }
       int prevRampupPercentage = 0;
-      final int nextRandom = this.getRandomNumberInRange(1, 100);
+      final int flowNameHashValMapping = ContainerImplUtils.getFlowNameHashValMapping(flow);
       for (final ImageRampup imageRampup : imageRampupList) {
         final int rampupPercentage = imageRampup.getRampupPercentage();
-        if (nextRandom >= prevRampupPercentage + 1
-            && nextRandom <= prevRampupPercentage + rampupPercentage) {
+        if (flowNameHashValMapping >= prevRampupPercentage + 1
+            && flowNameHashValMapping <= prevRampupPercentage + rampupPercentage) {
           imageTypeRampupVersionMap.put(imageTypeName,
               this.fetchImageVersion(imageTypeName, imageRampup.getImageVersion()).orElseThrow(() ->
                   new ImageMgmtException(String.format("Unable to fetch version %s from image "
@@ -336,7 +354,13 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
     if (CollectionUtils.isEmpty(imageVersions)) {
       return Optional.empty();
     }
-    return Optional.of(imageVersions.get(0));
+    // Return only the imageVersion only when the image type/name matches
+    for (ImageVersion version: imageVersions) {
+      if (version.getName().equals(imageType) && version.getVersion().equals(imageVersion)) {
+        return Optional.of(version);
+      }
+    }
+    return Optional.empty();
   }
 
   /**
@@ -352,21 +376,6 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
         new VersionInfo(v.getImageVersion().getVersion(), v.getImageVersion().getPath(),
             v.getImageVersion().getState())));
     return versionInfoMap;
-  }
-
-  /**
-   * Generate random number between min and max both inclusive
-   *
-   * @param min
-   * @param max
-   * @return int
-   */
-  private int getRandomNumberInRange(final int min, final int max) {
-    if (min >= max) {
-      throw new IllegalArgumentException("Max must be greater than min");
-    }
-    final Random r = new Random();
-    return r.nextInt((max - min) + 1) + min;
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -140,8 +140,13 @@ public class ContainerizedDispatchManagerTest {
   public void testAllowAndDenyList() throws Exception {
     // Flow 5 comprises of "command" and "noop" jobtypes
     initializeContainerizedDispatchImpl();
-    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(10);
+    this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of("ALL"));
     DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    Assert.assertEquals(DispatchMethod.CONTAINERIZED, dispatchMethod);
+
+    this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
+    dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
     Assert.assertEquals(DispatchMethod.POLL, dispatchMethod);
 
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(100);

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -188,7 +188,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(1);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class))).thenReturn(getVersionMap());
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     assert(jobTypes.contains("command"));
     assert(jobTypes.contains("hadoopJava"));
@@ -201,7 +201,7 @@ public class KubernetesContainerizedImplTest {
     allImageTypes.add(AZKABAN_CONFIG);
     allImageTypes.addAll(jobTypes);
     VersionSet versionSet = this.kubernetesContainerizedImpl
-        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes);
+        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes, flow);
     final V1PodSpec podSpec = this.kubernetesContainerizedImpl
         .createPodSpec(flow.getExecutionId(), versionSet, jobTypes, flowParam);
 
@@ -218,7 +218,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class))).thenReturn(getVersionMap());
     when(imageRampupManager.getVersionInfo(any(String.class), any(String.class)))
         .thenReturn(new VersionInfo("7.0.4", "path1", State.ACTIVE));
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
@@ -243,7 +243,7 @@ public class KubernetesContainerizedImplTest {
     flowParam.put(Constants.FlowParameters.FLOW_PARAM_VERSION_SET_ID,
         String.valueOf(presetVersionSet.getVersionSetId()));
     VersionSet versionSet = this.kubernetesContainerizedImpl
-        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes);
+        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes, flow);
 
     assert(versionSet.getVersion("kafkaPush").get()
         .equals(presetVersionSet.getVersion("kafkaPush").get()));
@@ -271,7 +271,7 @@ public class KubernetesContainerizedImplTest {
         KubernetesContainerizedImpl.IMAGE, "azkaban-base", KubernetesContainerizedImpl.VERSION),
         "7.0.4");
     versionSet = this.kubernetesContainerizedImpl
-        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes);
+        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes, flow);
 
     assert(versionSet.getVersion("kafkaPush").get()
         .equals(presetVersionSet.getVersion("kafkaPush").get()));
@@ -286,7 +286,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(Set.class))).thenReturn(getVersionMap());
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class))).thenReturn(getVersionMap());
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     // Add included job types
     jobTypes.add("hadoopJava");
@@ -302,7 +302,7 @@ public class KubernetesContainerizedImplTest {
     final Map<String, String> flowParam = new HashMap<>();
 
     VersionSet versionSet = this.kubernetesContainerizedImpl
-        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes);
+        .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes, flow);
 
     // Included jobs in the azkaban base image, so must not present in versionSet.
     Assert.assertEquals(false, versionSet.getVersion("hadoopJava").isPresent());


### PR DESCRIPTION
Current ramp-ups use the random generator to determine the version, which can lead to different executions of the same flow to have different versions.
This implementation uses flow name, compute murmur hash, map it to an integer value between 1 to 100, and determine the ramp-up version.
Implementation of hash is in ContainerImplUtils.java