### PR TITLE
🐛  Delete button bug fix

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -183,7 +183,7 @@
               <h4>Runtime Properties</h4>
               <hr>
               <div id="editTable">
-                <table class="table table-striped">
+                <table class="table table-condensed table-striped">
                   <thead>
                   <tr>
                     <th>Node</th>
@@ -214,13 +214,6 @@
             </div>
           #end
 
-          #*
-          #if ($triggerPlugins.size() > 0)
-            #foreach ($triggerPlugin in $triggerPlugins)
-                        <button type="button" class="btn btn-default" id=set-$triggerPlugin.pluginName>$triggerPlugin.pluginName</button>
-            #end
-          #end
-          *#
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-primary" id="execute-btn">Execute</button>
       </div><!-- /modal-footer -->
@@ -231,15 +224,5 @@
 #if (!$show_schedule || $show_schedule == 'true')
     #parse ("azkaban/webapp/servlet/velocity/schedulepanel.vm")
 #end
-
-#*
-#if ($triggerPlugins.size() > 0)
-  #foreach ($triggerPlugin in $triggerPlugins)
-    #set ($prefix = $triggerPlugin.pluginName)
-    #set ($webpath = $triggerPlugin.pluginPath)
-    #parse ($triggerPlugin.inputPanelVM)
-  #end
-#end
-*#
 
 <div id="contextMenu"></div>

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -319,7 +319,7 @@ azkaban.EditTableView = Backbone.View.extend({
   events: {
     "click table #add-btn": "handleAddRow",
     "click table .editable": "handleEditColumn",
-    "click table .remove-btn": "handleRemoveColumn"
+    "click table .remove-btn": "handleRemoveRow"
   },
 
   initialize: function (setting) {
@@ -384,13 +384,13 @@ azkaban.EditTableView = Backbone.View.extend({
     $(tdName).addClass("editable");
 
     $(tdValue).append(valueData);
-    $(tdValue).append(remove);
     $(tdValue).addClass("editable").addClass('value');
 
     $(tr).addClass("editRow");
     $(tr).append(tdJobOrFlow);
     $(tr).append(tdName);
     $(tr).append(tdValue);
+    $(tr).append(remove);
 
     $(tr).insertBefore(".addRow");
     return tr;
@@ -426,10 +426,10 @@ azkaban.EditTableView = Backbone.View.extend({
     });
   },
 
-  handleRemoveColumn: function (evt) {
+  handleRemoveRow: function (evt) {
     var curTarget = evt.currentTarget;
     // Should be the table
-    var row = curTarget.parentElement.parentElement;
+    var row = curTarget.parentElement;
     $(row).remove();
   },
 
@@ -442,17 +442,6 @@ azkaban.EditTableView = Backbone.View.extend({
     var valueData = document.createElement("span");
     $(valueData).addClass("spanValue");
     $(valueData).text(text);
-
-    if ($(parent).hasClass("value")) {
-      var remove = document.createElement("div");
-      $(remove).addClass("pull-right").addClass('remove-btn');
-      var removeBtn = document.createElement("button");
-      $(removeBtn).attr('type', 'button');
-      $(removeBtn).addClass('btn').addClass('btn-xs').addClass('btn-danger');
-      $(removeBtn).text('Delete');
-      $(remove).append(removeBtn);
-      $(parent).append(remove);
-    }
 
     $(parent).removeClass("editing");
     $(parent).append(valueData);


### PR DESCRIPTION



Users have requested that Azkaban be changed so that Runtime Properties are easier to delete.

Before: The delete button is only available on mouse over, and is a child element of the Value cell.

![Screen Shot 2021-08-25 at 1 08 18 AM](https://user-images.githubusercontent.com/84037211/130752806-f5559b29-f176-4b35-a3b8-0ab783fe2b40.png)

After: The delete button is available on all rows and is an element of the row itself.

![Screen Shot 2021-08-25 at 1 06 23 AM](https://user-images.githubusercontent.com/84037211/130752308-54e1d4f8-02de-4e84-896b-3e6d7baeceb2.png)

Tested locally and on in-house servers.