### PR TITLE
Making ExecJettyServer TLS aware

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -260,6 +260,7 @@ public class Constants {
     public static final String EXECUTOR_PORT_FILE = "executor.portfile";
     // To set a fixed port for executor-server. Otherwise some available port is used.
     public static final String EXECUTOR_PORT = "executor.port";
+    public static final String EXECUTOR_SSL_PORT = "executor.ssl.port";
 
     public static final String DEFAULT_TIMEZONE_ID = "default.timezone.id";
 

--- a/azkaban-common/src/main/java/azkaban/server/JettyServerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/JettyServerUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.server;
+
+import azkaban.utils.Props;
+import java.util.List;
+import org.mortbay.jetty.bio.SocketConnector;
+import org.mortbay.jetty.security.SslSocketConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for adding creating connectors, configurations, etc. to the Jetty Server.
+ */
+public class JettyServerUtils {
+
+  private static final int DEFAULT_HEADER_BUFFER_SIZE = 10 * 1024 * 1024;
+  private static final Logger logger = LoggerFactory.getLogger(JettyServerUtils.class);
+  private static final String JETTY_KEYSTORE = "jetty.keystore";
+  private static final String JETTY_PASSWORD = "jetty.password";
+  private static final String JETTY_KEYPASSWORD = "jetty.keypassword";
+  private static final String JETTY_TRUSTSTORE = "jetty.truststore";
+  private static final String JETTY_TRUSTPASSWORD = "jetty.trustpassword";
+
+  private JettyServerUtils() {
+    // Not to be instantiated
+  }
+
+  /**
+   * @param sslPortNumber Port number to bind for the socket
+   * @param props         Azkaban properties containing configurations for Jetty Server
+   * @return SSL enabled SocketConnector {@link SslSocketConnector}, for https connection to the
+   * jetty server
+   */
+  public static SslSocketConnector getSslSocketConnector(final int sslPortNumber,
+      final Props props) {
+    final SslSocketConnector secureConnector = new SslSocketConnector();
+    secureConnector.setPort(sslPortNumber);
+    secureConnector.setKeystore(props.getString(JETTY_KEYSTORE));
+    secureConnector.setPassword(props.getString(JETTY_PASSWORD));
+    secureConnector.setKeyPassword(props.getString(JETTY_KEYPASSWORD));
+    secureConnector.setTruststore(props.getString(JETTY_TRUSTSTORE));
+    secureConnector.setTrustPassword(props.getString(JETTY_TRUSTPASSWORD));
+    secureConnector.setHeaderBufferSize(DEFAULT_HEADER_BUFFER_SIZE);
+
+    // set up vulnerable cipher suites to exclude
+    final List<String> cipherSuitesToExclude = props
+        .getStringList("jetty.excludeCipherSuites");
+    logger.info("Excluded Cipher Suites: " + String.valueOf(cipherSuitesToExclude));
+    if (cipherSuitesToExclude != null && !cipherSuitesToExclude.isEmpty()) {
+      secureConnector.setExcludeCipherSuites(cipherSuitesToExclude.toArray(new String[0]));
+    }
+    return secureConnector;
+  }
+
+  /**
+   * @param port Port number to bind for the socket
+   * @return A plain {@link SocketConnector} for http connection to the jetty server
+   */
+  public static SocketConnector getSocketConnector(final int port) {
+    final SocketConnector connector = new SocketConnector();
+    connector.setPort(port);
+    connector.setHeaderBufferSize(DEFAULT_HEADER_BUFFER_SIZE);
+    return connector;
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiClientTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiClientTest.java
@@ -60,12 +60,13 @@ import org.mortbay.thread.QueuedThreadPool;
  */
 public class ExecutorApiClientTest {
 
-  private static final int JETTY_TLS_PORT = 31311;
-  private static final String TRUSTSTORE_PATH =
+  public static final int JETTY_TLS_PORT = 31311;
+  public static final int JETTY_PORT = 54321;
+  public static final String TRUSTSTORE_PATH =
       ExecutorApiClient.class.getResource("test-cacerts").getPath();
-  private static final String KEYSTORE_PATH =
+  public static final String KEYSTORE_PATH =
       ExecutorApiClient.class.getResource("test-keystore").getPath();
-  private static final String DEFAULT_PASSWORD = "changeit"; //for key, keystore and truststore
+  public static final String DEFAULT_PASSWORD = "changeit"; //for key, keystore and truststore
 
   public static final String REVERSE_PROXY_HOST = "reversehost";
   public static final int REVERSE_PROXY_PORT = 31234;
@@ -245,11 +246,13 @@ public class ExecutorApiClientTest {
         uri.toString());
   }
 
-  private static class SimpleServlet extends HttpServlet {
+  public static class SimpleServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1520347403053074355L;
     public static final String TLS_ENABLED_URI =
         "https://localhost:" + ExecutorApiClientTest.JETTY_TLS_PORT + "/simple";
+    public static final String TLS_DISABLED_URI =
+        "http://localhost:" + ExecutorApiClientTest.JETTY_PORT + "/simple";
     public static final String GET_RESPONSE_STRING = "{type: 'GET'}";
     public static final String POST_RESPONSE_STRING = "{type: 'POST'}";
 

--- a/azkaban-exec-server/src/main/java/azkaban/common/ExecJettyServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/common/ExecJettyServerModule.java
@@ -1,15 +1,17 @@
 package azkaban.common;
 
 import static azkaban.Constants.ConfigurationKeys.EXECUTOR_PORT;
+import static azkaban.Constants.ConfigurationKeys.EXECUTOR_SSL_PORT;
 import static azkaban.Constants.ConfigurationKeys.JETTY_HEADER_BUFFER_SIZE;
+import static azkaban.Constants.ConfigurationKeys.JETTY_USE_SSL;
 import static azkaban.Constants.MAX_FORM_CONTENT_SIZE;
 
-import azkaban.Constants;
 import azkaban.container.ContainerServlet;
 import azkaban.execapp.ExecutorServlet;
 import azkaban.execapp.JMXHttpServlet;
 import azkaban.execapp.ServerStatisticsServlet;
 import azkaban.execapp.StatsServlet;
+import azkaban.server.JettyServerUtils;
 import azkaban.utils.Props;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -40,15 +42,25 @@ public class ExecJettyServerModule extends AbstractModule {
   @Provides
   @Named(EXEC_JETTY_SERVER)
   @Singleton
-  private Server createJettyServer(final Props props) {
-    final int maxThreads = props.getInt("executor.maxThreads", DEFAULT_THREAD_NUMBER);
-
+  public Server createJettyServer(final Props props) {
+    final boolean useSsl = props.getBoolean(JETTY_USE_SSL, false);
+    final int port;
+    final Server server = new Server();
     /*
      * Default to a port number 0 (zero)
      * The Jetty server automatically finds an unused port when the port number is set to zero
      * TODO: This is using a highly outdated version of jetty [year 2010]. needs to be updated.
      */
-    final Server server = new Server(props.getInt(EXECUTOR_PORT, 0));
+    if (useSsl) {
+      port = props.getInt(EXECUTOR_SSL_PORT, 0);
+      server.addConnector(JettyServerUtils.getSslSocketConnector(port, props));
+      logger.info("Added SslSocketConnector as Ssl is enabled");
+    } else {
+      port = props.getInt(EXECUTOR_PORT, 0);
+      server.addConnector(JettyServerUtils.getSocketConnector(port));
+      logger.info("Added SocketConnector as Ssl is disabled");
+    }
+    final int maxThreads = props.getInt("executor.maxThreads", DEFAULT_THREAD_NUMBER);
     final QueuedThreadPool httpThreadPool = new QueuedThreadPool(maxThreads);
     server.setThreadPool(httpThreadPool);
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -273,7 +273,13 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
 
   private void initActive() throws ExecutorManagerException {
     final Executor executor;
-    final int port = this.props.getInt(ConfigurationKeys.EXECUTOR_PORT, -1);
+    final int port;
+    final boolean useSsl = props.getBoolean(ConfigurationKeys.JETTY_USE_SSL, true);
+    if (useSsl) {
+      port = this.props.getInt(ConfigurationKeys.EXECUTOR_SSL_PORT, -1);
+    } else {
+      port = this.props.getInt(ConfigurationKeys.EXECUTOR_PORT, -1);
+    }
     if (port != -1) {
       final String host = requireNonNull(getHost());
       // Check if this executor exists previously in the DB

--- a/azkaban-exec-server/src/test/java/azkaban/common/ExecJettyServerModuleTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/common/ExecJettyServerModuleTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package azkaban.common;
+
+import static azkaban.Constants.ConfigurationKeys.EXECUTOR_CLIENT_TLS_ENABLED;
+import static azkaban.Constants.ConfigurationKeys.EXECUTOR_CLIENT_TRUSTSTORE_PASSWORD;
+import static azkaban.Constants.ConfigurationKeys.EXECUTOR_CLIENT_TRUSTSTORE_PATH;
+import static azkaban.executor.ExecutorApiClientTest.DEFAULT_PASSWORD;
+import static azkaban.executor.ExecutorApiClientTest.JETTY_PORT;
+import static azkaban.executor.ExecutorApiClientTest.JETTY_TLS_PORT;
+import static azkaban.executor.ExecutorApiClientTest.KEYSTORE_PATH;
+import static azkaban.executor.ExecutorApiClientTest.TRUSTSTORE_PATH;
+
+import azkaban.DispatchMethod;
+import azkaban.executor.ExecutorApiClient;
+import azkaban.executor.ExecutorApiClientTest.SimpleServlet;
+import azkaban.utils.Props;
+import java.net.URI;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.bio.SocketConnector;
+import org.mortbay.jetty.security.SslSocketConnector;
+import org.mortbay.jetty.servlet.Context;
+import org.mortbay.jetty.servlet.ServletHolder;
+
+
+/**
+ * Test class for {@link ExecJettyServerModule}
+ */
+public class ExecJettyServerModuleTest {
+
+  /**
+   * This test tries to create the jetty-server and verify that it is reachable on the attached port
+   * via Http.
+   */
+  @Test
+  public void testSslDisabledJettyServer() throws Exception {
+    ExecJettyServerModule execJettyServerModule = new ExecJettyServerModule();
+
+    Props props = new Props();
+    props.put("jetty.use.ssl", "false");
+    props.put("executor.port", JETTY_PORT);
+    Server jettyServer = execJettyServerModule.createJettyServer(props);
+    Assert.assertEquals(1, jettyServer.getConnectors().length);
+    Assert.assertTrue(jettyServer.getConnectors()[0] instanceof SocketConnector);
+    SocketConnector socketConnector = (SocketConnector) jettyServer.getConnectors()[0];
+    Assert.assertEquals(JETTY_PORT, socketConnector.getPort());
+    final Context root = new Context(jettyServer, "/", Context.SESSIONS);
+    root.addServlet(new ServletHolder(new SimpleServlet()), "/simple");
+    jettyServer.start();
+    final ExecutorApiClient tlsDisabledClient = new ExecutorApiClient(new Props());
+    final String postResponse = tlsDisabledClient
+        .doPost(new URI(SimpleServlet.TLS_DISABLED_URI), DispatchMethod.CONTAINERIZED,
+            null);
+    Assert.assertEquals(SimpleServlet.POST_RESPONSE_STRING, postResponse);
+    jettyServer.stop();
+  }
+
+  /**
+   * This test tries to create the jetty-server and verify that it is reachable on the attached port
+   * via Https.
+   */
+  @Test
+  public void testSslEnabledJettyServer() throws Exception {
+    ExecJettyServerModule execJettyServerModule = new ExecJettyServerModule();
+
+    Props props = new Props();
+    props.put("jetty.use.ssl", "true");
+    props.put("executor.ssl.port", JETTY_TLS_PORT);
+    props.put("jetty.keystore", KEYSTORE_PATH);
+    props.put("jetty.password", DEFAULT_PASSWORD);
+    props.put("jetty.keypassword", DEFAULT_PASSWORD);
+    props.put("jetty.truststore", TRUSTSTORE_PATH);
+    props.put("jetty.trustpassword", DEFAULT_PASSWORD);
+    Server jettyServer = execJettyServerModule.createJettyServer(props);
+    Assert.assertEquals(1, jettyServer.getConnectors().length);
+    Assert.assertTrue(jettyServer.getConnectors()[0] instanceof SslSocketConnector);
+    SslSocketConnector sslSocketConnector = (SslSocketConnector) jettyServer.getConnectors()[0];
+    Assert.assertEquals(JETTY_TLS_PORT, sslSocketConnector.getPort());
+    final Context root = new Context(jettyServer, "/", Context.SESSIONS);
+    root.addServlet(new ServletHolder(new SimpleServlet()), "/simple");
+    jettyServer.start();
+
+    Props clientProps = new Props();
+    clientProps.put(EXECUTOR_CLIENT_TLS_ENABLED, "true");
+    clientProps
+        .put(EXECUTOR_CLIENT_TRUSTSTORE_PATH, TRUSTSTORE_PATH);
+    clientProps.put(EXECUTOR_CLIENT_TRUSTSTORE_PASSWORD, "changeit");
+
+    final ExecutorApiClient tlsEnabledClient = new ExecutorApiClient(clientProps);
+    final String postResponse = tlsEnabledClient
+        .doPost(new URI(SimpleServlet.TLS_ENABLED_URI), DispatchMethod.CONTAINERIZED,
+            null);
+    Assert.assertEquals(SimpleServlet.POST_RESPONSE_STRING, postResponse);
+    jettyServer.stop();
+  }
+}


### PR DESCRIPTION
Refactored the getSocketConnector() and getSslSocketConnector() from WebServerProvider class to JettyServerUtils class so that it can be reused in ExecJettyServerModule

Added the ExecJettyServerModuleTest to check if the correct props are set-up when SSL is enabled/disabled.