### PR TITLE
Adding null check to avoid NPE in logs (Fixes issue #1917)

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -136,6 +136,10 @@ public class FlowTriggerScheduler {
   public List<ScheduledFlowTrigger> getScheduledFlowTriggerJobs() {
     try {
       final Scheduler quartzScheduler = this.scheduler.getScheduler();
+      if(quartzScheduler == null) {
+        logger.warn("Unable to get scheduled flow triggers - Quartz scheduler has not been initialized");
+        return new ArrayList<>();
+      }
       final List<String> groupNames = quartzScheduler.getJobGroupNames();
 
       final List<ScheduledFlowTrigger> flowTriggerJobDetails = new ArrayList<>();


### PR DESCRIPTION
A small fix for https://github.com/azkaban/azkaban/issues/1917

This issue is originally caused by the initialization function at https://github.com/azkaban/azkaban/blob/master/azkaban-web-server/src/main/java/azkaban/scheduler/QuartzScheduler.java#L58 leaving this field null.

Adding a null check, which returns with the same value as the exception would result in. (Empty list)

This change does not change the behavior of anything except the log output.