### PR TITLE
Set start status for Containerized exectuions based on the dispatch method

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -251,6 +251,14 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   }
 
   /**
+   * @param execFlow {@link ExecutableFlow} containing all the information for a flow execution.
+   * @return Return the start status based on the {@link ExecutableFlow}.
+   */
+  public Status getStartStatus(ExecutableFlow execFlow) {
+    return getStartStatus();
+  }
+
+  /**
    * When a flow is submitted, insert a new execution into the database queue. {@inheritDoc}
    */
   @Override
@@ -294,9 +302,9 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       String message) throws ExecutorManagerException {
     final int projectId = exflow.getProjectId();
     exflow.setSubmitUser(userId);
-    exflow.setStatus(getStartStatus());
-    exflow.setSubmitTime(System.currentTimeMillis());
     exflow.setDispatchMethod(getDispatchMethod(exflow));
+    exflow.setStatus(getStartStatus(exflow));
+    exflow.setSubmitTime(System.currentTimeMillis());
 
     // Get collection of running flows given a project and a specific flow name
     final List<Integer> running = getRunningFlows(projectId, flowId);

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -201,6 +201,20 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   /**
+   * @param execFlow {@link ExecutableFlow} containing all the information for a flow execution
+   *                                       including dispatch method which will be utilized here.
+   * @return READY if the dispatchMethod is CONTAINERIZED otherwise PREPARING.
+   */
+  @Override
+  public Status getStartStatus(ExecutableFlow execFlow) {
+    if (execFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) {
+      return Status.READY;
+    } else {
+      return Status.PREPARING;
+    }
+  }
+
+  /**
    * This method will shutdown the queue processor thread. It won't pick up executions from queue
    * for dispatch after this. This method will be called when webserver will shutdown.
    */

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -141,12 +141,18 @@ public class ContainerizedDispatchManagerTest {
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
     for (int i = 0; i < 100; i++) {
       DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
+      this.flow5.setDispatchMethod(dispatchMethod);
+      Status startStatus = this.containerizedDispatchManager.getStartStatus(this.flow5);
       assertThat(dispatchMethod).isEqualTo(DispatchMethod.POLL);
+      assertThat(startStatus).isEqualTo(Status.PREPARING);
     }
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(100);
     for (int i = 0; i < 100; i++) {
       DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod();
+      this.flow5.setDispatchMethod(dispatchMethod);
+      Status startStatus = this.containerizedDispatchManager.getStartStatus(this.flow5);
       assertThat(dispatchMethod).isEqualTo(DispatchMethod.CONTAINERIZED);
+      assertThat(startStatus).isEqualTo(Status.READY);
     }
   }
 
@@ -175,11 +181,17 @@ public class ContainerizedDispatchManagerTest {
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(10);
     this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of("ALL"));
     DispatchMethod dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    this.flow5.setDispatchMethod(dispatchMethod);
+    Status startStatus = this.containerizedDispatchManager.getStartStatus(this.flow5);
     Assert.assertEquals(DispatchMethod.CONTAINERIZED, dispatchMethod);
+    Assert.assertEquals(Status.READY, startStatus);
 
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(0);
     dispatchMethod = this.containerizedDispatchManager.getDispatchMethod(this.flow5);
+    this.flow5.setDispatchMethod(dispatchMethod);
+    startStatus = this.containerizedDispatchManager.getStartStatus(this.flow5);
     Assert.assertEquals(DispatchMethod.POLL, dispatchMethod);
+    Assert.assertEquals(Status.PREPARING, startStatus);
 
     this.containerizedDispatchManager.getContainerRampUpCriteria().setRampUp(100);
     this.containerizedDispatchManager.getContainerJobTypeCriteria().updateAllowList(ImmutableSet.of("java", "command",


### PR DESCRIPTION
In containerization, When the dispatch method is containerized based on the ramp and jobtype filter, then start status should be READY otherwise PREPARING