### PR TITLE
Always show delete button of runtime properties

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowexecutionpanel.vm
@@ -189,11 +189,12 @@
                     <th>Node</th>
                     <th class="property-key">Name</th>
                     <th>Value</th>
+                    <th></th>
                   </tr>
                   </thead>
                   <tbody>
                   <tr id="addRow" class="addRow">
-                    <td id="addRow-col" colspan="3">
+                    <td id="addRow-col" colspan="4">
                       <button type="button" class="btn btn-success btn-xs" id="add-btn">Add Row
                       </button>
                     </td>

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execute-dialog.js
@@ -348,6 +348,7 @@ azkaban.EditTableView = Backbone.View.extend({
     var tdName = document.createElement("td");
     $(tdName).addClass('property-key');
     var tdValue = document.createElement("td");
+    var tdDelete = document.createElement("td");
 
     var remove = document.createElement("div");
     $(remove).addClass("pull-right").addClass('remove-btn');
@@ -384,13 +385,14 @@ azkaban.EditTableView = Backbone.View.extend({
     $(tdName).addClass("editable");
 
     $(tdValue).append(valueData);
-    $(tdValue).append(remove);
+    $(tdDelete).append(remove);
     $(tdValue).addClass("editable").addClass('value');
 
     $(tr).addClass("editRow");
     $(tr).append(tdJobOrFlow);
     $(tr).append(tdName);
     $(tr).append(tdValue);
+    $(tr).append(tdDelete);
 
     $(tr).insertBefore(".addRow");
     return tr;
@@ -442,17 +444,6 @@ azkaban.EditTableView = Backbone.View.extend({
     var valueData = document.createElement("span");
     $(valueData).addClass("spanValue");
     $(valueData).text(text);
-
-    if ($(parent).hasClass("value")) {
-      var remove = document.createElement("div");
-      $(remove).addClass("pull-right").addClass('remove-btn');
-      var removeBtn = document.createElement("button");
-      $(removeBtn).attr('type', 'button');
-      $(removeBtn).addClass('btn').addClass('btn-xs').addClass('btn-danger');
-      $(removeBtn).text('Delete');
-      $(remove).append(removeBtn);
-      $(parent).append(remove);
-    }
 
     $(parent).removeClass("editing");
     $(parent).append(valueData);


### PR DESCRIPTION
Proposing an alternative fix for the issue of https://github.com/azkaban/azkaban/pull/2924:

> Users have requested that Azkaban be changed so that Runtime Properties are easier to delete.

> Before: The delete button is only available on mouse over, and is a child element of the Value cell.

![](https://user-images.githubusercontent.com/84037211/130752806-f5559b29-f176-4b35-a3b8-0ab783fe2b40.png)

After: The delete button is always visible on all rows and has its own "column" in the table:

<img width="799" alt="Näyttökuva 2021-8-27 kello 22 39 42" src="https://user-images.githubusercontent.com/4446608/131180579-ab879271-f33c-4c51-a8b3-143ad8db9581.png">