### PR TITLE
Adding a way to setup env variables for a pod which can be honored from pod side.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -621,5 +621,7 @@ public class Constants {
     // Constant for memory request for flow container
     public static final String FLOW_PARAM_FLOW_CONTAINER_MEMORY_REQUEST = "flow.container.memory"
         + ".request";
+
+    public static final String FLOW_PARAM_POD_ENV_VAR = "pod.env.var.";
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -485,6 +485,7 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
         String.valueOf(executionId));
     setupJavaRemoteDebug(envVariables, flowParam);
     setupDevPod(envVariables, flowParam);
+    setupPodEnvVariables(envVariables, flowParam);
     // Add env variables to spec builder
     addEnvVariablesToSpecBuilder(v1SpecBuilder, envVariables);
 
@@ -530,6 +531,13 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
     return this.memoryRequest;
   }
 
+  /**
+   * This method is used to setup environment variable to enable remote debug on kubernetes flow
+   * container. Based on this environment variable, you can decide to enable or disable remote
+   * debug.
+   * @param envVariables
+   * @param flowParam
+   */
   private void setupJavaRemoteDebug(final Map<String, String> envVariables,
       final Map<String, String> flowParam) {
     if (flowParam != null && !flowParam.isEmpty() && flowParam
@@ -539,12 +547,37 @@ public class KubernetesContainerizedImpl implements ContainerizedImpl {
     }
   }
 
+  /**
+   * This method is used to setup environment variable to enable pod as dev pod which can be
+   * helpful for testing. Based on this environment variable, you can decide to start the flow
+   * container or not.
+   * @param envVariables
+   * @param flowParam
+   */
   private void setupDevPod(final Map<String, String> envVariables,
       final Map<String, String> flowParam) {
     if (flowParam != null && !flowParam.isEmpty() && flowParam
         .containsKey(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD)) {
       envVariables.put(ContainerizedDispatchManagerProperties.ENV_ENABLE_DEV_POD,
           flowParam.get(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD));
+    }
+  }
+
+  /**
+   * This method is used to setup any environment variable for a pod which can be passed from
+   * flow parameter. To provide the generic solution, it is adding all the flow parameters
+   * starting with @FlowParameters.FLOW_PARAM_POD_ENV_VAR
+   * @param envVariables
+   * @param flowParam
+   */
+  void setupPodEnvVariables(final Map<String, String> envVariables,
+      final Map<String, String> flowParam) {
+    if (flowParam != null && !flowParam.isEmpty()) {
+      flowParam.forEach((k, v) -> {
+        if (k.startsWith(FlowParameters.FLOW_PARAM_POD_ENV_VAR)) {
+          envVariables.put(StringUtils.removeStart(k, FlowParameters.FLOW_PARAM_POD_ENV_VAR), v);
+        }
+      });
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -173,6 +173,39 @@ public class KubernetesContainerizedImplTest {
         .equals(MEMORY_REQUESTED_IN_PROPS);
   }
 
+  /**
+   * This test is used to verify that if env variables are set correctly for pod which are set from
+   * flow param.
+   * @throws Exception
+   */
+  @Test
+  public void testPodEnvVariablesFromFlowParam() throws Exception {
+    final Map<String, String> flowParam = new HashMap<>();
+    flowParam.put(FlowParameters.FLOW_PARAM_POD_ENV_VAR + "azkaban-bas.version", "1.0.0");
+    flowParam.put(FlowParameters.FLOW_PARAM_POD_ENV_VAR + "azkaban-config.version", "0.1.0");
+    flowParam.put("any.other.param", "test");
+    Map<String,String> envVariables = new HashMap<>();
+    this.kubernetesContainerizedImpl.setupPodEnvVariables(envVariables, flowParam);
+    assert (envVariables.size() == 2);
+  }
+
+  /**
+   * This test is used to verify that if no env variables is set correctly for pod which are set
+   * from
+   * flow param.
+   * @throws Exception
+   */
+  @Test
+  public void testNoPodEnvVariablesFromFlowParam() throws Exception {
+    final Map<String, String> flowParam = new HashMap<>();
+    flowParam.put("azkaban-bas.version", "1.0.0");
+    flowParam.put("azkaban-config.version", "0.1.0");
+    flowParam.put("any.other.param", "test");
+    Map<String,String> envVariables = new HashMap<>();
+    this.kubernetesContainerizedImpl.setupPodEnvVariables(envVariables, flowParam);
+    assert (envVariables.size() == 0);
+  }
+
   @Test
   public void testJobTypesInFlow() throws Exception {
     final ExecutableFlow flow = createTestFlow();


### PR DESCRIPTION
If there are any flow parameters provided with prefix of "_pod.env.var._" then those will be set as environment variable for the Pod.