### PR TITLE
Add metrics for pod dispatch failure

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -436,6 +436,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
           ContainerizedDispatchManager.this.fireEventListeners(Event.create(dsFlow, EventType.FLOW_STATUS_CHANGED,
               new EventData(dsFlow)));
         } catch (ExecutorManagerException executorManagerException) {
+          ContainerizedDispatchManager.this.containerizationMetrics.markContainerDispatchFail();
           logger.error("Unable to update execution status to FAILED for : {}", executionId);
         }
       }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -432,11 +432,11 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
           dsFlow.setStatus(Status.FAILED);
           dsFlow.setUpdateTime(System.currentTimeMillis());
           ContainerizedDispatchManager.this.executorLoader.updateExecutableFlow(dsFlow);
+          ContainerizedDispatchManager.this.containerizationMetrics.markContainerDispatchFail();
           // Emit failed flow event
           ContainerizedDispatchManager.this.fireEventListeners(Event.create(dsFlow, EventType.FLOW_STATUS_CHANGED,
               new EventData(dsFlow)));
         } catch (ExecutorManagerException executorManagerException) {
-          ContainerizedDispatchManager.this.containerizationMetrics.markContainerDispatchFail();
           logger.error("Unable to update execution status to FAILED for : {}", executionId);
         }
       }

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
@@ -98,7 +98,7 @@ public class ContainerStatusMetricsListener implements AzPodStatusListener{
       return;
     }
     // Update AzPodStatus metrics for the flow-pod respectively
-    try {
+    if (containerizationMetrics.isInitialized()) {
       switch (event.getAzPodStatus()) {
         case AZ_POD_REQUESTED:
           containerizationMetrics.markPodRequested();
@@ -127,8 +127,8 @@ public class ContainerStatusMetricsListener implements AzPodStatusListener{
         default:
           // do nothing when status is AZ_POD_UNSET, AZ_POD_UNEXPECTED
       }
-    } catch (Exception e) {
-      logger.warn("Containerization metrics are not initialized.", e);
+    } else {
+      logger.warn ("Containerization metrics are not initialized");
     }
     updatePodStatus(event);
   }

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
@@ -125,7 +125,7 @@ public class ContainerStatusMetricsListener implements AzPodStatusListener{
           containerizationMetrics.markPodAppFailure();
           break;
         default:
-          // do nothing when status is AZ_POD_UNSET, AZ_POD_UNEXPECTED, AZ_POD_UNEXPECTED
+          // do nothing when status is AZ_POD_UNSET, AZ_POD_UNEXPECTED
       }
     } catch (Exception e) {
       logger.warn("Containerization metrics are not initialized.", e);

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/ContainerStatusMetricsListener.java
@@ -22,6 +22,7 @@ import azkaban.metrics.ContainerizationMetrics;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -97,33 +98,37 @@ public class ContainerStatusMetricsListener implements AzPodStatusListener{
       return;
     }
     // Update AzPodStatus metrics for the flow-pod respectively
-    switch (event.getAzPodStatus()) {
-      case AZ_POD_REQUESTED:
-        containerizationMetrics.markPodRequested();
-        break;
-      case AZ_POD_SCHEDULED:
-        containerizationMetrics.markPodScheduled();
-        break;
-      case AZ_POD_INIT_CONTAINERS_RUNNING:
-        containerizationMetrics.markInitContainerRunning();
-        break;
-      case AZ_POD_APP_CONTAINERS_STARTING:
-        containerizationMetrics.markAppContainerStarting();
-        break;
-      case AZ_POD_READY:
-        containerizationMetrics.markPodReady();
-        break;
-      case AZ_POD_COMPLETED:
-        containerizationMetrics.markPodCompleted();
-        break;
-      case AZ_POD_INIT_FAILURE:
-        containerizationMetrics.markPodInitFailure();
-        break;
-      case AZ_POD_APP_FAILURE:
-        containerizationMetrics.markPodAppFailure();
-        break;
-      default:
-        // do nothing when status is AZ_POD_UNSET, AZ_POD_UNEXPECTED, AZ_POD_UNEXPECTED
+    try {
+      switch (event.getAzPodStatus()) {
+        case AZ_POD_REQUESTED:
+          containerizationMetrics.markPodRequested();
+          break;
+        case AZ_POD_SCHEDULED:
+          containerizationMetrics.markPodScheduled();
+          break;
+        case AZ_POD_INIT_CONTAINERS_RUNNING:
+          containerizationMetrics.markInitContainerRunning();
+          break;
+        case AZ_POD_APP_CONTAINERS_STARTING:
+          containerizationMetrics.markAppContainerStarting();
+          break;
+        case AZ_POD_READY:
+          containerizationMetrics.markPodReady();
+          break;
+        case AZ_POD_COMPLETED:
+          containerizationMetrics.markPodCompleted();
+          break;
+        case AZ_POD_INIT_FAILURE:
+          containerizationMetrics.markPodInitFailure();
+          break;
+        case AZ_POD_APP_FAILURE:
+          containerizationMetrics.markPodAppFailure();
+          break;
+        default:
+          // do nothing when status is AZ_POD_UNSET, AZ_POD_UNEXPECTED, AZ_POD_UNEXPECTED
+      }
+    } catch (Exception e) {
+      logger.warn("Containerization metrics are not initialized.", e);
     }
     updatePodStatus(event);
   }

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -149,10 +149,10 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
               event.getAzPodStatus(),
               event.getPodName()));
       logger.error("Unsupported state transition.", transitionException);
