### PR TITLE
Revert "Use Apache's Parquet-Avro which uses Avro 1.9.2 (#2810)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext.deps = [
     mongoDriver          : 'org.mongodb:mongo-java-driver:2.14.0',
     mysqlConnector       : 'mysql:mysql-connector-java:8.0.20',
     pig                  : 'org.apache.pig:pig:' + versions.pig,
-    parquetAvro          : 'org.apache.parquet:parquet-avro:1.11.1',
+    parquetAvro          : 'com.twitter:parquet-avro:1.6.0',
     parquetBundle        : 'com.twitter:parquet-hadoop-bundle:1.3.2',
     powermock            : 'org.powermock:powermock-api-mockito2:2.0.2',
     powermockmodulejunit4: 'org.powermock:powermock-module-junit4:2.0.2',


### PR DESCRIPTION
This reverts commit 5e9c5fd94b0f35bb1693d5b3e187738b9467c36b.

Reverting this change temporarily as it breaks visualization of file contents on the HDFS viewer plugin. 
The issue is: Files that should be handled by the `TextFileViewer` (like JSON files) are now incorrectly handled by the `ParquetFileViewer`.