### PR TITLE
Intermittent testSetupFlowByMultipleThreads failures

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/FileIOUtils.java
@@ -201,7 +201,7 @@ public class FileIOUtils {
   /**
    * A thin wrapper for File.getCanonicalPath() that doesn't throw a checked exception
    *
-   * @param file input file
+   * @param f input file
    * @return String canonical path of the file
    */
   public static String getCanonicalPath(final File f) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -121,9 +121,10 @@ public class FlowPreparer extends AbstractFlowPreparer {
           (flowPrepCompletionTime - criticalSectionStartTime) / 1000,
           flow.getExecutionId(), execDir.getPath());
     } catch (final Exception ex) {
-      FileIOUtils.deleteDirectorySilently(tempDir);
       LOGGER.error("Error in preparing flow execution {}", flow.getExecutionId(), ex);
       throw new ExecutorManagerException(ex);
+    } finally {
+      FileIOUtils.deleteDirectorySilently(tempDir);
     }
   }
 
@@ -163,11 +164,10 @@ public class FlowPreparer extends AbstractFlowPreparer {
     return String.valueOf(proj.getProjectId()) + "." + String.valueOf(proj.getVersion());
   }
 
-  private File createTempDir(final ProjectDirectoryMetadata proj) {
+  private File createTempDir(final ProjectDirectoryMetadata proj) throws IOException {
     final String projectDir = generateProjectDirName(proj);
-    final File tempDir = new File(this.projectCacheDir,
-        "_temp." + projectDir + "." + System.currentTimeMillis());
-    tempDir.mkdirs();
+    final File tempDir = Files.createTempDirectory(
+        this.projectCacheDir.toPath(), "_temp." + projectDir + ".").toFile();
     return tempDir;
   }
 

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -20,14 +20,12 @@ package azkaban.execapp;
 import azkaban.execapp.metric.ProjectCacheHitRatio;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorManagerException;
-import azkaban.project.ProjectFileHandler;
 import azkaban.spi.Dependency;
-import azkaban.storage.ProjectStorageManager;
 import azkaban.test.executions.ThinArchiveTestUtils;
 import azkaban.utils.DependencyTransferManager;
 import azkaban.utils.FileIOUtils;
-import azkaban.utils.Utils;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -117,7 +115,7 @@ public class FlowPreparerTest extends FlowPreparerTestBase {
   }
 
   @Test
-  public void testSetupFlowByMultipleThreads() {
+  public void testSetupFlowByMultipleThreads() throws IOException {
     final int threadNum = 4;
 
     final ExecutableFlow[] executableFlows = new ExecutableFlow[]{
@@ -148,6 +146,9 @@ public class FlowPreparerTest extends FlowPreparerTestBase {
       assertTrue(execDir.exists());
       assertTrue(new File(execDir, SAMPLE_FLOW_01).exists());
     }
+
+    assertFalse("Temp files are left behind!",
+        Files.newDirectoryStream(projectsDir.toPath(), "_temp.*").iterator().hasNext());
   }
 
   @Test


### PR DESCRIPTION
Turns out that System.currentTimeMillis() is not a safe way to create temporary files.
Also we sometimes fail to delete temp dirs that we create for project downloads.