### PR TITLE
Adds Granular Breadcrumbs to Flow, Job, Job Properties and Execution Pages

### DIFF
--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -130,6 +130,7 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
 
     page.add("projectName", project.getName());
     page.add("flowid", flow.getId());
+    page.add("flowlist", flow.getId().split(":", 0));
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
     page.add("attemptStatus", attempt == node.getAttempt() ?

--- a/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
+++ b/az-jobsummary/src/main/java/azkaban/viewer/jobsummary/JobSummaryServlet.java
@@ -38,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
+import azkaban.Constants;
 
 
 public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
@@ -130,7 +131,8 @@ public class JobSummaryServlet extends LoginAbstractAzkabanServlet {
 
     page.add("projectName", project.getName());
     page.add("flowid", flow.getId());
-    page.add("flowlist", flow.getId().split(":", 0));
+    page.add("flowlist", flow.getId().split(Constants.PATH_DELIMITER, 0));
+    page.add("pathDelimiter", Constants.PATH_DELIMITER);
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
     page.add("attemptStatus", attempt == node.getAttempt() ?

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -379,7 +379,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
     page.add("projectName", project.getName());
     page.add("flowid", flow.getId());
-    page.add("flowlist", flow.getId().split(":", 0));
+    page.add("flowlist", flow.getId().split(Constants.PATH_DELIMITER, 0));
+    page.add("pathDelimiter", Constants.PATH_DELIMITER);
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
     page.add("jobType", node.getType());
@@ -446,7 +447,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", triggerInst.getFlowId());
-    page.add("flowlist", triggerInst.getFlowId().split(":", 0));
+    page.add("flowlist", triggerInst.getFlowId().split(Constants.PATH_DELIMITER, 0));
+    page.add("pathDelimiter", Constants.PATH_DELIMITER);
 
     page.render();
   }
@@ -497,7 +499,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", flow.getFlowId());
-    page.add("flowlist", flow.getFlowId().split(":", 0));
+    page.add("flowlist", flow.getFlowId().split(Constants.PATH_DELIMITER, 0));
+    page.add("pathDelimiter", Constants.PATH_DELIMITER);    
 
     // check the current flow definition to see if the flow is locked.
     final Flow currentFlow = project.getFlow(flow.getFlowId());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -379,6 +379,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
 
     page.add("projectName", project.getName());
     page.add("flowid", flow.getId());
+    page.add("flowlist", flow.getId().split(":", 0));
     page.add("parentflowid", node.getParentFlow().getFlowId());
     page.add("jobname", node.getId());
     page.add("jobType", node.getType());
@@ -445,6 +446,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", triggerInst.getFlowId());
+    page.add("flowlist", triggerInst.getFlowId().split(":", 0));
 
     page.render();
   }
@@ -495,6 +497,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectId", project.getId());
     page.add("projectName", project.getName());
     page.add("flowid", flow.getFlowId());
+    page.add("flowlist", flow.getFlowId().split(":", 0));
 
     // check the current flow definition to see if the flow is locked.
     final Flow currentFlow = project.getFlow(flow.getFlowId());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1506,6 +1506,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
+      page.add("flowlist", flow.getId().split(":", 0));
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1617,6 +1618,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
+      page.add("flowlist", flow.getId().split(":", 0));
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1710,6 +1712,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("errorMsg", "Flow " + flowName + " not found.");
       } else {
         page.add("flowid", flow.getId());
+        page.add("flowlist", flow.getId().split(":", 0));
         page.add("isLocked", flow.isLocked());
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1506,7 +1506,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
-      page.add("flowlist", flow.getId().split(":", 0));
+      page.add("flowlist", flow.getId().split(Constants.PATH_DELIMITER, 0));
+      page.add("pathDelimiter", Constants.PATH_DELIMITER);   
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1618,7 +1619,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
 
       page.add("flowid", flow.getId());
-      page.add("flowlist", flow.getId().split(":", 0));
+      page.add("flowlist", flow.getId().split(Constants.PATH_DELIMITER, 0));
+      page.add("pathDelimiter", Constants.PATH_DELIMITER);   
       final Node node = flow.getNode(jobName);
       if (node == null) {
         page.add("errorMsg", "Job " + jobName + " not found.");
@@ -1712,7 +1714,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("errorMsg", "Flow " + flowName + " not found.");
       } else {
         page.add("flowid", flow.getId());
-        page.add("flowlist", flow.getId().split(":", 0));
+        page.add("flowlist", flow.getId().split(Constants.PATH_DELIMITER, 0));
+        page.add("pathDelimiter", Constants.PATH_DELIMITER);         
         page.add("isLocked", flow.isLocked());
         if (flow.isLocked()) {
           final Props props = this.projectManager.getProps();

--- a/azkaban-web-server/src/main/less/header.less
+++ b/azkaban-web-server/src/main/less/header.less
@@ -67,5 +67,9 @@
     margin: 0px;
     padding: 0px;
     background: transparent;
+
+    .flowlink:before {
+      content: ":";
+    }
   }
 }

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -113,7 +113,7 @@
 
           <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
 
-          #set($ref = $ref + ":")
+          #set($ref = $ref + ${pathDelimiter})
         #end
 
         <li class="active"><strong>Execution</strong> $execid</li>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -97,13 +97,25 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName
-        </a></li>
-        <li><a
-            href="${context}/manager?project=${projectName}&flow=${flowid}"><strong>Flow</strong>
-          $flowid
-        </a></li>
+        <li><a href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName</a></li>
+
+        #set($ref = "${context}/manager?project=${projectName}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+            #set($linkclass = "")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = "flowlink")
+          #end
+
+          <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+
+          #set($ref = $ref + ":")
+        #end
+
         <li class="active"><strong>Execution</strong> $execid</li>
       </ol>
     </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -109,10 +109,29 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
-        </a></li>
-        <li class="active"><strong>Flow</strong> $flowid</li>
+
+        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+
+        #set($ref = "${context}/manager?project=${project.name}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+          #set($linkclass = "active")
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = $linkclass + " flowlink")
+          #end
+
+          #if( $foreach.hasNext )
+            <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+          #else
+            <li class="${linkclass}"><strong>$flowlabel</strong> $flow</li>
+          #end
+
+          #set($ref = $ref + ":")
+        #end
       </ol>
     </div>
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -130,7 +130,7 @@
             <li class="${linkclass}"><strong>$flowlabel</strong> $flow</li>
           #end
 
