### PR TITLE
Graph Manipulation Enhancements

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -71,6 +71,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
   private String name;
   private String label;
   private String color;
+  private String depth;
 
   private List<ViewerPlugin> viewerPlugins;
   private List<TriggerPlugin> triggerPlugins;
@@ -115,6 +116,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     this.name = props.getString("azkaban.name", "");
     this.label = props.getString("azkaban.label", "");
     this.color = props.getString("azkaban.color", "#FF0000");
+    this.depth = props.getString("azkaban.depth", "2");
     this.passwordPlaceholder = props.getString("azkaban.password.placeholder", "Password");
     this.displayExecutionPageSize = props.getInt(ConfigurationKeys.DISPLAY_EXECUTION_PAGE_SIZE, 16);
 
@@ -291,6 +293,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("azkaban_name", this.name);
     page.add("azkaban_label", this.label);
     page.add("azkaban_color", this.color);
+    page.add("azkaban_depth", this.depth);
     page.add("note_type", NoteServlet.type);
     page.add("note_message", NoteServlet.message);
     page.add("note_url", NoteServlet.url);
@@ -343,6 +346,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("azkaban_name", this.name);
     page.add("azkaban_label", this.label);
     page.add("azkaban_color", this.color);
+    page.add("azkaban_depth", this.depth);
     page.add("note_type", NoteServlet.type);
     page.add("note_message", NoteServlet.message);
     page.add("note_url", NoteServlet.url);

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -33,7 +33,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1579310616"></script>
   <script type="text/javascript">
@@ -47,6 +47,7 @@
     var flowId = "${flowid}";
     var execId = "${execid}";
     var triggerInstanceId = "${triggerInstanceId}";
+    var graphDepth = "${azkaban_depth}";
   </script>
   <link rel="stylesheet" type="text/css" href="${context}/css/morris.css"/>
   <link rel="stylesheet" type="text/css" href="${context}/css/jquery-ui-1.10.1.custom.css"/>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -33,7 +33,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1570835891"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1579310616"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
@@ -33,7 +33,7 @@
       <div class="panel-footer">
         <button type="button" class="btn btn-sm btn-default" id="resetPanZoomBtn">Reset Pan Zoom
         </button>
-        <button type="button" class="btn btn-sm btn-default" id="autoPanZoomBtn"
+        <button type="button" class="btn btn-sm btn-info" id="autoPanZoomBtn"
                 data-toggle="button">Auto Pan Zoom
         </button>
       </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -36,8 +36,8 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1588045179"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow.js"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow.js?v=1620232349"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -36,7 +36,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1588045179"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow.js"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
@@ -50,6 +50,7 @@
     var flowId = "${flowid}";
     var execId = null;
     var pageSize = "${size}";
