### PR TITLE
Auto-Expand Toggle Switch

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
@@ -31,11 +31,9 @@
       </div>
       <div id="joblist" class="graph-sidebar-list"></div>
       <div class="panel-footer">
-        <button type="button" class="btn btn-sm btn-default" id="resetPanZoomBtn">Reset Pan Zoom
-        </button>
-        <button type="button" class="btn btn-sm btn-info" id="autoPanZoomBtn"
-                data-toggle="button">Auto Pan Zoom
-        </button>
+        <button type="button" class="btn btn-sm btn-default" id="resetPanZoomBtn">Reset Pan Zoom</button>
+        <button type="button" class="btn btn-sm btn-info" id="autoPanZoomBtn" data-toggle="button">Auto Pan Zoom</button>
+        <button type="button" class="btn btn-sm btn-info" id="autoExpandBtn" data-toggle="button">Auto Expand Flows</button>
       </div>
     </div><!-- /.panel -->
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowgraphview.vm
@@ -33,7 +33,7 @@
       <div class="panel-footer">
         <button type="button" class="btn btn-sm btn-default" id="resetPanZoomBtn">Reset Pan Zoom</button>
         <button type="button" class="btn btn-sm btn-info" id="autoPanZoomBtn" data-toggle="button">Auto Pan Zoom</button>
-        <button type="button" class="btn btn-sm btn-info" id="autoExpandBtn" data-toggle="button">Auto Expand Flows</button>
+        <button type="button" class="btn btn-sm btn-info" id="autoExpandFlowsBtn" data-toggle="button">Auto Expand Flows</button>
       </div>
     </div><!-- /.panel -->
   </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/svgflowincludes.vm
@@ -31,9 +31,9 @@
 
 <script type="text/javascript" src="${context}/js/azkaban/util/flow-loader.js?v=1620232349"></script>
 <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1570835891"></script>
-<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js?v=1620232349"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/job-list.js?v=1623085074"></script>
+<script type="text/javascript" src="${context}/js/azkaban/model/svg-graph.js?v=1623085074"></script>
 <script type="text/javascript" src="${context}/js/azkaban/model/flow-trigger.js"></script>
-<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1620232349"></script>
+<script type="text/javascript" src="${context}/js/azkaban/view/svg-graph.js?v=1623085074"></script>
 
 <link rel="stylesheet" type="text/css" href="${context}/css/azkaban-graph.css?v=1621010355"/>