-          #set($ref = $ref + ":")
+          #set($ref = $ref + ${pathDelimiter})
         #end
       </ol>
     </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -77,7 +77,7 @@
 
         <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
 
-        #set($ref = $ref + ":")
+        #set($ref = $ref + ${pathDelimiter})
       #end
 
       <li><a href="${context}/executor?execid=${execid}#jobslist"><strong>Execution</strong> $execid</a></li>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobdetailsheader.vm
@@ -61,13 +61,26 @@
 <div class="page-breadcrumb">
   <div class="container-full">
     <ol class="breadcrumb">
-      <li><a href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName
-      </a></li>
-      <li><a
-          href="${context}/manager?project=${projectName}&flow=${flowid}"><strong>Flow</strong> $flowid
-      </a></li>
-      <li><a href="${context}/executor?execid=${execid}#jobslist"><strong>Execution</strong> $execid
-      </a></li>
+      <li><a href="${context}/manager?project=${projectName}"><strong>Project</strong> $projectName</a></li>
+
+      #set($ref = "${context}/manager?project=${projectName}&flow=")
+      #foreach( $flow in ${flowlist} )
+        #set($ref = $ref + $flow)
+
+        #if( $foreach.first )
+          #set($flowlabel = "Flow")
+          #set($linkclass = "")
+        #else
+          #set($flowlabel = "")
+          #set($linkclass = "flowlink")
+        #end
+
+        <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+
+        #set($ref = $ref + ":")
+      #end
+
+      <li><a href="${context}/executor?execid=${execid}#jobslist"><strong>Execution</strong> $execid</a></li>
       <li class="active"><strong>Job</strong> $jobid</li>
       <li class="active"><strong>Attempt</strong> $attempt</li>
     </ol>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -81,7 +81,7 @@
 
           <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
 
