### PR TITLE
Get Parquet-Avro from Apache instead of from Twitter.

### DIFF
--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
@@ -34,10 +34,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AccessControlException;
 import org.apache.log4j.Logger;
 
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-
 /**
  * This class implements a viewer of avro files
  *
@@ -156,17 +152,13 @@ public class AvroFileViewer extends HdfsFileViewer {
     }
 
     DataFileStream<Object> avroDatastream = null;
-    JsonGenerator g = null;
 
     try {
       avroDatastream = getAvroDataStream(fs, path);
       Schema schema = avroDatastream.getSchema();
       DatumWriter<Object> avroWriter = new GenericDatumWriter<Object>(schema);
 
-      g = new JsonFactory().createJsonGenerator(
-          outputStream, JsonEncoding.UTF8);
-      g.useDefaultPrettyPrinter();
-      Encoder encoder = EncoderFactory.get().jsonEncoder(schema, g);
+      Encoder encoder = EncoderFactory.get().jsonEncoder(schema, outputStream, true);
 
       long endTime = System.currentTimeMillis() + STOP_TIME;
       int lineno = 1; // line number starts from 1
@@ -186,9 +178,6 @@ public class AvroFileViewer extends HdfsFileViewer {
           .getLocalizedMessage()).getBytes("UTF-8"));
       throw e;
     } finally {
-      if (g != null) {
-        g.close();
-      }
       avroDatastream.close();
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext.deps = [
     mongoDriver          : 'org.mongodb:mongo-java-driver:2.14.0',
     mysqlConnector       : 'mysql:mysql-connector-java:5.1.28',
     pig                  : 'org.apache.pig:pig:' + versions.pig,
-    parquetAvro          : 'com.twitter:parquet-avro:1.6.0',
+    parquetAvro          : 'org.apache.parquet:parquet-avro:1.11.1',
     parquetBundle        : 'com.twitter:parquet-hadoop-bundle:1.3.2',
     powermock            : 'org.powermock:powermock-api-mockito2:2.0.2',
     powermockmodulejunit4: 'org.powermock:powermock-module-junit4:2.0.2',


### PR DESCRIPTION
Tested: `./gradlew build` on Mac OS X.