### PR TITLE
Order ImageRampup list by Id to perserve the order while ramping up

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
@@ -35,6 +35,7 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -679,6 +680,12 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
           imageRampupMap.put(imageTypeName, imageRampupList);
         }
       } while (rs.next());
+
+      for (List<ImageRampup> imageRampupList : imageRampupMap.values()) {
+        // Sort the list by id so that the ordering of the list is equivalent to the order
+        // specified in the json array at the time of using ImageRampUpAPIs
+        Collections.sort(imageRampupList, Comparator.comparingInt(ImageRampup::getId));
+      }
       return imageRampupMap;
     }
   }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
@@ -286,7 +286,6 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
     while (iterator.hasNext()) {
       final String imageTypeName = iterator.next();
       final List<ImageRampup> imageRampupList = imageTypeRampups.get(imageTypeName);
-      Collections.sort(imageRampupList, this.getRampupPercentageComparator());
       if (imageRampupList.isEmpty()) {
         log.info("ImageRampupList was empty, so continue");
         continue;
@@ -411,14 +410,5 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
         new VersionInfo(v.getImageVersion().getVersion(), v.getImageVersion().getPath(),
             v.getImageVersion().getState())));
     return versionInfoMap;
-  }
-
-  /**
-   * Return rampup percentage comparator
-   *
-   * @return Comparator<ImageRampup>
-   */
-  private Comparator<ImageRampup> getRampupPercentageComparator() {
-    return Comparator.comparingInt(ImageRampup::getRampupPercentage);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
@@ -120,10 +120,10 @@ public class ImageRampupManagerImplTest {
     imageTypeVersionMap = this.imageRampupManger
         .getVersionByImageTypes(flow, imageTypes);
     Assert.assertEquals("3.6.5", imageTypeVersionMap.get("azkaban_config").getVersion());
-    Assert.assertEquals("3.6.2", imageTypeVersionMap.get("azkaban_core").getVersion());
-    Assert.assertEquals("1.8.2", imageTypeVersionMap.get("azkaban_exec").getVersion());
-    Assert.assertEquals("2.1.2", imageTypeVersionMap.get("hive_job").getVersion());
-    Assert.assertEquals("1.1.2", imageTypeVersionMap.get("spark_job").getVersion());
+    Assert.assertEquals("3.6.1", imageTypeVersionMap.get("azkaban_core").getVersion());
+    Assert.assertEquals("1.8.1", imageTypeVersionMap.get("azkaban_exec").getVersion());
+    Assert.assertEquals("2.1.1", imageTypeVersionMap.get("hive_job").getVersion());
+    Assert.assertEquals("1.1.1", imageTypeVersionMap.get("spark_job").getVersion());
   }
 
   /**


### PR DESCRIPTION
The List<ImageRampup> fetched by ImageRampupDaoImpl.java  should be sorted by Id so that the ordering of the list is the same as the order specified in the JSON array while using Image Management APIs.
This ordering is important because while ramping up the 0-100 will be segmented in that order. Hence it will make the ramp-up algorithm deterministic. 