### PR TITLE
added flow status for pod failure

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -249,7 +249,9 @@ public class ExecutionControllerUtils {
       exFlow.setEndTime(time);
     }
 
-    exFlow.setStatus(Status.FAILED);
+    if (exFlow.getStatus() != Status.POD_FAILED) {
+      exFlow.setStatus(Status.FAILED);
+    }
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -249,7 +249,7 @@ public class ExecutionControllerUtils {
       exFlow.setEndTime(time);
     }
 
-    if (exFlow.getStatus() != Status.POD_FAILED) {
+    if (!Status.isStatusFinished(exFlow.getStatus())) {
       exFlow.setStatus(Status.FAILED);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -85,7 +85,6 @@ public enum Status {
 
   public static boolean isStatusFailed(final Status status) {
     switch (status) {
-      case POD_FAILED:
       case FAILED:
       case KILLED:
       case CANCELLED:

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -30,7 +30,7 @@ public enum Status {
   SUCCEEDED(50),
   KILLING(55),
   KILLED(60),
-  // EXECUTION_STOPPED refers to a terminating flow status due to crashed executor/container
+  // EXECUTION_STOPPED refers to a terminal flow status due to crashed executor/container
   EXECUTION_STOPPED(65),
   FAILED(70),
   FAILED_FINISHING(80),

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -30,8 +30,8 @@ public enum Status {
   SUCCEEDED(50),
   KILLING(55),
   KILLED(60),
-  // POD_FAILED refers to a failed containerized flow due to pod failure
-  POD_FAILED(65),
+  // EXECUTION_STOPPED refers to a terminating flow status due to crashed executor/container
+  EXECUTION_STOPPED(65),
   FAILED(70),
   FAILED_FINISHING(80),
   SKIPPED(90),
@@ -59,7 +59,7 @@ public enum Status {
 
   public static boolean isStatusFinished(final Status status) {
     switch (status) {
-      case POD_FAILED:
+      case EXECUTION_STOPPED:
       case FAILED:
       case KILLED:
       case SUCCEEDED:

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -30,6 +30,8 @@ public enum Status {
   SUCCEEDED(50),
   KILLING(55),
   KILLED(60),
+  // POD_FAILED refers to a failed containerized flow due to pod failure
+  POD_FAILED(65),
   FAILED(70),
   FAILED_FINISHING(80),
   SKIPPED(90),
@@ -57,6 +59,7 @@ public enum Status {
 
   public static boolean isStatusFinished(final Status status) {
     switch (status) {
+      case POD_FAILED:
       case FAILED:
       case KILLED:
       case SUCCEEDED:
@@ -82,6 +85,7 @@ public enum Status {
 
   public static boolean isStatusFailed(final Status status) {
     switch (status) {
+      case POD_FAILED:
       case FAILED:
       case KILLED:
       case CANCELLED:

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -288,7 +288,7 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
 
   /**
    * Finalize the flow for the given event and delete its container.
-   *  @param event
+   * @param event
    * @param finalStatus
    */
   private void finalizeFlowAndDeleteContainer(AzPodStatusMetadata event,

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -98,8 +98,7 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
    * @param event pod watch event
    * @returns true if transition is valid else false
    */
-  private boolean validateTransition(AzPodStatusMetadata event) {
-    final AzPodStatus currentStatus = getCurrentAzPodStatus(event.getPodName());
+  private boolean validateTransition(AzPodStatusMetadata event, AzPodStatus currentStatus) {
     logger.debug(format("Transition requested from %s -> %s, for pod %s",
         currentStatus,
         event.getAzPodStatus(),
@@ -123,16 +122,17 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
     long eventCount = flowContainerEventCount.incrementAndGet();
     logEventCacheStats(eventCount);
 
-    boolean isTransitionValid = validateTransition(event);
+    AzPodStatus currentStatus = getCurrentAzPodStatus(event.getPodName());
+    boolean isTransitionValid = validateTransition(event, currentStatus);
     if (!isTransitionValid) {
       IllegalStateException transitionException = new IllegalStateException(
           format("Pod status transition is not supported %s -> %s, for pod %s",
-              getCurrentAzPodStatus(event.getPodName()),
+              currentStatus,
               event.getAzPodStatus(),
               event.getPodName()));
       logger.error("Unsupported state transition.", transitionException);
       try {
-        finalizeFlowAndDeleteContainer(event);
+        finalizeFlowAndDeleteContainer(event, Status.EXECUTION_STOPPED);
       } catch (Exception deletionException) {
         transitionException.addSuppressed(deletionException);
       }
@@ -213,9 +213,11 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
    *
    * @implNote Flow status check and update is not atomic, details above.
    * @param event pod event
+   * @param finalStatus
    * @return
    */
-  private Optional<Status> compareAndFinalizeFlowStatus(AzPodStatusMetadata event) {
+  private Optional<Status> compareAndFinalizeFlowStatus(AzPodStatusMetadata event,
+      Status finalStatus) {
     requireNonNull(event, "event must not be null");
 
     int executionId = Integer.parseInt(event.getFlowPodMetadata().get().getExecutionId());
@@ -238,9 +240,9 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
       logger.info(format(
           "Flow execution-id %d for pod %s does not have a final status in database and will be "
               + "finalized.", executionId, event.getPodName()));
-      final String reason = "Flow Pod execution was completed.";
-      if (!validateTransition(event)) {
-        executableFlow.setStatus(Status.POD_FAILED);
+      final String reason = "Flow pod execution was completed.";
+      if (finalStatus == Status.EXECUTION_STOPPED) {
+        executableFlow.setStatus(Status.EXECUTION_STOPPED);
       }
       ExecutionControllerUtils.finalizeFlow(executorLoader, alerterHolder, executableFlow, reason,
           null);
@@ -288,15 +290,26 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
    * Finalize the flow for the given event and delete its container.
    *
    * @param event
+   * @param finalStatus
    */
-  private void finalizeFlowAndDeleteContainer(AzPodStatusMetadata event) {
-    Optional<Status> originalFlowStatus = compareAndFinalizeFlowStatus(event);
+  private void finalizeFlowAndDeleteContainer(AzPodStatusMetadata event,
+      Status finalStatus) {
+    Optional<Status> originalFlowStatus = compareAndFinalizeFlowStatus(event, finalStatus);
     if (originalFlowStatus.isPresent() &&
         !Status.isStatusFinished(originalFlowStatus.get())) {
       logger.warn(format("Flow for pod %s was in the non-final state %s and was finalized",
           event.getPodName(), originalFlowStatus.get()));
     }
     deleteFlowContainer(event);
+  }
+
+  /**
+   * Finalize the flow for the given event and delete its container.
+   *
+   * @param event
+   */
+  private void finalizeFlowAndDeleteContainer(AzPodStatusMetadata event) {
+    finalizeFlowAndDeleteContainer(event, Status.FAILED);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -26,8 +26,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Class implements ContainerMetrics and emit metrics for containerized executions
  */
-//Todo haqin: setup timeToDispatch, flowSubmitToExecutor, flowSubmitToContainer, implement
-//corresponding methods
 public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
   private static final Logger logger = LoggerFactory.getLogger(ContainerizationMetricsImpl.class);
@@ -53,6 +51,9 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.podReady = this.metricsManager.addMeter("Pod-Ready-Meter");
     this.podInitFailure = this.metricsManager.addMeter("Pod-Init-Failure-Meter");
     this.podAppFailure = this.metricsManager.addMeter("Pod-App-Failure-Meter");
+    this.flowSubmitToContainer = this.metricsManager.addMeter("Flow-Submit-to-Container-Meter");
+    this.flowSubmitToExecutor = this.metricsManager.addMeter("Flow-Submit-to-Executor-Meter");
+    this.timeToDispatch = this.metricsManager.addHistogram("Time-to-Dispatch-Pod-Histogram");
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Class implements ContainerMetrics and emit metrics for containerized executions
  */
+//Todo haqin: setup timeToDispatch, flowSubmitToExecutor, flowSubmitToContainer, implement
+//corresponding methods
 public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
   private static final Logger logger = LoggerFactory.getLogger(ContainerizationMetricsImpl.class);
@@ -51,9 +53,6 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.podReady = this.metricsManager.addMeter("Pod-Ready-Meter");
     this.podInitFailure = this.metricsManager.addMeter("Pod-Init-Failure-Meter");
     this.podAppFailure = this.metricsManager.addMeter("Pod-App-Failure-Meter");
-    this.flowSubmitToContainer = this.metricsManager.addMeter("Flow-Submit-to-Container-Meter");
-    this.flowSubmitToExecutor = this.metricsManager.addMeter("Flow-Submit-to-Executor-Meter");
-    this.timeToDispatch = this.metricsManager.addHistogram("Time-to-Dispatch-Pod-Histogram");
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -356,7 +356,7 @@ public class KubernetesWatchTest {
 
     // Verify that the previously RUNNING flow has been finalized to a failure state.
     verify(updatingListener.getExecutorLoader()).updateExecutableFlow(flow1);
-    assertThat(flow1.getStatus()).isEqualTo(Status.FAILED);
+    assertThat(flow1.getStatus()).isEqualTo(Status.POD_FAILED);
 
     // Verify the Pod deletion API is invoked.
     verify(updatingListener.getContainerizedImpl()).deleteContainer(EXECUTION_ID_WITH_INVALID_TRANSITIONS);

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -356,7 +356,7 @@ public class KubernetesWatchTest {
 
     // Verify that the previously RUNNING flow has been finalized to a failure state.
     verify(updatingListener.getExecutorLoader()).updateExecutableFlow(flow1);
-    assertThat(flow1.getStatus()).isEqualTo(Status.POD_FAILED);
+    assertThat(flow1.getStatus()).isEqualTo(Status.EXECUTION_STOPPED);
 
     // Verify the Pod deletion API is invoked.
     verify(updatingListener.getContainerizedImpl()).deleteContainer(EXECUTION_ID_WITH_INVALID_TRANSITIONS);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
@@ -93,8 +93,8 @@ public class WebUtils {
         return "Killing";
       case DISPATCHING:
         return "Dispatching";
-      case POD_FAILED:
-        return "Pod Failure";
+      case EXECUTION_STOPPED:
+        return "Execution stopped, crashed executor/container";
       default:
     }
     return "Unknown";

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
@@ -93,6 +93,8 @@ public class WebUtils {
         return "Killing";
       case DISPATCHING:
         return "Dispatching";
+      case POD_FAILED:
+        return "Pod Failure";
       default:
     }
     return "Unknown";

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/WebUtils.java
@@ -94,7 +94,7 @@ public class WebUtils {
       case DISPATCHING:
         return "Dispatching";
       case EXECUTION_STOPPED:
-        return "Execution stopped, crashed executor/container";
+        return "Execution stopped";
       default:
     }
     return "Unknown";

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -78,7 +78,7 @@
     background-color: @flow-succeeded-color;
   }
 
-  &.POD_FAILED {
+  &.EXECUTION_STOPPED {
     background-color: @flow-failed-color;
   }
 
@@ -148,7 +148,7 @@ td {
       background-color: @flow-succeeded-color;
     }
 
-    &.POD_FAILED {
+    &.EXECUTION_STOPPED {
       background-color: @flow-failed-color;
     }
 
@@ -219,7 +219,7 @@ td {
     color: @flow-paused-color;
   }
 
-  &.POD_FAILED {
+  &.EXECUTION_STOPPED {
     color: @flow-failed-color;
   }
 
@@ -376,7 +376,7 @@ li.tree-list-item {
       background-position: 48px 0px;
     }
 
-    &.POD_FAILED .icon {
+    &.EXECUTION_STOPPED .icon {
       background-position: 0px 0px;
     }
 

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -78,6 +78,10 @@
     background-color: @flow-succeeded-color;
   }
 
+  &.POD_FAILED {
+    background-color: @flow-failed-color;
+  }
+
   &.FAILED {
     background-color: @flow-failed-color;
   }
@@ -142,6 +146,10 @@ td {
 
     &.SUCCEEDED {
       background-color: @flow-succeeded-color;
+    }
+
+    &.POD_FAILED {
+      background-color: @flow-failed-color;
     }
 
     &.FAILED {
@@ -209,6 +217,10 @@ td {
 
   &.PAUSED {
     color: @flow-paused-color;
+  }
+
+  &.POD_FAILED {
+    color: @flow-failed-color;
   }
 
   &.FAILED {
@@ -362,6 +374,10 @@ li.tree-list-item {
 
     &.SUCCEEDED .icon {
       background-position: 48px 0px;
+    }
+
+    &.POD_FAILED .icon {
+      background-position: 0px 0px;
     }
 
     &.FAILED .icon {

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/historypage.vm
@@ -249,6 +249,7 @@
                     <option value=50>Succeed</option>
                     <option value=55>Killing</option>
                     <option value=60>Killed</option>
+                    <option value=65>Execution Stopped</option>
                     <option value=70>Failed</option>
                     <option value=80>Failed Finishing</option>
                     <option value=90>Skipped</option>

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -16,7 +16,7 @@
 
 var statusList = ["FAILED", "FAILED_FINISHING", "SUCCEEDED", "RUNNING",
   "WAITING", "KILLED", "DISABLED", "READY", "CANCELLED", "UNKNOWN", "PAUSED",
-  "SKIPPED", "QUEUED", "FAILED_SUCCEEDED", "DISPATCHING", "POD_FAILED"];
+  "SKIPPED", "QUEUED", "FAILED_SUCCEEDED", "DISPATCHING", "EXECUTION_STOPPED"];
 var statusStringMap = {
   "QUEUED": "Queued",
   "SKIPPED": "Skipped",
@@ -35,5 +35,5 @@ var statusStringMap = {
   "PAUSED": "Paused",
   "FAILED_SUCCEEDED": "Failed, treated as success",
   "DISPATCHING": "Dispatching",
-  "POD_FAILED": "Pod Failure"
+  "EXECUTION_STOPPED": "Execution stopped, crashed executor/container"
 };

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -35,5 +35,5 @@ var statusStringMap = {
   "PAUSED": "Paused",
   "FAILED_SUCCEEDED": "Failed, treated as success",
   "DISPATCHING": "Dispatching",
-  "EXECUTION_STOPPED": "Execution stopped, crashed executor/container"
+  "EXECUTION_STOPPED": "Execution stopped"
 };

--- a/azkaban-web-server/src/web/js/azkaban/util/job-status.js
+++ b/azkaban-web-server/src/web/js/azkaban/util/job-status.js
@@ -16,7 +16,7 @@
 
 var statusList = ["FAILED", "FAILED_FINISHING", "SUCCEEDED", "RUNNING",
   "WAITING", "KILLED", "DISABLED", "READY", "CANCELLED", "UNKNOWN", "PAUSED",
-  "SKIPPED", "QUEUED", "FAILED_SUCCEEDED", "DISPATCHING"];
+  "SKIPPED", "QUEUED", "FAILED_SUCCEEDED", "DISPATCHING", "POD_FAILED"];
 var statusStringMap = {
   "QUEUED": "Queued",
   "SKIPPED": "Skipped",
@@ -34,5 +34,6 @@ var statusStringMap = {
   "UNKNOWN": "Unknown",
   "PAUSED": "Paused",
   "FAILED_SUCCEEDED": "Failed, treated as success",
-  "DISPATCHING": "Dispatching"
+  "DISPATCHING": "Dispatching",
+  "POD_FAILED": "Pod Failure"
 };

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -218,7 +218,7 @@ azkaban.FlowTabView = Backbone.View.extend({
     } else if (data.status == "KILLED") {
       $("#executebtn").show();
     } else if (data.status == "KILLING") {
-    } else if (data.status == "POD_FAILED") {
+    } else if (data.status == "EXECUTION_STOPPED") {
       $("#executebtn").show();
     }
   },

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -218,6 +218,8 @@ azkaban.FlowTabView = Backbone.View.extend({
     } else if (data.status == "KILLED") {
       $("#executebtn").show();
     } else if (data.status == "KILLING") {
+    } else if (data.status == "POD_FAILED") {
+      $("#executebtn").show();
     }
   },
 


### PR DESCRIPTION
A new state will help identify flow failures due to pod (k8s) related failures.
Needs to account for state showing up correctly on UI
Tested on local dev box solo server and h6 web server. 