### PR TITLE
Allow longer project events to be recorded.

### DIFF
--- a/azkaban-db/src/main/sql/create.project_events.sql
+++ b/azkaban-db/src/main/sql/create.project_events.sql
@@ -3,7 +3,7 @@ CREATE TABLE project_events (
   event_type TINYINT NOT NULL,
   event_time BIGINT  NOT NULL,
   username   VARCHAR(64),
-  message    TEXT
+  message    VARCHAR(65400)
 );
 
 CREATE INDEX log

--- a/azkaban-db/src/main/sql/create.project_events.sql
+++ b/azkaban-db/src/main/sql/create.project_events.sql
@@ -3,7 +3,7 @@ CREATE TABLE project_events (
   event_type TINYINT NOT NULL,
   event_time BIGINT  NOT NULL,
   username   VARCHAR(64),
-  message    VARCHAR(512)
+  message    TEXT
 );
 
 CREATE INDEX log

--- a/azkaban-db/src/main/sql/create.project_events.sql
+++ b/azkaban-db/src/main/sql/create.project_events.sql
@@ -3,7 +3,7 @@ CREATE TABLE project_events (
   event_type TINYINT NOT NULL,
   event_time BIGINT  NOT NULL,
   username   VARCHAR(64),
-  message    VARCHAR(65400)
+  message    VARCHAR(65000)
 );
 
 CREATE INDEX log

--- a/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
@@ -1,0 +1,3 @@
+-- DB Migration from release 4.10.0 to 4.11.0
+-- Increase the size of the column recording project events.
+ALTER TABLE project_events MODIFY message TEXT;

--- a/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
@@ -1,3 +1,3 @@
 -- DB Migration from release 4.10.0 to 4.11.0
 -- Increase the size of the column recording project event details.
-ALTER TABLE project_events MODIFY message VARCHAR(65400);
+ALTER TABLE project_events MODIFY message VARCHAR(65000);

--- a/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
@@ -1,3 +1,3 @@
 -- DB Migration from release 4.10.0 to 4.11.0
--- Increase the size of the column recording project events.
-ALTER TABLE project_events MODIFY message TEXT;
+-- Increase the size of the column recording project event details.
+ALTER TABLE project_events MODIFY message VARCHAR(65400);


### PR DESCRIPTION
User actions on projects are recorded in the DB and available for inspection.
Examples of those actions are uploading a new zip file, granting permissions to users and adding/modifying/deleting job properties in a flow through the UI.
When users update multiple job properties at a time or the value of one of them is very long it can happen (we often see it in the web server logs) that the event fails to be saved in the DB because the log message is too long.
To account for those scenarios the size of the MySQL column storing the log message is increased.