--- a/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
@@ -18,8 +18,8 @@ $.namespace('azkaban');
 
 azkaban.GraphModel = Backbone.Model.extend({
   initialize: function () {
-    this.set({'autoPanZoom': (localStorage.getItem("LiAz-autoPanZoom") !== 'false')});
-    this.set({'autoExpand': (localStorage.getItem("LiAz-autoExpand") !== 'false')});
+    this.set({'autoPanZoom': (localStorage.getItem("Azkaban-autoPanZoom") !== 'false')});
+    this.set({'autoExpandFlows': (localStorage.getItem("Azkaban-autoExpandFlows") !== 'false')});
   },
 
   /*

--- a/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/model/svg-graph.js
@@ -18,7 +18,8 @@ $.namespace('azkaban');
 
 azkaban.GraphModel = Backbone.Model.extend({
   initialize: function () {
-    this.set({'autoPanZoom': true});
+    this.set({'autoPanZoom': (localStorage.getItem("LiAz-autoPanZoom") !== 'false')});
+    this.set({'autoExpand': (localStorage.getItem("LiAz-autoExpand") !== 'false')});
   },
 
   /*

--- a/azkaban-web-server/src/web/js/azkaban/view/job-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-list.js
@@ -24,6 +24,7 @@ azkaban.JobListView = Backbone.View.extend({
     "click li.listElement": "handleJobClick",
     "click #resetPanZoomBtn": "handleResetPanZoom",
     "click #autoPanZoomBtn": "handleAutoPanZoom",
+    "click #autoExpandBtn": "handleAutoExpand",
     "contextmenu li.listElement": "handleContextMenuClick",
     "click .expandarrow": "handleToggleMenuExpand",
     "click .expandallarrow": "handleToggleMenuExpandAll",
@@ -43,6 +44,20 @@ azkaban.JobListView = Backbone.View.extend({
     this.list = $(this.el).find("#joblist");
     this.contextMenu = settings.contextMenuCallback;
     this.listNodes = {};
+
+    this.presetToggleBtn("autoPanZoom");
+    this.presetToggleBtn("autoExpand");
+  },
+
+  presetToggleBtn: function(name) {
+    var target = "#" + name + "Btn";
+    if (localStorage.getItem("LiAz-" + name) !== 'false') {
+      if ($(target).hasClass('btn-default')) $(target).removeClass('btn-default');
+      $(target).addClass('btn-info');
+    } else {
+      if ($(target).hasClass('btn-info')) $(target).removeClass('btn-info');
+      $(target).addClass('btn-default');
+    }
   },
 
   filterJobs: function (self) {
@@ -71,10 +86,8 @@ azkaban.JobListView = Backbone.View.extend({
       var spanlabel = $(li).find("> a > span");
 
       var endIndex = index + filter.length;
-      var newHTML = nodeName.substring(0, index)
-          + "<span class=\"filterHighlight\">" +
-          nodeName.substring(index, endIndex) + "</span>" +
-          nodeName.substring(endIndex, nodeName.length);
+      var newHTML = nodeName.substring(0, index) + "<span class=\"filterHighlight\">" +
+        nodeName.substring(index, endIndex) + "</span>" + nodeName.substring(endIndex, nodeName.length);
       $(spanlabel).html(newHTML);
 
       // Apply classes to all the included embedded flows.
@@ -85,7 +98,6 @@ azkaban.JobListView = Backbone.View.extend({
         $(parentLi).show();
         $(parentLi).addClass("subFilter");
       }
-
       $(li).show();
     }
   },
@@ -345,20 +357,31 @@ azkaban.JobListView = Backbone.View.extend({
     this.model.trigger("resetPanZoom");
   },
 
-  handleAutoPanZoom: function (evt) {
+  handleToggleButton: function (evt, name) {
     var target = evt.currentTarget;
+    var isToggleOn = false;
+
     if ($(target).hasClass('btn-default')) {
       $(target).removeClass('btn-default');
       $(target).addClass('btn-info');
-    }
-    else if ($(target).hasClass('btn-info')) {
+      isToggleOn = true;
+    } else if ($(target).hasClass('btn-info')) {
       $(target).removeClass('btn-info');
       $(target).addClass('btn-default');
     }
+    var props = {}; // dancing around no-es6
+    props[name] = isToggleOn;
+    this.model.set(props);
+    localStorage.setItem("LiAz-" + name, isToggleOn);
+    return isToggleOn;
+  },
 
-    // Using $().hasClass('active') does not use here because it appears that
-    // this is called before the Bootstrap toggle completes.
-    this.model.set({"autoPanZoom": $(target).hasClass('btn-info')});
+  handleAutoPanZoom: function (evt) {
+    if (this.handleToggleButton(evt, "autoPanZoom")) this.model.trigger("resetPanZoom");
+  },
+
+  handleAutoExpand: function (evt) {
+    this.model.trigger((this.handleToggleButton(evt, "autoExpand")) ? "autoExpandFlows" : "collapseAllFlows");
   },
 
   handleClose: function (evt) {

--- a/azkaban-web-server/src/web/js/azkaban/view/job-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-list.js
@@ -24,7 +24,7 @@ azkaban.JobListView = Backbone.View.extend({
     "click li.listElement": "handleJobClick",
     "click #resetPanZoomBtn": "handleResetPanZoom",
     "click #autoPanZoomBtn": "handleAutoPanZoom",
-    "click #autoExpandBtn": "handleAutoExpand",
+    "click #autoExpandFlowsBtn": "handleAutoExpandFlows",
     "contextmenu li.listElement": "handleContextMenuClick",
     "click .expandarrow": "handleToggleMenuExpand",
     "click .expandallarrow": "handleToggleMenuExpandAll",
@@ -46,12 +46,12 @@ azkaban.JobListView = Backbone.View.extend({
     this.listNodes = {};
 
     this.presetToggleBtn("autoPanZoom");
-    this.presetToggleBtn("autoExpand");
+    this.presetToggleBtn("autoExpandFlows");
   },
 
   presetToggleBtn: function(name) {
     var target = "#" + name + "Btn";
-    if (localStorage.getItem("LiAz-" + name) !== 'false') {
+    if (localStorage.getItem("Azkaban-" + name) !== 'false') {
       if ($(target).hasClass('btn-default')) $(target).removeClass('btn-default');
       $(target).addClass('btn-info');
     } else {
@@ -372,7 +372,7 @@ azkaban.JobListView = Backbone.View.extend({
     var props = {}; // dancing around no-es6
     props[name] = isToggleOn;
     this.model.set(props);
-    localStorage.setItem("LiAz-" + name, isToggleOn);
+    localStorage.setItem("Azkaban-" + name, isToggleOn);
     return isToggleOn;
   },
 
@@ -380,8 +380,8 @@ azkaban.JobListView = Backbone.View.extend({
     if (this.handleToggleButton(evt, "autoPanZoom")) this.model.trigger("resetPanZoom");
   },
 
-  handleAutoExpand: function (evt) {
-    this.model.trigger((this.handleToggleButton(evt, "autoExpand")) ? "autoExpandFlows" : "collapseAllFlows");
+  handleAutoExpandFlows: function (evt) {
+    this.model.trigger((this.handleToggleButton(evt, "autoExpandFlows")) ? "autoExpandFlows" : "collapseAllFlows");
   },
 
   handleClose: function (evt) {

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -524,7 +524,9 @@ azkaban.SvgGraphView = Backbone.View.extend({
     }
   },
 
-  relayoutFlow: function (node) {
+  relayoutFlow: function (node, delay) {
+    if (typeof delay === 'undefined') delay = 250;
+
     if (node.expanded) {
       this.layoutExpandedFlowNode(node);
     }
@@ -532,20 +534,22 @@ azkaban.SvgGraphView = Backbone.View.extend({
     var parent = node.parent;
     if (parent) {
       layoutGraph(parent.nodes, parent.edges, 10);
-      this.relayoutFlow(parent);
+      this.relayoutFlow(parent, delay);
       // Move all points again.
-      this.moveNodeEdges(parent.nodes, parent.edges);
-      this.animateExpandedFlowNode(node, 250);
+      this.moveNodeEdges(parent.nodes, parent.edges, delay);
+      this.animateExpandedFlowNode(node, delay);
     }
   },
 
-  moveNodeEdges: function (nodes, edges) {
+  moveNodeEdges: function (nodes, edges, delay) {
+    if (typeof delay === 'undefined') delay = 250;
+
     var svg = this.svg;
     for (var i = 0; i < nodes.length; ++i) {
       var node = nodes[i];
       var gNode = node.gNode;
 
-      $(gNode).animate({"svgTransform": translateStr(node.x, node.y)}, 250);
+      $(gNode).animate({"svgTransform": translateStr(node.x, node.y)}, delay);
     }
 
     for (var j = 0; j < edges.length; ++j) {
@@ -567,7 +571,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
         }
         pointArray.push([endNode.x, endPointY]);
 
-        animatePolylineEdge(svg, edge, pointArray, 250);
+        animatePolylineEdge(svg, edge, pointArray, delay);
         edge.oldpoints = pointArray;
       }
       else {

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -33,6 +33,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
     this.model.bind('change:updateAll', this.handleUpdateAllStatus, this);
     this.model.bind('expandFlow', this.expandFlow, this);
     this.model.bind('collapseFlow', this.collapseFlow, this);
+    this.model.bind('autoExpandFlows', this.autoExpandFlows, this);
     this.model.bind('expandAllFlows', this.expandAllFlows, this);
     this.model.bind('expandFlows1', this.expandFlows1, this);
     this.model.bind('expandFlows2', this.expandFlows2, this);
@@ -90,8 +91,12 @@ azkaban.SvgGraphView = Backbone.View.extend({
     $(this.mainG).empty();
 
     this.graphBounds = this.renderGraph(this.model.get("data"), this.mainG);
-    this.expandAllFlows(null, graphDepth || 1);
-    this.resetPanZoom(0);
+    
+    if (this.model.get("autoExpand")) {
+      this.autoExpandFlows();
+    } else {
+      this.resetPanZoom(0);
+    }
   },
 
   renderGraph: function (data, g) {
@@ -448,6 +453,11 @@ azkaban.SvgGraphView = Backbone.View.extend({
     }
   },
 
+  autoExpandFlows: function() {
+    this.expandAllFlows(null, graphDepth || 1);
+    this.resetPanZoom(0);
+  },
+
   expandAllFlows: function (node, maxDepth, depth) {
     if (maxDepth === undefined) maxDepth = Number.MAX_SAFE_INTEGER;
     if (depth === undefined) depth = 0;
@@ -525,7 +535,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
       this.relayoutFlow(parent);
       // Move all points again.
       this.moveNodeEdges(parent.nodes, parent.edges);
-      this.animateExpandedFlowNode(node, 20);
+      this.animateExpandedFlowNode(node, 250);
     }
   },
 
@@ -535,7 +545,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
       var node = nodes[i];
       var gNode = node.gNode;
 
-      $(gNode).animate({"svgTransform": translateStr(node.x, node.y)}, 20);
+      $(gNode).animate({"svgTransform": translateStr(node.x, node.y)}, 250);
     }
 
     for (var j = 0; j < edges.length; ++j) {
@@ -557,7 +567,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
         }
         pointArray.push([endNode.x, endPointY]);
 
-        animatePolylineEdge(svg, edge, pointArray, 20);
+        animatePolylineEdge(svg, edge, pointArray, 250);
         edge.oldpoints = pointArray;
       }
       else {
@@ -799,7 +809,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
 
   panZoom: function (params) {
     params.maxScale = 2;
-    if (typeof params.duration === 'undefined') params.duration = 5;
+    if (typeof params.duration === 'undefined') params.duration = 500;
     $(this.svgGraph).svgNavigate("transformToBox", params);
   }
 });

--- a/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/svg-graph.js
@@ -92,7 +92,7 @@ azkaban.SvgGraphView = Backbone.View.extend({
 
     this.graphBounds = this.renderGraph(this.model.get("data"), this.mainG);
     
-    if (this.model.get("autoExpand")) {
+    if (this.model.get("autoExpandFlows")) {
       this.autoExpandFlows();
     } else {
       this.resetPanZoom(0);


### PR DESCRIPTION
# Auto-Expand Toggle Switch
Since the newer auto-expand feature is not a desired capability for all users, a configuration switch is now included in the flow menu in the graph.
The default value is auto-expand. The setting is saved in local storage. So it applies to the user, on her workstation. It is saved from session to session, but not across devices.

## Flow Menu
Click on it to expand it.
![flow-menu-collapsed](https://user-images.githubusercontent.com/5375891/121229717-2a1f7200-c843-11eb-99a7-fe4b39f2c0c1.png)

## Auto-Expand Toggle Button
Click on it to disable the flow auto-expansion feature.  Once you disable it in a graph, it will stay that way for all the graphs, unless you click again to enable the named feature.
Likewise, the **Auto Pan Zoom** setting is now also saved in local storage. 
![auto-expand-toggle](https://user-images.githubusercontent.com/5375891/121229744-35729d80-c843-11eb-9464-e8e9d2404c18.png)
