### PR TITLE
JobRunner may see dangling references in jobProps post PR-2786

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -387,10 +387,10 @@ public class JobTypeManager {
 
       // inject cluster jars and native libraries into jobs through properties
       Props clusterSpecificProps = getClusterSpecificJobProps(targetCluster, jobProps, pluginLoadProps);
-      for (final String k : clusterSpecificProps.getKeySet()) {
+      for (final String key : clusterSpecificProps.getKeySet()) {
         // User's job props should take precedence over cluster props
-        if (!jobProps.containsKey(k)) {
-          jobProps.put(k, clusterSpecificProps.get(k));
+        if (!jobProps.containsKey(key)) {
+          jobProps.put(key, clusterSpecificProps.get(key));
         }
       }
       Props nonOverriddableClusterProps = getClusterSpecificNonOverridableJobProps(clusterSpecificProps);


### PR DESCRIPTION
Post https://github.com/azkaban/azkaban/pull/2786, after JobRunner.createJobParams() is called, the JobRunner may have dangling references in jobProps that it passed in to createJobParams().

This is because in PR-2786, we added the cluster-specific properties to a new instance of Props, `finalProps`, while still adding properties that may reference cluster-specific ones to `jobProps`. The `finalProps` is passed to Job constructors, which is fine. But `jobProps` might be left with dangling references to cluster-specific properties that can never be resolved.

JobCallbackManager is one place where `jobProps` of the jobRunner is consumed after JobRunner.createJobParams(). When it tries to resolve `jobProps`, it fails and drops the callback on the floor. 


In this change, we  reimplement PR-2786 by always writing to `jobProps` and only add cluster-specific properties if they are not already defined in 'jobProps' to main job properties' precedence.
