### PR TITLE
Set flow effectiveUsers and resource utilization to FLOW_FINISHED_EVENT

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -182,6 +182,9 @@ public class Constants {
     public static final String QUEUE_DURATION = "queueDuration";
     public static final String FAILURE_MESSAGE = "failureMessage";
     public static final String JOB_STATUS = "jobStatus";
+    public static final String EFFECTIVE_USERS = "effectiveUsers";
+    public static final String CPU_UTILIZED = "cpuUtilized";
+    public static final String MEMORY_UTILIZED_IN_BYTES = "memoryUtilizedInBytes";
   }
 
   public static class ConfigurationKeys {
@@ -680,6 +683,8 @@ public class Constants {
     public static final String ENV_FLOW_EXECUTION_ID = "FLOW_EXECUTION_ID";
     public static final String ENV_JAVA_ENABLE_DEBUG = "JAVA_ENABLE_DEBUG";
     public static final String ENV_ENABLE_DEV_POD = "ENABLE_DEV_POD";
+    public static final String ENV_CPU_REQUEST = "CPU_REQUEST";
+    public static final String ENV_MEMORY_REQUEST = "MEMORY_REQUEST";
   }
 
   public static class ImageMgmtConstants {

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testCompile deps.hadoopAnnotations
     testCompile deps.hadoopAuth
     testCompile deps.hadoopHdfs
+    testCompile deps.systemRules
 }
 
 distributions {

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -271,7 +271,7 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
   }
 
   @VisibleForTesting
-  void setFlowRunner(FlowRunner flowRunner) {
+  void setFlowRunner(final FlowRunner flowRunner) {
     this.flowRunner = flowRunner;
   }
 
@@ -334,10 +334,10 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
    */
   @VisibleForTesting
   void setResourceUtilization() {
-    FlowRunnerProxy flowRunnerProxy = this.flowRunner.getProxy();
-    String cpuRequest = System
+    final FlowRunnerProxy flowRunnerProxy = this.flowRunner.getProxy();
+    final String cpuRequest = System
         .getenv(Constants.ContainerizedDispatchManagerProperties.ENV_CPU_REQUEST);
-    String memoryRequest = System
+    final String memoryRequest = System
         .getenv(Constants.ContainerizedDispatchManagerProperties.ENV_MEMORY_REQUEST);
 
     // cpuRequest and memoryRequest are converted to Quantity object to get the parsed value from
@@ -345,11 +345,11 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
     //   1KiB will be converted to 1024 bytes
     //   500m will be converted to 0.500
     if (null != cpuRequest) {
-      Quantity cpuRequestQuantity = new Quantity(cpuRequest);
+      final Quantity cpuRequestQuantity = new Quantity(cpuRequest);
       flowRunnerProxy.setCpuUtilization(cpuRequestQuantity.getNumber().doubleValue());
     }
     if (null != memoryRequest) {
-      Quantity memoryRequestQuantity = new Quantity(memoryRequest);
+      final Quantity memoryRequestQuantity = new Quantity(memoryRequest);
       try {
         flowRunnerProxy.setMemoryUtilization(memoryRequestQuantity.getNumber().longValueExact());
       } catch (ArithmeticException e) {

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -35,6 +35,7 @@ import azkaban.execapp.AbstractFlowPreparer;
 import azkaban.execapp.AzkabanExecutorServer;
 import azkaban.execapp.ExecMetrics;
 import azkaban.execapp.FlowRunner;
+import azkaban.execapp.FlowRunner.FlowRunnerProxy;
 import azkaban.execapp.TriggerManager;
 import azkaban.execapp.event.FlowWatcher;
 import azkaban.execapp.event.JobCallbackManager;
@@ -71,6 +72,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.kubernetes.client.custom.Quantity;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -268,6 +270,11 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
     }
   }
 
+  @VisibleForTesting
+  void setFlowRunner(FlowRunner flowRunner) {
+    this.flowRunner = flowRunner;
+  }
+
   /**
    * Set Azkaban Props
    *
@@ -317,7 +324,38 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
     logVersionSet(flow);
 
     createFlowRunner(flow);
+    setResourceUtilization();
     submitFlowRunner();
+  }
+
+  /**
+   * This method reads the CPU and MEMORY REQUEST ENV variables. If they are present then they will
+   * be used to set the Resource Utilization in FlowRunner object via FlowRunnerProxy.
+   */
+  @VisibleForTesting
+  void setResourceUtilization() {
+    FlowRunnerProxy flowRunnerProxy = this.flowRunner.getProxy();
+    String cpuRequest = System
+        .getenv(Constants.ContainerizedDispatchManagerProperties.ENV_CPU_REQUEST);
+    String memoryRequest = System
+        .getenv(Constants.ContainerizedDispatchManagerProperties.ENV_MEMORY_REQUEST);
+
+    // cpuRequest and memoryRequest are converted to Quantity object to get the parsed value from
+    // the human readable string. Example:
+    //   1KiB will be converted to 1024 bytes
+    //   500m will be converted to 0.500
+    if (null != cpuRequest) {
+      Quantity cpuRequestQuantity = new Quantity(cpuRequest);
+      flowRunnerProxy.setCpuUtilization(cpuRequestQuantity.getNumber().doubleValue());
+    }
+    if (null != memoryRequest) {
+      Quantity memoryRequestQuantity = new Quantity(memoryRequest);
+      try {
+        flowRunnerProxy.setMemoryUtilization(memoryRequestQuantity.getNumber().longValueExact());
+      } catch (ArithmeticException e) {
+        logger.info("Unable to set Memory Utilization", e);
+      }
+    }
   }
 
   /**

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1618,7 +1618,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
      * @param effectiveUser
      * @param jobType
      */
-    public void setEffectiveUser(String jobId, String effectiveUser, Optional<String> jobType) {
+    public void setEffectiveUser(final String jobId, final String effectiveUser,
+        final Optional<String> jobType) {
       if (StringUtils.isBlank(jobId)) {
         logger.error("Job effective user can't be set as jobId string is blank.");
         return;
@@ -1627,7 +1628,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         logger.error("Job effective user can't be set as effectiveUser string is blank.");
         return;
       }
-      String previousVal;
+      final String previousVal;
       if (!jobType.isPresent()) {
         logger.error("Job effective user can't be set as jobType is absent.");
         return;
@@ -1655,7 +1656,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
      *            cloud providers and 1 hyperthread on bare-metal Intel processors. Fractional
      *            values are allowed.
      */
-    public void setCpuUtilization(Double cpuUtilized) {
+    public void setCpuUtilization(final Double cpuUtilized) {
       FlowRunner.this.cpuUtilized = Optional.ofNullable(cpuUtilized);
     }
 
@@ -1663,7 +1664,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
      *
      * @param memoryUtilizedInBytes by the Azkaban flow.
      */
-    public void setMemoryUtilization(Long memoryUtilizedInBytes) {
+    public void setMemoryUtilization(final Long memoryUtilizedInBytes) {
       FlowRunner.this.memoryUtilizedInBytes = Optional.ofNullable(memoryUtilizedInBytes);
     }
   }
@@ -1794,8 +1795,9 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
      * @param flowRunner
      * @param flowMetadata
      */
-    private void setEffectiveUsers(FlowRunner flowRunner, Map<String, String> flowMetadata) {
-      HashSet<String> effectiveUsers = new HashSet<>();
+    private void setEffectiveUsers(final FlowRunner flowRunner,
+        final Map<String, String> flowMetadata) {
+      final HashSet<String> effectiveUsers = new HashSet<>();
 
       // Utilize effectiveUsers for ignored jobtypes only when effectiveUsers for other
       // jobtypes are not present. Hence if a flow has only one job which is noop, then the
@@ -1806,7 +1808,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         effectiveUsers.addAll(new HashSet<>(flowRunner.jobEffectiveUsers.values()));
       }
       if (!effectiveUsers.isEmpty()) {
-        String effectiveUsersString = String.join(",", effectiveUsers);
+        final String effectiveUsersString = String.join(",", effectiveUsers);
         flowRunner.logger.info("All EffectiveUsers: " + effectiveUsersString);
         flowMetadata.put(EventReporterConstants.EFFECTIVE_USERS, effectiveUsersString);
       }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -99,6 +99,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Layout;
@@ -136,8 +137,14 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       .newSetFromMap(new ConcurrentHashMap<>());
   // Thread safe swap queue for finishedExecutions.
   private final SwapQueue<ExecutableNode> finishedNodes;
+  private final ConcurrentHashMap<String, String> jobEffectiveUsers = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, String> ignoredJobEffectiveUsers =
+      new ConcurrentHashMap<>();
+  private final FlowRunnerProxy flowRunnerProxy;
   private final AzkabanEventReporter azkabanEventReporter;
   private final AlerterHolder alerterHolder;
+  private Optional<Double> cpuUtilized = Optional.empty();
+  private Optional<Long> memoryUtilizedInBytes = Optional.empty();
   private Logger logger;
   private Appender flowAppender;
   private File logFile;
@@ -262,6 +269,20 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
     this.projectFileHandler =
         this.projectLoader.fetchProjectMetaData(this.flow.getProjectId(), this.flow.getVersion());
+    this.flowRunnerProxy = new FlowRunnerProxy();
+  }
+
+  /**
+   * @return the proxy class object associated with this instance.
+   */
+  @VisibleForTesting
+  public FlowRunnerProxy getProxy() {
+    return this.flowRunnerProxy;
+  }
+
+  @VisibleForTesting
+  ConcurrentHashMap<String, String> getJobEffectiveUsers() {
+    return this.jobEffectiveUsers;
   }
 
   public FlowRunner setFlowWatcher(final FlowWatcher watcher) {
@@ -1260,7 +1281,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
     final JobRunner jobRunner =
         new JobRunner(node, path.getParentFile(), this.executorLoader,
-            this.jobtypeManager, this.azkabanProps);
+            this.jobtypeManager, this.azkabanProps, this.flowRunnerProxy);
 
     if (this.watcher != null) {
       jobRunner.setPipeline(this.watcher, this.pipelineLevel);
@@ -1581,6 +1602,72 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     return this.flowListener;
   }
 
+  /**
+   * This class is responsible to making changes to the {@link FlowRunner} object. This proxy class
+   * object can be passed to other class objects without risking the flowRunner object itself.
+   * <p>
+   * Example: This proxy class object can be passed to JobRunner class object for setting
+   * effectiveUsers in the FlowRunner which doesn't have a direct reference to FlowRunner class
+   * object.
+   */
+  public class FlowRunnerProxy {
+
+    /**
+     *
+     * @param jobId
+     * @param effectiveUser
+     * @param jobType
+     */
+    public void setEffectiveUser(String jobId, String effectiveUser, Optional<String> jobType) {
+      if (StringUtils.isBlank(jobId)) {
+        logger.error("Job effective user can't be set as jobId string is blank.");
+        return;
+      }
+      if (StringUtils.isBlank(effectiveUser)) {
+        logger.error("Job effective user can't be set as effectiveUser string is blank.");
+        return;
+      }
+      String previousVal;
+      if (!jobType.isPresent()) {
+        logger.error("Job effective user can't be set as jobType is absent.");
+        return;
+      }
+      // Currently noop is the only jobtype for ignoredJobEffectiveUsers, but in future there can
+      // be more.
+      if (jobType.get().equals("noop")) {
+        previousVal = FlowRunner.this.ignoredJobEffectiveUsers.put(jobId, effectiveUser);
+      } else {
+        previousVal = FlowRunner.this.jobEffectiveUsers.put(jobId, effectiveUser);
+      }
+      if (null != previousVal) {
+        logger.info(
+            String.format("Updated effectiveUser map for id: %s, prevVal: %s, newVal: %s", jobId,
+                previousVal, effectiveUser));
+      } else {
+        logger.info(String
+            .format("Updated effectiveUser map for id: %s, val: %s", jobId, effectiveUser));
+      }
+    }
+
+    /**
+     *
+     * @param cpuUtilized measured in cpu Units. One cpu is equivalent to 1 vCPU/Core for
+     *            cloud providers and 1 hyperthread on bare-metal Intel processors. Fractional
+     *            values are allowed.
+     */
+    public void setCpuUtilization(Double cpuUtilized) {
+      FlowRunner.this.cpuUtilized = Optional.ofNullable(cpuUtilized);
+    }
+
+    /**
+     *
+     * @param memoryUtilizedInBytes by the Azkaban flow.
+     */
+    public void setMemoryUtilization(Long memoryUtilizedInBytes) {
+      FlowRunner.this.memoryUtilizedInBytes = Optional.ofNullable(memoryUtilizedInBytes);
+    }
+  }
+
   // Class helps report the flow start and stop events.
   @VisibleForTesting
   class FlowRunnerEventListener implements EventListener<Event> {
@@ -1687,8 +1774,41 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
           final Map<String, String> flowMetadata = getFlowMetadata(flowRunner);
           flowMetadata.put(EventReporterConstants.END_TIME, String.valueOf(flow.getEndTime()));
           flowMetadata.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
+
+          // Add the unique effectiveUsers across all jobs as a comma separated string.
+          setEffectiveUsers(flowRunner, flowMetadata);
+
+          // Add resource utilization if they are present
+          cpuUtilized.ifPresent(val -> flowMetadata.put(EventReporterConstants.CPU_UTILIZED,
+              Double.toString(val)));
+          memoryUtilizedInBytes
+              .ifPresent(val -> flowMetadata.put(EventReporterConstants.MEMORY_UTILIZED_IN_BYTES,
+                  Long.toString(val)));
+          logger.info("FLOW_FINISHED metadata: \n" + flowMetadata);
           FlowRunner.this.azkabanEventReporter.report(event.getType(), flowMetadata);
         }
+      }
+    }
+
+    /**
+     * @param flowRunner
+     * @param flowMetadata
+     */
+    private void setEffectiveUsers(FlowRunner flowRunner, Map<String, String> flowMetadata) {
+      HashSet<String> effectiveUsers = new HashSet<>();
+
+      // Utilize effectiveUsers for ignored jobtypes only when effectiveUsers for other
+      // jobtypes are not present. Hence if a flow has only one job which is noop, then the
+      // effectiveUsers of flow will have the effectiveUser of the noop job.
+      if (flowRunner.jobEffectiveUsers.isEmpty()) {
+        effectiveUsers.addAll(new HashSet<>(flowRunner.ignoredJobEffectiveUsers.values()));
+      } else {
+        effectiveUsers.addAll(new HashSet<>(flowRunner.jobEffectiveUsers.values()));
+      }
+      if (!effectiveUsers.isEmpty()) {
+        String effectiveUsersString = String.join(",", effectiveUsers);
+        flowRunner.logger.info("All EffectiveUsers: " + effectiveUsersString);
+        flowMetadata.put(EventReporterConstants.EFFECTIVE_USERS, effectiveUsersString);
       }
     }
   }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -21,6 +21,7 @@ import azkaban.Constants.JobProperties;
 import azkaban.event.Event;
 import azkaban.event.EventData;
 import azkaban.event.EventHandler;
+import azkaban.execapp.FlowRunner.FlowRunnerProxy;
 import azkaban.execapp.event.BlockingStatus;
 import azkaban.execapp.event.FlowWatcher;
 import azkaban.executor.ClusterInfo;
@@ -41,6 +42,7 @@ import azkaban.utils.PatternLayoutEscaped;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
 import azkaban.utils.UndefinedPropertyException;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -80,6 +82,7 @@ public class JobRunner extends EventHandler implements Runnable {
   private final Layout loggerLayout;
   private final String jobId;
   private final Set<String> pipelineJobs = new HashSet<>();
+  private final FlowRunnerProxy flowRunnerProxy;
   private Logger logger = null;
   private Logger flowLogger = null;
   private Appender jobAppender = null;
@@ -109,13 +112,15 @@ public class JobRunner extends EventHandler implements Runnable {
   private volatile long killDuration = 0;
 
   public JobRunner(final ExecutableNode node, final File workingDir, final ExecutorLoader loader,
-      final JobTypeManager jobtypeManager, final Props azkabanProps) {
+      final JobTypeManager jobtypeManager, final Props azkabanProps, final FlowRunnerProxy flowRunnerProxy) {
     this.props = node.getInputProps();
     this.node = node;
     this.workingDir = workingDir;
 
     this.executionId = node.getParentFlow().getExecutionId();
     this.jobId = node.getId();
+
+    this.flowRunnerProxy = flowRunnerProxy;
 
     this.loader = loader;
     this.jobtypeManager = jobtypeManager;
@@ -125,6 +130,11 @@ public class JobRunner extends EventHandler implements Runnable {
 
     this.loggerLayout = new EnhancedPatternLayout(jobLogLayout);
     this.threadClassLoader = Thread.currentThread().getContextClassLoader();
+  }
+
+  @VisibleForTesting
+  FlowRunnerProxy getFlowRunnerProxy() {
+    return this.flowRunnerProxy;
   }
 
   public static String createLogFileName(final ExecutableNode node, final int attempt) {
@@ -204,8 +214,7 @@ public class JobRunner extends EventHandler implements Runnable {
    *
    * @return {@link Optional} effective user for the Job
    */
-  public Optional<String> determineEffectiveUser() {
-    Optional<String> jobType = JobTypeManager.getJobType(this.props);
+  public Optional<String> determineEffectiveUser(Optional<String> jobType) {
     if (jobType.isPresent()) {
       // JobTypePluginSet is never NULL
       Optional<String> defaultProxyUser = this.jobtypeManager.getJobTypePluginSet()
@@ -781,14 +790,17 @@ public class JobRunner extends EventHandler implements Runnable {
       } else {
         this.props.put(AbstractProcessJob.WORKING_DIR, this.workingDir.getAbsolutePath());
       }
-
-      Optional<String> effectiveUserOptional = determineEffectiveUser();
+      Optional<String> jobType = JobTypeManager.getJobType(this.props);
+      Optional<String> effectiveUserOptional = determineEffectiveUser(jobType);
       // Fail if the effective user is not present
       if (!effectiveUserOptional.isPresent()) {
         return false;
       }
       this.effectiveUser = effectiveUserOptional.get();
       this.props.put(JobProperties.USER_TO_PROXY, this.effectiveUser);
+      if (null != this.flowRunnerProxy) {
+        this.flowRunnerProxy.setEffectiveUser(this.jobId, this.effectiveUser, jobType);
+      }
 
       final Props props = this.node.getRampProps();
       if (props != null) {

--- a/azkaban-exec-server/src/test/java/azkaban/container/FlowContainerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/container/FlowContainerTest.java
@@ -21,6 +21,8 @@ import azkaban.AzkabanCommonModule;
 import azkaban.common.ExecJettyServerModule;
 import azkaban.db.DatabaseOperator;
 import azkaban.execapp.AzkabanExecutorServerTest;
+import azkaban.execapp.FlowRunner;
+import azkaban.execapp.FlowRunner.FlowRunnerProxy;
 import azkaban.execapp.event.JobCallbackManager;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorLoader;
@@ -40,7 +42,10 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.mockito.Mockito;
 
 import static azkaban.Constants.ConfigurationKeys.*;
 import static azkaban.ServiceProvider.*;
@@ -52,6 +57,8 @@ import static org.mockito.Mockito.*;
 public class FlowContainerTest {
 
   private static final Logger logger = Logger.getLogger(FlowContainerTest.class);
+  @Rule
+  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   public static final String AZKABAN_LOCAL_TEST_STORAGE = "AZKABAN_LOCAL_TEST_STORAGE";
   public static final String AZKABAN_DB_SQL_PATH = "azkaban-db/src/main/sql";
@@ -165,5 +172,37 @@ public class FlowContainerTest {
     // Get the instance
     final JobCallbackManager jobCallbackManager = JobCallbackManager.getInstance();
     assert jobCallbackManager != null;
+  }
+
+  @Test
+  public void testSetResourceUtilization() {
+    FlowContainer flowContainerMock = mock(FlowContainer.class);
+    FlowRunner flowRunnerMock = mock(FlowRunner.class);
+    FlowRunnerProxy flowRunnerProxyMock = mock(FlowRunnerProxy.class);
+
+    Mockito.doReturn(flowRunnerProxyMock).when(flowRunnerMock).getProxy();
+    Mockito.doCallRealMethod().when(flowContainerMock).setResourceUtilization();
+    Mockito.doCallRealMethod().when(flowContainerMock).setFlowRunner(flowRunnerMock);
+
+    flowContainerMock.setFlowRunner(flowRunnerMock);
+    flowContainerMock.setResourceUtilization();
+
+    // CPU_REQUEST and MEMORY_REQUEST ENV variables are not set
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(0)).setCpuUtilization(anyDouble());
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(0)).setMemoryUtilization(anyLong());
+
+    // Set CPU_REQUEST ENV variable
+    environmentVariables.set("CPU_REQUEST", "500m");
+
+    flowContainerMock.setResourceUtilization();
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(1)).setCpuUtilization(0.5d);
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(0)).setMemoryUtilization(524288000L);
+
+    // Set MEMORY_REQUEST ENV variable
+    environmentVariables.set("MEMORY_REQUEST", "500Mi");
+    flowContainerMock.setResourceUtilization();
+    // Times will be two as it already executed once before
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(2)).setCpuUtilization(0.5d);
+    Mockito.verify(flowRunnerProxyMock, Mockito.times(1)).setMemoryUtilization(524288000L);
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -67,7 +67,7 @@ public class FlowRunnerTestBase {
 
   public void waitFlowRunner(final FlowRunner runner,
       final Function<FlowRunner, Boolean> statusCheck) {
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 3000; i++) {
       if (statusCheck.apply(runner)) {
         return;
       }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import azkaban.Constants.JobProperties;
 import azkaban.event.Event;
 import azkaban.event.EventData;
+import azkaban.execapp.FlowRunner.FlowRunnerProxy;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.ExecutorLoader;
@@ -47,6 +48,7 @@ import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -54,6 +56,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class JobRunnerTest {
 
@@ -108,6 +111,8 @@ public class JobRunnerTest {
         createJobRunner(1, "testJob", 0, false, loader, eventCollector);
     runner.run();
     effectiveUser = runner.getEffectiveUser();
+    Mockito.verify(runner.getFlowRunnerProxy(), Mockito.times(1)).setEffectiveUser(runner.getJobId(),
+        runner.getEffectiveUser(), Optional.of("test"));
     Assert.assertEquals("defaultTestUser", effectiveUser);
     Assert.assertEquals(effectiveUser, runner.getProps().get("user.to.proxy"));
   }
@@ -476,8 +481,9 @@ public class JobRunnerTest {
     node.setInputProps(props);
     final HashSet<String> proxyUsers = new HashSet<>();
     proxyUsers.add(flow.getSubmitUser());
+    FlowRunnerProxy flowRunnerProxy = Mockito.mock(FlowRunnerProxy.class);
     final JobRunner runner = new JobRunner(node, this.workingDir, loader, this.jobtypeManager,
-        azkabanProps);
+        azkabanProps, flowRunnerProxy);
     runner.setLogSettings(this.logger, "5MB", 4);
 
     runner.addListener(listener);

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ ext.deps = [
     jasypt               : 'org.jasypt:jasypt:1.9.2',
     jacksonCore          : 'com.fasterxml.jackson.core:jackson-core:2.9.2',
     jsonassert           : 'org.skyscreamer:jsonassert:1.5.0',
+    systemRules         : 'com.github.stefanbirkner:system-rules:1.19.0',
     javaxValidation      : 'javax.validation:validation-api:2.0.1.Final',
     hibernateValidator   : 'org.hibernate:hibernate-validator:6.1.5.Final']
 


### PR DESCRIPTION
This change adds the comma-separated list of effective users across all the jobs to the FLOW_FINISHED_EVENT. This enables us to determine at one place all the effective users for a flow.

This change also exposes the method to set CPU and MEMORY Utilization as part of FLOW_FINISHED_EVENT. However, this method is currently called only by the FlowContainer, i.e., for containerized executions. It reads the data of CPU and Memory requested from the Container ENV variables.