### PR TITLE
Status page should show latest active version for containerized status

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageVersionMetadataResponseDTO.java
@@ -27,8 +27,9 @@ import org.codehaus.jackson.annotate.JsonPropertyOrder;
 @JsonPropertyOrder({"version", "state", "path", "releaseTag", "message", "rampups"})
 public class ImageVersionMetadataResponseDTO {
 
-  // Represents version for an image type selected based on random rampup or current active version.
-  @JsonProperty("version")
+  // Represents version for an image type selected based on deterministic rampup or current active
+  //version.
+  @JsonProperty("latestVersion")
   private final String version;
   // Current state of the version.
   @JsonProperty("state")

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
@@ -30,9 +30,7 @@ import azkaban.imagemgmt.models.ImageVersion.State;
 import azkaban.imagemgmt.models.ImageVersionMetadata;
 import azkaban.imagemgmt.version.VersionInfo;
 import azkaban.imagemgmt.version.VersionSet;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,7 +69,7 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
   private final ImageVersionDao imageVersionDao;
   private final ImageRampupDao imageRampupDao;
   private static final String MSG_RANDOM_RAMPUP_VERSION_SELECTION = "The version selection is "
-      + "based on random rampup.";
+      + "based on deterministic rampup.";
   private static final String MSG_ACTIVE_VERSION_SELECTION = "The version selection is "
       + "based on latest available ACTIVE version.";
   private static final String MSG_NON_ACTIVE_VERSION_SELECTION = "Non ACTIVE "
@@ -294,13 +292,8 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
         continue;
       }
       if (null == flow) {
+        // When flow object is null, there is no utility in rampup version.
         log.info("Flow object is null, so continue");
-        final ImageRampup firstImageRampup = imageRampupList.get(0);
-        imageTypeRampupVersionMap.put(imageTypeName,
-            this.fetchImageVersion(imageTypeName, firstImageRampup.getImageVersion())
-                .orElseThrow(() -> new ImageMgmtException(
-                    String.format("Unable to fetch version %s from image " + "versions table.",
-                        firstImageRampup.getImageVersion()))));
         continue;
       }
       int prevRampupPercentage = 0;

