### PR TITLE
Make the rampup logic more deterministic by sorting the result images by versionID.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageRampupDaoImpl.java
@@ -326,7 +326,9 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
   public Map<String, List<ImageRampup>> getRampupForAllImageTypes()
       throws ImageMgmtException {
     try {
-      return this.databaseOperator.query(SELECT_ALL_IMAGE_TYPE_RAMPUP_QUERY,
+      final StringBuilder queryBuilder = new StringBuilder(SELECT_ALL_IMAGE_TYPE_RAMPUP_QUERY);
+      queryBuilder.append(" order by iv.version");
+      return this.databaseOperator.query(queryBuilder.toString(),
           new FetchImageTypeRampupHandler(), true, true);
     } catch (final SQLException ex) {
       log.error("Exception while fetching rampup for image types.", ex);
@@ -349,6 +351,7 @@ public class ImageRampupDaoImpl implements ImageRampupDao {
         queryBuilder.append("? ,");
       }
       queryBuilder.append("? )");
+      queryBuilder.append(" order by iv.version");
       log.info("fetchRampupByImageTypes query: " + queryBuilder.toString());
       final List<Object> params = new ArrayList<>();
       // Select active image rampup plan

--- a/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
@@ -122,7 +122,7 @@ public class ImageRampupManagerImplTest {
     Assert.assertEquals("3.6.5", imageTypeVersionMap.get("azkaban_config").getVersion());
     Assert.assertEquals("3.6.2", imageTypeVersionMap.get("azkaban_core").getVersion());
     Assert.assertEquals("1.8.2", imageTypeVersionMap.get("azkaban_exec").getVersion());
-    Assert.assertEquals("2.1.2", imageTypeVersionMap.get("hive_job").getVersion());
+    Assert.assertEquals("2.1.3", imageTypeVersionMap.get("hive_job").getVersion());
     Assert.assertEquals("1.1.2", imageTypeVersionMap.get("spark_job").getVersion());
   }
 

--- a/azkaban-common/src/test/resources/image_management/all_image_types_new_and_rampup_version.json
+++ b/azkaban-common/src/test/resources/image_management/all_image_types_new_and_rampup_version.json
@@ -32,6 +32,14 @@
     "releaseTag": "2.1.2"
   },
   {
+    "imagePath": "hive_job",
+    "imageVersion": "2.1.3",
+    "imageType": "hive_job",
+    "description": "hive job",
+    "versionState": "NEW",
+    "releaseTag": "2.1.3"
+  },
+  {
     "imagePath": "azkaban_core",
     "imageVersion": "3.6.1",
     "imageType": "azkaban_core",

--- a/azkaban-common/src/test/resources/image_management/image_type_rampups.json
+++ b/azkaban-common/src/test/resources/image_management/image_type_rampups.json
@@ -16,7 +16,11 @@
     },
     {
       "imageVersion": "2.1.2",
-      "rampupPercentage": "70"
+      "rampupPercentage": "20"
+    },
+    {
+      "imageVersion": "2.1.3",
+      "rampupPercentage": "50"
     }
   ],
   "azkaban_core": [

--- a/azkaban-common/src/test/resources/image_management/image_type_rampups.json
+++ b/azkaban-common/src/test/resources/image_management/image_type_rampups.json
@@ -1,42 +1,42 @@
 {
   "spark_job": [
     {
-      "imageVersion": "1.1.2",
-      "rampupPercentage": "70"
-    },
-    {
       "imageVersion": "1.1.1",
       "rampupPercentage": "30"
+    },
+    {
+      "imageVersion": "1.1.2",
+      "rampupPercentage": "70"
     }
   ],
   "hive_job": [
     {
-      "imageVersion": "2.1.2",
-      "rampupPercentage": "70"
-    },
-    {
       "imageVersion": "2.1.1",
       "rampupPercentage": "30"
+    },
+    {
+      "imageVersion": "2.1.2",
+      "rampupPercentage": "70"
     }
   ],
   "azkaban_core": [
     {
-      "imageVersion": "3.6.2",
-      "rampupPercentage": "80"
-    },
-    {
       "imageVersion": "3.6.1",
       "rampupPercentage": "20"
+    },
+    {
+      "imageVersion": "3.6.2",
+      "rampupPercentage": "80"
     }
   ],
   "azkaban_exec": [
     {
-      "imageVersion": "1.8.2",
-      "rampupPercentage": "60"
-    },
-    {
       "imageVersion": "1.8.1",
       "rampupPercentage": "40"
+    },
+    {
+      "imageVersion": "1.8.2",
+      "rampupPercentage": "60"
     }
   ],
   "azkaban_config": [

--- a/azkaban-web-server/src/test/resources/image_management/image_type_rampups.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_type_rampups.json
@@ -16,7 +16,11 @@
     },
     {
       "imageVersion": "2.1.2",
-      "rampupPercentage": "70"
+      "rampupPercentage": "20"
+    },
+    {
+      "imageVersion": "2.1.3",
+      "rampupPercentage": "50"
     }
   ],
   "azkaban_core": [

--- a/azkaban-web-server/src/test/resources/image_management/image_type_rampups.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_type_rampups.json
@@ -1,42 +1,42 @@
 {
   "spark_job": [
     {
-      "imageVersion": "1.1.2",
-      "rampupPercentage": "70"
-    },
-    {
       "imageVersion": "1.1.1",
       "rampupPercentage": "30"
+    },
+    {
+      "imageVersion": "1.1.2",
+      "rampupPercentage": "70"
     }
   ],
   "hive_job": [
     {
-      "imageVersion": "2.1.2",
-      "rampupPercentage": "70"
-    },
-    {
       "imageVersion": "2.1.1",
       "rampupPercentage": "30"
+    },
+    {
+      "imageVersion": "2.1.2",
+      "rampupPercentage": "70"
     }
   ],
   "azkaban_core": [
     {
-      "imageVersion": "3.6.2",
-      "rampupPercentage": "80"
-    },
-    {
       "imageVersion": "3.6.1",
       "rampupPercentage": "20"
+    },
+    {
+      "imageVersion": "3.6.2",
+      "rampupPercentage": "80"
     }
   ],
   "azkaban_exec": [
     {
-      "imageVersion": "1.8.2",
-      "rampupPercentage": "60"
-    },
-    {
       "imageVersion": "1.8.1",
       "rampupPercentage": "40"
+    },
+    {
+      "imageVersion": "1.8.2",
+      "rampupPercentage": "60"
     }
   ],
   "azkaban_config": [


### PR DESCRIPTION
Make the rampup logic more deterministic by sorting the result images by versionID.

Updated the input JSONs for tests in sorted order as it would be if it were queried from the db.