### PR TITLE
Setup environment variables for RPMs based on flow-params

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -669,6 +669,7 @@ public class Constants {
     public static final String ENV_FLOW_EXECUTION_ID = "FLOW_EXECUTION_ID";
     public static final String ENV_JAVA_ENABLE_DEBUG = "JAVA_ENABLE_DEBUG";
     public static final String ENV_ENABLE_DEV_POD = "ENABLE_DEV_POD";
+    public static final String ENV_RPM_PREFIX = "RPM_";
   }
 
   public static class ImageMgmtConstants {
@@ -692,6 +693,10 @@ public class Constants {
 
     // Constant to enable pod for developer testing
     public static final String FLOW_PARAM_ENABLE_DEV_POD = "enable.dev.pod";
+
+    // Params with this prefix will be set as environment variables to the flow container and can
+    // be utilized by any script for download/installation.
+    public static final String FLOW_PARAM_RPM_PREFIX = "flow.container.rpm.";
 
     // Constant to disable pod cleanup through the kubernetes watch
     public static final String FLOW_PARAM_DISABLE_POD_CLEANUP = "disable.pod.cleanup";

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -421,6 +421,21 @@ public class KubernetesContainerizedImplTest {
             .get(AZKABAN_BASE_IMAGE).getVersion());
   }
 
+  @Test
+  public void testSetupRPMs() {
+    final Map<String, String> envVariables = new HashMap<>();
+    final Map<String, String> flowParam = new HashMap<>();
+    flowParam.put("mykey", "myprop");
+    flowParam.put("flow.container.rpm.cluster1.hadoop", "rpm_hadoop_cluster1_1.1");
+    flowParam.put("flow.container.rpm.cluster2.hadoop", "rpm_hadoop_cluster2_1.1");
+    flowParam.put("flow.container.rpm.cluster1.hive", "rpm_hive_cluster1_3.1");
+    KubernetesContainerizedImpl.setupRPMs(envVariables, flowParam);
+    Assert.assertEquals(3, envVariables.size());
+    Assert.assertEquals("rpm_hadoop_cluster1_1.1", envVariables.get("RPM_CLUSTER1_HADOOP"));
+    Assert.assertEquals("rpm_hadoop_cluster2_1.1", envVariables.get("RPM_CLUSTER2_HADOOP"));
+    Assert.assertEquals("rpm_hive_cluster1_3.1", envVariables.get("RPM_CLUSTER1_HIVE"));
+  }
+
   private ExecutableFlow createTestFlow() throws Exception {
     return TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
   }


### PR DESCRIPTION
This change allows setting up a list of RPMs via flow params as ENV variables to the flow container. 

The motivation is that the startup scripts for the flow containers can utilize this ENV variable to install the RPMs for various testing purposes.