### PR TITLE
Add metrics for time to dispatch a Kubernetes pod, number of flows dispatched to containers and to bare metal executors

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -18,6 +18,7 @@ package azkaban.executor;
 import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
 import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.ContainerizationMetrics;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import java.lang.Thread.State;
@@ -49,8 +50,10 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
   public ExecutionController(final Props azkProps, final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final AlerterHolder alerterHolder, final
-  ExecutorHealthChecker executorHealthChecker, EventListener eventListener) {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener);
+  ExecutorHealthChecker executorHealthChecker, final EventListener eventListener,
+      final ContainerizationMetrics containerizationMetrics) {
+    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
+        containerizationMetrics);
     this.executorHealthChecker = executorHealthChecker;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -23,6 +23,7 @@ import azkaban.executor.selector.ExecutorComparator;
 import azkaban.executor.selector.ExecutorFilter;
 import azkaban.executor.selector.ExecutorSelector;
 import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
@@ -89,7 +90,8 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final ExecutorManagerUpdaterStage updaterStage,
       final ExecutionFinalizer executionFinalizer,
       final RunningExecutionsUpdaterThread updaterThread) {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, null, new DummyEventListener());
+    super(azkProps, executorLoader, commonMetrics, apiGateway, null, new DummyEventListener(),
+        new DummyContainerizationMetricsImpl());
     this.runningExecutions = runningExecutions;
     this.activeExecutors = activeExecutors;
     this.updaterStage = updaterStage;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -33,6 +33,7 @@ import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.ContainerizationMetrics;
 import azkaban.spi.EventType;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
@@ -78,8 +79,11 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final CommonMetrics commonMetrics, final ExecutorApiGateway apiGateway,
       final ContainerizedImpl containerizedImpl,
       final AlerterHolder alerterHolder,
