### PR TITLE
Adds Granular Breadcrumbs to FlowPage and JobPage

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1506,6 +1506,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
+      page.add("flowlist", flow.getId().split(":", 0));
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1710,6 +1711,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("errorMsg", "Flow " + flowName + " not found.");
       } else {
         page.add("flowid", flow.getId());
+        page.add("flowlist", flow.getId().split(":", 0));
         page.add("isLocked", flow.isLocked());
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();

--- a/azkaban-web-server/src/main/less/header.less
+++ b/azkaban-web-server/src/main/less/header.less
@@ -67,5 +67,9 @@
     margin: 0px;
     padding: 0px;
     background: transparent;
+
+    .flowlink:before {
+      content: ":";
+    }
   }
 }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -109,10 +109,29 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
-        </a></li>
-        <li class="active"><strong>Flow</strong> $flowid</li>
+
+        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+
+        #set($ref = "${context}/manager?project=${project.name}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+            #set($linkclass = "")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = "flowlink")
+          #end
+
+          #if( $foreach.hasNext )
+            <li class=$linkclass><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+          #else
+            <li class=$linkclass><strong>$flowlabel</strong> $flow</li>
+          #end
+
+          #set($ref = $ref + ":")
+        #end
       </ol>
     </div>
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -65,12 +65,25 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
-        </a></li>
-        <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowid
-        </a></li>
+        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+
+        #set($ref = "${context}/manager?project=${project.name}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+            #set($linkclass = "")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = "flowlink")
+          #end
+
+          <li class=$linkclass><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+
+          #set($ref = $ref + ":")
+        #end
+
         <li class="active"><strong>Job</strong> $jobid</li>
       </ol>
     </div>


### PR DESCRIPTION
# Issue Description

## No Intermediate Breadcrumbs in Job Page
When you are visiting Job Pages, there is no way to go back to the main flow, not to mention the intermediate sub-flows. The only way you have is either going to the sub-flow where the job belongs, or first going all the way back to the project, and then to the main flow and sub-flows from there:
![job-no-link-back](https://user-images.githubusercontent.com/5375891/115775940-63218700-a368-11eb-95c0-ef59b12ad411.png)

## No Intermediate Breadcrumbs in Flow Page
When you are visiting a Flow Page, there is no way to go back to the main flow, not to mention the intermediate sub-flows. The only way you have is first going all the way back to the project, and then to the main flow or other sub-flows from there:
![flow-no-link-back](https://user-images.githubusercontent.com/5375891/115776402-ec38be00-a368-11eb-9979-151117234bd6.png)

# Solution
Nested flows are now directly accessible via detailed breadcrumbs in FlowPages and JobPages.
![breadcrumbs2](https://user-images.githubusercontent.com/5375891/115784499-0d061100-a373-11eb-9a81-c67e52d551e8.gif)