-          #set($ref = $ref + ":")
+          #set($ref = $ref + ${pathDelimiter})
         #end
 
         <li class="active"><strong>Job</strong> $jobid</li>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -65,12 +65,25 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
-        </a></li>
-        <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowid
-        </a></li>
+        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+
+        #set($ref = "${context}/manager?project=${project.name}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+            #set($linkclass = "")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = "flowlink")
+          #end
+
+          <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+
+          #set($ref = $ref + ":")
+        #end
+
         <li class="active"><strong>Job</strong> $jobid</li>
       </ol>
     </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
@@ -69,7 +69,7 @@
 
           <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
 
-          #set($ref = $ref + ":")
+          #set($ref = $ref + ${pathDelimiter})
         #end
 
         <li><a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}"><strong>Job</strong> $jobid</a></li>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
@@ -53,15 +53,26 @@
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a
-            href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name
-        </a></li>
-        <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}"><strong>Flow</strong> $flowid
-        </a></li>
-        <li><a
-            href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}"><strong>Job</strong> $jobid
-        </a></li>
+        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+
+        #set($ref = "${context}/manager?project=${project.name}&flow=")
+        #foreach( $flow in ${flowlist} )
+          #set($ref = $ref + $flow)
+
+          #if( $foreach.first )
+            #set($flowlabel = "Flow")
+            #set($linkclass = "")
+          #else
+            #set($flowlabel = "")
+            #set($linkclass = "flowlink")
+          #end
+
+          <li class="${linkclass}"><a href="${ref}"><strong>$flowlabel</strong> $flow</a></li>
+
+          #set($ref = $ref + ":")
+        #end
+
+        <li><a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}"><strong>Job</strong> $jobid</a></li>
         <li class="active"><strong>Properties</strong> $property</li>
       </ol>
     </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=1616099857" rel="stylesheet">
+<link href="/css/azkaban.css?v=1621010355" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -36,4 +36,4 @@
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js"></script>
 
-<link rel="stylesheet" type="text/css" href="${context}/css/azkaban-graph.css"/>
+<link rel="stylesheet" type="text/css" href="${context}/css/azkaban-graph.css?v=1621010355"/>


### PR DESCRIPTION
# Issue Description

## No Intermediate Breadcrumbs in Job Page
When you are visiting Job Pages, there is no way to go back to the main flow, not to mention the intermediate sub-flows. The only way you have is either going to the sub-flow where the job belongs, or first going all the way back to the project, and then to the main flow and sub-flows from there:
![job-no-link-back](https://user-images.githubusercontent.com/5375891/115775940-63218700-a368-11eb-95c0-ef59b12ad411.png)

## No Intermediate Breadcrumbs in Flow Page
When you are visiting a Flow Page, there is no way to go back to the main flow, not to mention the intermediate sub-flows. The only way you have is first going all the way back to the project, and then to the main flow or other sub-flows from there:
![flow-no-link-back](https://user-images.githubusercontent.com/5375891/115776402-ec38be00-a368-11eb-9979-151117234bd6.png)

## No Intermediate Breadcrumbs in Properties Page
![properties-page-no-links](https://user-images.githubusercontent.com/5375891/116589371-6c16d900-a8d1-11eb-9c3b-2bdb0bccdcec.png)

## No Intermediate Breadcrumbs in Flow Execution Page
![flow-execution-no-links](https://user-images.githubusercontent.com/5375891/116588771-ccf1e180-a8d0-11eb-8e40-8f2b5d3cab00.png)

# Solution
Nested flows are now directly accessible via detailed breadcrumbs in FlowPages and JobPages.
![breadcrumbs2](https://user-images.githubusercontent.com/5375891/115784499-0d061100-a373-11eb-9a81-c67e52d551e8.gif)

## Job Properties w/Granular Breadcrumbs
![properties-page-with-links2](https://user-images.githubusercontent.com/5375891/116588634-a2a02400-a8d0-11eb-863e-205a4d9ad7ef.png)

## Flow Execution w/Granular Breadcrumbs
![exec-page-with-links](https://user-images.githubusercontent.com/5375891/116589140-2d811e80-a8d1-11eb-834e-a070acae3508.png)
