### PR TITLE
Improve logging of email send error

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
+++ b/azkaban-common/src/main/java/azkaban/utils/EmailMessage.java
@@ -19,6 +19,7 @@ package azkaban.utils;
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -28,6 +29,7 @@ import javax.activation.DataSource;
 import javax.activation.FileDataSource;
 import javax.mail.BodyPart;
 import javax.mail.Message;
+import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
@@ -246,12 +248,18 @@ public class EmailMessage {
         s.sendMessage(message, message.getRecipients(Message.RecipientType.TO));
         return;
       } catch (final Exception e) {
-        this.logger.error("Sending email messages failed, attempt: " + attempt, e);
+        this.logger.error("Sending email message failed, attempt: " + attempt
+            + ", message: " + messageToString(message), e);
       }
     }
     s.close();
     throw new MessagingException("Failed to send email messages after "
         + attempt + " attempts.");
+  }
+
+  private static String messageToString(Message message) throws MessagingException {
+    return "[recipients: " + Arrays.toString(message.getRecipients(RecipientType.TO))
+        + ", subject: " + message.getSubject() + "]";
   }
 
   public void setBody(final String body, final String mimeType) {

--- a/azkaban-common/src/test/java/azkaban/utils/EmailMessageTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/EmailMessageTest.java
@@ -16,6 +16,7 @@
 
 package azkaban.utils;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -24,9 +25,11 @@ import static org.mockito.Mockito.when;
 import javax.mail.Address;
 import javax.mail.Message;
 import javax.mail.Message.RecipientType;
+import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class EmailMessageTest {
 
@@ -65,6 +68,20 @@ public class EmailMessageTest {
     this.em.sendEmail();
     verify(this.mimeMessage).addRecipient(RecipientType.TO, this.addresses[0]);
     verify(this.mailSender).sendMessage(this.mimeMessage, this.addresses);
+  }
+
+  @Test
+  public void testSendEmailFailed() throws Exception {
+    Mockito.doThrow(new IllegalArgumentException("mocked exception"))
+        .when(this.mailSender).sendMessage(this.mimeMessage, this.addresses);
+    this.em.setTLS("true");
+    this.em.addToAddress(this.toAddr);
+    this.em.setFromAddress(this.sender);
+    this.em.setSubject("azkaban test email");
+    this.em.setBody("azkaban test email");
+    assertThatExceptionOfType(MessagingException.class).isThrownBy(() -> this.em.sendEmail());
+    verify(this.mimeMessage).addRecipient(RecipientType.TO, this.addresses[0]);
+    verify(this.mailSender, Mockito.times(5)).sendMessage(this.mimeMessage, this.addresses);
   }
 
 }


### PR DESCRIPTION
If email sending fails, log the message subject & recipient to Azkaban server log