### PR TITLE
Merge containers from pod-spec template and dynamically generated pod-spec

### DIFF
--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
@@ -81,6 +81,22 @@ public class AzKubernetesV1PodTemplate {
   }
 
   /**
+   * @return The Flow Container which must be the first container among all app-containers
+   */
+  public V1Container getFlowContainer() {
+    List<V1Container> containers = this.podFromTemplate.getSpec().getContainers();
+    return containers.isEmpty() ? null : containers.get(FLOW_CONTAINER_INDEX);
+  }
+
+  /**
+   * @return The list of all app-containers.
+   */
+  public List<V1Container> getAllContainers() {
+    return this.podFromTemplate.getSpec().getContainers();
+  }
+
+
+  /**
    * @return the {@link V1Pod} POD generated from the template.
    */
   public V1Pod getPodFromTemplate() {

--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
@@ -84,7 +84,7 @@ public class AzKubernetesV1PodTemplate {
    * @return The Flow Container which must be the first container among all app-containers
    */
   public V1Container getFlowContainer() {
-    List<V1Container> containers = this.podFromTemplate.getSpec().getContainers();
+    final List<V1Container> containers = this.podFromTemplate.getSpec().getContainers();
     return containers.isEmpty() ? null : containers.get(FLOW_CONTAINER_INDEX);
   }
 

--- a/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
@@ -16,11 +16,14 @@
 package azkaban.container.models;
 
 import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class consists of various methods to merge pod-spec with the pod template
@@ -42,80 +45,25 @@ public class PodTemplateMergeUtils {
   public static void mergePodSpec(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
     mergeVolumes(podSpec, podTemplate);
     mergeInitContainers(podSpec, podTemplate);
-    mergeContainerVolumes(podSpec, podTemplate);
-    mergeReadinessProbe(podSpec, podTemplate);
-    mergeLivelinessProbe(podSpec, podTemplate);
-    mergeStartupProbe(podSpec, podTemplate);
+    mergeFlowContainer(podSpec, podTemplate);
+  }
+
+  private static void mergeFlowContainer(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
+    V1Container podSpecFlowContainer = podSpec.getContainers()
+        .get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX);
+    V1Container podTemplateFlowContainer = podTemplate.getFlowContainer();
+    mergeTemplateAndPodSpecContainer(podTemplateFlowContainer, podSpecFlowContainer);
+    podSpec.setContainers(podTemplate.getAllContainers());
   }
 
   /**
-   * Set the StartupProbe for flowContainer derived from the podTemplate to the podSpec
-   *
-   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
-   */
-  private static void mergeStartupProbe(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
-    V1Probe containerStartupProbe = podTemplate.getContainerStartupProbe();
-    if (null != containerStartupProbe) {
-      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
-          .setStartupProbe(containerStartupProbe);
-    }
-  }
-
-  /**
-   * Set the LivelinessProbe for flowContainer derived from the podTemplate to the podSpec
-   *
-   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
-   */
-  private static void mergeLivelinessProbe(V1PodSpec podSpec,
-      AzKubernetesV1PodTemplate podTemplate) {
-    V1Probe containerLivelinessProbe = podTemplate.getContainerLivelinessProbe();
-    if (null != containerLivelinessProbe) {
-      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
-          .setLivenessProbe(containerLivelinessProbe);
-    }
-  }
-
-  /**
-   * Set the ReadinessProbe for flowContainer derived from the podTemplate to the podSpec
-   *
-   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
-   */
-  private static void mergeReadinessProbe(V1PodSpec podSpec,
-      AzKubernetesV1PodTemplate podTemplate) {
-    V1Probe containerReadinessProbe = podTemplate.getContainerReadinessProbe();
-    if (null != containerReadinessProbe) {
-      podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
-          .setReadinessProbe(containerReadinessProbe);
-    }
-  }
-
-  /**
-   * Add those container volumes which are not already available in the podSpec
-   *
-   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
-   */
-  private static void mergeContainerVolumes(V1PodSpec podSpec,
-      AzKubernetesV1PodTemplate podTemplate) {
-    List<V1VolumeMount> podContainerVolumeMounts =
-        podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
-            .getVolumeMounts();
-    if (null != podContainerVolumeMounts) {
-      List<V1VolumeMount> templateContainerVolumeMounts = podTemplate.getContainerVolumeMounts(
-          tempVolMount -> podContainerVolumeMounts.stream().map(V1VolumeMount::getName)
-              .noneMatch(name -> name.equals(tempVolMount.getName())));
-      for (V1VolumeMount volumeMountItem : templateContainerVolumeMounts) {
-        podSpec.getContainers().get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX)
-            .addVolumeMountsItem(volumeMountItem);
-      }
-    }
-  }
-
-  /**
-   * Add those initContainers which are not already available in the podSpec
+   * Merge InitContainers from the dynamically generated pod-spec and podTemplate, such that: 1) Add
+   * all the init containers which are only part of podTemplate. 2) Add all the init containers
+   * which are only part of pod-spec. 3) Add the init containers which are part of both pod-spec and
+   * pod-template by merging them such that: a) Skeleton of templateInitContainer is utilized. b)
+   * Environment variables from podSpecInitContainer are added to corresponding
+   * templateInitContainer. c) ImagePullPolicy, Image, and VolumeMounts are overridden from
+   * podSpecInitContainer to templateInitContainer.
    *
    * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
    * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
@@ -124,13 +72,153 @@ public class PodTemplateMergeUtils {
       AzKubernetesV1PodTemplate podTemplate) {
     List<V1Container> podSpecInitContainers = podSpec.getInitContainers();
     if (null != podSpecInitContainers) {
-      List<V1Container> templateInitContainers = podTemplate.getInitContainers(
-          tempInitContainer -> podSpecInitContainers.stream().map(V1Container::getName)
-              .noneMatch(name -> name.equals(tempInitContainer.getName())));
-      for (V1Container containerItem : templateInitContainers) {
-        podSpec.addInitContainersItem(containerItem);
-      }
+      // Get init containers from podTemplate which are not part of pod-spec init containers.
+      final List<V1Container> templateOnlyInitContainers = podTemplate.getInitContainers(
+          templateInitContainer -> podSpecInitContainers.stream().map(V1Container::getName)
+              .noneMatch(name -> name.equals(templateInitContainer.getName())));
+
+      // Get init containers from podTemplate which are also part of pod-spec init containers
+      // i.e. the other containers apart from the above list templateOnlyInitContainers.
+      final List<V1Container> templateAlsoInitContainers = podTemplate.getInitContainers(
+          templateInitContainer -> templateOnlyInitContainers.stream().map(V1Container::getName)
+              .noneMatch(name -> name.equals(templateInitContainer.getName())));
+
+      // Get init containers from pod-spec which are not part of podTemplate init containers.
+      final List<V1Container> podSpecOnlyInitContainers =
+          podSpec.getInitContainers().stream().filter(
+              podSpecInitContainer -> templateAlsoInitContainers.stream().map(V1Container::getName)
+                  .noneMatch(name -> name.equals(podSpecInitContainer.getName()))
+          ).collect(Collectors.toList());
+
+      // Get init containers from pod-spec which are also part of podTemplate init containers
+      // i.e. the other containers apart from the above list podSpecOnlyInitContainers.
+      final Map<String, V1Container> podSpecAlsoInitContainers =
+          podSpec.getInitContainers().stream().filter(
+              podSpecInitContainer -> podSpecOnlyInitContainers.stream().map(V1Container::getName)
+                  .noneMatch(name -> name.equals(podSpecInitContainer.getName()))
+          ).collect(Collectors.toMap(V1Container::getName, e -> e));
+
+      final List<V1Container> allInitContainers = new ArrayList<>();
+      allInitContainers.addAll(podSpecOnlyInitContainers);
+      allInitContainers.addAll(templateOnlyInitContainers);
+
+      // Merge templateAlsoInitContainers and podSpecAlsoInitContainers.
+      List<V1Container> mergedInitContainers = getMergedInitContainers(templateAlsoInitContainers,
+          podSpecAlsoInitContainers);
+      allInitContainers.addAll(mergedInitContainers);
+
+      // This resets the init containers already part of pod-spec.
+      podSpec.setInitContainers(allInitContainers);
     }
+  }
+
+  /**
+   * This method combines the templateAlsoInitContainers with their corresponding
+   * podSpecAlsoInitContainers.
+   *
+   * @param templateAlsoInitContainers List of all initContainers form the pod-spec template which
+   *                                   are also part of dynamically generated pod-spec.
+   * @param podSpecAlsoInitContainers  List of all initContainers from the dynamically generated
+   *                                   pod-spec which are also part of pod-spec template.
+   * @return List of InitContainers by merging templateAlsoInitContainers and podAlsoInitContainers.
+   */
+  private static List<V1Container> getMergedInitContainers(
+      List<V1Container> templateAlsoInitContainers,
+      Map<String, V1Container> podSpecAlsoInitContainers) {
+    final List<V1Container> mergedInitContainers = new ArrayList<>();
+    for (V1Container templateInitContainer : templateAlsoInitContainers) {
+      V1Container podSpecInitContainer =
+          podSpecAlsoInitContainers.get(templateInitContainer.getName());
+
+      mergeTemplateAndPodSpecContainer(templateInitContainer, podSpecInitContainer);
+
+      // Add the modified templateInitContainer with overrides from corresponding
+      // podSpecInitContainer.
+      mergedInitContainers.add(templateInitContainer);
+    }
+    return mergedInitContainers;
+  }
+
+  /**
+   * This method combines the templateContainer and podSpecContainer such that: 1) Skeleton of
+   * templateContainer is utilized. 2) Environment variables from podSpecContainer are added to
+   * corresponding templateContainer. 3) ImagePullPolicy, Image, and VolumeMounts are overridden
+   * from podSpecContainer to templateContainer.
+   *
+   * @param templateContainer Container form the pod-spec template
+   * @param podSpecContainer  Container from the dynamically generated pod-spec
+   */
+  private static void mergeTemplateAndPodSpecContainer(V1Container templateContainer,
+      V1Container podSpecContainer) {
+    // Add env from podSpecContainer to templateContainer.
+    final List<V1EnvVar> podSpecInitContainerEnv = podSpecContainer.getEnv();
+    if (null != podSpecInitContainerEnv && !podSpecInitContainerEnv.isEmpty()) {
+      podSpecInitContainerEnv.forEach(templateContainer::addEnvItem);
+    }
+
+    // Override name from the podSpecContainer to templateContainer.
+    if (null != podSpecContainer.getName()) {
+      templateContainer.setName(podSpecContainer.getName());
+    }
+
+    // Override ImagePullPolicy from the corresponding podSpecContainer.
+    if (null != podSpecContainer.getImagePullPolicy()) {
+      templateContainer.setImagePullPolicy(podSpecContainer.getImagePullPolicy());
+    }
+
+    // Override Image from the corresponding podSpecContainer.
+    if (null != podSpecContainer.getImage()) {
+      templateContainer.setImage(podSpecContainer.getImage());
+    }
+
+    // Override Resources from the corresponding podSpecContainer.
+    if (null != podSpecContainer.getResources()) {
+      templateContainer.setResources(podSpecContainer.getResources());
+    }
+
+    // Merge Volume Mounts with podSpecContainerVolumeMounts overriding
+    // templateContainerVolumeMounts.
+    final List<V1VolumeMount> templateContainerVolumeMounts =
+        templateContainer.getVolumeMounts();
+    final List<V1VolumeMount> podSpecContainerVolumeMounts =
+        podSpecContainer.getVolumeMounts();
+    final List<V1VolumeMount> mergedContainerVolumeMounts =
+        getMergedContainerVolumeMounts(
+            templateContainerVolumeMounts, podSpecContainerVolumeMounts);
+    templateContainer.setVolumeMounts(mergedContainerVolumeMounts);
+  }
+
+  /**
+   * This method merges VolumeMounts such that: 1) All VolumeMounts from the
+   * podSpecContainerVolumeMounts are added. 2) Only those VolumeMounts of
+   * templateContainerVolumeMounts are added which are not already part of
+   * podSpecContainerVolumeMounts.
+   *
+   * @param templateContainerVolumeMounts List of VolumeMounts from templateContainer.
+   * @param podSpecContainerVolumeMounts  List of VolumeMounts from podSpecContainer.
+   * @return List of VolumeMounts after merging templateInitContainerVolumeMounts and
+   * podSpecInitContainerVolumeMounts.
+   */
+  private static List<V1VolumeMount> getMergedContainerVolumeMounts(
+      List<V1VolumeMount> templateContainerVolumeMounts,
+      List<V1VolumeMount> podSpecContainerVolumeMounts) {
+    final List<V1VolumeMount> allContainerVolumeMounts = new ArrayList<>();
+    if (null != templateContainerVolumeMounts && null != podSpecContainerVolumeMounts) {
+      List<V1VolumeMount> templateOnlyInitContainerVolumeMounts = templateContainerVolumeMounts
+          .stream()
+          .filter(templateInitContainerVolumeMount -> podSpecContainerVolumeMounts.stream()
+              .map(V1VolumeMount::getName)
+              .noneMatch(name -> name.equals(templateInitContainerVolumeMount.getName()))
+          ).collect(Collectors.toList());
+
+      allContainerVolumeMounts.addAll(podSpecContainerVolumeMounts);
+      allContainerVolumeMounts.addAll(templateOnlyInitContainerVolumeMounts);
+    } else if (null != templateContainerVolumeMounts) {
+      allContainerVolumeMounts.addAll(templateContainerVolumeMounts);
+    } else if (null != podSpecContainerVolumeMounts) {
+      allContainerVolumeMounts.addAll(podSpecContainerVolumeMounts);
+    }
+    return allContainerVolumeMounts;
   }
 
   /**
@@ -150,5 +238,4 @@ public class PodTemplateMergeUtils {
       }
     }
   }
-
 }

--- a/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
+++ b/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
@@ -17,7 +17,6 @@
 
 package azkaban.container.models;
 
-import azkaban.executor.container.KubernetesContainerizedImpl;
 import azkaban.utils.TestUtils;
 import com.google.common.collect.ImmutableMap;
 import io.kubernetes.client.openapi.models.V1Pod;

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTest2.yaml
@@ -50,18 +50,9 @@ spec:
       name: azkaban-private-properties
     - mountPath: /var/run/kubelet
       name: kubelet
+    - mountPath: azBasePath/plugins/jobtypes/custom-spark
+      name: jobtype-volume-custom-spark
   initContainers:
-  - env:
-    - name: AZ_CLUSTER
-      value: mycluster
-    - name: JOBTYPE_MOUNT_PATH
-      value: /data/jobtypes/spark
-    image: path/spark-jobtype:0.0.5
-    imagePullPolicy: IfNotPresent
-    name: jobtype-init-spark
-    volumeMounts:
-    - mountPath: /data/jobtypes/spark
-      name: jobtype-volume-spark
   - command:
     - chown
     - -R
@@ -74,6 +65,21 @@ spec:
     volumeMounts:
     - mountPath: /var/run/kubelet
       name: kubelet
+  - env:
+    - name: CUSTOM_ENV
+      value: customVal
+    - name: AZ_CLUSTER
+      value: mycluster
+    - name: JOBTYPE_MOUNT_PATH
+      value: /data/jobtypes/spark
+    image: path/spark-jobtype:0.0.5
+    imagePullPolicy: IfNotPresent
+    name: jobtype-init-spark
+    volumeMounts:
+    - mountPath: /data/jobtypes/spark
+      name: jobtype-volume-spark
+    - mountPath: /data/jobtypes/custom-spark
+      name: jobtype-volume-custom-spark
   restartPolicy: Never
   volumes:
   - emptyDir: {}
@@ -86,6 +92,8 @@ spec:
     secret:
       defaultMode: 256
       secretName: azkaban-private-properties
+  - emptyDir: {}
+    name: jobtype-volume-custom-spark
   - hostPath:
       type: Directory
       path: /export/content/lid/apps/kubelet/i002/var

--- a/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
+++ b/azkaban-common/src/test/resources/azkaban/container/models/v1PodTestTemplate1.yaml
@@ -5,6 +5,17 @@ metadata:
   namespace: "az-team"
 spec:
   initContainers:
+    - env:
+        - name: CUSTOM_ENV
+          value: customVal
+      image: path/spark-jobtype:0.0.4
+      imagePullPolicy: IfNotPresent
+      name: jobtype-init-spark
+      volumeMounts:
+        - mountPath: /data/jobtypes/spark2
+          name: jobtype-volume-spark
+        - mountPath: /data/jobtypes/custom-spark
+          name: jobtype-volume-custom-spark
     - name: chown-kubelet
       image: path/my-image:0.0.5
       command:
@@ -38,9 +49,13 @@ spec:
       volumeMounts:
         - name: kubelet
           mountPath: "/var/run/kubelet"
+        - name: jobtype-volume-custom-spark
+          mountPath: "azBasePath/plugins/jobtypes/custom-spark"
   volumes:
     - emptyDir: {}
       name: jobtype-volume-spark
+    - emptyDir: {}
+      name: jobtype-volume-custom-spark
     - name: kubelet
       hostPath:
         path: /export/content/lid/apps/kubelet/i002/var


### PR DESCRIPTION
The current merge method for init containers from the pod-spec template and dynamically generated pod-spec is a simple append to the list, i.e. take all the init containers from the dynamically generated pod-spec and take only those init containers from the pod-spec template which are not part of generated pod-spec.

However, the init containers from generated pod-spec are relatively simple with only a couple of env variables, one fixed volume which gets mounted to the init container as well as flow container. There is a need for more complex init containers where the complex part can come from the pod-spec template.

This change updates the merge method for init containers from the pod-spec template and dynamically generated pod-spec, such that:
1) Add all the init containers which are only part of podTemplate. 
2) Add all the init containers which are only part of pod-spec. 
3) Add the init containers which are part of both pod-spec and pod-template by merging them such that: 
    a) Skeleton of templateInitContainer is utilized. 
    b) Environment variables from podSpecInitContainer are added to the corresponding  templateInitContainer. 
    c) ImagePullPolicy, Image, and VolumeMounts are overridden from podSpecInitContainer to templateInitContainer.


This change is also leveraged to merge the flow-container from the pod template and the dynamically generated pod-spec. Hence removed the unnecessary methods.