### PR TITLE
Changed to 'create index IF NOT EXISTS' to fix single server startup failure

### DIFF
--- a/azkaban-db/src/main/sql/create.containerization-tables-all.sql
+++ b/azkaban-db/src/main/sql/create.containerization-tables-all.sql
@@ -11,10 +11,10 @@ CREATE TABLE IF NOT EXISTS image_types (
   modified_by      VARCHAR(64)     NOT NULL
 );
 
-CREATE INDEX image_types_name
+CREATE INDEX IF NOT EXISTS image_types_name
   ON image_types (name);
 
-CREATE INDEX image_types_active
+CREATE INDEX IF NOT EXISTS image_types_active
   ON image_types (active);
 
 -- Definition for image_versions table. This table is used for storing versions of an image type
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS image_versions (
   UNIQUE (type_id, version)
 );
 
-CREATE INDEX image_versions_type_id
+CREATE INDEX IF NOT EXISTS image_versions_type_id
   ON image_versions (type_id);
 
 -- Definition for image_ownerships table. This table is used for storing ownership information for
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS image_ownerships (
   modified_by      VARCHAR(64)     NOT NULL
 );
 
-CREATE INDEX image_ownerships_type_id
+CREATE INDEX IF NOT EXISTS image_ownerships_type_id
   ON image_ownerships (type_id);
 
 
@@ -72,10 +72,10 @@ CREATE TABLE IF NOT EXISTS image_rampup_plan (
 --  One option is to move each table create scripts to separate file. But all the  containerization
 --  tables are placed in this file so that it easier to manage.
 
-CREATE INDEX image_rampup_plan_type_id
+CREATE INDEX IF NOT EXISTS image_rampup_plan_type_id
   ON image_rampup_plan (type_id);
 
-CREATE INDEX image_rampup_plan_active
+CREATE INDEX IF NOT EXISTS image_rampup_plan_active
   ON image_rampup_plan (active);
 
 -- Definition for image_rampup table. This table contains information of the image versions being
@@ -92,10 +92,10 @@ CREATE TABLE IF NOT EXISTS image_rampup (
   modified_by       VARCHAR(64)    NOT NULL
 );
 
-CREATE INDEX image_rampup_plan_id
+CREATE INDEX IF NOT EXISTS image_rampup_plan_id
   ON image_rampup (plan_id);
 
-CREATE INDEX image_rampup_version_id
+CREATE INDEX IF NOT EXISTS image_rampup_version_id
   ON image_rampup (version_id);
 
 -- Definition for version_set table. Version set contains set of image versions and will be
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS version_set (
      PRIMARY KEY (id)
 );
 
-CREATE UNIQUE INDEX version_set_md5
+CREATE UNIQUE INDEX IF NOT EXISTS version_set_md5
  ON version_set (md5);
 
 -- TODO: Add the alter table script in the specific release


### PR DESCRIPTION
When debugging azkaban via ide, or running azkaban via solo-server on local dev box,
"create.containerization-tables-all.sql"
would break the web server start up process.

The log is:
```
ERROR [AzkabanWebServer] [main] [Azkaban] Failed to start single server. Shutting down.
java.sql.SQLException: Index "IMAGE_TYPES_NAME" already exists; SQL statement:
CREATE INDEX image_types_name
  ON image_types (name) [42111-193] Query: CREATE INDEX image_types_name
  ON image_types (name) Parameters: []
	at org.apache.commons.dbutils.AbstractQueryRunner.rethrow(AbstractQueryRunner.java:363)
	at org.apache.commons.dbutils.QueryRunner.update(QueryRunner.java:490)
	at org.apache.commons.dbutils.QueryRunner.update(QueryRunner.java:376)
	at azkaban.database.AzkabanDatabaseSetup.runTableScripts(AzkabanDatabaseSetup.java:388)
	at azkaban.database.AzkabanDatabaseSetup.createNewTables(AzkabanDatabaseSetup.java:322)
	at azkaban.database.AzkabanDatabaseSetup.updateDatabase(AzkabanDatabaseSetup.java:166)
	at azkaban.database.AzkabanDatabaseUpdater.runDatabaseUpdater(AzkabanDatabaseUpdater.java:93)
	at azkaban.soloserver.AzkabanSingleServer.start(AzkabanSingleServer.java:93)
	at azkaban.soloserver.AzkabanSingleServer.main(AzkabanSingleServer.java:58)
```
 This change aims to skip creating indexes that already exist. 