### PR TITLE
Added a way to read failure action specified in the Yaml

### DIFF
--- a/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
+++ b/azkaban-common/src/main/java/azkaban/flow/CommonJobProperties.java
@@ -154,6 +154,12 @@ public class CommonJobProperties {
    */
   public static final String FLOW_UUID = "azkaban.flow.uuid";
 
+  /**
+   * An optional config specified from the DSL to override the default
+   * failure options
+   */
+  public static final String FAILURE_ACTION_PROPERTY = "failure.action";
+
   public static final String JOB_LINK = "azkaban.link.job.url";
   public static final String WORKFLOW_LINK = "azkaban.link.workflow.url";
   public static final String EXECUTION_LINK = "azkaban.link.execution.url";

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -16,6 +16,8 @@
 
 package azkaban.flow;
 
+import static azkaban.flow.CommonJobProperties.FAILURE_ACTION_PROPERTY;
+
 import azkaban.Constants;
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.utils.Pair;
@@ -61,6 +63,16 @@ public class Flow {
   private int numLevels = -1;
   private final List<String> failureEmail = new ArrayList<>();
   private final List<String> successEmail = new ArrayList<>();
+
+  public String getFailureAction() {
+    return failureAction;
+  }
+
+  public void setFailureAction(final String failureAction) {
+    this.failureAction = failureAction;
+  }
+
+  private String failureAction;
   private String mailCreator = DefaultMailCreator.DEFAULT_MAIL_CREATOR;
   private ArrayList<String> errors;
   private Map<String, Object> metadata = new HashMap<>();
@@ -111,7 +123,9 @@ public class Flow {
         .getOrDefault(SUCCESS_EMAIL_PROPERTY, flow.getSuccessEmails());
     final String mailCreator = (String) flowObject
         .getOrDefault(MAIL_CREATOR_PROPERTY, flow.getMailCreator());
-
+    final String failureAction = (String) flowObject.getOrDefault(
+        FAILURE_ACTION_PROPERTY, flow.getFailureAction()
+    );
     flow.setLayedOut(layedout);
     flow.setEmbeddedFlow(isEmbeddedFlow);
     flow.setAzkabanFlowVersion(azkabanFlowVersion);
@@ -124,7 +138,7 @@ public class Flow {
     flow.addFailureEmails(failureEmails);
     flow.addSuccessEmails(successEmails);
     flow.setMailCreator(mailCreator);
-
+    flow.setFailureAction(failureAction);
     // Loading projects
     final Map<String, FlowProps> properties = loadPropertiesFromObject(propertiesList);
     flow.addAllFlowProperties(properties.values());
@@ -388,6 +402,9 @@ public class Flow {
     flowObj.put(IS_LOCKED_PROPERTY, this.isLocked);
     flowObj.put(FLOW_LOCK_ERROR_MESSAGE_PROPERTY, this.flowLockErrorMessage);
 
+    if (this.failureAction != null) {
+      flowObj.put(FAILURE_ACTION_PROPERTY, this.failureAction);
+    }
     if (this.errors != null) {
       flowObj.put(ERRORS_PROPERTY, this.errors);
     }

--- a/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/DirectoryYamlFlowLoader.java
@@ -16,6 +16,8 @@
 
 package azkaban.project;
 
+import static azkaban.flow.CommonJobProperties.FAILURE_ACTION_PROPERTY;
+
 import azkaban.Constants;
 import azkaban.flow.ConditionOnJobStatus;
 import azkaban.flow.Edge;
@@ -150,6 +152,10 @@ public class DirectoryYamlFlowLoader implements FlowLoader {
     flow.setAzkabanFlowVersion(Constants.AZKABAN_FLOW_VERSION_2_0);
     final Props props = azkabanFlow.getProps();
     FlowLoaderUtils.addEmailPropsToFlow(flow, props);
+    String failureAction = props.getString(FAILURE_ACTION_PROPERTY, null);
+    if (failureAction != null) {
+      flow.setFailureAction(failureAction);
+    }
     props.setSource(flowFile.getName());
 
     flow.addAllFlowProperties(ImmutableList.of(new FlowProps(props)));

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -15,6 +15,8 @@
  */
 package azkaban.server;
 
+import static azkaban.executor.ExecutionOptions.FAILURE_ACTION_OVERRIDE;
+
 import azkaban.Constants.FlowParameters;
 import azkaban.executor.DisabledJob;
 import azkaban.executor.ExecutionOptions;
@@ -67,6 +69,11 @@ public class HttpRequestUtils {
     if (hasParam(req, "successEmailsOverride")) {
       final boolean override = getBooleanParam(req, "successEmailsOverride", false);
       execOptions.setSuccessEmailsOverridden(override);
+    }
+
+    if (hasParam(req, FAILURE_ACTION_OVERRIDE)) {
+      final boolean override = getBooleanParam(req, FAILURE_ACTION_OVERRIDE, false);
+      execOptions.setFailureActionOverride(override);
     }
 
     if (hasParam(req, "failureEmails")) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -500,7 +500,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("projectName", project.getName());
     page.add("flowid", flow.getFlowId());
     page.add("flowlist", flow.getFlowId().split(Constants.PATH_DELIMITER, 0));
-    page.add("pathDelimiter", Constants.PATH_DELIMITER);    
+    page.add("pathDelimiter", Constants.PATH_DELIMITER);
 
     // check the current flow definition to see if the flow is locked.
     final Flow currentFlow = project.getFlow(flow.getFlowId());
@@ -999,6 +999,16 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     }
     options.setMailCreator(flow.getMailCreator());
 
+    /**
+     * If the user has not explicitly overridden the failure action from the UI or
+     * through API, we will consider the value specified in DSL/Yaml
+     * By providing this override option, user can still choose to modify failure
+     * option.
+     */
+    if (!options.isFailureActionOverridden() && flow.getFailureAction() != null) {
+      options.setFailureAction(
+          options.mapToFailureAction(flow.getFailureAction()));
+    }
     try {
       HttpRequestUtils.filterAdminOnlyFlowParams(this.userManager, options, user);
       final String message =


### PR DESCRIPTION
**Change:** read the `failure.action` key specified in the Yaml and use it in the ad-hoc executions. Optionally, the user can override the value by explicitly passing the request param failureActionOverride=true. In this case, we will give precedence to the value the user passes through UI or API. 

**Testing:** 
1. Tested by having a sample workflow that has the following config section and another workflow that doesn't have this config section. I was able to see the `failure.action` value getting used in the first case, and in the second case, we picked the default value. 

<pre>
config: 
  failure.action: finish_all_possible
</pre>

2. when we pass the additional param `failureActionOverride=true` the value selected in the UI or the value passed in the API gets used. In the UI, we should add a change similar to the override failure email. But that change can be added as a second step to this.
