### PR TITLE
VARCHAR column lengths cannot exceed 21845 when DB/table uses utf8 encoding.

### DIFF
--- a/azkaban-db/src/main/sql/create.project_events.sql
+++ b/azkaban-db/src/main/sql/create.project_events.sql
@@ -3,7 +3,7 @@ CREATE TABLE project_events (
   event_type TINYINT NOT NULL,
   event_time BIGINT  NOT NULL,
   username   VARCHAR(64),
-  message    VARCHAR(65000)
+  message    VARCHAR(16000)
 );
 
 CREATE INDEX log

--- a/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
+++ b/azkaban-db/src/main/sql/upgrade.4.10.0.to.4.11.0.sql
@@ -1,3 +1,3 @@
 -- DB Migration from release 4.10.0 to 4.11.0
 -- Increase the size of the column recording project event details.
-ALTER TABLE project_events MODIFY message VARCHAR(65000);
+ALTER TABLE project_events MODIFY message VARCHAR(16000);


### PR DESCRIPTION
This is a follow up on PR #2841 to adjust VARCHAR size of `message` column in `project_events` table based on the SQL statement in [upgrade.3.43.0.to.3.44.0.sql](https://github.com/azkaban/azkaban/blob/master/azkaban-db/src/main/sql/upgrade.3.43.0.to.3.44.0.sql#L8):
```
ALTER DATABASE <database_name> CHARACTER SET utf8 COLLATE utf8_general_ci;
```
which indicates that the Azkaban DB should be using utf8 charset. 
That encoding uses 3 bytes per character for storage so the max size for a VARCHAR column is 65535 (row size)/3=21845.