### PR TITLE
set job status to terminal state when pod goes down

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -220,33 +220,45 @@ public class ExecutionControllerUtils {
    */
   public static void failEverything(final ExecutableFlow exFlow) {
     final long time = System.currentTimeMillis();
-    for (final ExecutableNode node : exFlow.getExecutableNodes()) {
-      switch (node.getStatus()) {
-        case SUCCEEDED:
-        case FAILED:
-        case KILLED:
-        case SKIPPED:
-        case DISABLED:
-          continue;
-          // case UNKNOWN:
-        case READY:
-          // if flow status is EXECUTION_STOPPED due to e.g. pod failure, set sub node to KILLED
-          if (exFlow.getStatus()==Status.EXECUTION_STOPPED) {
-            node.setStatus(Status.KILLED);
-          } else {
-            node.setStatus(Status.KILLING);
-          }
-          break;
-        default:
-          node.setStatus(Status.FAILED);
-          break;
+    final LinkedList<ExecutableNode> queue = new LinkedList<>();
+    queue.add(exFlow);
+    // Traverse the DAG and fail every node that's not in a terminal state
+    while (!queue.isEmpty()) {
+      final ExecutableNode node = queue.poll();
+      if (node instanceof ExecutableFlowBase) {
+        final ExecutableFlowBase base = (ExecutableFlowBase) node;
+        for (final ExecutableNode subNode : base.getExecutableNodes()) {
+          queue.add(subNode);
+        }
       }
+      if (node != exFlow) {
+        switch (node.getStatus()) {
+          case SUCCEEDED:
+          case FAILED:
+          case KILLED:
+          case SKIPPED:
+          case DISABLED:
+            continue;
+            // case UNKNOWN:
+          case READY:
+            // if flow status is EXECUTION_STOPPED due to e.g. pod failure, set sub node to KILLED
+            if (exFlow.getStatus()==Status.EXECUTION_STOPPED) {
+              node.setStatus(Status.KILLED);
+            } else {
+              node.setStatus(Status.KILLING);
+            }
+            break;
+          default:
+            node.setStatus(Status.FAILED);
+            break;
+        }
 
-      if (node.getStartTime() == -1) {
-        node.setStartTime(time);
-      }
-      if (node.getEndTime() == -1) {
-        node.setEndTime(time);
+        if (node.getStartTime() == -1) {
+          node.setStartTime(time);
+        }
+        if (node.getEndTime() == -1) {
+          node.setEndTime(time);
+        }
       }
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -220,7 +221,7 @@ public class ExecutionControllerUtils {
    */
   public static void failEverything(final ExecutableFlow exFlow) {
     final long time = System.currentTimeMillis();
-    final LinkedList<ExecutableNode> queue = new LinkedList<>();
+    final Queue<ExecutableNode> queue = new LinkedList<>();
     queue.add(exFlow);
     // Traverse the DAG and fail every node that's not in a terminal state
     while (!queue.isEmpty()) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -230,7 +230,12 @@ public class ExecutionControllerUtils {
           continue;
           // case UNKNOWN:
         case READY:
-          node.setStatus(Status.KILLING);
+          // if flow status is EXECUTION_STOPPED due to e.g. pod failure, set sub node to KILLED
+          if (exFlow.getStatus()==Status.EXECUTION_STOPPED) {
+            node.setStatus(Status.KILLED);
+          } else {
+            node.setStatus(Status.KILLING);
+          }
           break;
         default:
           node.setStatus(Status.FAILED);

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -27,6 +27,7 @@ import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.DispatchMethod;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.Status;
@@ -51,6 +52,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -345,7 +347,10 @@ public class KubernetesWatchTest {
     statusDriver.registerAzPodStatusListener(updatingListener);
 
     // Mocked flow in RUNNING state.
-    ExecutableFlow flow1 = createExecutableFlow(EXECUTION_ID_WITH_INVALID_TRANSITIONS, Status.RUNNING);
+    ExecutableFlow flow1 = TestUtils.createTestExecutableFlowFromYaml("embeddedflowyamltest",
+        "embedded_flow");
+    flow1.setExecutionId(EXECUTION_ID_WITH_INVALID_TRANSITIONS);
+    flow1.setStatus(Status.RUNNING);
     when(updatingListener.getExecutorLoader().fetchExecutableFlow(EXECUTION_ID_WITH_INVALID_TRANSITIONS))
         .thenReturn(flow1);
 
@@ -358,9 +363,22 @@ public class KubernetesWatchTest {
     // Verify that the previously RUNNING flow has been finalized to a terminal state, and sub
     // nodes set to terminal state, too.
     verify(updatingListener.getExecutorLoader()).updateExecutableFlow(flow1);
-    assertThat(flow1.getStatus()).isEqualTo(Status.EXECUTION_STOPPED);
-    for (final ExecutableNode node: flow1.getExecutableNodes()) {
-      assertThat(node.getStatus()).isEqualTo(Status.KILLED);
+    Queue<ExecutableNode> queue = new LinkedList<>();
+    queue.add(flow1);
+    // traverse through every node in flow1
+    while(!queue.isEmpty()) {
+      ExecutableNode node = queue.poll();
+      if (node==flow1) {
+        assertThat(node.getStatus()).isEqualTo(Status.EXECUTION_STOPPED);
+      } else {
+        assertThat(node.getStatus()).isEqualTo(Status.KILLED);
+      }
+      if (node instanceof ExecutableFlowBase) {
+        final ExecutableFlowBase base = (ExecutableFlowBase) node;
+        for (final ExecutableNode subNode : base.getExecutableNodes()) {
+          queue.add(subNode);
+        }
+      }
     }
 
     // Verify the Pod deletion API is invoked.


### PR DESCRIPTION
In containerized executions, when a pod crashes, the jobs need to be in a terminal state. This PR aims to fix a bug that when a flow was finalized from RUNNING to FAILED/EXECUTION_STOPPED due to pod failure, the job nodes showed KILLING status. 