### PR TITLE
Version selection based on max rampup percentage when flow is not specified.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
@@ -296,11 +296,16 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
       if (null == flow) {
         log.info("Flow object is null, so continue");
         final ImageRampup firstImageRampup = imageRampupList.get(0);
+
+        // Find the imageVersion in the Rampup list with maximum rampup percentage.
+        final ImageRampup maxImageRampup = imageRampupList.stream()
+            .max(Comparator.comparing(ImageRampup::getRampupPercentage))
+            .orElseGet(() -> firstImageRampup);
         imageTypeRampupVersionMap.put(imageTypeName,
-            this.fetchImageVersion(imageTypeName, firstImageRampup.getImageVersion())
+            this.fetchImageVersion(imageTypeName, maxImageRampup.getImageVersion())
                 .orElseThrow(() -> new ImageMgmtException(
                     String.format("Unable to fetch version %s from image " + "versions table.",
-                        firstImageRampup.getImageVersion()))));
+                        maxImageRampup.getImageVersion()))));
         continue;
       }
       int prevRampupPercentage = 0;

--- a/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
@@ -277,13 +277,20 @@ public class ImageRampupManagerImplTest {
     final Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
         .getVersionForAllImageTypes(null);
     Assert.assertNotNull(imageTypeVersionMap);
-    // Below image type versions are obtained from active ramp up. Version is selected randomly
-    // based on rampup percentage.
+    // Below image type versions are obtained from active ramp up. Version is selected based on
+    // the maximum rampup percentage value.
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_config"));
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_core"));
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_exec"));
     Assert.assertNotNull(imageTypeVersionMap.get("hive_job"));
     Assert.assertNotNull(imageTypeVersionMap.get("spark_job"));
+
+    Assert.assertEquals("3.6.5", imageTypeVersionMap.get("azkaban_config").getVersion());
+    Assert.assertEquals("3.6.2", imageTypeVersionMap.get("azkaban_core").getVersion());
+    Assert.assertEquals("1.8.2", imageTypeVersionMap.get("azkaban_exec").getVersion());
+    Assert.assertEquals("2.1.3", imageTypeVersionMap.get("hive_job").getVersion());
+    Assert.assertEquals("1.1.2", imageTypeVersionMap.get("spark_job").getVersion());
+
     // Below two image types are from based on active image version
     Assert.assertNotNull(imageTypeVersionMap.get("pig_job"));
     Assert.assertEquals("4.1.2", imageTypeVersionMap.get("pig_job").getVersion());


### PR DESCRIPTION
After deterministic ramp up, a version is selected based on the ramp-up percentages of job types and the hash value derived from the flow name.
However when the flow is not specified, currently the first element in the ramp-up plan will be selected. Flow is not specified when loading the status page. This creates an abnormal state on the status UI, when a ramp-up of 100 is specified, but is not the first element.

This change, makes sure that in such a scenario, the version with the maximum ramp-up is selected and hence the status UI will display that version.