### PR TITLE
Fixing intermittently failing ContainerizedDispatchManagerTest

### DIFF
--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -312,7 +312,6 @@ public class ContainerizedDispatchManagerTest {
   @Test
   public void testSubmitFlowsExceedingMaxConcurrentRuns() throws Exception {
     initializeContainerizedDispatchImpl();
-    this.containerizedDispatchManager.disableQueueProcessorThread();
     this.props.put(ConfigurationKeys.CONCURRENT_RUNS_ONEFLOW_WHITELIST, "exectest1,"
         + "exec2,3");
     submitFlow(this.flow2, this.ref2);
@@ -326,7 +325,6 @@ public class ContainerizedDispatchManagerTest {
   @Test
   public void testSubmitFlowsConcurrentWhitelist() throws Exception {
     initializeContainerizedDispatchImpl();
-    this.containerizedDispatchManager.disableQueueProcessorThread();
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
     submitFlow(this.flow2, this.ref2);
     submitFlow(this.flow3, this.ref3);
@@ -369,6 +367,7 @@ public class ContainerizedDispatchManagerTest {
   @Test
   public void testDisablingQueueProcessThread() throws Exception {
     initializeContainerizedDispatchImpl();
+    this.containerizedDispatchManager.start();
     Assert.assertEquals(this.containerizedDispatchManager.isQueueProcessorThreadActive(), true);
     this.containerizedDispatchManager.disableQueueProcessorThread();
     Assert.assertEquals(this.containerizedDispatchManager.isQueueProcessorThreadActive(), false);
@@ -379,6 +378,7 @@ public class ContainerizedDispatchManagerTest {
   @Test
   public void testEnablingQueueProcessThread() throws Exception {
     initializeContainerizedDispatchImpl();
+    this.containerizedDispatchManager.start();
     this.containerizedDispatchManager.disableQueueProcessorThread();
     Assert.assertEquals(this.containerizedDispatchManager.isQueueProcessorThreadActive(), false);
     this.containerizedDispatchManager.enableQueueProcessorThread();
@@ -407,7 +407,6 @@ public class ContainerizedDispatchManagerTest {
         this.commonMetrics,
         this.apiGateway, this.containerizedImpl, null, null, this.eventListener,
             this.containerizationMetrics);
-    this.containerizedDispatchManager.start();
   }
 
   @Test


### PR DESCRIPTION
Various tests in azkaban.executor.ContainerizedDispatchManagerTest were failing with the error:

    org.mockito.exceptions.misusing.WrongTypeOfReturnValue: 
    RegularImmutableMap cannot be returned by selectAndUpdateExecutionWithLocking()
    selectAndUpdateExecutionWithLocking() should return Set
    ***
    If you're unsure why you're getting above error read on.
    Due to the nature of the syntax above problem might occur because:
    1. This exception *might* occur in wrongly written multi-threaded tests.
       Please refer to Mockito FAQ on limitations of concurrency testing.
    2. A spy is stubbed using when(spy.foo()).then() syntax. It is safer to stub spies - 
       - with doReturn|Throw() family of methods. More in javadocs for Mockito.spy() method.


**This failure occurs because:**

the mocked azkaban.executor.ExecutorLoader 
is used to initialize azkaban.executor.container.ContainerizedDispatchManager. 
This ContainerizedDispatchManager is started in the method azkaban.executor.ContainerizedDispatchManagerTest#initializeContainerizedDispatchImpl 
which starts the 
azkaban.executor.container.ContainerizedDispatchManager.QueueProcessorThread

The method QueueProcessorThread#run  calls QueueProcessorThread#processQueuedFlows which tries to execute
executorLoader.selectAndUpdateExecutionWithLocking()

The method selectAndUpdateExecutionWithLocking is not stubbed for the mocked executorLoader. Also as mentioned in the wiki https://github.com/mockito/mockito/wiki/FAQ#is-mockito-thread-safe, mocks are not fully thread-safe.


**Fix**

After checking various test cases in the ContainerizedDispatchManagerTest, the conclusion is that, it is not necessary to "start" the initialized ContainerizedDispatchManager, and hence the processor thread won't be initialized. Only the methods which require testing around QueueProcessorThread, can "start" the ContainerizedDispatchManager instance.