### PR TITLE
Using a new instance of V1PodSpec from the template to avoid corruption from previous merging of pod-specs

### DIFF
--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1PodTemplate.java
@@ -16,55 +16,41 @@
 
 package azkaban.container.models;
 
-import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
-import io.kubernetes.client.openapi.models.V1Probe;
-import io.kubernetes.client.openapi.models.V1Volume;
-import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.util.Yaml;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
- * A singleton class which reads a k8s pod-spec yaml file as template. Items like InitContainers,
- * Volumes and VolumeMounts for the application-container/flow-container will be extracted from the
- * POD created from this template file.
+ * A singleton class which reads a k8s pod-spec yaml file as template.
  * <p>
- * Extracted Items are later merged via {@link PodTemplateMergeUtils#mergePodSpec(V1PodSpec, AzKubernetesV1PodTemplate)} (V1PodSpec,
- * AzKubernetesV1PodTemplate)} with the pod-spec created using {@link AzKubernetesV1SpecBuilder}
+ * Items are later merged via {@link PodTemplateMergeUtils#mergePodSpec(V1PodSpec, V1PodSpec)}
+ * (V1PodSpec, AzKubernetesV1PodTemplate)} with the pod-spec created using {@link
+ * AzKubernetesV1SpecBuilder}
  * <p>