--- a/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
@@ -105,19 +105,11 @@ public class ImageRampupManagerImplTest {
     imageTypes.add("azkaban_exec");
     when(this.imageRampupDao.getRampupByImageTypes(any(Set.class))).thenReturn(imageTypeRampups);
     when(this.imageVersionDao.findImageVersions(any(ImageMetadataRequest.class))).thenReturn(newAndRampupImageVersions);
-    Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
-        .getVersionByImageTypes(null, imageTypes);
-    Assert.assertNotNull(imageTypeVersionMap);
-    Assert.assertNotNull(imageTypeVersionMap.get("azkaban_config"));
-    Assert.assertNotNull(imageTypeVersionMap.get("azkaban_core"));
-    Assert.assertNotNull(imageTypeVersionMap.get("azkaban_exec"));
-    Assert.assertNotNull(imageTypeVersionMap.get("hive_job"));
-    Assert.assertNotNull(imageTypeVersionMap.get("spark_job"));
 
     // Assert the for a flow, versions are always deterministic and remain the same
     final ExecutableFlow flow = TestUtils
         .createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
-    imageTypeVersionMap = this.imageRampupManger
+    Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
         .getVersionByImageTypes(flow, imageTypes);
     Assert.assertEquals("3.6.5", imageTypeVersionMap.get("azkaban_config").getVersion());
     Assert.assertEquals("3.6.2", imageTypeVersionMap.get("azkaban_core").getVersion());
@@ -147,7 +139,7 @@ public class ImageRampupManagerImplTest {
     imageTypes.add("pig_job");
     imageTypes.add("hadoop_job");
     final String jsonImageTypeActiveVersion = JSONUtils.readJsonFileAsString("image_management"
-        + "/image_type_active_version.json");
+        + "/all_image_types_active_version.json");
     final List<ImageVersionDTO> activeImageVersionDTOs = converterUtils.convertToDTOs(
         jsonImageTypeActiveVersion, ImageVersionDTO.class);
     final List<ImageVersion> activeImageVersions =
@@ -238,7 +230,7 @@ public class ImageRampupManagerImplTest {
 
   /**
    * This test is a success test for getting version for all the available image types. The versions
-   * are either from active rampup or based on active image version.
+   * are from active image version.
    *
    * @throws Exception
    */
@@ -277,13 +269,19 @@ public class ImageRampupManagerImplTest {
     final Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
         .getVersionForAllImageTypes(null);
     Assert.assertNotNull(imageTypeVersionMap);
-    // Below image type versions are obtained from active ramp up. Version is selected randomly
-    // based on rampup percentage.
+    // Below image type versions are obtained from latest active version.
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_config"));
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_core"));
     Assert.assertNotNull(imageTypeVersionMap.get("azkaban_exec"));
     Assert.assertNotNull(imageTypeVersionMap.get("hive_job"));
     Assert.assertNotNull(imageTypeVersionMap.get("spark_job"));
+
+    Assert.assertEquals("3.6.7", imageTypeVersionMap.get("azkaban_config").getVersion());
+    Assert.assertEquals("3.6.3", imageTypeVersionMap.get("azkaban_core").getVersion());
+    Assert.assertEquals("1.8.3", imageTypeVersionMap.get("azkaban_exec").getVersion());
+    Assert.assertEquals("2.1.4", imageTypeVersionMap.get("hive_job").getVersion());
+    Assert.assertEquals("1.1.3", imageTypeVersionMap.get("spark_job").getVersion());
+
     // Below two image types are from based on active image version
     Assert.assertNotNull(imageTypeVersionMap.get("pig_job"));
     Assert.assertEquals("4.1.2", imageTypeVersionMap.get("pig_job").getVersion());
@@ -334,8 +332,10 @@ public class ImageRampupManagerImplTest {
     when(this.imageVersionDao.findImageVersions(any(ImageMetadataRequest.class))).thenReturn(newAndRampupImageVersions);
     when(this.imageVersionDao.getActiveVersionByImageTypes(any(Set.class)))
         .thenReturn(activeImageVersions);
+    final ExecutableFlow flow = TestUtils
+        .createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
     final Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
-        .getVersionForAllImageTypes(null);
+        .getVersionForAllImageTypes(flow);
     Assert.assertNotNull(imageTypeVersionMap);
     // Below image type versions are obtained from active ramp up. Version is selected randomly
     // based on rampup percentage.

--- a/azkaban-common/src/test/resources/image_management/all_image_types_active_version.json
+++ b/azkaban-common/src/test/resources/image_management/all_image_types_active_version.json
@@ -38,6 +38,46 @@
     "description": "kabootar job",
     "versionState": "ACTIVE",
     "releaseTag": "1.1.4"
+  },
+  {
+    "imagePath": "path_spark_job",
+    "imageVersion": "1.1.3",
+    "imageType": "spark_job",
+    "description": "spark job",
+    "versionState": "ACTIVE",
+    "releaseTag": "1.1.3"
+  },
+  {
+    "imagePath": "path_hive_job",
+    "imageVersion": "2.1.4",
+    "imageType": "hive_job",
+    "description": "hive job",
+    "versionState": "ACTIVE",
+    "releaseTag": "2.1.4"
+  },
+  {
+    "imagePath": "path_azkaban_core",
+    "imageVersion": "3.6.3",
+    "imageType": "azkaban_core",
+    "description": "azkaban_core",
+    "versionState": "ACTIVE",
+    "releaseTag": "3.6.3"
+  },
+  {
+    "imagePath": "azkaban_exec",
+    "imageVersion": "1.8.3",
+    "imageType": "azkaban_exec",
+    "description": "azkaban_exec",
+    "versionState": "ACTIVE",
+    "releaseTag": "1.8.3"
+  },
+  {
+    "imagePath": "azkaban_config",
+    "imageVersion": "3.6.7",
+    "imageType": "azkaban_config",
+    "description": "azkaban_config",
+    "versionState": "ACTIVE",
+    "releaseTag": "3.6.7"
   }
 ]
 

--- a/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
+++ b/azkaban-web-server/src/test/resources/azkaban/webapp/containerized_cluster_status
@@ -18,7 +18,7 @@
   },
   "imageTypeVersionMap" : {
     "myJobType" : {
-      "version" : "0.0.7",
+      "latestVersion" : "0.0.7",
       "state" : "ACTIVE",
       "path" : "registry/myPath",
       "releaseTag" : "0.0.7",


### PR DESCRIPTION
- After deterministic ramp up, a version is selected based on the ramp-up percentages of job types and the hash value derived from the flow name.
- However when the flow is not specified, currently the first element in the ramp-up plan will be selected. Flow is not specified when loading the status page. This creates an abnormal state on the staus page.
- This change, makes sure that in such a scenario, the latest active version will be shown in the UI.

**Note:** This change doesn't affect the actual flow executions, as the flow object passed won't be null in such cases.