-      try {
+      if (containerizationMetrics.isInitialized()) {
         containerizationMetrics.markExecutionStopped();
-      } catch (Exception e) {
-        logger.warn("Containerization metrics are not initialized.", e);
+      } else {
+        logger.warn ("Containerization metrics are not initialized");
       }
       try {
         finalizeFlowAndDeleteContainer(event, Optional.of(Status.EXECUTION_STOPPED));

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -149,7 +149,11 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
               event.getAzPodStatus(),
               event.getPodName()));
       logger.error("Unsupported state transition.", transitionException);
-      containerizationMetrics.markExecutionStopped();
+      try {
+        containerizationMetrics.markExecutionStopped();
+      } catch (Exception e) {
+        logger.warn("Containerization metrics are not initialized.", e);
+      }
       try {
         finalizeFlowAndDeleteContainer(event, Optional.of(Status.EXECUTION_STOPPED));
       } catch (Exception deletionException) {

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -27,6 +27,7 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.executor.container.ContainerizedImpl;
 import azkaban.executor.container.watch.AzPodStatus.TransitionValidator;
+import azkaban.metrics.ContainerizationMetrics;
 import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
@@ -62,6 +63,8 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
   private final Cache<String, AzPodStatusMetadata> podStatusCache;
   private final ExecutorService executor;
 
+  private final ContainerizationMetrics containerizationMetrics;
+
   // Note about the cache size.
   // Each incoming event is expected to be less than 5KB in size and the maximum cache size will be
   // about 5KB * maxCacheEntries.
@@ -73,7 +76,8 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
   public FlowStatusManagerListener(Props azkProps,
       ContainerizedImpl containerizedImpl,
       ExecutorLoader executorLoader,
-      AlerterHolder alerterHolder) {
+      AlerterHolder alerterHolder, ContainerizationMetrics containerizationMetrics) {
+    this.containerizationMetrics = containerizationMetrics;
     requireNonNull(azkProps, "azkaban properties must not be null");
     requireNonNull(containerizedImpl, "container implementation must not be null");
     requireNonNull(executorLoader, "executor loader must not be null");
@@ -145,6 +149,7 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
               event.getAzPodStatus(),
               event.getPodName()));
       logger.error("Unsupported state transition.", transitionException);