- * Merging criteria is such that, if the item in the already created pod-spec has the same name as
- * of the item extracted from the template, then it will be retained.
- * <p>
- * This template design enables declaration of static initContainers, volumes, volumeMounts, etc.
- * which are not job-types but are useful. For example: init container which will fetch the required
- * certificates/tokens etc. writes to a volume and then that volume will be mounted to the
- * application-container/flow-container.
- *
  * The template must have only one non-init container. Azkaban k8s design is such that
  * flow-container will be the only non-init container.
  */
 public class AzKubernetesV1PodTemplate {
 
-  public static final int FLOW_CONTAINER_INDEX = 0;
-  private V1Pod podFromTemplate;
   private static AzKubernetesV1PodTemplate instance;
+  private final File templateFile;
+  private final String templatePodString;
 
   /**
    * Private constructor to make this class singleton
    *
    * @param templatePath th where the template file is located.
-   * @throws IOException If unable to read the template file.
    */
   private AzKubernetesV1PodTemplate(String templatePath) throws IOException {
-    File templateFile = Paths.get(templatePath).toFile();
-    this.podFromTemplate = (V1Pod) Yaml.load(templateFile);
+    this.templateFile = Paths.get(templatePath).toFile();
+
+    // Rather than reading the template file string, load and dump again. This ensures that if
+    // there is a problem with template string, error will be thrown earlier.
+    V1Pod v1Pod = (V1Pod) Yaml.load(templateFile);
+    this.templatePodString = Yaml.dump(v1Pod);
   }
 
   /**
@@ -81,138 +67,11 @@ public class AzKubernetesV1PodTemplate {
   }
 
   /**
-   * @return The Flow Container which must be the first container among all app-containers
+   * Always returns a new instance of V1PodSpec generated from the template.
+   * @return the {@link V1PodSpec} POD spec generated from the template.
+   * @throws IOException If unable to read the template file.
    */
-  public V1Container getFlowContainer() {
-    final List<V1Container> containers = this.podFromTemplate.getSpec().getContainers();
-    return containers.isEmpty() ? null : containers.get(FLOW_CONTAINER_INDEX);
-  }
-
-  /**
-   * @return The list of all app-containers.
-   */
-  public List<V1Container> getAllContainers() {
-    return this.podFromTemplate.getSpec().getContainers();
-  }
-
-
-  /**
-   * @return the {@link V1Pod} POD generated from the template.
-   */
-  public V1Pod getPodFromTemplate() {
-    return this.podFromTemplate;
-  }
-
-  /**
-   * @param filterPredicate Predicate to filter the init containers.
-   * @return The list of filtered init Containers derived from the POD specified in the template.
-   */
-  public List<V1Container> getInitContainers(Predicate<? super V1Container> filterPredicate) {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    if (null == spec) {
-      return Collections.emptyList();
-    }
-    List<V1Container> initContainers = spec.getInitContainers();
-    return initContainers == null ? Collections.emptyList() :
-        initContainers.stream().filter(filterPredicate).collect(Collectors.toList());
-  }
-
-  /**
-   * @return The list of init Containers derived from the POD specified in the template.
-   */
-  public List<V1Container> getInitContainers() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    return spec == null ? Collections.emptyList() : spec.getInitContainers();
-  }
-
-  /**
-   * @param filterPredicate Predicate to filter the volumes.
-   * @return The list of filtered Volumes derived from the POD specified in the template.
-   */
-  public List<V1Volume> getVolumes(Predicate<? super V1Volume> filterPredicate) {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    if (null == spec) {
-      return Collections.emptyList();
-    }
-    List<V1Volume> volumes = spec.getVolumes();
-    return volumes == null ?
-        Collections.emptyList() :
-        volumes.stream().filter(filterPredicate).collect(Collectors.toList());
-  }
-
-  /**
-   * @return The list of filtered Volumes derived from the POD specified in the template.
-   */
-  public List<V1Volume> getVolumes() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    return spec == null ? Collections.emptyList() : spec.getVolumes();
-  }
-
-  /**
-   * This method returns volume mounts only for the first container.
-   *
-   * @param filterPredicate Predicate to filter the Volume Mounts.
-   * @return The list of filtered Volume Mounts to the appContainer derived from the POD specified
-   * in the template.
-   */
-  public List<V1VolumeMount> getContainerVolumeMounts(
-      Predicate<? super V1VolumeMount> filterPredicate) {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    if (null == spec) {
-      return Collections.emptyList();
-    }
-    List<V1Container> containers = spec.getContainers();
-    if (null == containers || containers.isEmpty()) {
-      return Collections.emptyList();
-    }
-    List<V1VolumeMount> volumeMounts =
-        spec.getContainers().get(FLOW_CONTAINER_INDEX).getVolumeMounts();
-    return null == volumeMounts ? Collections.emptyList()
-        : volumeMounts.stream().filter(filterPredicate).collect(Collectors.toList());
-  }
-
-  /**
-   * This method returns volume mounts only for the first container.
-   *
-   * @return The list of Volume Mounts to the appContainer derived from the POD specified in the
-   * template.
-   */
-  public List<V1VolumeMount> getContainerVolumeMounts() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
-    return containers.isEmpty() ? Collections.emptyList() :
-        containers.get(FLOW_CONTAINER_INDEX).getVolumeMounts();
-  }
-
-  /**
-   * @return The Liveliness probe for the appContainer derived form the POD specified in the
-   * template.
-   */
-  public V1Probe getContainerLivelinessProbe() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
-    return containers.isEmpty() ? null :
-        containers.get(FLOW_CONTAINER_INDEX).getLivenessProbe();
-  }
-
-  /**
-   * @return The Readiness probe for the appContainer derived form the POD specified in the
-   * template.
-   */
-  public V1Probe getContainerReadinessProbe() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
-    return containers.isEmpty() ? null :
-        containers.get(FLOW_CONTAINER_INDEX).getReadinessProbe();
-  }
-
-  /**
-   * @return The Startup probe for the appContainer derived form the POD specified in the template.
-   */
-  public V1Probe getContainerStartupProbe() {
-    V1PodSpec spec = this.podFromTemplate.getSpec();
-    List<V1Container> containers = spec == null ? Collections.emptyList() : spec.getContainers();
-    return containers.isEmpty() ? null :
-        containers.get(FLOW_CONTAINER_INDEX).getStartupProbe();
+  public synchronized V1PodSpec getPodSpecFromTemplate() throws IOException {
+    return ((V1Pod) Yaml.load(this.templatePodString)).getSpec();
   }
 }

