### PR TITLE
Add param for disabling pod cleanup

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -686,6 +686,9 @@ public class Constants {
     // Constant to enable pod for developer testing
     public static final String FLOW_PARAM_ENABLE_DEV_POD = "enable.dev.pod";
 
+    // Constant to disable pod cleanup through the kubernetes watch
+    public static final String FLOW_PARAM_DISABLE_POD_CLEANUP = "disable.pod.cleanup";
+
     // Constant to dispatch execution to Containerization
     public static final String FLOW_PARAM_DISPATCH_EXECUTION_TO_CONTAINER = "dispatch.execution.to"
         + ".container";

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusMetadata.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusMetadata.java
@@ -16,6 +16,7 @@
 package azkaban.executor.container.watch;
 
 import static azkaban.executor.container.KubernetesContainerizedImpl.CLUSTER_LABEL_NAME;
+import static azkaban.executor.container.KubernetesContainerizedImpl.DISABLE_CLEANUP_LABEL_NAME;
 import static azkaban.executor.container.KubernetesContainerizedImpl.EXECUTION_ID_LABEL_NAME;
 import static azkaban.executor.container.KubernetesContainerizedImpl.EXECUTION_ID_LABEL_PREFIX;
 import static java.lang.String.format;
@@ -71,10 +72,16 @@ public class AzPodStatusMetadata {
   public static class FlowPodMetadata {
     private final String executionId;
     private final String clusterName;
+    private final boolean isCleanupDisabled;
 
-    private FlowPodMetadata(String executionId, String clusterName) {
+    private FlowPodMetadata(String executionId, String clusterName, boolean isCleanupDisabled) {
       this.executionId = executionId;
       this.clusterName = clusterName;
+      this.isCleanupDisabled = isCleanupDisabled;
+    }
+
+    public FlowPodMetadata(String executionId, String clusterName) {
+      this(executionId, clusterName, false);
     }
 
     public String getExecutionId() {
@@ -85,6 +92,10 @@ public class AzPodStatusMetadata {
       return this.clusterName;
     }
 
+    public boolean isCleanupDisabled() {
+      return this.isCleanupDisabled;
+    }
+
     public static Optional<FlowPodMetadata> extract(AzPodStatusExtractor podStatusExtractor) {
       requireNonNull(podStatusExtractor.getV1Pod(), "pod must not be null");
       requireNonNull(podStatusExtractor.getV1Pod().getMetadata(), "pod metadata must not be null");
@@ -93,6 +104,7 @@ public class AzPodStatusMetadata {
       String podName = podStatusExtractor.getV1Pod().getMetadata().getName();
       String executionId = null;
       String clusterName = null;
+      boolean isCleanupDisabled = false;
 
       if (podStatusExtractor.getV1Pod().getMetadata().getLabels() == null) {
         logger.warn("No labels found for pod: " + podName);
@@ -110,7 +122,21 @@ public class AzPodStatusMetadata {
         return Optional.empty();
       }
       executionId = executionLabel.substring(EXECUTION_ID_LABEL_PREFIX.length());
-      return Optional.of(new FlowPodMetadata(executionId, clusterName));
+
+      String cleanupDisabledLabel =
+          podStatusExtractor.getV1Pod().getMetadata().getLabels().get(DISABLE_CLEANUP_LABEL_NAME);
+      if (cleanupDisabledLabel != null) {
+        // Any value other than false or 0 will is considered as true. The label is expected to
+        // to be assigned sparingly and only for the purpose of debugging any issues.
+        if (!cleanupDisabledLabel.equalsIgnoreCase("false") &&
+            !cleanupDisabledLabel.equals("0")) {
+          isCleanupDisabled = true;
+        }
+      } else {
+        logger.debug(format("Label %s is not found for pod %s", DISABLE_CLEANUP_LABEL_NAME,
+            podName));
+      }
+      return Optional.of(new FlowPodMetadata(executionId, clusterName, isCleanupDisabled));
     }
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -266,6 +266,11 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
    */
   private void deleteFlowContainer(AzPodStatusMetadata event) {
     logger.info("Deleting Flow Pod: " + event.getPodName());
+    if (event.getFlowPodMetadata().get().isCleanupDisabled()) {
+      logger.warn(format("Pod deletion is disabled for pod %s, please delete it manually.",
+          event.getPodName()));
+      return;
+    }
     try {
       containerizedImpl.deleteContainer(
           Integer.parseInt(

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -188,6 +188,7 @@ public class HttpRequestUtils {
       params.remove(ExecutionOptions.USE_EXECUTOR);
       params.remove(FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
       params.remove(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
+      params.remove(FlowParameters.FLOW_PARAM_DISABLE_POD_CLEANUP);
       // Passing test version will be allowed for Azkaban ADMIN role only
       params.remove(FlowParameters.FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION);
     } else {
@@ -195,6 +196,7 @@ public class HttpRequestUtils {
       validateIntegerParam(params, ExecutionOptions.USE_EXECUTOR);
       validateBooleanParam(params, FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
       validateBooleanParam(params, FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
+      validateBooleanParam(params, FlowParameters.FLOW_PARAM_DISABLE_POD_CLEANUP);
       // Passing of test version is allowed for azkaban admin only. Validate
       // if it is boolean param
       validateBooleanParam(params, FlowParameters.FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION);

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -267,7 +267,7 @@ public class KubernetesContainerizedImplTest {
     assert (podSpec != null);
 
     final V1Pod pod = this.kubernetesContainerizedImpl
-        .createPodFromSpec(flow.getExecutionId(), podSpec);
+        .createPodFromSpec(flow.getExecutionId(), podSpec, flowParam);
     final String podSpecYaml = Yaml.dump(pod).trim();
     assert (!podSpecYaml.isEmpty());
     log.info("Pod spec for execution id {} is {}", flow.getExecutionId(), podSpecYaml);


### PR DESCRIPTION
Introduces a flow parameter `disable.pod.cleanup`, if it's set
the flow-pod will not be auto-cleaned after flow execution ends.