### PR TITLE
Add restartability when flow is in EXECUTION_STOPPED state

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -147,6 +147,9 @@ public class Constants {
   // AZ_HOME in containerized execution
   public static final String AZ_HOME = "AZ_HOME";
 
+  // Flow restart action on EXECUTION_STOPPED
+  public static final String RESTART_FLOW = "Restart Flow";
+
   // Azkaban event reporter constants
   public static class EventReporterConstants {
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -721,5 +721,9 @@ public class Constants {
     // Constant to allow test version to be passed as flow parameter. Passing test version will be
     // allowed for Azkaban ADMIN role only
     public static final String FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION = "allow.image.test.version";
+
+    //
+    public static final String FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED = "allow"
+        + ".restart.on.execution.stopped";
   }
 }

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -722,8 +722,7 @@ public class Constants {
     // allowed for Azkaban ADMIN role only
     public static final String FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION = "allow.image.test.version";
 
-    //
-    public static final String FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED = "allow"
-        + ".restart.on.execution.stopped";
+    public static final String FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED =
+        "allow.restart.on.execution.stopped";
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -18,6 +18,7 @@ package azkaban.executor;
 
 import static java.util.Objects.requireNonNull;
 
+import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.alert.Alerter;
 import azkaban.project.ProjectManager;
@@ -113,9 +114,9 @@ public class ExecutionControllerUtils {
     if (flow.getStatus() == Status.EXECUTION_STOPPED) {
       final ExecutionOptions options = flow.getExecutionOptions();
       if (options != null && !options.isExecutionRetried()) {
-        final Map<String, String> flowParam = options.getFlowParameters();
-        if (flowParam != null && !flowParam.isEmpty()) {
-          if (Boolean.valueOf(flowParam.getOrDefault(FlowParameters
+        final Map<String, String> flowParams = options.getFlowParameters();
+        if (flowParams != null && !flowParams.isEmpty()) {
+          if (Boolean.valueOf(flowParams.getOrDefault(FlowParameters
               .FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false"))) {
             final ExecutorService executor = Executors.newSingleThreadExecutor(
                 new ThreadFactoryBuilder().setNameFormat("azk-restart-flow").build());
@@ -135,7 +136,7 @@ public class ExecutionControllerUtils {
    * @param flow
    */
   protected static void restartFlow(ExecutableFlow flow) {
-    onExecutionEventListener.onExecutionEvent(flow, "Restart Flow");
+    onExecutionEventListener.onExecutionEvent(flow, Constants.RESTART_FLOW);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -303,9 +303,10 @@ public class ExecutionOptions {
     this.slaOptions = slaOptions;
   }
 
-  public boolean isExecutionRetried() { return isExecutionRetried; }
+  public boolean isExecutionRetried() { return this.isExecutionRetried; }
 
-  public void setExecutionRetried(boolean executionRetried) { isExecutionRetried = executionRetried; }
+  public void setExecutionRetried(boolean executionRetried) { this.isExecutionRetried =
+      executionRetried; }
 
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -63,6 +63,9 @@ public class ExecutionOptions {
   public static final String FAILURE_ACTION_OVERRIDE = "failureActionOverride";
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
+  // Flow restartability check
+  private static final String EXECUTION_RETRY = "executionRetryByAzkaban";
+  private boolean isExecutionRetried = false;
 
   private boolean notifyOnFirstFailure = true;
   private boolean notifyOnLastFailure = false;
@@ -153,6 +156,8 @@ public class ExecutionOptions {
     // Note: slaOptions was originally outside of execution options, so it parsed and set
     // separately for the original JSON format. New formats should include slaOptions as
     // part of execution options.
+
+    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRY, false));
 
     return options;
   }
@@ -298,6 +303,10 @@ public class ExecutionOptions {
     this.slaOptions = slaOptions;
   }
 
+  public boolean isExecutionRetried() { return isExecutionRetried; }
+
+  public void setExecutionRetried(boolean executionRetried) { isExecutionRetried = executionRetried; }
+
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
@@ -318,6 +327,7 @@ public class ExecutionOptions {
     flowOptionObj.put(FAILURE_ACTION_OVERRIDE, this.failureActionOverride);
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
+    flowOptionObj.put(EXECUTION_RETRY, this.isExecutionRetried);
     return flowOptionObj;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -1,0 +1,88 @@
+package azkaban.executor;
+
+import azkaban.Constants;
+import azkaban.DispatchMethod;
+import azkaban.flow.Flow;
+import azkaban.flow.FlowUtils;
+import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class OnContainerizedExecutionEventListener implements OnExecutionEventListener{
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(OnContainerizedExecutionEventListener.class);
+  private final ExecutorLoader executorLoader;
+  private final ExecutorManagerAdapter executorManagerAdapter;
+  private final ProjectManager projectManager;
+
+  @Inject
+  public OnContainerizedExecutionEventListener(ExecutorLoader executorLoader,
+      ExecutorManagerAdapter executorManagerAdapter, ProjectManager projectManager) {
+    this.executorLoader = executorLoader;
+    this.executorManagerAdapter = executorManagerAdapter;
+    this.projectManager = projectManager;
+  }
+
+  @Override
+  public void onExecutionEvent(final ExecutableFlow flow, final String action) {
+    if (action.equals("Restart Flow")) {
+      if (restartExecutableFlow(flow)) {
+        // Update the flow options so that the flow will be not retried by Azkaban
+        final ExecutionOptions options = flow.getExecutionOptions();
+        options.setExecutionRetried(true);
+        flow.setExecutionOptions(options);
+        try {
+          executorLoader.updateExecutableFlow(flow);
+        } catch (ExecutorManagerException e) {
+          logger.error("Unable to update flow retry value: " + e.getMessage());
+        }
+      }
+    }
+  }
+
+  /**
+   * A new execution will be dispatched based on the original ExecutableFLow
+   * @param exFlow
+   */
+  public boolean restartExecutableFlow(final ExecutableFlow exFlow) {
+    if (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) { // Enable restartability
+      // for containerized execution
+      final Project project;
+      final Flow flow;
+      try {
+        project = FlowUtils.getProject(projectManager, exFlow.getProjectId());
+        flow = FlowUtils.getFlow(project, exFlow.getFlowId());
+      } catch (final RuntimeException e) {
+        logger.error(e.getMessage());
+        return false;
+      }
+      final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
+      executableFlow.setSubmitUser(exFlow.getSubmitUser());
+      executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
+
+      final ExecutionOptions options = exFlow.getExecutionOptions();
+      if(!options.isFailureEmailsOverridden()) {
+        options.setFailureEmails(flow.getFailureEmails());
+      }
+      if (!options.isSuccessEmailsOverridden()) {
+        options.setSuccessEmails(flow.getSuccessEmails());
+      }
+      options.setMailCreator(flow.getMailCreator());
+      executableFlow.setExecutionOptions(options);
+      try {
+        logger.info("Restarting flow " + project.getName() + "." + executableFlow.getFlowName());
+        executorManagerAdapter.submitExecutableFlow(executableFlow, executableFlow.getSubmitUser());
+      } catch (final ExecutorManagerException e) {
+        logger.error("Failed to restart flow "+ executableFlow.getFlowId() + ". " + e.getMessage());
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -50,39 +50,37 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
    * @param exFlow
    */
   public boolean restartExecutableFlow(final ExecutableFlow exFlow) {
-    if (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) { // Enable restartability
-      // for containerized execution
-      final Project project;
-      final Flow flow;
-      try {
-        project = FlowUtils.getProject(projectManager, exFlow.getProjectId());
-        flow = FlowUtils.getFlow(project, exFlow.getFlowId());
-      } catch (final RuntimeException e) {
-        logger.error(e.getMessage());
-        return false;
-      }
-      final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
-      executableFlow.setSubmitUser(exFlow.getSubmitUser());
-      executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
-
-      final ExecutionOptions options = exFlow.getExecutionOptions();
-      if(!options.isFailureEmailsOverridden()) {
-        options.setFailureEmails(flow.getFailureEmails());
-      }
-      if (!options.isSuccessEmailsOverridden()) {
-        options.setSuccessEmails(flow.getSuccessEmails());
-      }
-      options.setMailCreator(flow.getMailCreator());
-      executableFlow.setExecutionOptions(options);
-      try {
-        logger.info("Restarting flow " + project.getName() + "." + executableFlow.getFlowName());
-        executorManagerAdapter.submitExecutableFlow(executableFlow, executableFlow.getSubmitUser());
-      } catch (final ExecutorManagerException e) {
-        logger.error("Failed to restart flow "+ executableFlow.getFlowId() + ". " + e.getMessage());
-        return false;
-      }
-      return true;
+    if (exFlow.getDispatchMethod() != DispatchMethod.CONTAINERIZED) return false;
+    // Enable restartability for containerized execution
+    final Project project;
+    final Flow flow;
+    try {
+      project = FlowUtils.getProject(projectManager, exFlow.getProjectId());
+      flow = FlowUtils.getFlow(project, exFlow.getFlowId());
+    } catch (final RuntimeException e) {
+      logger.error(e.getMessage());
+      return false;
     }
-    return false;
+    final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
+    executableFlow.setSubmitUser(exFlow.getSubmitUser());
+    executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
+
+    final ExecutionOptions options = exFlow.getExecutionOptions();
+    if(!options.isFailureEmailsOverridden()) {
+      options.setFailureEmails(flow.getFailureEmails());
+    }
+    if (!options.isSuccessEmailsOverridden()) {
+      options.setSuccessEmails(flow.getSuccessEmails());
+    }
+    options.setMailCreator(flow.getMailCreator());
+    executableFlow.setExecutionOptions(options);
+    try {
+      logger.info("Restarting flow " + project.getName() + "." + executableFlow.getFlowName());
+      executorManagerAdapter.submitExecutableFlow(executableFlow, executableFlow.getSubmitUser());
+    } catch (final ExecutorManagerException e) {
+      logger.error("Failed to restart flow "+ executableFlow.getFlowId() + ". " + e.getMessage());
+      return false;
+    }
+    return true;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/OnExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnExecutionEventListener.java
@@ -1,0 +1,9 @@
+package azkaban.executor;
+
+public interface OnExecutionEventListener {
+
+  /**
+   * Perform an execution action when callback method is invoked
+   */
+  void onExecutionEvent(final ExecutableFlow flow, String action);
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -51,50 +51,50 @@ public class ExecutionControllerUtilsRestartFlowTest {
     loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir("embedded"));
     this.project.setFlows(loader.getFlowMap());
     this.project.setVersion(1);
-    this.flow = FlowUtils.getFlow(project, "jobe");
-    this.flow1 = FlowUtils.createExecutableFlow(project, flow);
+    this.flow = FlowUtils.getFlow(this.project, "jobe");
+    this.flow1 = FlowUtils.createExecutableFlow(this.project, this.flow);
     final ExecutionOptions executionOptions = new ExecutionOptions();
     final Map<String, String> flowParam = new HashMap<>();
     flowParam.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true");
     flowParam.put(FlowParameters.FLOW_PARAM_DISPATCH_EXECUTION_TO_CONTAINER, "true");
     executionOptions.addAllFlowParameters(flowParam);
-    flow1.setExecutionOptions(executionOptions);
-    flow1.setDispatchMethod(DispatchMethod.CONTAINERIZED);
-    flow1.setExecutionId(executionId);
+    this.flow1.setExecutionOptions(executionOptions);
+    this.flow1.setDispatchMethod(DispatchMethod.CONTAINERIZED);
+    this.flow1.setExecutionId(executionId);
     this.user = TestUtils.getTestUser();
-    flow1.setSubmitUser(user.getUserId());
+    this.flow1.setSubmitUser(this.user.getUserId());
 
     this.executorLoader = new MockExecutorLoader();
-    executorLoader.uploadExecutableFlow(flow1);
+    this.executorLoader.uploadExecutableFlow(this.flow1);
 
     this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props,
         this.executorLoader, this.commonMetrics, mock(ExecutorApiGateway.class),
         mock(ContainerizedImpl.class),null, null,
         new DummyEventListener(), new DummyContainerizationMetricsImpl());
     this.projectManager = mock(ProjectManager.class);
-    when(projectManager.getProject(projectId)).thenReturn(project);
+    when(this.projectManager.getProject(projectId)).thenReturn(this.project);
 
-    this.listener = new OnContainerizedExecutionEventListener(executorLoader,
-        containerizedDispatchManager, projectManager);
-    ExecutionControllerUtils.onExecutionEventListener = listener;
+    this.listener = new OnContainerizedExecutionEventListener(this.executorLoader,
+        this.containerizedDispatchManager, this.projectManager);
+    ExecutionControllerUtils.onExecutionEventListener = this.listener;
   }
 
   @Test
   public void testRestartOnExecutionStopped() throws Exception {
     this.flow1.setStatus(Status.EXECUTION_STOPPED);
 
-    ExecutionControllerUtils.restartFlow(flow1);
+    ExecutionControllerUtils.restartFlow(this.flow1);
 
     final ExecutableFlow restartedExFlow = this.executorLoader.fetchExecutableFlow(-1);
-    assertTrue(restartedExFlow.getFlowId().equals(flow1.getFlowId()));
-    assertTrue(restartedExFlow.getProjectName().equals(project.getName()));
-    assertTrue(restartedExFlow.getSubmitUser().equals(flow1.getSubmitUser()));
+    assertTrue(restartedExFlow.getFlowId().equals(this.flow1.getFlowId()));
+    assertTrue(restartedExFlow.getProjectName().equals(this.project.getName()));
+    assertTrue(restartedExFlow.getSubmitUser().equals(this.flow1.getSubmitUser()));
     assertTrue(restartedExFlow.getDispatchMethod().equals(DispatchMethod.CONTAINERIZED));
 
-    final ExecutionOptions options1 = flow1.getExecutionOptions();
+    final ExecutionOptions options1 = this.flow1.getExecutionOptions();
     assertTrue(options1.isExecutionRetried());
-    final ExecutableFlow flow2 = executorLoader.fetchExecutableFlow(executionId);
-    final ExecutionOptions options2 = flow1.getExecutionOptions();
+    final ExecutableFlow flow2 = this.executorLoader.fetchExecutableFlow(executionId);
+    final ExecutionOptions options2 = this.flow1.getExecutionOptions();
     assertTrue(options2.isExecutionRetried());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -1,0 +1,93 @@
+package azkaban.executor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import azkaban.Constants.FlowParameters;
+import azkaban.DispatchMethod;
+import azkaban.executor.container.ContainerizedDispatchManager;
+import azkaban.executor.container.ContainerizedImpl;
+import azkaban.flow.Flow;
+import azkaban.flow.FlowUtils;
+import azkaban.metrics.CommonMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.metrics.MetricsManager;
+import azkaban.project.DirectoryFlowLoader;
+import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import azkaban.test.executions.ExecutionsTestUtil;
+import azkaban.user.User;
+import azkaban.utils.Props;
+import azkaban.utils.TestUtils;
+import com.codahale.metrics.MetricRegistry;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class ExecutionControllerUtilsRestartFlowTest {
+  private Project project;
+  private Props props;
+  private Flow flow;
+  private ExecutableFlow flow1;
+  private MockExecutorLoader executorLoader;
+  private User user;
+  private ContainerizedDispatchManager containerizedDispatchManager;
+  private final CommonMetrics commonMetrics = new CommonMetrics(
+      new MetricsManager(new MetricRegistry()));
+  private ProjectManager projectManager;
+  private static final int executionId = 111;
+  private static final int projectId = 1;
+
+  @Before
+  public void setup() throws Exception {
+    // Set up project and flow
+    this.project = new Project(projectId, "testProject");
+    this.props = new Props();
+    final DirectoryFlowLoader loader = new DirectoryFlowLoader(this.props);
+    loader.loadProjectFlow(this.project, ExecutionsTestUtil.getFlowDir("embedded"));
+    this.project.setFlows(loader.getFlowMap());
+    this.project.setVersion(1);
+    this.flow = FlowUtils.getFlow(project, "jobe");
+    this.flow1 = FlowUtils.createExecutableFlow(project, flow);
+    final ExecutionOptions executionOptions = new ExecutionOptions();
+    final Map<String, String> flowParam = new HashMap<>();
+    flowParam.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true");
+    flowParam.put(FlowParameters.FLOW_PARAM_DISPATCH_EXECUTION_TO_CONTAINER, "true");
+    executionOptions.addAllFlowParameters(flowParam);
+    flow1.setExecutionOptions(executionOptions);
+    flow1.setDispatchMethod(DispatchMethod.CONTAINERIZED);
+    flow1.setExecutionId(executionId);
+    this.user = TestUtils.getTestUser();
+    flow1.setSubmitUser(user.getUserId());
+
+    this.executorLoader = new MockExecutorLoader();
+    executorLoader.uploadExecutableFlow(flow1);
+
+    this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props,
+        this.executorLoader, this.commonMetrics, mock(ExecutorApiGateway.class),
+        mock(ContainerizedImpl.class),null, null,
+        new DummyEventListener(), new DummyContainerizationMetricsImpl());
+    this.projectManager = mock(ProjectManager.class);
+    when(projectManager.getProject(projectId)).thenReturn(project);
+    ExecutionControllerUtils.setExecutorManagerAdapter(this.containerizedDispatchManager);
+    ExecutionControllerUtils.setProjectManager(this.projectManager);
+  }
+
+  @Test
+  public void testRestartOnExecutionStopped() throws Exception {
+    this.flow1.setStatus(Status.EXECUTION_STOPPED);
+
+    ExecutionControllerUtils.finalizeFlow(this.executorLoader, mock(AlerterHolder.class),
+        this.flow1, "EXECUTION_STOPPED", null);
+    assertTrue(this.executorLoader.flowUpdateCount==4);
+
+    ExecutableFlow restartedExFlow = this.executorLoader.fetchExecutableFlow(-1);
+    assertTrue(restartedExFlow.getFlowId().equals(flow1.getFlowId()));
+    assertTrue(restartedExFlow.getProjectName().equals(project.getName()));
+    assertTrue(restartedExFlow.getSubmitUser().equals(flow1.getSubmitUser()));
+    assertTrue(restartedExFlow.getDispatchMethod().equals(DispatchMethod.CONTAINERIZED));
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -28,6 +28,7 @@ import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.executor.ExecutionController;
+import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutorManager;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.container.ContainerizedDispatchManager;
@@ -208,6 +209,10 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     this.containerizationMetrics = containerizationMetrics;
 
     loadBuiltinCheckersAndActions();
+
+    // For flow restart in EXECUTION_STOPPED state due to infra failure
+    ExecutionControllerUtils.setProjectManager(this.projectManager);
+    ExecutionControllerUtils.setExecutorManagerAdapter(this.executorManagerAdapter);
 
     // load all trigger agents here
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -210,10 +210,6 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
 
     loadBuiltinCheckersAndActions();
 
-    // For flow restart in EXECUTION_STOPPED state due to infra failure
-    ExecutionControllerUtils.setProjectManager(this.projectManager);
-    ExecutionControllerUtils.setExecutorManagerAdapter(this.executorManagerAdapter);
-
     // load all trigger agents here
 
     final String triggerPluginDir =

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -24,9 +24,12 @@ import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutionController;
+import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManager;
 import azkaban.executor.ExecutorManagerAdapter;
+import azkaban.executor.OnContainerizedExecutionEventListener;
+import azkaban.executor.OnExecutionEventListener;
 import azkaban.executor.container.ContainerizedWatch;
 import azkaban.executor.FlowStatusChangeEventListener;
 import azkaban.executor.container.watch.AzPodStatusDrivingListener;
@@ -59,6 +62,7 @@ import azkaban.imagemgmt.version.VersionSetLoader;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.ContainerizationMetricsImpl;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
 import azkaban.user.UserManager;
@@ -313,5 +317,18 @@ public class AzkabanWebServerModule extends AbstractModule {
         Logger.getLogger("org.apache.velocity.Logger"));
     engine.setProperty("parser.pool.size", 3);
     return engine;
+  }
+
+  @Inject
+  @Singleton
+  @Provides
+  public OnExecutionEventListener createOnContainerizationExecutionEventListener (
+      final ExecutorLoader executorLoader,
+      final ExecutorManagerAdapter executorManagerAdapter,
+      final ProjectManager projectManager) {
+    OnExecutionEventListener listener = new OnContainerizedExecutionEventListener(executorLoader,
+        executorManagerAdapter, projectManager);
+    ExecutionControllerUtils.onExecutionEventListener = listener;
+    return listener;
   }
 }


### PR DESCRIPTION
This task is an on-going effort in continuation to:
1. added flow status for pod failure (#2892)
2. set job status to terminal state when pod goes down (#2907)

Context:
Add flow cleanup for abrupt pod terminations. Azkaban finalizes the flow and sets it to a new terminal flow state EXECUTION_STOPPED  that better indicates a pod failure. 
This work:
Based on user setting in flow parameters,  the flow could:
1. [default option] remain in EXECUTION_STOPPED state, waiting for further actions from user
2. restart the overall execution with a new execution id
