### PR TITLE
Added executing detail page for single executors

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractExecutorManagerAdapter extends EventHandler implements
     ExecutorManagerAdapter {
-
+  private static final int EXECUTOR_DETAIL_COUNT = 50;
   private static final Logger logger =
       LoggerFactory.getLogger(AbstractExecutorManagerAdapter.class);
   protected final Props azkProps;
@@ -134,6 +134,18 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     try {
       flows = this.executorLoader.fetchRecentlyFinishedFlows(
           RECENTLY_FINISHED_LIFETIME);
+    } catch (final ExecutorManagerException e) {
+      logger.error("Failed to fetch recently finished flows.", e);
+    }
+    return flows;
+  }
+
+  @Override
+  public List<ExecutableFlow> getRecentlyFinishedFlows(int executorID) {
+    List<ExecutableFlow> flows = new ArrayList<>();
+    try {
+      flows = this.executorLoader.fetchRecentlyFinishedFlows(
+              EXECUTOR_DETAIL_COUNT, executorID);
     } catch (final ExecutorManagerException e) {
       logger.error("Failed to fetch recently finished flows.", e);
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -208,6 +208,17 @@ public class ExecutionFlowDao {
     }
   }
 
+  List<ExecutableFlow> fetchRecentlyFinishedFlows(final int maxCount, int executorID)
+          throws ExecutorManagerException {
+    try {
+      return this.dbOperator.query(
+              String.format("%s LIMIT %d", FetchRecentlyFinishedFlows.FETCH_RECENTLY_FINISHED_EXECUTOR_FLOW, maxCount),
+              new FetchRecentlyFinishedFlows(), executorID);
+    } catch (final SQLException e) {
+      throw new ExecutorManagerException("Error fetching recently finished flows", e);
+    }
+  }
+
   List<ExecutableFlow> fetchFlowHistory(final String projectNameContains,
       final String flowNameContains, final String userNameContains, final int status,
       final long startTime, final long endTime, final int skip, final int num)
@@ -698,6 +709,10 @@ public class ExecutionFlowDao {
     private static final String FETCH_RECENTLY_FINISHED_FLOW =
         "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
             + "WHERE end_time > ? AND status IN (?, ?, ?)";
+
+    private static final String FETCH_RECENTLY_FINISHED_EXECUTOR_FLOW =
+            "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
+                    + "WHERE executor_id = ? ORDER BY end_time DESC";
 
     @Override
     public List<ExecutableFlow> handle(

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -38,6 +38,9 @@ public interface ExecutorLoader {
   List<ExecutableFlow> fetchRecentlyFinishedFlows(Duration maxAge)
       throws ExecutorManagerException;
 
+  List<ExecutableFlow> fetchRecentlyFinishedFlows(int maxCount, int executorID)
+          throws ExecutorManagerException;
+
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -61,6 +61,8 @@ public interface ExecutorManagerAdapter {
 
   public List<ExecutableFlow> getRecentlyFinishedFlows();
 
+  public List<ExecutableFlow> getRecentlyFinishedFlows(int executorID);
+
   public List<ExecutableFlow> getExecutableFlows(int skip, int size)
       throws ExecutorManagerException;
 

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -117,6 +117,12 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public List<ExecutableFlow> fetchRecentlyFinishedFlows(final int maxCount, int executorID)
+          throws ExecutorManagerException {
+    return this.executionFlowDao.fetchRecentlyFinishedFlows(maxCount, executorID);
+  }
+
+  @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
       throws ExecutorManagerException {
     return this.fetchActiveFlowDao.fetchActiveFlows();

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -487,6 +487,11 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public List<ExecutableFlow> fetchRecentlyFinishedFlows(int maxCount, int executorID) throws ExecutorManagerException {
+    return new ArrayList<>();
+  }
+
+  @Override
   public int selectAndUpdateExecution(final int executorId, final boolean isActive,
       final DispatchMethod dispatchMethod)
       throws ExecutorManagerException {


### PR DESCRIPTION
This is an enhancement to the executor page (e.g. `http://azkaban/executor`) to view details specific to a single executor (e.g. via `http://azkaban/executor?worker=29`) which is useful for example when investigating what happens when an executor node dies and what the recovery steps may be (i.e. which flows need to be restarted)