### PR TITLE
Document python venv for docs building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ currentpid
 # pytest
 .pytest_cache/
 
+# python venv
+venv/
+
 #python
 __pycache__/
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ See [the contribution guide](https://github.com/azkaban/azkaban/blob/master/CONT
 If you want to contribute to the documentation or the release tool (inside the `tools` folder), 
 please make sure python3 is installed in your environment. python virtual environment is recommended to run these scripts.
 
-To download the python3 dependencies, run 
+To create a venv & install the python3 dependencies inside it, run
 
 ```bash
+python3 -m venv venv
+source venv/bin/activate
 pip3 install -r requirements.txt
 ```
 After, enter the documentation folder `docs` and make the build by running
@@ -70,6 +72,13 @@ cd docs
 make html
 ```
 
+Find the built docs under `_build/html/`.
+
+For example on a Mac, open them in browser with:
+
+```bash
+open -a "Google Chrome" _build/html/index.html
+```
 
 **[July, 2018]** We are actively improving our documentation. Everyone in the AZ community is 
 welcome to submit a pull request to edit/fix the documentation.


### PR DESCRIPTION
IMHO it's better to offer readymade commands for at least some way of creating the venv. Otherwise the docs building can be painful to setup for developers that are not so familiar with Python.