### PR TITLE
Add release tag as a part of status API for each version

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
@@ -98,7 +98,7 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
    * This query selects rampup records for all the active image types.
    */
   private static final String SELECT_ALL_IMAGE_TYPE_RAMPUP_QUERY = "select ir.id, ir.plan_id, "
-      + "iv.version image_version, ir.rampup_percentage, ir.stability_tag, it.name "
+      + "iv.version image_version, iv.release_tag, ir.rampup_percentage, ir.stability_tag, it.name "
       + "image_type_name, ir.created_on, ir.created_by, ir.modified_on, ir.modified_by from "
       + "image_types it, image_versions iv, image_rampup_plan irp, image_rampup ir where "
       + "irp.id = ir.plan_id and iv.id = ir.version_id and irp.type_id = it.id and irp.active = ? "
@@ -660,6 +660,7 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
         final String createdBy = rs.getString("created_by");
         final String modifiedOn = rs.getString("modified_on");
         final String modifiedBy = rs.getString("modified_by");
+        final String releaseTag = rs.getString("release_tag");
         final ImageRampup imageRampup = new ImageRampup();
         imageRampup.setId(id);
         imageRampup.setImageVersion(imageVersion);
@@ -669,6 +670,7 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
         imageRampup.setCreatedBy(createdBy);
         imageRampup.setModifiedBy(modifiedBy);
         imageRampup.setModifiedOn(modifiedOn);