+    var graphDepth = "${azkaban_depth}";
 
     var flowPageSettings = {
       projectId: ${project.id},

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -23,7 +23,7 @@
   #parse ("azkaban/webapp/servlet/velocity/svgflowincludes.vm")
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1620232349"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpage.vm
@@ -23,7 +23,7 @@
   #parse ("azkaban/webapp/servlet/velocity/svgflowincludes.vm")
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1569610022"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1619379665"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project.js?v=1556216524794"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/project-modals.js"></script>
   <script type="text/javascript">
@@ -36,6 +36,7 @@
     var projectId = ${project.id};
     var execAccess = ${exec};
     var projectName = "$project.name";
+    var graphDepth = "${azkaban_depth}";
   </script>
   <link rel="stylesheet" type="text/css" href="${context}/css/bootstrap-datetimepicker.css"/>
   <link rel="stylesheet" type="text/css" href="${context}/css/jquery-ui.css">

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -23,17 +23,17 @@
 <script type="text/javascript" src="${context}/js/azkaban/util/ajax.js?v=1579310616"></script>
 
 <script type="text/javascript" src="${context}/js/azkaban/util/svgutils.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/util/svg-navigate.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/util/layout.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/svg-navigate.js?v=1620232349"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/layout.js?v=1620232349"></script>
 
-<script type="text/javascript" src="${context}/js/azkaban/view/context-menu.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/context-menu.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-status.js"></script>
 
-<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1619379665"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1619379665"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1620232349"></script>
 
 <link rel="stylesheet" type="text/css" href="${context}/css/azkaban-graph.css"/>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -32,7 +32,7 @@
 <script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1570835891"></script>
-<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1620232349"></script>
 

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -29,11 +29,11 @@
 <script type="text/javascript" src="${context}/js/azkaban/view/context-menu.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-status.js"></script>
 
-<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1569610022"></script>
+<script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1619379665"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1570835891"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1619379665"></script>
 
 <link rel="stylesheet" type="text/css" href="${context}/css/azkaban-graph.css"/>

--- a/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
@@ -18,7 +18,7 @@ $.namespace('azkaban');
 
 azkaban.GraphModel = Backbone.Model.extend({
   initialize: function () {
-
+    this.set({'autoPanZoom': true});
   },
 
   /*

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -43,13 +43,12 @@ var openJobDisplayCallback = function (nodeId, flowId, evt) {
       "json"
     );
     */
-}
+};
 
 var createNewPanel = function (node, model, evt) {
   var parentPath = node.parentPath;
 
-  var nodeInfoPanelID = parentPath ? parentPath + ":" + node.id + "-info"
-      : node.id + "-info";
+  var nodeInfoPanelID = parentPath ? parentPath + ":" + node.id + "-info" : node.id + "-info";
   var cloneStuff = $("#flowInfoBase").clone();
   cloneStuff.data = node;
   $(cloneStuff).attr("id", nodeInfoPanelID);
@@ -59,22 +58,19 @@ var createNewPanel = function (node, model, evt) {
       {el: cloneStuff, model: model});
   node.panel = backboneView;
   backboneView.showExtendedView(evt);
-}
+};
 
 var closeAllSubDisplays = function () {
   $(".flowExtendedView").hide();
-}
+};
 
 var nodeClickCallback = function (event, model, node) {
-  var target = event.currentTarget;
   var type = node.type;
   var flowId = node.parent.flow;
   var jobId = node.id;
 
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId + "&job=" + jobId;
-  var logURL = contextURL + "/executor?execid=" + execId + "&job="
-      + node.nestedId + "&attempt=" + node.attempt;
+  var requestURL = contextURL + "/manager?project=" + projectName + "&flow=" + flowId + "&job=" + jobId;
+  var logURL = contextURL + "/executor?execid=" + execId + "&job=" + node.nestedId + "&attempt=" + node.attempt;
   var menu = [];
 
   if (type == "flow") {
@@ -162,7 +158,7 @@ var nodeClickCallback = function (event, model, node) {
       {break: 1},
       {
         title: "Center Job", callback: function () {
-          model.trigger("centerNode", node)
+          model.trigger("centerNode", node);
         }
       }
     ]);
@@ -188,21 +184,19 @@ var nodeClickCallback = function (event, model, node) {
     }
   }
   contextMenuView.show(event, menu);
-}
+};
 
 var jobClickCallback = function (event, model, node) {
-  var target = event.currentTarget;
   var type = node.type;
   var flowId = node.parent.flow;
-  var jobId = node.id;
-
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId + "&job=" + node.id;
-
+  // var jobId = node.id;
+  
+  var requestURL = contextURL + "/manager?project=" + projectName + "&flow=" + flowId + "&job=" + node.id;
   var menu;
+
   if (type == "flow") {
-    var flowRequestURL = contextURL + "/manager?project=" + projectName
-        + "&flow=" + node.flowId;
+    var flowRequestURL = contextURL + "/manager?project=" + projectName + "&flow=" + node.flowId;
+
     menu = [
       //  {title: "View Properties...", callback: function() {openJobDisplayCallback(jobId, flowId, event)}},
       //  {break: 1},
@@ -230,7 +224,7 @@ var jobClickCallback = function (event, model, node) {
       {break: 1},
       {
         title: "Center Flow", callback: function () {
-          model.trigger("centerNode", node)
+          model.trigger("centerNode", node);
         }
       }
     ];
@@ -252,21 +246,20 @@ var jobClickCallback = function (event, model, node) {
       {break: 1},
       {
         title: "Center Job", callback: function () {
-          graphModel.trigger("centerNode", node)
+          graphModel.trigger("centerNode", node);
         }
       }
     ];
   }
   contextMenuView.show(event, menu);
-}
+};
 
 var edgeClickCallback = function (event, model) {}
 
 var graphClickCallback = function (event, model) {
   var data = model.get("data");
   var flowId = data.flow;
-  var requestURL = contextURL + "/manager?project=" + projectName + "&flow="
-      + flowId;
+  var requestURL = contextURL + "/manager?project=" + projectName + "&flow=" + flowId;
 
   var menu = [
     {
@@ -278,6 +271,25 @@ var graphClickCallback = function (event, model) {
     {
       title: "Collapse All Flows...", callback: function () {
         model.trigger("collapseAllFlows");
+        model.trigger("resetPanZoom");
+      }
+    },
+    {break: 1},
+    {
+      title: "Expand Flows 1 Level...", callback: function () {
+        model.trigger("expandFlows1");
+        model.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Expand Flows 2 Levels...", callback: function () {
+        model.trigger("expandFlows2");
+        model.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Expand Flows 3 Levels...", callback: function () {
+        model.trigger("expandFlows3");
         model.trigger("resetPanZoom");
       }
     },
@@ -299,7 +311,5 @@ var graphClickCallback = function (event, model) {
       }
     }
   ];
-
   contextMenuView.show(event, menu);
-}
-
+};

