### PR TITLE
Focus on Login, Create Project Dialogs

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/index.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/index.vm
@@ -22,7 +22,7 @@
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
 
   <script type="text/javascript" src="${context}/js/azkaban/view/table-sort.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/main.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/main.js?v=1619118833"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/login.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/login.vm
@@ -21,7 +21,7 @@
   #parse("azkaban/webapp/servlet/velocity/style.vm")
   #parse("azkaban/webapp/servlet/velocity/javascript.vm")
 
-  <script type="text/javascript" src="${context}/js/azkaban/view/login.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/login.js?v=1619118833"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
   </script>

--- a/azkaban-web-server/src/web/js/azkaban/view/login.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/login.js
@@ -25,6 +25,7 @@ azkaban.LoginView = Backbone.View.extend({
 
   initialize: function (settings) {
     $('#error-msg').hide();
+    $('#username').focus();
   },
 
   handleLogin: function (evt) {

--- a/azkaban-web-server/src/web/js/azkaban/view/main.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/main.js
@@ -133,6 +133,7 @@ azkaban.ProjectHeaderView = Backbone.View.extend({
 
   handleCreateProjectJob: function (evt) {
     $('#create-project-modal').modal();
+    $('#path').focus();
   },
 
   render: function () {


### PR DESCRIPTION
Very simple couple of fixes (mostly to try out the PR mechanics).

# Bug descriptions:

## Focus on User Name in Login dialog.
   When you open the login dialog, the focus is not in the username input field. It would have to be there.
   If you start typing, your input is not picked up.

## Focus on Project Name in New Project dialog.
   When you open the Create New Project dialog, the focus is not in the project name input field.
   It would have to be there.

# Before:
![login_no-focus](https://user-images.githubusercontent.com/5375891/115770388-7bda6e80-a361-11eb-9d8d-d116fdd807fd.png)
![create-project_no-focus](https://user-images.githubusercontent.com/5375891/115770405-84cb4000-a361-11eb-9137-2e7be879186a.png)

# After:
![login-focus](https://user-images.githubusercontent.com/5375891/115606953-318dba80-a299-11eb-8424-4c66b47937cc.png)
![create-project-focus](https://user-images.githubusercontent.com/5375891/115606985-3d797c80-a299-11eb-8e65-a65952e72ef2.png)