+      containerizationMetrics.markExecutionStopped();
       try {
         finalizeFlowAndDeleteContainer(event, Optional.of(Status.EXECUTION_STOPPED));
       } catch (Exception deletionException) {

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -83,4 +83,13 @@ public interface ContainerizationMetrics {
    */
   void markFlowSubmitToContainer();
 
+  /**
+   * Record number of flow executions stopped due to container infra failure
+   */
+  void markExecutionStopped();
+
+  /**
+   * Record number of container dispatch failure
+   */
+  void markContainerDispatchFail();
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -28,6 +28,11 @@ public interface ContainerizationMetrics {
   void startReporting(final Props props);
 
   /**
+   * @return isInitialized status
+   */
+  public boolean isInitialized();
+
+  /**
    *  Record the number of pod whose application containers exited without errors
    */
   void markPodCompleted();

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -35,6 +35,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
   private Meter executionStopped, containerDispatchFail;
   private Histogram timeToDispatch;
+  private boolean isInitialized = false;
 
   @Inject
   public ContainerizationMetricsImpl(MetricsManager metricsManager) {
@@ -63,6 +64,12 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   public void startReporting(Props props) {
     logger.info(String.format("Start reporting container metrics"));
     this.metricsManager.startReporting("AZ-WEB", props);
+    this.isInitialized = true;
+  }
+
+  @Override
+  public boolean isInitialized() {
+    return isInitialized;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -33,6 +33,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Meter podCompleted, podRequested, podScheduled, initContainerRunning,
       appContainerStarting, podReady, podInitFailure, podAppFailure;
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
+  private Meter executionStopped, containerDispatchFail;
   private Histogram timeToDispatch;
 
   @Inject
@@ -54,12 +55,14 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.flowSubmitToExecutor = this.metricsManager.addMeter("Flow-Submit-To-Executor-Meter");
     this.flowSubmitToContainer = this.metricsManager.addMeter("Flow-Submit-To-Container-Meter");
     this.timeToDispatch = this.metricsManager.addHistogram("Time-To-Dispatch-Pod-Histogram");
+    this.executionStopped = this.metricsManager.addMeter("Execution-Stopped-Meter");
+    this.containerDispatchFail = this.metricsManager.addMeter("Container-Dispatch-Fail-Meter");
   }
 
   @Override
   public void startReporting(Props props) {
     logger.info(String.format("Start reporting container metrics"));
-    this.metricsManager.startReporting("AZ-WEB", props);
+    this.metricsManager.startReporting("AZ-CONTAINER", props);
   }
 
   /**
@@ -113,4 +116,10 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
   @Override
   public void markFlowSubmitToContainer() { flowSubmitToContainer.mark(); }
+
+  @Override
+  public void markExecutionStopped() { executionStopped.mark(); }
+
+  @Override
+  public void markContainerDispatchFail() { containerDispatchFail.mark(); }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -35,7 +35,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
   private Meter executionStopped, containerDispatchFail;
   private Histogram timeToDispatch;
-  private boolean isInitialized = false;
+  private volatile boolean isInitialized = false;
 
   @Inject
   public ContainerizationMetricsImpl(MetricsManager metricsManager) {
@@ -61,7 +61,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   }
 
   @Override
-  public void startReporting(Props props) {
+  public synchronized void startReporting(Props props) {
     logger.info(String.format("Start reporting container metrics"));
     this.metricsManager.startReporting("AZ-WEB", props);
     this.isInitialized = true;

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -62,7 +62,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   @Override
   public void startReporting(Props props) {
     logger.info(String.format("Start reporting container metrics"));
-    this.metricsManager.startReporting("AZ-CONTAINER", props);
+    this.metricsManager.startReporting("AZ-WEB", props);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -35,6 +35,11 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
   }
 
   @Override
+  public boolean isInitialized() {
+    return false;
+  }
+
+  @Override
   public void markPodCompleted() {
   }
 

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -72,11 +72,17 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
 
   @Override
   public void markFlowSubmitToExecutor() {
-
   }
 
   @Override
   public void markFlowSubmitToContainer() {
+  }
 
+  @Override
+  public void markExecutionStopped() {
+  }
+
+  @Override
+  public void markContainerDispatchFail() {
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -113,6 +113,7 @@ public class KubernetesWatchTest {
       AzPodStatus.AZ_POD_COMPLETED);
 
   private ApiClient defaultApiClient;
+  private ContainerizationMetrics containerizationMetrics = new DummyContainerizationMetricsImpl();
 
   @Before
   public void setUp() throws Exception {
@@ -166,7 +167,7 @@ public class KubernetesWatchTest {
 
   private FlowStatusManagerListener flowStatusUpdatingListener(Props azkProps) {
     return new FlowStatusManagerListener(azkProps, mockedContainerizedImpl(),
-        mockedExecutorLoader(), mock(AlerterHolder.class));
+        mockedExecutorLoader(), mock(AlerterHolder.class), containerizationMetrics);
   }
 
   private AzPodStatusDrivingListener statusDriverWithListener(AzPodStatusListener listener) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -230,8 +230,9 @@ public class AzkabanWebServerModule extends AbstractModule {
       final Props azkProps,
       final ContainerizedImpl containerizedImpl,
       final ExecutorLoader executorLoader,
-      final AlerterHolder alerterHolder) {
-    return new FlowStatusManagerListener(azkProps, containerizedImpl, executorLoader, alerterHolder);
+      final AlerterHolder alerterHolder, final ContainerizationMetrics containerizationMetrics) {
+    return new FlowStatusManagerListener(azkProps, containerizedImpl, executorLoader, alerterHolder,
+        containerizationMetrics);
   }
 
   @Inject


### PR DESCRIPTION
The new metrics `executionStopped` that records number of flow executions stopped due to container infra failure and `containerDispatchFail` that records number of container dispatch failure are essential for health monitoring of containerized azkaban clusters.