--- a/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/flow-loader.js
@@ -189,7 +189,6 @@ var nodeClickCallback = function (event, model, node) {
 var jobClickCallback = function (event, model, node) {
   var type = node.type;
   var flowId = node.parent.flow;
-  // var jobId = node.id;
   
   var requestURL = contextURL + "/manager?project=" + projectName + "&flow=" + flowId + "&job=" + node.id;
   var menu;

--- a/azkaban-web-server/src/web/js/azkaban/util/layout.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/layout.js
@@ -30,7 +30,7 @@ var idSort = function (a, b) {
   else {
     return 0;
   }
-}
+};
 
 function prepareLayout(nodes, hmargin, layers, nodeMap) {
   var maxLayer = 0;
@@ -367,7 +367,6 @@ function spaceVertically(layers, maxLayer) {
       }
     }
 
-    console.log("Max " + maxDelta);
     var calcHeight = maxDelta * degreeRatio;
 
     var newMinHeight = minHeight + startMaxHeight / 2 + layerMaxHeight / 2;

--- a/azkaban-web-server/src/web/js/azkaban/util/svg-navigate.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/svg-navigate.js
@@ -23,7 +23,7 @@
     target.mx = evt.clientX;
     target.my = evt.clientY;
     target.mDown = false;
-  }
+  };
 
   var mouseDown = function (evt) {
     if (evt.button > 1) {
@@ -34,14 +34,14 @@
     target.mx = evt.clientX;
     target.my = evt.clientY;
     target.mDown = true;
-  }
+  };
 
   var mouseOut = function (evt) {
     var target = evt.target;
     target.mx = evt.clientX;
     target.my = evt.clientY;
     target.mDown = false;
-  }
+  };
 
   var mouseMove = function (evt) {
     var target = evt.target;
@@ -56,11 +56,11 @@
 
     target.mx = evt.clientX;
     target.my = evt.clientY;
-  }
+  };
 
   var mouseDrag = function (evt) {
     translateDeltaGraph(evt.target, evt.dragX, evt.dragY);
-  }
+  };
 
   var mouseScrolled = function (evt) {
     if (!evt) {
@@ -113,7 +113,7 @@
     evt.preventDefault();
 
     scaleGraph(target, scale, x, y);
-  }
+  };
 
   this.boundZoomLevel = function (target, level) {
     if (level >= target.settings.zoomNumLevels) {
@@ -122,9 +122,8 @@
     else if (level <= 0) {
       return 0;
     }
-
     return level;
-  }
+  };
 
   this.scaleGraph = function (target, scale, x, y) {
     var sfactor = scale / target.scale;
@@ -137,7 +136,7 @@
       target.model.trigger("scaled");
     }
     retransform(target);
-  }
+  };
 
   this.translateDeltaGraph = function (target, x, y) {
     target.translateX += x;
@@ -146,13 +145,12 @@
       target.model.trigger("panned");
     }
     retransform(target);
-  }
+  };
 
   this.retransform = function (target) {
     var gs = target.childNodes;
 
-    var transformString = "translate(" + target.translateX + ","
-        + target.translateY +
+    var transformString = "translate(" + target.translateX + "," + target.translateY +
         ") scale(" + target.scale + ")";
 
     for (var i = 0; i < gs.length; ++i) {
@@ -175,7 +173,7 @@
         obj.y2 = obj.y1 + obj.height * obj.scale;
       }
     }