+        imageRampup.setReleaseTag(releaseTag);
         if (imageRampupMap.containsKey(imageTypeName)) {
           imageRampupMap.get(imageTypeName).add(imageRampup);
         } else {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
@@ -24,7 +24,7 @@ import org.codehaus.jackson.annotate.JsonPropertyOrder;
 /**
  * This DTO class represents API specific image version metadata response.
  */
-@JsonPropertyOrder({"version", "state", "path", "message", "rampups"})
+@JsonPropertyOrder({"version", "state", "path", "releaseTag", "message", "rampups"})
 public class ImageVersionMetadataResponseDTO {
 
   // Represents version for an image type selected based on random rampup or current active version.
@@ -42,14 +42,21 @@ public class ImageVersionMetadataResponseDTO {
   // either random rampup or based on latest available active version.
   @JsonProperty("message")
   private final String message;
+  @JsonProperty("releaseTag")
+  private final String releaseTag;
 
   public ImageVersionMetadataResponseDTO(final String version, final State state, final String path,
-      final List<RampupMetadata> rampups, final String message) {
+      final List<RampupMetadata> rampups, final String message, final String releaseTag) {
     this.version = version;
     this.state = state;
     this.path = path;
     this.rampups = rampups;
     this.message = message;
+    this.releaseTag = releaseTag;
+  }
+
+  public String getReleaseTag() {
+    return releaseTag;
   }
 
   public String getVersion() {
@@ -75,7 +82,7 @@ public class ImageVersionMetadataResponseDTO {
   /**
    * Represents rampup metadata for an image type.
    */
-  @JsonPropertyOrder({"version", "stabilityTag", "rampupPercentage"})
+  @JsonPropertyOrder({"version", "stabilityTag", "releaseTag", "rampupPercentage"})
   public static class RampupMetadata {
 
     @JsonProperty("version")
@@ -84,16 +91,23 @@ public class ImageVersionMetadataResponseDTO {
     private final Integer rampupPercentage;
     @JsonProperty("stabilityTag")
     private final StabilityTag stabilityTag;
+    @JsonProperty("releaseTag")
+    private final String releaseTag;
 
     public RampupMetadata(final String version, final Integer rampupPercentage,
-        final StabilityTag stabilityTag) {
+        final StabilityTag stabilityTag, final String releaseTag) {
       this.version = version;
       this.rampupPercentage = rampupPercentage;
       this.stabilityTag = stabilityTag;
+      this.releaseTag = releaseTag;
     }
 
     public String getVersion() {
       return this.version;
+    }
+
+    public String getReleaseTag() {
+      return this.releaseTag;
     }
 
     public Integer getRampupPercentage() {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampup.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampup.java
@@ -31,6 +31,16 @@ public class ImageRampup extends BaseModel {
   private Integer rampupPercentage;
   // Stability tag of the version being ramped up
   private StabilityTag stabilityTag;
+  // Release tag of the version being ramped up
+  private String releaseTag;
+
+  public void setReleaseTag(String releaseTag) {
+    this.releaseTag = releaseTag;
+  }
+
+  public String getReleaseTag() {
+    return this.releaseTag;
+  }
 
   public int getPlanId() {
     return planId;

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageVersionMetadataServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageVersionMetadataServiceImpl.java
@@ -69,14 +69,15 @@ public class ImageVersionMetadataServiceImpl implements ImageVersionMetadataServ
     if (!CollectionUtils.isEmpty(versionMetadata.getImageRampups())) {
       rampups = versionMetadata.getImageRampups().stream().map(
           imageRampup -> new RampupMetadata(imageRampup.getImageVersion(),
-              imageRampup.getRampupPercentage(), imageRampup.getStabilityTag()))
+              imageRampup.getRampupPercentage(), imageRampup.getStabilityTag(), imageRampup.getReleaseTag()))
           .collect(Collectors.toList());
     }
     final ImageVersion imageVersion = versionMetadata.getImageVersion();
     final String version = imageVersion != null ? imageVersion.getVersion() : null;
     final State state = imageVersion != null ? imageVersion.getState() : null;
     final String path = imageVersion != null ? imageVersion.getPath() : null;
+    final String releaseTag = imageVersion != null ? imageVersion.getReleaseTag() : null;
     return new ImageVersionMetadataResponseDTO(version, state, path, rampups,
-        versionMetadata.getMessage());
+        versionMetadata.getMessage(), releaseTag);
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/StatusService.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/StatusService.java
@@ -145,7 +145,8 @@ public class StatusService {
     Map<String, ImageVersionMetadataResponseDTO> imageTypeVersionMap = new TreeMap<>();
     try {
       imageTypeVersionMap =
-          this.getImageVersionMetadataService().getVersionMetadataForAllImageTypes();
+          this.getImageVersionMetadataService().
+              getVersionMetadataForAllImageTypes();
     } catch (final Exception ex) {
       log.error("Error while geting version metadata for all the image types", ex);
     }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/StatusServiceTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/StatusServiceTest.java
@@ -78,7 +78,8 @@ public class StatusServiceTest {
         "50");
     ImageVersionMetadataResponseDTO imageVersionMetadataResponseDTO = new ImageVersionMetadataResponseDTO(
         "0.0.7", State.ACTIVE, "registry/myPath",
-        Collections.singletonList(new RampupMetadata("0.0.7", 100, StabilityTag.STABLE)), "");
+        Collections.singletonList(new RampupMetadata("0.0.7", 100, StabilityTag.STABLE, "0.0.7")),
+        "", "0.0.7");
 
     Mockito.when(this.dbOperator.query(Mockito.any(), Mockito.any())).thenReturn(true);
     Mockito.when(this.imageVersionMetadataService.getVersionMetadataForAllImageTypes())

--- a/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
+++ b/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
@@ -20,10 +20,12 @@
       "version" : "0.0.7",
       "state" : "ACTIVE",
       "path" : "registry/myPath",
+      "releaseTag" : "0.0.7",
       "message" : "",
       "rampups" : [ {
         "version" : "0.0.7",
         "stabilityTag" : "STABLE",
+        "releaseTag" : "0.0.7",
         "rampupPercentage" : 100
       } ]
     }


### PR DESCRIPTION
Updated ImageRampup to have releaseTag as a field.
Updated SELECT_ALL_IMAGE_TYPE_RAMPUP_QUERY query to return releaseTag.
Updated FetchImageTypeRampupHandler to put releaseTag from the result-set to  ImageRampup
Updated ImageVersionMetadataResponseDTO to have releaseTag as a field.

Updated the test StatusServiceTest to validate that releaseTag is visible as part of status JSON.