--- a/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
@@ -21,84 +21,84 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * This class consists of various methods to merge pod-spec with the pod template
+ * This class consists of various methods to merge pod-spec with the podSpecFromTemplate.
  */
 public class PodTemplateMergeUtils {
+  private static final int FLOW_CONTAINER_INDEX = 0;
 
   private PodTemplateMergeUtils() {
     // Not to be instantiated
   }
 
   /**
-   * Items extracted from the podTemplate will be merged with the pod-spec. Merging criteria is such
+   * Items extracted from the podSpecFromTemplate will be merged with the pod-spec. Merging criteria is such
    * that, if the item, in the already created pod-spec, has the same name as of the item extracted
-   * from the template, then it will retained.
+   * from the podSpecFromTemplate, then it will retained.
    *
    * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   * @param podSpecFromTemplate PodSpec generated from {@link AzKubernetesV1PodTemplate}
    */
-  public static void mergePodSpec(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
-    mergeVolumes(podSpec, podTemplate);
-    mergeInitContainers(podSpec, podTemplate);
-    mergeFlowContainer(podSpec, podTemplate);
+  public static void mergePodSpec(V1PodSpec podSpec, V1PodSpec podSpecFromTemplate) {
+    mergeVolumes(podSpec, podSpecFromTemplate);
+    mergeInitContainers(podSpec, podSpecFromTemplate);
+    mergeFlowContainer(podSpec, podSpecFromTemplate);
   }
 
-  private static void mergeFlowContainer(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
-    V1Container podSpecFlowContainer = podSpec.getContainers()
-        .get(AzKubernetesV1PodTemplate.FLOW_CONTAINER_INDEX);
-    V1Container podTemplateFlowContainer = podTemplate.getFlowContainer();
+  private static void mergeFlowContainer(V1PodSpec podSpec, V1PodSpec podSpecFromTemplate) {
+    V1Container podSpecFlowContainer = getFlowContainer(podSpec);
+    V1Container podTemplateFlowContainer = getFlowContainer(podSpecFromTemplate);
     mergeTemplateAndPodSpecContainer(podTemplateFlowContainer, podSpecFlowContainer);
-    podSpec.setContainers(podTemplate.getAllContainers());
+    podSpec.setContainers(podSpecFromTemplate.getContainers());
   }
 
   /**
-   * Merge InitContainers from the dynamically generated pod-spec and podTemplate, such that: 1) Add
-   * all the init containers which are only part of podTemplate. 2) Add all the init containers
+   * Merge InitContainers from the dynamically generated pod-spec and podSpecFromTemplate, such that: 1) Add
+   * all the init containers which are only part of podSpecFromTemplate. 2) Add all the init containers
    * which are only part of pod-spec. 3) Add the init containers which are part of both pod-spec and
-   * pod-template by merging them such that: a) Skeleton of templateInitContainer is utilized. b)
+   * podSpecFromTemplate by merging them such that: a) Skeleton of templateInitContainer is utilized. b)
    * Environment variables from podSpecInitContainer are added to corresponding
    * templateInitContainer. c) ImagePullPolicy, Image, and VolumeMounts are overridden from
    * podSpecInitContainer to templateInitContainer.
    *
-   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}.
+   * @param podSpecFromTemplate PodSpec from {@link AzKubernetesV1PodTemplate}.
    */
   private static void mergeInitContainers(V1PodSpec podSpec,
-      AzKubernetesV1PodTemplate podTemplate) {
+      V1PodSpec podSpecFromTemplate) {
     List<V1Container> podSpecInitContainers = podSpec.getInitContainers();
     if (null == podSpecInitContainers) {
       return;
     }
-    // Get init containers from podTemplate which are not part of pod-spec init containers.
-    final List<V1Container> templateOnlyInitContainers = podTemplate.getInitContainers(
+    // Get init containers from podSpecFromTemplate which are not part of pod-spec init containers.
+    final List<V1Container> templateOnlyInitContainers = getInitContainers(podSpecFromTemplate,
         templateInitContainer -> podSpecInitContainers.stream().map(V1Container::getName)
-            .noneMatch(name -> name.equals(templateInitContainer.getName())));
+        .noneMatch(name -> name.equals(templateInitContainer.getName())));
 
-    // Get init containers from podTemplate which are also part of pod-spec init containers
+    // Get init containers from podSpecFromTemplate which are also part of pod-spec init containers
     // i.e. the other containers apart from the above list templateOnlyInitContainers.
-    final List<V1Container> templateAlsoInitContainers = podTemplate.getInitContainers(
+
+    final List<V1Container> templateAlsoInitContainers = getInitContainers(podSpecFromTemplate,
         templateInitContainer -> templateOnlyInitContainers.stream().map(V1Container::getName)
             .noneMatch(name -> name.equals(templateInitContainer.getName())));
 
-    // Get init containers from pod-spec which are not part of podTemplate init containers.
-    final List<V1Container> podSpecOnlyInitContainers =
-        podSpec.getInitContainers().stream().filter(
+    // Get init containers from pod-spec which are not part of podSpecFromTemplate init containers.
+    final List<V1Container> podSpecOnlyInitContainers = getInitContainers(podSpec,
             podSpecInitContainer -> templateAlsoInitContainers.stream().map(V1Container::getName)
-                .noneMatch(name -> name.equals(podSpecInitContainer.getName()))
-        ).collect(Collectors.toList());
+                .noneMatch(name -> name.equals(podSpecInitContainer.getName())));
 
-    // Get init containers from pod-spec which are also part of podTemplate init containers
+    // Get init containers from pod-spec which are also part of podSpecFromTemplate init containers
     // i.e. the other containers apart from the above list podSpecOnlyInitContainers.
-    final Map<String, V1Container> podSpecAlsoInitContainers =
-        podSpec.getInitContainers().stream().filter(
-            podSpecInitContainer -> podSpecOnlyInitContainers.stream().map(V1Container::getName)
-                .noneMatch(name -> name.equals(podSpecInitContainer.getName()))
-        ).collect(Collectors.toMap(V1Container::getName, e -> e));
+    final Map<String, V1Container> podSpecAlsoInitContainers = getInitContainers(podSpec,
+        podSpecInitContainer -> podSpecOnlyInitContainers.stream().map(V1Container::getName)
+            .noneMatch(name -> name.equals(podSpecInitContainer.getName()))).stream()
+        .collect(Collectors.toMap(V1Container::getName, e -> e));
 
     final List<V1Container> allInitContainers = new ArrayList<>();
     allInitContainers.addAll(podSpecOnlyInitContainers);
@@ -224,17 +224,54 @@ public class PodTemplateMergeUtils {
    * Add those volumes which are not already available in the podSpec
    *
    * @param podSpec     Already created podSpec using the {@link AzKubernetesV1SpecBuilder}
-   * @param podTemplate Instance of the class {@link AzKubernetesV1PodTemplate} to extract items
+   * @param podSpecFromTemplate PodSpec from {@link AzKubernetesV1PodTemplate}
    */
-  private static void mergeVolumes(V1PodSpec podSpec, AzKubernetesV1PodTemplate podTemplate) {
+  private static void mergeVolumes(V1PodSpec podSpec, V1PodSpec podSpecFromTemplate) {
     List<V1Volume> podSpecVolumes = podSpec.getVolumes();
     if (null != podSpecVolumes) {
-      List<V1Volume> templateVolumes = podTemplate.getVolumes(
+      List<V1Volume> templateVolumes = getVolumes(podSpecFromTemplate,
           tempVol -> podSpecVolumes.stream().map(V1Volume::getName)
               .noneMatch(name -> name.equals(tempVol.getName())));
       for (V1Volume volumeItem : templateVolumes) {
         podSpec.addVolumesItem(volumeItem);
       }
     }
+  }
+
+  /**
+   * @return The Flow Container which must be the first container among all app-containers
+   */
+  private static V1Container getFlowContainer(V1PodSpec podSpec) {
+    final List<V1Container> containers = podSpec.getContainers();
+    return containers.isEmpty() ? null : containers.get(FLOW_CONTAINER_INDEX);
+  }
+
+  /**
+   * @param filterPredicate Predicate to filter the init containers.
+   * @return The list of filtered init Containers derived from the pod-spec.
+   */
+  private static List<V1Container> getInitContainers(V1PodSpec podSpec, Predicate<?
+      super V1Container> filterPredicate) {
+    if (null == podSpec) {
+      return Collections.emptyList();
+    }
+    List<V1Container> initContainers = podSpec.getInitContainers();
+    return initContainers == null ? Collections.emptyList() :
+        initContainers.stream().filter(filterPredicate).collect(Collectors.toList());
+  }
+
+  /**
+   * @param filterPredicate Predicate to filter the volumes.
+   * @return The list of filtered Volumes derived from the pod-spec.
+   */
+  private static List<V1Volume> getVolumes(V1PodSpec podSpec,
+      Predicate<? super V1Volume> filterPredicate) {
+    if (null == podSpec) {
+      return Collections.emptyList();
+    }
+    List<V1Volume> volumes = podSpec.getVolumes();
+    return volumes == null ?
+        Collections.emptyList() :
+        volumes.stream().filter(filterPredicate).collect(Collectors.toList());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
+++ b/azkaban-common/src/test/java/azkaban/container/models/AzKubernetesV1PodBuilderTest.java
@@ -65,7 +65,8 @@ public class AzKubernetesV1PodBuilderTest {
         // Merge the podSpec created earlier with the pod from the template
         AzKubernetesV1PodTemplate podTemplate = AzKubernetesV1PodTemplate.getInstance(
             this.getClass().getResource("v1PodTestTemplate1.yaml").getFile());
-        PodTemplateMergeUtils.mergePodSpec(podSpec, podTemplate);
+        V1PodSpec podSpecFromTemplate = podTemplate.getPodSpecFromTemplate();
+        PodTemplateMergeUtils.mergePodSpec(podSpec, podSpecFromTemplate);
         V1Pod pod2 = new AzKubernetesV1PodBuilder(podName, podNameSpace, podSpec)
             .withPodLabels(labels)
             .withPodAnnotations(annotations)
@@ -73,5 +74,18 @@ public class AzKubernetesV1PodBuilderTest {
         String createdPodSpec2 = Yaml.dump(pod2).trim();
         String readPodSpec2 = TestUtils.readResource("v1PodTest2.yaml", this).trim();
         Assert.assertEquals(readPodSpec2, createdPodSpec2);
+
+        // Verify that the number of volumeMounts to flow container after Merge is five in the
+        // podSpecFromTemplate
+        Assert.assertEquals(5, podSpecFromTemplate.getContainers().get(0)
+            .getVolumeMounts().size());
+
+        // Verify that the number of volumeMounts in a new podSpecFromTemplate is two and hence
+        // it is not corrupted by the previous Merge
+        podTemplate = AzKubernetesV1PodTemplate.getInstance(
+            this.getClass().getResource("v1PodTestTemplate1.yaml").getFile());
+        podSpecFromTemplate = podTemplate.getPodSpecFromTemplate();
+        Assert.assertEquals(2, podSpecFromTemplate.getContainers().get(0)
+            .getVolumeMounts().size());
     }
 }


### PR DESCRIPTION
After the PR https://github.com/azkaban/azkaban/pull/2913 
azkaban.container.models.PodTemplateMergeUtils#mergePodSpec 
makes changes in the Pod generated from the Template which is a singleton and has only one instance of Pod stored internally. Hence multiple executions lead to corruption of the same instance of POD in the singleton class.

This can be fixed by making sure that a new instance of POD is generated from the template every time during the course of pod spec creation. Since this instance will be local to the method, multiple threads won't affect it.