-      final ContainerizedWatch containerizedWatch, final EventListener eventListener) throws ExecutorManagerException {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener);
+      final ContainerizedWatch containerizedWatch,
+      final EventListener eventListener,
+      final ContainerizationMetrics containerizationMetrics) throws ExecutorManagerException {
+    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
+        containerizationMetrics);
     rateLimiter =
         RateLimiter.create(azkProps
             .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -105,17 +105,11 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
 
   @Override
-  public void addTimeToDispatch(final long time) {
-    //TODO haqin: implement metric that records time taken to dispatch flow to a container
-  }
+  public void addTimeToDispatch(final long time) { timeToDispatch.update(time); }
 
   @Override
-  public void markFlowSubmitToExecutor() {
-    //TODO haqin: implement metric that records number of flows dispatched to bare metal executor
-  }
+  public void markFlowSubmitToExecutor() { flowSubmitToExecutor.mark(); }
 
   @Override
-  public void markFlowSubmitToContainer() {
-    //TODO haqin: implement metric that records number of flows dispatched to a container
-  }
+  public void markFlowSubmitToContainer() { flowSubmitToContainer.mark(); }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -37,6 +37,8 @@ import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.executor.container.ContainerizedImpl;
 import azkaban.executor.container.ContainerizedImplType;
 import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.ContainerizationMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.metrics.MetricsManager;
 import azkaban.spi.EventType;
 import azkaban.user.User;
@@ -86,7 +88,8 @@ public class ContainerizedDispatchManagerTest {
   private ExecutionReference ref1;
   private ExecutionReference ref2;
   private ExecutionReference ref3;
-  private EventListener eventListener = new DummyEventListener();
+  private EventListener eventListener;
+  private ContainerizationMetrics containerizationMetrics;
 
   @Before
   public void setup() throws Exception {
@@ -147,6 +150,9 @@ public class ContainerizedDispatchManagerTest {
             flow1);
     when(this.loader.fetchUnfinishedFlows()).thenReturn(ImmutableMap.of(flow1.getExecutionId(),
         executionReferencePair));
+
+    this.eventListener = new DummyEventListener();
+    this.containerizationMetrics = new DummyContainerizationMetricsImpl();
   }
 
   @Test
@@ -399,7 +405,8 @@ public class ContainerizedDispatchManagerTest {
     this.containerizedDispatchManager =
         new ContainerizedDispatchManager(this.props, this.loader,
         this.commonMetrics,
-        this.apiGateway, this.containerizedImpl, null, null, this.eventListener);
+        this.apiGateway, this.containerizedImpl, null, null, this.eventListener,
+            this.containerizationMetrics);
     this.containerizedDispatchManager.start();
   }
 
@@ -481,7 +488,8 @@ public class ContainerizedDispatchManagerTest {
       Props containerEnabledProps) throws Exception {
     ContainerizedDispatchManager dispatchManager =
         new ContainerizedDispatchManager(containerEnabledProps, this.loader,
-            this.commonMetrics, apiGateway, this.containerizedImpl,null, null, new DummyEventListener());
+            this.commonMetrics, apiGateway, this.containerizedImpl,null, null, this.eventListener,
+            this.containerizationMetrics);
     dispatchManager.start();
     return dispatchManager;
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -30,6 +30,8 @@ import azkaban.event.Event;
 import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.ContainerizationMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.metrics.MetricsManager;
 import azkaban.spi.EventType;
 import azkaban.user.User;
@@ -77,6 +79,7 @@ public class ExecutionControllerTest {
   private ExecutionReference ref2;
   private ExecutionReference ref3;
   private EventListener eventListener = new DummyEventListener();
+  private ContainerizationMetrics containerizationMetrics= new DummyContainerizationMetricsImpl();
 
   @Before
   public void setup() throws Exception {
@@ -88,7 +91,7 @@ public class ExecutionControllerTest {
     this.alertHolder = mock(AlerterHolder.class);
     this.executorHealthChecker = mock(ExecutorHealthChecker.class);
     this.controller = new ExecutionController(this.props, this.loader, this.commonMetrics,
-        this.apiGateway, this.alertHolder, this.executorHealthChecker, this.eventListener);
+        this.apiGateway, this.alertHolder, this.executorHealthChecker, this.eventListener, this.containerizationMetrics);
 
     final Executor executor1 = new Executor(1, "localhost", 12345, true);
     final Executor executor2 = new Executor(2, "localhost", 12346, true);

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import azkaban.AzkabanCommonModule;
 import azkaban.Constants;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
-import azkaban.Constants.EventReporterConstants;
 import azkaban.Constants.FlowParameters;
 import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
@@ -64,7 +63,8 @@ import azkaban.imagemgmt.version.VersionInfo;
 import azkaban.imagemgmt.version.VersionSet;
 import azkaban.imagemgmt.version.VersionSetBuilder;
 import azkaban.imagemgmt.version.VersionSetLoader;
-import azkaban.spi.ExecutorType;
+import azkaban.metrics.ContainerizationMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.test.Utils;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
@@ -116,6 +116,7 @@ public class KubernetesContainerizedImplTest {
   private static Converter<ImageRampupPlanRequestDTO, ImageRampupPlanResponseDTO,
       ImageRampupPlan> imageRampupPlanConverter;
   private static FlowStatusChangeEventListener flowStatusChangeEventListener;
+  private static ContainerizationMetrics containerizationMetrics;
 
   private static final Logger log = LoggerFactory.getLogger(KubernetesContainerizedImplTest.class);
 
@@ -150,9 +151,10 @@ public class KubernetesContainerizedImplTest {
     SERVICE_PROVIDER.unsetInjector();
     SERVICE_PROVIDER.setInjector(getInjector(this.props));
     this.flowStatusChangeEventListener = new FlowStatusChangeEventListener(this.props);
+    this.containerizationMetrics = new DummyContainerizationMetricsImpl();
     this.kubernetesContainerizedImpl = new KubernetesContainerizedImpl(this.props,
         this.executorLoader, this.loader, this.imageRampupManager, null,
-        flowStatusChangeEventListener);
+        flowStatusChangeEventListener, containerizationMetrics);
   }
 
   /**

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.executor.DummyEventListener;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.sla.SlaAction;
 import azkaban.sla.SlaOption;
 import azkaban.sla.SlaType;
@@ -130,7 +131,8 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
   @Test
   public void testPostAjaxUpdateProperty() throws Exception {
     ContainerizedDispatchManager containerizedDispatchManager = new ContainerizedDispatchManager(
-        new Props(), null, null, null, null, null, null, new DummyEventListener());
+        new Props(), null, null, null, null, null, null, new DummyEventListener(),
+        new DummyContainerizationMetricsImpl());
     Mockito.when(this.azkabanWebServer.getExecutorManager())
         .thenReturn(containerizedDispatchManager);
     this.executorServlet.init(this.servletConfig);


### PR DESCRIPTION
This is an effort in continuation to https://github.com/azkaban/azkaban/pull/2856 (Added meter metrics for Azkaban pod statuses)