### PR TITLE
[UI] Load all inherited properties in Job Page for flows using Flow 2.0.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -296,6 +296,8 @@ public class Flow {
 
   /**
    * Return all flow parents of this flow. From each parent its name and node path are returned.
+   *
+   * @return the list of parents
    */
   public List<Pair<String, String>> getParents() {
     final List<Pair<String, String>> parents = new ArrayList<>(); // Tuple (flow name, node path)

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -18,6 +18,7 @@ package azkaban.flow;
 
 import azkaban.Constants;
 import azkaban.executor.mail.DefaultMailCreator;
+import azkaban.utils.Pair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,7 +48,7 @@ public class Flow {
   private static final String IS_LOCKED_PROPERTY = "isLocked";
   private static final String FLOW_LOCK_ERROR_MESSAGE_PROPERTY = "flowLockErrorMessage";
 
-  private final String id;  // This is actually the flow name
+  private final String id;  // This is actually the node path. I.e. rootFlow:subFlow1:subFlow2
   private int projectId;
   private int version = -1; // This is actually the project version
   private final HashMap<String, Node> nodes = new HashMap<>();
@@ -293,6 +294,22 @@ public class Flow {
     return this.id;
   }
 
+  /**
+   * Return all flow parents of this flow. From each parent its name and node path are returned.
+   */
+  public List<Pair<String, String>> getParents() {
+    final List<Pair<String, String>> parents = new ArrayList<>(); // Tuple (flow name, node path)
+    final String[] parentNames = getId().split(Constants.PATH_DELIMITER, 0);
+    parents.add(new Pair<>(parentNames[0], parentNames[0])); // root flow is first element
+    for (int i = 1; i < parentNames.length; i++) {
+      final String nodePath = String
+          .join(Constants.PATH_DELIMITER, parents.get(parents.size() - 1).getSecond(),
+              parentNames[i]);
+      parents.add(new Pair<>(parentNames[i], nodePath));
+    }
+    return parents;
+  }
+
   public void addError(final String error) {
     if (this.errors == null) {
       this.errors = new ArrayList<>();
@@ -485,7 +502,7 @@ public class Flow {
     return this.isLocked;
   }
 
-  public void setLocked(boolean locked) {
+  public void setLocked(final boolean locked) {
     this.isLocked = locked;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -86,6 +86,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1550,19 +1551,19 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       // Resolve inherited properties
       final List<Pair<String, String>> allParentFlows = flow.getParents();
       // List of triplets of NAME and NODE PATH of flows from which properties are
-      // inherited as well as the FILE NAME where they are to be found
-      final List<String[]> inheritedProperties = new ArrayList<>();
+      // inherited as well as the FILE NAME where they are to be found.
+      final List<Triple<String, String, String>> inheritedProperties = new ArrayList<>();
       final String nodePropsSource = node.getPropsSource();
       if (nodePropsSource != null) {
         if (flow.getAzkabanFlowVersion() == Constants.AZKABAN_FLOW_VERSION_2_0) {
           allParentFlows.stream().forEach(p -> inheritedProperties
-              .add(new String[]{p.getFirst(), p.getSecond(), nodePropsSource}));
+              .add(Triple.of(p.getFirst(), p.getSecond(), nodePropsSource)));
         } else {
-          inheritedProperties.add(new String[]{nodePropsSource, flowId, nodePropsSource});
+          inheritedProperties.add(Triple.of(nodePropsSource, flowId, nodePropsSource));
           FlowProps parent = flow.getFlowProps(nodePropsSource);
           while (parent.getInheritedSource() != null) {
             final String inheritedSource = parent.getInheritedSource();
-            inheritedProperties.add(new String[]{inheritedSource, flowId, inheritedSource});
+            inheritedProperties.add(Triple.of(inheritedSource, flowId, inheritedSource));
             parent = flow.getFlowProps(parent.getInheritedSource());
           }
         }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1589,7 +1589,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     // The name of the file where properties are located
     final String propsSource = getParam(req, "prop");
     // The properties that should be retrieved:
-    // In Flow 1.0 is the entire .properties file, so prop and proNode parameters have same value
+    // In Flow 1.0 is the entire .properties file. Flow and proNode parameters have same value
     // In Flow 2.0 is just the properties of provided node.
     final String propsNodePath = getParam(req, "propNode");
 
@@ -1664,7 +1664,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       }
       page.add("propsSourceLabel", propsSourceLabel);
       page.add("propsSource", propsSource);
-      page.add(".createAPIEndpoints", propsNodePath);
+      page.add("propsNodePath", propsNodePath);
 
       // Resolve property dependencies
       final List<String> inheritProps = new ArrayList<>();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1549,15 +1549,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
       // Resolve inherited properties
       final List<Pair<String, String>> allParentFlows = flow.getParents();
-      final List<Pair<String, String>> reversedParents = new ArrayList<>(allParentFlows);
-      Collections.reverse(reversedParents); // direct parent first, root flow last
       // List of triplets of NAME and NODE PATH of flows from which properties are
       // inherited as well as the FILE NAME where they are to be found
       final List<String[]> inheritedProperties = new ArrayList<>();
       final String nodePropsSource = node.getPropsSource();
       if (nodePropsSource != null) {
         if (flow.getAzkabanFlowVersion() == Constants.AZKABAN_FLOW_VERSION_2_0) {
-          reversedParents.stream().forEach(p -> inheritedProperties
+          allParentFlows.stream().forEach(p -> inheritedProperties
               .add(new String[]{p.getFirst(), p.getSecond(), nodePropsSource}));
         } else {
           inheritedProperties.add(new String[]{nodePropsSource, flowId, nodePropsSource});

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -48,14 +48,15 @@
     <div class="container-full">
       <div class="row">
         <div class="header-title">
-          <h1><a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}">Job
-            <small>$jobid</small>
-          </a></h1>
+          <h1>
+            <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}">
+              Job <small>$jobid</small>
+            </a>
+          </h1>
         </div>
         <div class="header-control">
           <div class="pull-right header-form">
-            <a href="${context}/manager?project=${project.name}&job=$jobid&history"
-               class="btn btn-info btn-sm">History</a>
+            <a href="${context}/manager?project=${project.name}&job=$jobid&history" class="btn btn-info btn-sm">History</a>
           </div>
           <div class="clearfix"></div>
         </div>
@@ -101,8 +102,7 @@
         <div class="panel panel-default">
           <div class="panel-heading">
             <div class="pull-right">
-              <button id="edit-job-btn" class="btn btn-xs btn-primary"
-                      onclick='jobEditView.show("${project.name}", "${flowid}", "${jobid}")'>Edit
+              <button id="edit-job-btn" class="btn btn-xs btn-primary" onclick='jobEditView.show("${project.name}", "${flowid}", "${jobid}")'>Edit
               </button>
             </div>
             Job Properties
@@ -111,16 +111,16 @@
           <table class="table table-striped table-bordered properties-table">
             <thead>
             <tr>
-              <th class="tb-pname">Parameter Name</th>
+              <th class="tb-pname">Property Name</th>
               <th class="tb-pvalue">Value</th>
             </tr>
             </thead>
             <tbody>
-              #foreach ($parameter in $parameters)
-              <tr>
-                <td class="property-key">$parameter.first</td>
-                <td class="property-value">$parameter.second</td>
-              </tr>
+              #foreach ($prop in $jobProperties)
+                <tr>
+                  <td class="property-key">$prop.first</td>
+                  <td class="property-value">$prop.second</td>
+                </tr>
               #end
             </tbody>
           </table>
@@ -142,57 +142,57 @@
             #if ($condition)
               <li class="list-group-item">$condition</li>
             #else
-              <li class="list-group-item">No Condition</li>
+              <li class="list-group-item">No conditions.</li>
             #end
           </ul>
         </div><!-- /panel -->
 
-      ## Dependencies
+        ## Dependencies
 
         <div class="panel panel-default">
           <div class="panel-heading">Dependencies</div>
           <ul class="list-group">
-            #if ($dependencies)
+            #if (${dependencies.isEmpty()})
+              <li class="list-group-item">No dependencies.</li>
+            #else
               #foreach($dependency in $dependencies)
                 <li class="list-group-item">
                   <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=$dependency">$dependency</a>
                 </li>
               #end
-            #else
-              <li class="list-group-item">No Dependencies</li>
             #end
           </ul>
         </div><!-- /panel -->
 
-      ## Dependents
+        ## Dependents
 
         <div class="panel panel-default">
           <div class="panel-heading">Dependents</div>
           <ul class="list-group">
-            #if ($dependents)
+            #if (${dependents.isEmpty()})
+              <li class="list-group-item">No dependents.</li>
+            #else
               #foreach($dependent in $dependents)
                 <li class="list-group-item">
                   <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=$dependent">$dependent</a>
                 </li>
               #end
-            #else
-              <li class="list-group-item">No Dependencies</li>
             #end
 
           </ul>
         </div><!-- /panel -->
 
         <div class="panel panel-default">
-          <div class="panel-heading">Properties</div>
+          <div class="panel-heading">Inherited Properties</div>
           <ul class="list-group">
-            #if ($properties)
-              #foreach($property in $properties)
+            #if (${inheritedProperties.isEmpty})
+              <li class="list-group-item">No inherited properties.</li>
+            #else
+              #foreach($prop in ${inheritedProperties})
                 <li class="list-group-item">
-                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=$property">$property</a>
+                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${prop[2]}&propNode=${prop[1]}">${prop[0]}</a>
                 </li>
               #end
-            #else
-              <li class="list-group-item">No Property Files For This Job</li>
             #end
           </ul>
         </div><!-- /panel -->
@@ -205,8 +205,7 @@
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                    id="close-btn">&times;
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true" id="close-btn">&times;
             </button>
             <h4 class="modal-title">Edit Job</h4>
           </div>
@@ -223,33 +222,28 @@
                 <td id="jobType"></td>
               </tr>
               </tbody>
-              <table>
-                <h4>General Job Settings</h4>
-                <p><strong>Be Aware:</strong> A job may be shared by multiple flows. The change will
-                  be global!</p>
-                <table id="generalProps" class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
-                    <th class="property-key">Name</th>
-                    <th>Value</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr id="addRow">
-                    <td id="addRow-col" colspan="2">
-                      <button type="button" class="btn btn-xs btn-success" id="add-btn">Add Row
-                      </button>
-                    </td>
-                  </tr>
-                  </tbody>
-                </table>
+            </table>
+            <h4>General Job Settings</h4>
+            <p><strong>Be Aware:</strong> A job may be shared by multiple flows. The change will be global!</p>
+            <table id="generalProps" class="table table-striped table-bordered">
+              <thead>
+              <tr>
+                <th class="property-key">Name</th>
+                <th>Value</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr id="addRow">
+                <td id="addRow-col" colspan="2">
+                  <button type="button" class="btn btn-xs btn-success" id="add-btn">Add Row</button>
+                </td>
+              </tr>
+              </tbody>
+            </table>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" id="cancel-btn" data-dismiss="modal">
-              Cancel
-            </button>
-            <button type="button" class="btn btn-primary" id="set-btn">Set/Change Job Description
-            </button>
+            <button type="button" class="btn btn-default" id="cancel-btn" data-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-primary" id="set-btn">Set/Change Job Description</button>
           </div>
         </div>
       </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -190,7 +190,7 @@
             #else
               #foreach($prop in ${inheritedProperties})
                 <li class="list-group-item">
-                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${prop[2]}&propNode=${prop[1]}">${prop[0]}</a>
+                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${prop.right}&propNode=${prop.middle}">${prop.left}</a>
                 </li>
               #end
             #end

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/propertypage.vm
@@ -40,20 +40,25 @@
     #parse("azkaban/webapp/servlet/velocity/errormsg.vm")
   #else
 
-  ## Page header
+    ## Page header
 
   <div class="az-page-header page-header-bare">
     <div class="container-full">
-      <h1><a
-          href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${property}">Properties
-        <small>$property</small>
-      </a></h1>
+      <h1>
+        <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${propsSource}&propNode=${propsNodePath}">
+          Properties <small>$propsSourceLabel</small>
+        </a>
+      </h1>
     </div>
   </div>
   <div class="page-breadcrumb">
     <div class="container-full">
       <ol class="breadcrumb">
-        <li><a href="${context}/manager?project=${project.name}"><strong>Project</strong> $project.name</a></li>
+        <li>
+          <a href="${context}/manager?project=${project.name}">
+            <strong>Project</strong> $project.name
+          </a>
+        </li>
 
         #set($ref = "${context}/manager?project=${project.name}&flow=")
         #foreach( $flow in ${flowlist} )
@@ -72,8 +77,12 @@
           #set($ref = $ref + ${pathDelimiter})
         #end
 
-        <li><a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}"><strong>Job</strong> $jobid</a></li>
-        <li class="active"><strong>Properties</strong> $property</li>
+        <li>
+          <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}">
+            <strong>Job</strong> $jobid
+          </a>
+        </li>
+        <li class="active"><strong>Properties</strong> $propsSourceLabel</li>
       </ol>
     </div>
   </div>
@@ -85,24 +94,24 @@
     <div class="row row-offcanvas row-offcanvas-right">
       <div class="col-xs-12 col-sm-9">
 
-      ## Properties
+        ## Properties
 
         <div class="panel panel-default">
-          <div class="panel-heading">$property</div>
+          <div class="panel-heading">$propsSourceLabel</div>
 
           <table class="table table-striped table-bordered properties-table">
             <thead>
             <tr>
-              <th class="tb-pname">Parameter Name</th>
+              <th class="tb-pname">Property Name</th>
               <th class="tb-pvalue">Value</th>
             </tr>
             </thead>
             <tbody>
-              #foreach ($parameter in $parameters)
-              <tr>
-                <td class="property-key">$parameter.first</td>
-                <td>$parameter.second</td>
-              </tr>
+              #foreach ($prop in $properties)
+                <tr>
+                  <td class="property-key">$prop.first</td>
+                  <td>$prop.second</td>
+                </tr>
               #end
             </tbody>
           </table>
@@ -111,7 +120,7 @@
       <div class="col-xs-6 col-sm-3 sidebar-offcanvas">
         <div class="well" id="job-summary">
           <h4>Properties
-            <small>$property</small>
+            <small>$propsSourceLabel</small>
           </h4>
           <p><strong>Job</strong> $jobid</p>
         </div>
@@ -119,14 +128,16 @@
         <div class="panel panel-default">
           <div class="panel-heading">Inherited From</div>
           <ul class="list-group">
-            #if ($inheritedproperties)
+            #if (${inheritedproperties.isEmpty()})
+              <li class="list-group-item">No inherited properties.</li>
+            #else
               #foreach ($inheritedproperty in $inheritedproperties)
-                <li class="list-group-item"><a
-                    href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=$inheritedproperty">$inheritedproperty</a>
+                <li class="list-group-item">
+                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=${inheritedproperty}&propNode=${flowid}">
+                    $inheritedproperty
+                  </a>
                 </li>
               #end
-            #else
-              <li class="list-group-item">No inherited properties.</li>
             #end
           </ul>
         </div>
@@ -134,14 +145,16 @@
         <div class="panel panel-default">
           <div class="panel-heading">Source of</div>
           <ul class="list-group">
-            #if ($dependingproperties)
+            #if (${dependingproperties.isEmpty()})
+              <li class="list-group-item">No dependents.</li>
+            #else
               #foreach ($dependingproperty in $dependingproperties)
-                <li class="list-group-item"><a
-                    href="${context}/manager?project=${project.name}&flow=${flowid}&job=${jobid}&prop=$dependingproperty">$dependingproperty</a>
+                <li class="list-group-item">
+                  <a href="${context}/manager?project=${project.name}&flow=${flowid}&job=$jobid&prop=${dependingproperty}&propNode=${flowid}">
+                    $dependingproperty
+                  </a>
                 </li>
               #end
-            #else
-              <li class="list-group-item">No dependents.</li>
             #end
           </ul>
         </div>


### PR DESCRIPTION
In the Job page, job inherited properties are not generated properly for flows using Flow 2.0. 
Here is what's currently rendered for an embedded job:
<img width="1255" alt="Screen Shot 2021-06-10 at 11 45 49 AM" src="https://user-images.githubusercontent.com/44478711/121585746-c8e4d380-c9e7-11eb-9a7c-655fcff71711.png">

**Issues**:
-The `longLongs.flow` link suggests that root flow properties will be displayed when clicked but in fact the properties of direct parent (emb_5) of job jobE5B are shown instead.
-Properties inherited from parents emb_3, emb_2 and root flow itself are not available for inspection.

With changes in this PR inherited properties from all parents are listed and loaded correctly:
<img width="1261" alt="Screen Shot 2021-06-10 at 11 52 04 AM" src="https://user-images.githubusercontent.com/44478711/121586141-2b3dd400-c9e8-11eb-99d5-3189d7c5bb82.png">
Example Properties Page:
<img width="1413" alt="Screen Shot 2021-06-10 at 12 37 35 PM" src="https://user-images.githubusercontent.com/44478711/121586586-af905700-c9e8-11eb-8516-c265c66715d9.png">

**Test** the changes locally. I verified that inherited properties continue to load correctly for flows using Flow 1.0.

**Follow up**:
-Populate the sections `Inherited From` and `Source of` in the Property Page for flows written with Flow 2.0 syntax.