### PR TITLE
Introducing the defaultProxyUser feature for the jobTypes

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -571,6 +571,13 @@ public class Constants {
     public static final String COMMONCONFFILE = "common.properties";
     // common private properties for multiple plugins
     public static final String COMMONSYSCONFFILE = "commonprivate.properties";
+    // mapping for the jobType to default proxy user
+    public static final String DEFAULT_PROXY_USERS_FILE = "default-proxy-users.properties";
+    // allowed jobType classes for default proxy user
+    public static final String DEFAULT_PROXY_USERS_JOBTYPE_CLASSES = "default.proxyusers.jobtype"
+        + ".classes";
+    // users not allowed as default proxy user
+    public static final String DEFAULT_PROXY_USERS_FILTER = "default.proxyusers.filter";
   }
 
   public static class ContainerizedDispatchManagerProperties {

--- a/azkaban-common/src/test/resources/plugins/jobtypes/commonprivate.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypes/commonprivate.properties
@@ -1,3 +1,5 @@
 commonprivate1=commonprivate1
 commonprivate2=commonprivate2
 commonprivate3=commonprivate3
+default.proxyusers.jobtype.classes=azkaban.jobtype.FakeJavaJob2
+default.proxyusers.filter=root,azkaban,azkabanUser4

--- a/azkaban-common/src/test/resources/plugins/jobtypes/default-proxy-users.properties
+++ b/azkaban-common/src/test/resources/plugins/jobtypes/default-proxy-users.properties
@@ -1,0 +1,4 @@
+testjob=azkabanUser1
+anothertestjob=azkabanUser2
+notestjob=azkabanUser3
+testjobwithpropsprocessor=azkabanUser4

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -352,7 +352,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
             flowMetadata.get(AZ_WEBSERVER));
     Assert.assertEquals("Event metadata not created as expected.", "unknown",
             flowMetadata.get(AZ_HOST));
-    Assert.assertNull("Event metadata not created as expected.", flowMetadata.get(SUBMIT_USER));
     Assert.assertEquals("Event metadata not created as expected.", "test",
             flowMetadata.get(PROJECT_NAME));
     Assert.assertEquals("Event metadata not created as expected.", "derived-member-data",

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -200,6 +200,7 @@ public class FlowRunnerTestUtil {
       throws Exception {
     final ExecutableFlow exFlow = FlowRunnerTestUtil
         .prepareExecDir(this.workingDir, this.projectDir, flowName, 1);
+    exFlow.setSubmitUser("submitUser");
     exFlow.setDispatchMethod(DispatchMethod.POLL);
     if (watcher != null) {
       options.setPipelineLevel(pipeline);
@@ -243,6 +244,7 @@ public class FlowRunnerTestUtil {
     LOG.info("Creating a FlowRunner for flow '" + flowName + "'");
     final Flow flow = this.flowMap.get(flowName);
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    exFlow.setSubmitUser("submitUser");
     return createFromExecutableFlow(eventCollector, exFlow, options, flowParams,
         azkabanProps);
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -90,6 +90,29 @@ public class JobRunnerTest {
   }
 
   @Test
+  public void testEffectiveUser() throws Exception {
+    final MockExecutorLoader loader = new MockExecutorLoader();
+    final EventCollectorListener eventCollector = new EventCollectorListener();
+    JobRunner runner =
+        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+    runner.run();
+    String effectiveUser = runner.getEffectiveUser();
+    Assert.assertEquals(SUBMIT_USER, effectiveUser);
+    Assert.assertEquals(effectiveUser, runner.getProps().get("user.to.proxy"));
+
+    this.jobtypeManager.getJobTypePluginSet()
+        .addDefaultProxyUsersJobTypeClasses(InteractiveTestJob.class.getName());
+    this.jobtypeManager.getJobTypePluginSet().addDefaultProxyUser("test", "defaultTestUser");
+
+    runner =
+        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+    runner.run();
+    effectiveUser = runner.getEffectiveUser();
+    Assert.assertEquals("defaultTestUser", effectiveUser);
+    Assert.assertEquals(effectiveUser, runner.getProps().get("user.to.proxy"));
+  }
+
+  @Test
   public void testBasicRun() throws Exception {
     final MockExecutorLoader loader = new MockExecutorLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();


### PR DESCRIPTION

### Background
In the current setup, Azkaban allows users to define a “user.to.proxy” property for each Azkaban Job irrespective of the Azkaban JobType. If such a property is defined, Azkaban will ensure that the Azkaban Job process will get executed as the “user.to.proxy” UID.
Azkaban will honour the “user.to.proxy” only when it is also added as part of the “Proxy Users” section under Azkaban project permissions.

### ProblemStatement
Azkaban Job Type owners/developers require their Azkaban Job to always be executed as a default “user.to.proxy”, irrespective of the property defined in the Azkaban Job Properties or the submitting user.

### Solution
The solution is to provide the optional ability to define a default proxy-user mapping for the Job Type. If such a mapping is defined then,

- Azkaban won’t check if the proxy user defined in the mapping is part of the “Proxy Users” in the Azkaban Project Permissions for such Azkaban Job Type.
- Azkaban won’t honor the “user.to.proxy” set by the users in the Azkaban job properties for such Azkaban Job Type.

Constraints,
- Configurable list of users who are not allowed as the default proxy users. Example: root, azkaban, etc.
- Configurable list of job type classes that are allowed for the default proxy users.
