### PR TITLE
Allow Hadoop to be configured with FileSystem implementations not using the 'hdfs://' scheme.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/HdfsStorage.java
@@ -17,6 +17,9 @@
 
 package azkaban.storage;
 
+import static azkaban.HadoopModule.HADOOP_FS_AUTH;
+import static azkaban.HadoopModule.HDFS_CACHED_HTTP_FS;
+import static azkaban.HadoopModule.HADOOP_FILE_CONTEXT;
 import static java.util.Objects.requireNonNull;
 
 import azkaban.AzkabanCommonModuleConfig;
@@ -46,13 +49,15 @@ import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Singleton
 public class HdfsStorage implements Storage {
+
   private static final String TMP_PROJECT_UPLOAD_FILENAME = "upload.tmp";
-  private static final Logger log = Logger.getLogger(HdfsStorage.class);
+  private static final Logger log = LoggerFactory.getLogger(HdfsStorage.class);
 
   // Size of the buffer used while transferring data upstream. Value is based on the default
   // value used in FileSystem.copyFromLocalFile().
@@ -76,9 +81,9 @@ public class HdfsStorage implements Storage {
 
   @Inject
   public HdfsStorage(final AzkabanCommonModuleConfig config,
-      @Named("hdfsAuth") final AbstractHdfsAuth hdfsAuth,
-      @Named("hdfsFileContext") final FileContext hdfsFileContext,
-      @Named("hdfs_cached_httpFS") @Nullable final FileSystem http) {
+      @Named(HADOOP_FS_AUTH) final AbstractHdfsAuth hdfsAuth,
+      @Named(HADOOP_FILE_CONTEXT) final FileContext hdfsFileContext,
+      @Named(HDFS_CACHED_HTTP_FS) @Nullable final FileSystem http) {
     this.hdfsAuth = requireNonNull(hdfsAuth);
     this.hdfsFileContext = requireNonNull(hdfsFileContext);
     this.http = http; // May be null if thin archives is not enabled
@@ -90,7 +95,7 @@ public class HdfsStorage implements Storage {
   @Override
   public InputStream getProject(final String key) throws IOException {
     this.hdfsAuth.authorize();
-    Path projectFilePath = fullProjectPath(key);
+    final Path projectFilePath = fullProjectPath(key);
     log.info("Opening for reading, project file " + projectFilePath);
     return this.hdfsFileContext.open(projectFilePath);
   }
@@ -111,17 +116,16 @@ public class HdfsStorage implements Storage {
   }
 
   /**
-   * Copy a file from the local file system to a location given by the file context.
-   * {@code remotePath and remoteFileContext} will typically point to an external location
-   * but don't have to.
-   * If {@code remotePath} already exists, it will be overwritten.
-   *
-   * Note that FileSystem includes a convenient {@code copyFromLocalFile} method that can
-   * be directly used in place of this. FileContext does not appear to have a similar functionality
+   * Copy a file from the local file system to a location given by the file context. {@code
+   * remotePath and remoteFileContext} will typically point to an external location but don't have
+   * to. If {@code remotePath} already exists, it will be overwritten.
+   * <p>
+   * Note that FileSystem includes a convenient {@code copyFromLocalFile} method that can be
+   * directly used in place of this. FileContext does not appear to have a similar functionality
    * built-in, requiring this implementation.
    *
-   * @param localPath location on local disk
-   * @param remotePath location where the file will be copied to
+   * @param localPath         location on local disk
+   * @param remotePath        location where the file will be copied to
    * @param remoteFileContext file context for the remote file path
    * @throws IOException
    */
@@ -169,7 +173,7 @@ public class HdfsStorage implements Storage {
 
       // Copy file to HDFS
       log.info(String.format("Creating project artifact: meta: %s path: %s", metadata, targetPath));
-      uploadLocalFile(localFilePath, tmpPath, hdfsFileContext);
+      uploadLocalFile(localFilePath, tmpPath, this.hdfsFileContext);
 
       // Rename the tmp file to the final file and overwrite the final file if it already exists
       // (i.e. if the hash is the same).
@@ -223,7 +227,7 @@ public class HdfsStorage implements Storage {
     return new Path(this.projectRootUri.toString(), key);
   }
 
-  private Path resolveAbsoluteDependencyURI(Dependency dep) {
+  private Path resolveAbsoluteDependencyURI(final Dependency dep) {
     return new Path(this.dependencyRootUri.toString(), StorageUtils.getTargetDependencyPath(dep));
   }
 

--- a/azkaban-common/src/main/java/azkaban/storage/LocalHadoopStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalHadoopStorage.java
@@ -1,5 +1,8 @@
 package azkaban.storage;
 
+import static azkaban.HadoopModule.LOCAL_CACHED_HTTP_FS;
+import static azkaban.utils.StorageUtils.getTargetDependencyPath;
+
 import azkaban.AzkabanCommonModuleConfig;
 import azkaban.spi.Dependency;
 import java.io.IOException;
@@ -10,24 +13,25 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.log4j.Logger;
-
-import static azkaban.utils.StorageUtils.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
- * LocalHadoopStorage is an extension of LocalStorage that adds support for dependency fetching. LocalHadoopStorage
- * depends on hadoop-common and can only be injected when hadoop-common is on the classpath.
+ * LocalHadoopStorage is an extension of LocalStorage that adds support for dependency fetching.
+ * LocalHadoopStorage depends on hadoop-common and can only be injected when hadoop-common is on the
+ * classpath.
  */
 public class LocalHadoopStorage extends LocalStorage {
-  private static final Logger log = Logger.getLogger(LocalHadoopStorage.class);
+
+  private static final Logger log = LoggerFactory.getLogger(LocalHadoopStorage.class);
 
   final FileSystem http;
   final URI dependencyRootUri;
 
   @Inject
   public LocalHadoopStorage(final AzkabanCommonModuleConfig config,
-      @Named("local_cached_httpFS") @Nullable final FileSystem http) {
+      @Named(LOCAL_CACHED_HTTP_FS) @Nullable final FileSystem http) {
     super(config);
 
     this.http = http; // May be null if thin archives is not enabled
@@ -53,7 +57,7 @@ public class LocalHadoopStorage extends LocalStorage {
     return dependencyFetchingEnabled() ? this.dependencyRootUri.toString() : null;
   }
 
-  private Path resolveAbsoluteDependencyURI(Dependency dep) {
+  private Path resolveAbsoluteDependencyURI(final Dependency dep) {
     return new Path(this.dependencyRootUri.toString(), getTargetDependencyPath(dep));
   }
 }

--- a/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
+++ b/azkaban-common/src/main/java/azkaban/storage/LocalStorage.java
@@ -18,33 +18,36 @@
 package azkaban.storage;
 
 
-import static azkaban.utils.StorageUtils.*;
+import static azkaban.utils.StorageUtils.getTargetProjectFilename;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import azkaban.AzkabanCommonModuleConfig;
 import azkaban.spi.Dependency;
+import azkaban.spi.ProjectStorageMetadata;
 import azkaban.spi.Storage;
 import azkaban.spi.StorageException;
-import azkaban.spi.ProjectStorageMetadata;
 import azkaban.utils.FileIOUtils;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class LocalStorage implements Storage {
-  private static final Logger log = Logger.getLogger(LocalStorage.class);
+
+  private static final Logger log = LoggerFactory.getLogger(LocalStorage.class);
 
   final File rootDirectory;
 
   @Inject
   public LocalStorage(final AzkabanCommonModuleConfig config) {
-    this.rootDirectory = validateDirectory(createIfDoesNotExist(config.getLocalStorageBaseDirPath()));
+    this.rootDirectory = validateDirectory(
+        createIfDoesNotExist(config.getLocalStorageBaseDirPath()));
   }
 
   private static File createIfDoesNotExist(final File baseDirectory) {
@@ -108,7 +111,8 @@ public class LocalStorage implements Storage {
   // Use LocalHadoopStorage or HdfsStorage instead for thin archive support.
   @Override
   public InputStream getDependency(final Dependency dep) throws IOException {
-    throw new UnsupportedOperationException("Dependency fetching is not supported with LocalStorage.");
+    throw new UnsupportedOperationException(
+        "Dependency fetching is not supported with LocalStorage.");
   }
 
   @Override

--- a/azkaban-common/src/test/resources/hdfs_conf/core-site.xml
+++ b/azkaban-common/src/test/resources/hdfs_conf/core-site.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://test.com:9000</value>
+  </property>
+
+  <property>
+    <name>fs.AbstractFileSystem.hdfs.impl</name>
+    <value>org.apache.hadoop.fs.Hdfs</value>
+  </property>
+</configuration>

--- a/azkaban-common/src/test/resources/hdfs_conf/hdfs-site.xml
+++ b/azkaban-common/src/test/resources/hdfs_conf/hdfs-site.xml
@@ -1,6 +1,0 @@
-<configuration>
-  <property>
-    <name>fs.defaultFS</name>
-    <value>hdfs://test.com:9000</value>
-  </property>
-</configuration>


### PR DESCRIPTION
Previously, Azkaban always expected the HDFS scheme to be available in a Hadoop installation, so it would choose a default HDFS configuration when it didn't find the corresponding (HDFS specific) properties in the Hadoop configuration files. This is OK as long as a HDFS file system is available (possibly alongside others), but causes problems when it's not.

To fix this I'm removing the default Hadoop configurations provided by Azkaban, since, in practice, HDFS is usually and should be configured in Hadoop's config files. Although this is not a backward compatible change and issues may arise for those with Hadoop configurations not defining a file system properly this should be very rare.

Also, this change includes refactoring of the HadoopModule class (use of constants in the named bindings
 and removal of Props object from constructor method) but no changes in functionality are expected from that.