### PR TITLE
Upgrade mysql connector version in Azkaban to 8.0.20

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
+++ b/azkaban-common/src/main/java/azkaban/database/DataSourceUtils.java
@@ -115,7 +115,7 @@ public class DataSourceUtils {
       this.url = "jdbc:mysql://" + (host + ":" + port + "/" + dbName);
       addConnectionProperty("useUnicode", "yes");
       addConnectionProperty("characterEncoding", "UTF-8");
-      setDriverClassName("com.mysql.jdbc.Driver");
+      setDriverClassName("com.mysql.cj.jdbc.Driver");
       setUsername(user);
       setPassword(password);
       setUrl(this.url);

--- a/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
+++ b/azkaban-db/src/main/java/azkaban/db/MySQLDataSource.java
@@ -48,7 +48,7 @@ public class MySQLDataSource extends AzkabanDataSource {
     final String url = "jdbc:mysql://" + (host + ":" + port + "/" + dbName);
     addConnectionProperty("useUnicode", "yes");
     addConnectionProperty("characterEncoding", "UTF-8");
-    setDriverClassName("com.mysql.jdbc.Driver");
+    setDriverClassName("com.mysql.cj.jdbc.Driver");
     setUsername(user);
     setPassword(password);
     setUrl(url);

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ ext.deps = [
     metricsJvm           : 'io.dropwizard.metrics:metrics-jvm:3.1.0',
     mockito              : 'org.mockito:mockito-core:2.28.2',
     mongoDriver          : 'org.mongodb:mongo-java-driver:2.14.0',
-    mysqlConnector       : 'mysql:mysql-connector-java:5.1.28',
+    mysqlConnector       : 'mysql:mysql-connector-java:8.0.20',
     pig                  : 'org.apache.pig:pig:' + versions.pig,
     parquetAvro          : 'org.apache.parquet:parquet-avro:1.11.1',
     parquetBundle        : 'com.twitter:parquet-hadoop-bundle:1.3.2',


### PR DESCRIPTION
This change upgrades the mysql connector version and makes code changes
to use the new connector. Using conector version 8 helps with using
MySQL DB version 8 for Azkaban while maintaining compatability with
version 5.x