-  }
+  };
 
   this.resetTransform = function (target) {
     var settings = target.settings;
@@ -203,7 +201,7 @@
       target.zoomIndex = boundZoomLevel(target, settings.zoomIndex);
       target.scale = target.zoomLevels[target.zoomIndex];
     }
-  }
+  };
 
   this.animateTransform = function (target, scale, x, y, duration) {
     var zoomLevel = calculateZoomLevel(scale, target.zoomLevels);
@@ -219,7 +217,7 @@
     target.endTime = target.startTime + duration;
 
     this.animateTick(target);
-  }
+  };
 
   this.animateTick = function (target) {
     var time = new Date().getTime();
@@ -227,8 +225,7 @@
       var timeDiff = time - target.startTime;
       var progress = timeDiff / (target.endTime - target.startTime);
 
-      target.scale = (target.toScale - target.fromScale) * progress
-          + target.fromScale;
+      target.scale = (target.toScale - target.fromScale) * progress + target.fromScale;
       target.translateX = (target.toX - target.fromX) * progress + target.fromX;
       target.translateY = (target.toY - target.fromY) * progress + target.fromY;
       retransform(target);
@@ -243,7 +240,7 @@
       target.translateY = target.toY;
       retransform(target);
     }
-  }
+  };
 
   this.calculateZoomScale = function (scaleLevel, numLevels, points) {
     if (scaleLevel <= 0) {
@@ -259,7 +256,7 @@
     var b = factor - floorIdx;
 
     return b * (points[ceilingIdx] - points[floorIdx]) + points[floorIdx];
-  }
+  };
 
   this.calculateZoomLevel = function (scale, zoomLevels) {
     if (scale >= zoomLevels[zoomLevels.length - 1]) {
@@ -283,7 +280,7 @@
     }
 
     return i;
-  }
+  };
 
   var methods = {
     init: function (options) {
@@ -333,6 +330,7 @@
       var y = arguments.y;
       var factor = 0.9;
       var duration = arguments.duration;
+      if (typeof duration === 'undefined') duration = 500;
 
       var width = arguments.width ? arguments.width : 1;
       var height = arguments.height ? arguments.height : 1;
@@ -343,9 +341,8 @@
       var aspectRatioGraph = height / width;
       var aspectRatioDiv = divHeight / divWidth;
 
-      var scale = aspectRatioGraph > aspectRatioDiv
-          ? (divHeight / height) * factor
-          : (divWidth / width) * factor;
+      var scale = aspectRatioGraph > aspectRatioDiv ?
+        (divHeight / height) * factor : (divWidth / width) * factor;
 
       if (arguments.maxScale) {
         if (scale > arguments.maxScale) {
@@ -364,11 +361,6 @@
 
       var sx = (divWidth - scaledWidth) / 2 - scale * x;
       var sy = (divHeight - scaledHeight) / 2 - scale * y;
-      console.log("sx,sy:" + sx + "," + sy);
-
-      if (duration != 0 && !duration) {
-        duration = 500;
-      }
 
       animateTransform(target, scale, sx, sy, duration);
     },

--- a/azkaban-web-server/src/web/js/azkaban/view/context-menu.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/context-menu.js
@@ -30,7 +30,6 @@ azkaban.ContextMenuView = Backbone.View.extend({
   },
 
   show: function (evt, menu) {
-    console.log("Show context menu");
     $(".contextMenu").remove();
     var x = evt.pageX;
     var y = evt.pageY;
@@ -41,12 +40,10 @@ azkaban.ContextMenuView = Backbone.View.extend({
   },
 
   hide: function (evt) {
-    console.log("Hide context menu");
     $(".contextMenu").remove();
   },
 
   handleClick: function (evt) {
-    console.log("handling click");
   },
 
   setupMenu: function (menu) {

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -232,18 +232,15 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
   },
 
   scheduleClick: function () {
-    console.log("click schedule button.");
     this.hideExecutionOptionPanel();
     schedulePanelView.showSchedulePanel();
   },
 
   loadFlowInfo: function (projectName, flowId, execId) {
-    console.log("Loading flow " + flowId);
     fetchFlowInfo(this.model, projectName, flowId, execId);
   },
 
   loadGraph: function (projectName, flowId, exgraph, callback) {
-    console.log("Loading flow " + flowId);
     var requestURL = contextURL + "/executor";
 
     var graphModel = executableGraphModel;
@@ -302,8 +299,6 @@ azkaban.FlowExecuteDialogView = Backbone.View.extend({
   },
 
   handleExecuteFlow: function (evt) {
-    console.log("click schedule button.");
-    var executeURL = contextURL + "/executor";
     var executingData = this.getExecutionOptionData();
     executeFlow(executingData);
   }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -774,6 +774,25 @@ var expanelGraphClickCallback = function (event, model) {
     },
     {break: 1},
     {
+      title: "Expand Flows 1 Level...", callback: function () {
+        executableGraphModel.trigger("expandFlows1");
+        executableGraphModel.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Expand Flows 2 Levels...", callback: function () {
+        executableGraphModel.trigger("expandFlows2");
+        executableGraphModel.trigger("resetPanZoom");
+      }
+    },
+    {
+      title: "Expand Flows 3 Levels...", callback: function () {
+        executableGraphModel.trigger("expandFlows3");
+        executableGraphModel.trigger("resetPanZoom");
+      }
+    },
+    {break: 1},
+    {
       title: "Enable All", callback: function () {
         enableAll();
       }

--- a/azkaban-web-server/src/web/js/azkaban/view/flow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow.js
@@ -65,7 +65,6 @@ azkaban.FlowTabView = Backbone.View.extend({
   },
 
   render: function () {
-    console.log("render graph");
   },
 
   handleGraphLinkClick: function () {
@@ -388,7 +387,6 @@ azkaban.SummaryView = Backbone.View.extend({
     };
 
     var successHandler = function (data) {
-      console.log(data);
       model.set({
         jobTypes: data.jobTypes,
         condition: data.condition
@@ -603,7 +601,6 @@ var initFlowPage = function (settings) {
     "flow": settings.flowId
   };
   var successHandler = function (data) {
-    console.log("data fetched");
     graphModel.addFlow(data);
     graphModel.trigger("change:graph");
 

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -408,6 +408,10 @@ azkaban.SvgGraphView = Backbone.View.extend({
     bounds.maxX = bounds.maxX ? bounds.maxX + margin : margin;
     bounds.maxY = bounds.maxY ? bounds.maxY + margin : margin;
     this.graphBounds = bounds;
+
+    if (this.model.get("autoPanZoom")) {
+      this.model.trigger("resetPanZoom");
+    }
   },
 
   collapseFlow: function (node) {
@@ -438,6 +442,10 @@ azkaban.SvgGraphView = Backbone.View.extend({
     this.graphBounds = bounds;
 
     this.expandedLevel = 0;
+
+    if (this.model.get("autoPanZoom")) {
+      this.model.trigger("resetPanZoom");
+    }
   },
 
   expandAllFlows: function (node, maxDepth, depth) {

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -72,7 +72,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
     var self = this;
     if (self.rightClick && self.rightClick.graph) {
       $(svg).on("contextmenu", function (evt) {
-        console.log("graph click");
         var currentTarget = evt.currentTarget;
 
         self.rightClick.graph(evt, self.model, currentTarget.data);
@@ -104,7 +103,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
     // Create a g node for edges, so that they're forced in the back.
     var edgeG = this.svg.group(g);
     if (nodes.length == 0) {
-      console.log("No results");
       return;
     }
 
@@ -156,7 +154,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
         // Proper children selectors don't work properly on svg
         for (var i = 0; i < nodes.length; ++i) {
           $(nodes[i].gNode).on("contextmenu", function (evt) {
-            console.log("node click");
             var currentTarget = evt.currentTarget;
             self.rightClick.node(evt, self.model, currentTarget.data);
             return false;
@@ -165,7 +162,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
       }
       if (this.rightClick.graph) {
         $(g).on("contextmenu", function (evt) {
-          console.log("graph click");
           var currentTarget = evt.currentTarget;
 
           self.rightClick.graph(evt, self.model, currentTarget.data);
@@ -233,7 +229,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
   },
 
   changeSelected: function (self) {
-    console.log("change selected");
     var selected = this.model.get("selected");
     var previous = this.model.previous("selected");
 
@@ -247,7 +242,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
       var g = selected.gNode;
       addClass(g, "selected");
 
-      console.log(this.model.get("autoPanZoom"));
       if (this.model.get("autoPanZoom")) {
         this.centerNode(selected);
       }
@@ -417,7 +411,6 @@ azkaban.SvgGraphView = Backbone.View.extend({
   },
 
   collapseFlow: function (node) {
-    console.log("Collapsing flow");
     var svg = this.svg;
     var gnode = node.gNode;
     node.expanded = false;
@@ -713,8 +706,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
     var totalHeight = labelBBox.height + 2 * verticalMargin;
 
     svg.change(labelG, {
-      transform: translateStr(horizontalMargin, labelBBox.height / 2
-          + verticalMargin)
+      transform: translateStr(horizontalMargin, labelBBox.height / 2 + verticalMargin)
     });
     svg.change(innerG,
         {transform: translateStr(-totalWidth / 2, -totalHeight / 2)});
@@ -753,8 +745,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
     var innerG = gNode.innerG;
     var borderRect = innerG.borderRect;
 
-    $(innerG).animate(
-        {svgTransform: translateStr(-node.width / 2, -node.height / 2)}, time);
+    $(innerG).animate({svgTransform: translateStr(-node.width / 2, -node.height / 2)}, time);
     $(borderRect).animate({svgWidth: node.width, svgHeight: node.height}, time);
     $(borderRect).animate({svgFill: 'white'}, time);
   },
@@ -800,6 +791,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
 
   panZoom: function (params) {
     params.maxScale = 2;
+    if (typeof params.duration === 'undefined') params.duration = 5;
     $(this.svgGraph).svgNavigate("transformToBox", params);
   }
 });

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,6 +36,13 @@ General Properties
 |                       | color for the Azkaban |                       |
 |                       | UI.                   |                       |
 +-----------------------+-----------------------+-----------------------+
+|   azkaban.depth       | Graph expansion level.| 2                     |
+|                       | Zero (0) means all    | This means the flows  |
+|                       | flows are collapsed   | will be recursively   |
+|                       | when the graph is     | expanded up to two    |
+|                       | rendered for the      | levels down when the  |
+|                       | first time.           | graph is 1st shown.   |
++-----------------------+-----------------------+-----------------------+
 |   web.resource.dir    | Sets the directory    | web/                  |
 |                       | for the ui’s css and  |                       |
 |                       | javascript files.     |                       |


### PR DESCRIPTION
# Flow Expansion and Collapse 

## Default Flow Expansion
Flows in the graph are now recursively open up to a certain *azkaban.depth* value, set in the Azkaban configuration file , with a default value of 2.
![flows-expanded-2-levels](https://user-images.githubusercontent.com/5375891/117404371-b0e8d400-aebe-11eb-9919-e7e279f81b09.png)

# Flow Expansion Commands 
There are 3 new commands in the graph context menu, which allow for the direct recursive flow expansion up to 1, 2 or 3 levels down.
![expansionmenu](https://user-images.githubusercontent.com/5375891/117404225-66675780-aebe-11eb-9d87-5a5aa638f24c.gif)

## Sample Graph with Flow Expansion Context Menu
![flow-expansion-menu](https://user-images.githubusercontent.com/5375891/117404464-d8d83780-aebe-11eb-9edc-90118740a52a.png)

## Sample Flow Execution Page with Flow Expansion Context Menu
![flow-exec-with-exp-menu](https://user-images.githubusercontent.com/5375891/117405470-88fa7000-aec0-11eb-9d80-b8f52bd524aa.png)


# *Auto Pan Zoom* on Flow Expansion and Collapse
- *Auto Pan Zoom* is now by default preset to ON 
- If *Auto Pan Zoom* is ON, *Reset Pan Zoom* will be automatically applied whenever a flow is collapsed or expanded in the graph.

## Sample graph all collapsed
![all-flows-collapsed](https://user-images.githubusercontent.com/5375891/117403407-f86e6080-aebc-11eb-9d7d-0148fa244f16.png)

## Same sample graph with flow slot-103 expanded and *Auto Pan Zoom* OFF
(Context menu, normally hidden, is shown for demo purposes only)
![One-Flow-Exp-APZ-Off](https://user-images.githubusercontent.com/5375891/117403479-176cf280-aebd-11eb-853d-a211a0c35db3.png)

## Sample graph with the same flow expanded and *Auto Pan Zoom* ON
(Context menu, normally hidden, is shown for demo purposes only)
![One-Flow-Exp-APZ-ON](https://user-images.githubusercontent.com/5375891/117403513-281d6880-aebd-11eb-8948-67ede7d82de2.png)

