### PR TITLE
Context path in jetty working : )

### DIFF
--- a/azkaban-exec-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-exec-server/src/main/resources/conf/azkaban.properties
@@ -17,6 +17,7 @@ velocity.dev.mode=false
 jetty.use.ssl=false
 jetty.maxThreads=25
 jetty.port=8081
+jetty.contextPath=/azkaban
 # Where the Azkaban web server is located
 azkaban.webserver.url=http://localhost:8081
 # mail settings

--- a/azkaban-solo-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-solo-server/src/main/resources/conf/azkaban.properties
@@ -20,6 +20,7 @@ velocity.dev.mode=false
 jetty.use.ssl=false
 jetty.maxThreads=25
 jetty.port=8081
+jetty.contextPath=/azkaban
 # Azkaban Executor settings
 executor.port=12321
 # mail settings

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -429,7 +429,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   }
 
   private void configureRoutes() throws TriggerManagerException {
-    final Context root = new Context(this.server, this.props.getString("jetty.contextPath"), "/", Context.SESSIONS); 
+    final Context root = new Context(this.server, this.props.getString("jetty.contextPath" , "/") , Context.SESSIONS); 
     root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
     root.setAttribute(AZKABAN_SERVLET_CONTEXT_KEY, this);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -429,7 +429,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   }
 
   private void configureRoutes() throws TriggerManagerException {
-    final Context root = new Context(this.server, "/", Context.SESSIONS);
+    final Context root = new Context(this.server, this.props.getString("jetty.contextPath"), "/", Context.SESSIONS); 
     root.setMaxFormContentSize(MAX_FORM_CONTENT_SIZE);
     root.setAttribute(AZKABAN_SERVLET_CONTEXT_KEY, this);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/IndexRedirectServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/IndexRedirectServlet.java
@@ -43,12 +43,12 @@ public class IndexRedirectServlet extends LoginAbstractAzkabanServlet {
   @Override
   protected void handleGet(final HttpServletRequest req, final HttpServletResponse resp,
       final Session session) throws ServletException, IOException {
-    resp.sendRedirect(this.defaultServletPath);
+    resp.sendRedirect(req.getContextPath() + this.defaultServletPath);
   }
 
   @Override
   protected void handlePost(final HttpServletRequest req, final HttpServletResponse resp,
       final Session session) throws ServletException, IOException {
-    resp.sendRedirect(this.defaultServletPath);
+    resp.sendRedirect(req.getContextPath() + this.defaultServletPath);
   }
 }

--- a/azkaban-web-server/src/main/less/navbar.less
+++ b/azkaban-web-server/src/main/less/navbar.less
@@ -49,7 +49,7 @@
   margin-bottom: 0;
 
   .navbar-logo {
-    background: url('../../images/logo.png') top left no-repeat;
+    background: url('../images/logo.png') top left no-repeat;
     color: #ffffff;
     font-size: 156.25%;
     font-weight: bold;

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -19,8 +19,8 @@
 
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
-<link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=1621010355" rel="stylesheet">
+<link href="${context}/css/bootstrap.css" rel="stylesheet">
+<link href="${context}/css/azkaban.css?v=1621010355" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};
@@ -37,6 +37,6 @@
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
-  <script src="/js/html5shiv.js"></script>
-  <script src="/js/respond.min.js"></script>
+  <script src="${context}/js/html5shiv.js"></script>
+  <script src="${context}/js/respond.min.js"></script>
 <![endif]-->

--- a/azkaban-web-server/src/main/resources/conf/azkaban.properties
+++ b/azkaban-web-server/src/main/resources/conf/azkaban.properties
@@ -17,6 +17,7 @@ velocity.dev.mode=false
 jetty.use.ssl=false
 jetty.maxThreads=25
 jetty.port=8081
+jetty.contextPath=/azkaban
 # Azkaban Executor settings
 # mail settings
 mail.sender=

--- a/azkaban-web-server/src/web/css/bootstrap.css
+++ b/azkaban-web-server/src/web/css/bootstrap.css
@@ -2822,8 +2822,8 @@ input[type="button"].btn-block {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../../fonts/glyphicons-halflings-regular.eot');
-  src: url('../../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('../fonts/glyphicons-halflings-regular.eot');
+  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
 }
 
 .glyphicon {

--- a/azkaban-web-server/src/web/js/azkaban/view/job-edit.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/job-edit.js
@@ -29,7 +29,7 @@ azkaban.JobEditView = Backbone.View.extend({
   },
 
   initialize: function (setting) {
-    this.projectURL = contextURL + "manager"
+    this.projectURL = contextURL + "/manager"
     this.generalParams = {}
     this.overrideParams = {}
   },

--- a/azkaban-web-server/src/web/js/azkaban/view/login.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/login.js
@@ -35,7 +35,7 @@ azkaban.LoginView = Backbone.View.extend({
 
     $.ajax({
       async: "false",
-      url: contextURL,
+      url: contextURL + "/",
       dataType: "json",
       type: "POST",
       data: {

--- a/test/local-conf-templates/conf/azkaban.properties
+++ b/test/local-conf-templates/conf/azkaban.properties
@@ -38,6 +38,7 @@ jetty.use.ssl=false
 jetty.ssl.port=8043
 jetty.maxThreads=25
 jetty.port=8081
+jetty.contextPath=/azkaban
 # Azkaban Executor settings
 executor.port=12321
 executor.maxThreads=50


### PR DESCRIPTION
Context path in jetty as "jetty.contextPath=/azkaban" .
This changes helps with proxified environments, fixes some problems with that situations (beacause context path is non exisistent until now) , so makes azkaban's exposition in a web server front so much easier.
Based on changes in [this](https://github.com/azkaban/azkaban/pull/654/)