### PR TITLE
Made 'Finish all possible' as default failure-option

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -126,7 +126,7 @@
                       class="form-control form-control-auto">
                 <option value="finishCurrent">Finish Current Running</option>
                 <option value="cancelImmediately">Cancel All</option>
-                <option value="finishPossible">Finish All Possible</option>
+                <option value="finishPossible" selected>Finish All Possible</option>
               </select>
             </div>
 


### PR DESCRIPTION
This is a specific use case in conditional flows (https://azkaban.readthedocs.io/en/latest/conditionalFlow.html). If we consider the following flow, the user wants to run JobC regardless of failure in any node. Currently, when jobX fails, the remaining nodes get canceled. 

JobX
    |
JobA 
   |
JobB -> all_success (default) 
   |
JobC -> conditioned all_done 

**Current behaviour:** if a node fails, we decide to run subsequent nodes based on the flag "failure option". The default value of this is finish currently running nodes. 
**Expected behaviour:** In the case of conditional flows, we should evaluate all nodes ideally as the condition can be placed on any node and the condition influence the nodes to run regardless of any previous nodes' failure or success. 
**Fix:** Modifying the default failure option to "finish all" will make sure that all nodes will run for conditional flows. This will not affect any existing schedules. The non-conditional flows shouldn't have any functional problem because of this. cc: @ypadron-in 

**Testing:** Tested this change by starting an ad-hoc flow/scheduling a flow in a local machine. 