### PR TITLE
[REVERT-2778] Changed start status to READY instead of PREPARING for poll based dispatch

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -240,7 +240,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
    */
   @Override
   public Status getStartStatus() {
-    return Status.READY;
+    return Status.PREPARING;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -163,11 +163,6 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
         new ThreadFactoryBuilder().setNameFormat("azk-refresher-pool-%d").build());
   }
 
-  @Override
-  public Status getStartStatus() {
-    return Status.PREPARING;
-  }
-
   /**
    * {@inheritDoc}
    *

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -201,7 +201,7 @@ public class FetchActiveFlowDao {
             // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
             + " AND NOT ("
             + "   ex.executor_id IS NULL"
-            + "   AND ex.status = " + Status.READY.getNumVal()
+            + "   AND ex.status = " + Status.PREPARING.getNumVal()
             + " )";
 
     @Override
@@ -282,7 +282,7 @@ public class FetchActiveFlowDao {
             // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
             + " AND NOT ("
             + "   ex.executor_id IS NULL"
-            + "   AND ex.status = " + Status.READY.getNumVal()
+            + "   AND ex.status = " + Status.PREPARING.getNumVal()
             + " )";
 
     @Override

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -86,7 +86,7 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   @Override
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException {
-    return fetchQueuedFlows(Status.READY);
+    return fetchQueuedFlows(Status.PREPARING);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -162,6 +162,18 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   /**
+   * Get the status for executions maintained in queue. For other dispatch implementations, the
+   * status for executions in queue is PREPARING. But for containerized dispatch method, the status
+   * will be READY.
+   *
+   * @return
+   */
+  @Override
+  public Status getStartStatus() {
+    return Status.READY;
+  }
+
+  /**
    * This method will shutdown the queue processor thread. It won't pick up executions from queue
    * for dispatch after this. This method will be called when webserver will shutdown.
    */

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -211,7 +211,7 @@ public class ExecutionControllerTest {
   public void testKillQueuedFlow() throws Exception {
     // Flow1 is not assigned to any executor and is in PREPARING status.
     submitFlow(this.flow1, this.ref1);
-    this.flow1.setStatus(Status.READY);
+    this.flow1.setStatus(Status.PREPARING);
     this.controller.cancelFlow(this.flow1, this.user.getUserId());
     // Verify that the status of flow1 is finalized.
     assertThat(this.flow1.getStatus()).isEqualTo(Status.FAILED);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -118,7 +118,7 @@ public class ExecutionFlowDaoTest {
 
     final ExecutableFlow flow = createTestFlow();
     flow.setSubmitUser("testUser1");
-    flow.setStatus(Status.READY);
+    flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(System.currentTimeMillis());
     flow.setExecutionId(0);
     flow.setDispatchMethod(DispatchMethod.POLL);
@@ -169,13 +169,13 @@ public class ExecutionFlowDaoTest {
   @Test
   public void fetchFlowHistoryWithStartTime() throws Exception {
     final ExecutableFlow flow1 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.PREPARING);
     final ExecutableFlow flow2 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
     final ExecutableFlow flow3 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
     final ExecutableFlow flow4 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"), Status.PREPARING);
 
     final List<ExecutableFlow> expectedFlows = new ArrayList<>();
     expectedFlows.add(flow1);
@@ -245,7 +245,7 @@ public class ExecutionFlowDaoTest {
         ExecutionOptions.DEFAULT_FLOW_PRIORITY, DispatchMethod.POLL);
 
     final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows =
-        this.executionFlowDao.fetchQueuedFlows(Status.READY);
+        this.executionFlowDao.fetchQueuedFlows(Status.PREPARING);
     assertThat(fetchedQueuedFlows.size()).isEqualTo(2);
     final Pair<ExecutionReference, ExecutableFlow> fetchedFlow1 = fetchedQueuedFlows.get(0);
     final Pair<ExecutionReference, ExecutableFlow> fetchedFlow2 = fetchedQueuedFlows.get(1);
@@ -388,10 +388,10 @@ public class ExecutionFlowDaoTest {
     final Executor executor = this.executorDao.addExecutor("test", 1);
     final long currentTime = System.currentTimeMillis();
 
-    final ExecutableFlow flow1 = createExecutionAndAssign(Status.READY, executor);
+    final ExecutableFlow flow1 = createExecutionAndAssign(Status.PREPARING, executor);
 
     // flow2 is not assigned
-    final ExecutableFlow flow2 = createExecution(currentTime, Status.READY);
+    final ExecutableFlow flow2 = createExecution(currentTime, Status.PREPARING);
 
     final ExecutableFlow flow3 = createExecutionAndAssign(Status.RUNNING, executor);
     flow3.setStartTime(currentTime + 1);
@@ -439,7 +439,7 @@ public class ExecutionFlowDaoTest {
     flow.setSubmitUser("testUser");
     flow.setSubmitTime(startTime - 1);
     flow.setStartTime(startTime);
-    flow.setStatus(Status.READY);
+    flow.setStatus(Status.PREPARING);
     this.executionFlowDao.uploadExecutableFlow(flow);
     flow.setStatus(status);
     this.executionFlowDao.updateExecutableFlow(flow);
@@ -518,7 +518,7 @@ public class ExecutionFlowDaoTest {
   @Test
   public void testSelectAndUpdateExecution() throws Exception {
     final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
-    flow.setStatus(Status.READY);
+    flow.setStatus(Status.PREPARING);
     flow.setSubmitTime(System.currentTimeMillis());
     flow.setDispatchMethod(DispatchMethod.POLL);
     this.executionFlowDao.uploadExecutableFlow(flow);
@@ -527,20 +527,6 @@ public class ExecutionFlowDaoTest {
         .isEqualTo(flow.getExecutionId());
     assertThat(this.executorDao.fetchExecutorByExecutionId(flow.getExecutionId())).isEqualTo
         (executor);
-  }
-
-  @Test
-  public void testSelectAndUpdateExecutionWithStatusUpdate() throws Exception {
-    final ExecutableFlow flow = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
-    flow.setStatus(Status.READY);
-    flow.setSubmitTime(System.currentTimeMillis());
-    flow.setDispatchMethod(DispatchMethod.POLL);
-    this.executionFlowDao.uploadExecutableFlow(flow);
-    final Executor executor = this.executorDao.addExecutor("localhost", 12345);
-    assertThat(this.executionFlowDao.selectAndUpdateExecution(executor.getId(), true, DispatchMethod.POLL))
-        .isEqualTo(flow.getExecutionId());
-    assertThat(this.executionFlowDao
-        .fetchExecutableFlow(flow.getExecutionId()).getStatus()).isEqualTo(Status.PREPARING);
   }
 
   @Test
@@ -554,8 +540,6 @@ public class ExecutionFlowDaoTest {
     final Executor executor1 = this.executorDao.addExecutor("localhost", 12345);
     assertThat(this.executionFlowDao.selectAndUpdateExecutionWithLocking(executor1.getId(), true, DispatchMethod.POLL))
         .isEqualTo(flow1.getExecutionId());
-    assertThat(this.executionFlowDao.fetchExecutableFlow(flow1.getExecutionId()).getStatus())
-        .isEqualTo(Status.PREPARING);
   }
 
   @Test
@@ -788,11 +772,11 @@ public class ExecutionFlowDaoTest {
   @Test
   public void fetchFlowStatusWithFlowHistoryByStartTime() throws Exception {
     final ExecutableFlow flow1 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 10:00:00"), Status.PREPARING);
     final ExecutableFlow flow2 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
     final ExecutableFlow flow3 = createExecution(
-        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.READY);
+        TimeUtils.convertDateTimeToUTCMillis("2018-09-01 09:00:00"), Status.PREPARING);
     final ExecutableFlow flow4 = createExecution(
         TimeUtils.convertDateTimeToUTCMillis("2018-09-01 08:00:00"), Status.QUEUED);
 
@@ -874,15 +858,15 @@ public class ExecutionFlowDaoTest {
     this.executionFlowDao.updateExecutableFlow(flow1);
 
     final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows1 =
-        this.executionFlowDao.fetchQueuedFlows(Status.READY);
+        this.executionFlowDao.fetchQueuedFlows(Status.PREPARING);
     assertThat(fetchedQueuedFlows1).isEmpty();
 
-    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.READY);
+    makeFlowStatusInconsistent(flow1.getExecutionId(), Status.PREPARING);
 
     final List<Pair<ExecutionReference, ExecutableFlow>> fetchedQueuedFlows2 =
-        this.executionFlowDao.fetchQueuedFlows(Status.READY);
+        this.executionFlowDao.fetchQueuedFlows(Status.PREPARING);
     assertThat(fetchedQueuedFlows2).isNotEmpty();
-    assertThat(fetchedQueuedFlows2.get(0).getSecond().getStatus()).isEqualTo(Status.READY);
+    assertThat(fetchedQueuedFlows2.get(0).getSecond().getStatus()).isEqualTo(Status.PREPARING);
   }
 
   @Test
@@ -949,7 +933,7 @@ public class ExecutionFlowDaoTest {
   private ExecutableFlow submitNewFlow(final String projectName, final String flowName,
       final long submitTime, final int flowPriority, DispatchMethod dispatchMethod) throws IOException,
       ExecutorManagerException {
-    return submitNewFlow(projectName, flowName, submitTime, flowPriority, Status.READY,
+    return submitNewFlow(projectName, flowName, submitTime, flowPriority, Status.PREPARING,
         Optional.empty(), dispatchMethod);
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -432,7 +432,7 @@ public class MockExecutorLoader implements ExecutorLoader {
   @Override
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException {
-    return fetchQueuedFlows(Status.READY);
+    return fetchQueuedFlows(Status.PREPARING);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/NumExecutionsDaoTest.java
@@ -70,7 +70,7 @@ public class NumExecutionsDaoTest {
   @Test
   public void testFetchNumExecutableFlows() throws Exception {
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.POLL);
-    flow1.setStatus(Status.READY);
+    flow1.setStatus(Status.PREPARING);
     this.executionFlowDao.uploadExecutableFlow(flow1);
 
     final ExecutableFlow flow2 = TestUtils.createTestExecutableFlow("exectest1", "exec2", DispatchMethod.POLL);


### PR DESCRIPTION
The changes in PR 2778, force webserver and executor-server to be deployed in parallel. If one is on an older version, flows will not be polled. Hence, reverting the change.