### PR TITLE
Fix startup error of missing containerization-tables-all

### DIFF
--- a/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
+++ b/azkaban-common/src/main/java/azkaban/database/AzkabanDatabaseSetup.java
@@ -239,7 +239,19 @@ public class AzkabanDatabaseSetup {
         // pattern doesn't match with any of those. Until this new file the convention has been that
         // each file has a single table and the file name matches the table name.
         if ("quartz-tables-all".equals(tableName)) {
-          continue;
+          if (!this.installedVersions.containsKey("quartz-tables-all")) {
+            this.missingTables.add(tableName);
+          } else {
+            continue;
+          }
+        }
+        // TODO same as above
+        if ("containerization-tables-all".equals(tableName)) {
+          if (!this.installedVersions.containsKey("containerization-tables-all")) {
+            this.missingTables.add(tableName);
+          } else {
+            continue;
+          }
         }
         if (!this.tables.containsKey(tableName)) {
           this.missingTables.add(tableName);


### PR DESCRIPTION
I tried to run `AzkabanSingleServer` locally (using h2 db), got this error:
```
2021/08/27 22:02:25.501 +0300  INFO [AzkabanDatabaseSetup] [main] [Azkaban] The following are missing tables that need to be installed
'2021/08/27 22:02:25.502 +0300  INFO [AzkabanDatabaseSetup] [main] [Azkaban]  containerization-tables-all'
2021/08/27 22:02:25.502 +0300  INFO [AzkabanDatabaseSetup] [main] [Azkaban] No tables need to be updated.
2021/08/27 22:02:25.502 +0300 ERROR [AzkabanWebServer] [main] [Azkaban] Exiting with error.
```

Fixing this bug in the same way as had been previously done for a similar `quartz-tables-all` script.

But I also tried to improve the check for both of these special cases: making it a bit more strict. Now it should catch if these scripts have not been run at all. So instead of just ignoring them, require them to have been at least registered in the version properties table. The version is still not checked, but that would always be the same anyway because these are the original scripts, not table migrations.