### PR TITLE
Marking nscd mount as read only

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -602,6 +602,8 @@ public class Constants {
         AZKABAN_KUBERNETES_PREFIX + "nscd.socket.volume.mount.path";
     public static final String KUBERNETES_POD_NSCD_SOCKET_HOST_PATH =
         AZKABAN_KUBERNETES_PREFIX + "nscd.socket.host.path";
+    public static final String KUBERNETES_POD_NSCD_MOUNT_READ_ONLY =
+        AZKABAN_KUBERNETES_PREFIX + "nscd.mount.read.only";
 
     // Kubernetes flow container related properties
     public static final String KUBERNETES_FLOW_CONTAINER_PREFIX = AZKABAN_KUBERNETES_PREFIX +

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -599,11 +599,11 @@ public class Constants {
     public static final String KUBERNETES_POD_PREFIX = AZKABAN_KUBERNETES_PREFIX + "pod.";
     public static final String KUBERNETES_POD_NAME_PREFIX = KUBERNETES_POD_PREFIX + "name.prefix";
     public static final String KUBERNETES_POD_NSCD_SOCKET_VOLUME_MOUNT_PATH =
-        AZKABAN_KUBERNETES_PREFIX + "nscd.socket.volume.mount.path";
+        KUBERNETES_POD_PREFIX + "nscd.socket.volume.mount.path";
     public static final String KUBERNETES_POD_NSCD_SOCKET_HOST_PATH =
-        AZKABAN_KUBERNETES_PREFIX + "nscd.socket.host.path";
+        KUBERNETES_POD_PREFIX + "nscd.socket.host.path";
     public static final String KUBERNETES_POD_NSCD_MOUNT_READ_ONLY =
-        AZKABAN_KUBERNETES_PREFIX + "nscd.mount.read.only";
+        KUBERNETES_POD_PREFIX + "nscd.mount.read.only";
 
     // Kubernetes flow container related properties
     public static final String KUBERNETES_FLOW_CONTAINER_PREFIX = AZKABAN_KUBERNETES_PREFIX +

--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
@@ -171,13 +171,14 @@ public class AzKubernetesV1SpecBuilder {
      * @param volMountPath Path to be mounted for the flow container.
      */
     public AzKubernetesV1SpecBuilder addHostPathVolume(final String volName, final String hostPath,
-        final String hostPathType, final String volMountPath) {
+        final String hostPathType, final String volMountPath, final boolean readOnly) {
         final V1Volume hostPathVolume = new V1VolumeBuilder().withName(volName).withNewHostPath()
             .withPath(hostPath).withType(hostPathType).endHostPath().build();
         this.appVolumes.add(hostPathVolume);
         final V1VolumeMount hostPathVolMount = new V1VolumeMountBuilder()
             .withName(volName)
             .withMountPath(volMountPath)
+            .withReadOnly(readOnly)
             .build();
         this.appVolumeMounts.add(hostPathVolMount);
         return this;

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -104,6 +104,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DEFAULT_NSCD_SOCKET_HOST_PATH = "/var/run/nscd/socket";
   public static final String HOST_PATH_TYPE = "Socket";
   public static final String DEFAULT_NSCD_SOCKET_VOLUME_MOUNT_PATH = "/var/run/nscd/socket";
+  public static final boolean DEFAULT_NSCD_MOUNT_READ_ONLY = true;
   public static final String DEFAULT_SECRET_NAME = "azkaban-k8s-secret";
   public static final String DEFAULT_SECRET_VOLUME = DEFAULT_SECRET_NAME;
   public static final String DEFAULT_SECRET_MOUNTPATH = "/var/azkaban/private";
@@ -131,6 +132,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private final long serviceTimeout;
   private final String nscdSocketHostPath;
   private final String nscdSocketVolumeMountPath;
+  private final boolean isNscdMountReadOnly;
   private final VersionSetLoader versionSetLoader;
   private final ImageRampupManager imageRampupManager;
   private final KubernetesWatch kubernetesWatch;
@@ -212,6 +214,9 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         this.azkProps.getString(
             ContainerizedDispatchManagerProperties.KUBERNETES_POD_NSCD_SOCKET_VOLUME_MOUNT_PATH,
             DEFAULT_NSCD_SOCKET_VOLUME_MOUNT_PATH);
+    this.isNscdMountReadOnly = this.azkProps.getBoolean(
+        ContainerizedDispatchManagerProperties.KUBERNETES_POD_NSCD_MOUNT_READ_ONLY,
+        DEFAULT_NSCD_MOUNT_READ_ONLY);
     this.secretName = this.azkProps
         .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_SECRET_NAME,
             DEFAULT_SECRET_NAME);
@@ -635,7 +640,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private void addNscdSocketInVolume(final AzKubernetesV1SpecBuilder v1SpecBuilder) {
     v1SpecBuilder
         .addHostPathVolume(NSCD_SOCKET_VOLUME_NAME, this.nscdSocketHostPath, HOST_PATH_TYPE,
-            this.nscdSocketVolumeMountPath);
+            this.nscdSocketVolumeMountPath, this.isNscdMountReadOnly);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
+++ b/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
@@ -49,7 +49,7 @@ public class AzKubernetesV1PodBuilderTest {
             .addFlowContainer(flowContainerName, flowContainerImage, ImagePullPolicy.IF_NOT_PRESENT,
                 azConfVer)
             .addHostPathVolume("nscd-socket", "/var/run/nscd/socket", "Socket",
-                "/var/run/nscd/socket")
+                "/var/run/nscd/socket", true)
             .addSecretVolume("azkaban-private-properties", "azkaban-private-properties",
                 "/var/azkaban/private/conf")
             .addEnvVarToFlowContainer("envKey", "envValue")

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest1.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest1.yaml
@@ -31,6 +31,7 @@ spec:
       name: jobtype-volume-spark
     - mountPath: /var/run/nscd/socket
       name: nscd-socket
+      readOnly: true
     - mountPath: /var/azkaban/private/conf
       name: azkaban-private-properties
   initContainers:

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
@@ -45,6 +45,7 @@ spec:
       name: jobtype-volume-spark
     - mountPath: /var/run/nscd/socket
       name: nscd-socket
+      readOnly: true
     - mountPath: /var/azkaban/private/conf
       name: azkaban-private-properties
     - mountPath: /var/run/kubelet


### PR DESCRIPTION
For some volume mounts like nscd, it needs to be marked as read only for security reason. If it doesn't need to be kept read only then that can be set from property as well
azkaban.kubernetes.pod.nscd.mount.read.only=false