### PR TITLE
Added EC2 autoscaling protection feature

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -316,6 +316,9 @@ public interface ExecutorLoader {
   int selectAndUpdateExecutionWithLocking(final int executorId, boolean isActive, final DispatchMethod dispatchMethod)
       throws ExecutorManagerException;
 
+  int checkExecutionQueueSize(int executor_id, boolean isActive)
+      throws ExecutorManagerException;
+
   /**
    * This method is used to select executions in batch. It will apply lock and fetch executions. It
    * will also update the status of those executions as mentioned in updatedStatus field.

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -390,6 +390,11 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public int checkExecutionQueueSize(int executor_id, boolean isActive) throws ExecutorManagerException {
+    return this.executionFlowDao.checkExecutionQueueSize(executor_id, isActive);
+  }
+
+  @Override
   public ExecutableRampMap fetchExecutableRampMap() throws ExecutorManagerException {
     return this.executionRampDao.fetchExecutableRampMap();
   }

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -501,6 +501,11 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public int checkExecutionQueueSize(int executor_id, boolean isActive) throws ExecutorManagerException {
+    return 0;
+  }
+
+  @Override
   public Set<Integer> selectAndUpdateExecutionWithLocking(final boolean batchEnabled,
       final int limit,
       final Status updatedStatus,

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -24,6 +24,8 @@ dependencies {
         transitive = false
     }
 
+    compile deps.awsEC2
+    compile deps.awsAutoscale
     compile deps.hadoopCommon
     compile deps.guava
     compile deps.jsr305

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/EC2Util.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/EC2Util.java
@@ -1,0 +1,97 @@
+package azkaban.execapp;
+
+import com.amazonaws.services.autoscaling.AmazonAutoScaling;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
+import com.amazonaws.services.autoscaling.model.DescribeAutoScalingInstancesRequest;
+import com.amazonaws.services.autoscaling.model.SetInstanceProtectionRequest;
+import com.amazonaws.util.EC2MetadataUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EC2Util {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EC2Util.class);
+
+  private static String instanceId;
+  private static String autoScalingGroupName;
+  private static AmazonAutoScaling asg;
+  private static final AtomicBoolean localState = new AtomicBoolean(false);
+  private static final AtomicBoolean awsState = new AtomicBoolean(false);
+  private static volatile Thread syncThread;
+  private static final Object syncThreadLock = new Object();
+
+  public static void markASGProtection(boolean protectedFromScaleIn) {
+    try {
+      if(localState.get() == protectedFromScaleIn) return;
+      initializeBackgroundThread();
+      localState.set(protectedFromScaleIn);
+      attemptUpdate();
+    } catch (Throwable e) {
+      LOGGER.warn("Error setting ASG protection", e);
+    }
+  }
+
+  private static boolean setASGProtection(boolean protectedFromScaleIn) {
+    if(null == instanceId) {
+      instanceId = EC2MetadataUtils.getInstanceId();
+    }
+    if(null == asg) {
+      asg = AmazonAutoScalingClientBuilder.standard().build();
+    }
+    if(null == autoScalingGroupName) {
+      autoScalingGroupName = asg.describeAutoScalingInstances(
+              new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId))
+              .getAutoScalingInstances().get(0).getAutoScalingGroupName();
+    }
+    asg.setInstanceProtection(new SetInstanceProtectionRequest()
+            .withInstanceIds(instanceId)
+            .withAutoScalingGroupName(autoScalingGroupName)
+            .withProtectedFromScaleIn(protectedFromScaleIn));
+    LOGGER.info(String.format("Set ASG protection for %s to %s", autoScalingGroupName, protectedFromScaleIn));
+    return protectedFromScaleIn;
+  }
+
+  private static void initializeBackgroundThread() {
+    if(null==syncThread) {
+      synchronized (syncThreadLock) {
+        if(null==syncThread) {
+          syncThread = new Thread(()->{
+            while(true) {
+              attemptUpdate();
+              try {
+                Thread.sleep(1000);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            }
+          });
+          syncThread.setDaemon(true);
+          syncThread.setName("EC2 Scale-In Protection");
+          syncThread.start();
+        }
+      }
+    }
+  }
+
+  private static void attemptUpdate() {
+    synchronized (syncThreadLock) {
+      try {
+        if(localState.get() != awsState.get()) {
+          awsState.set(setASGProtection(localState.get()));
+        }
+      } catch (Throwable e) {
+        LOGGER.warn("Error synchronizing EC2 scale-in protection", e);
+      }
+    }
+  }
+
+  public static void onIdle() {
+    markASGProtection(false);
+  }
+
+  public static void onBusy() {
+    markASGProtection(true);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -65,6 +65,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.lang.Thread.State;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -81,6 +83,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -158,6 +161,8 @@ public class FlowRunnerManager implements EventListener<Event>,
   private final int jobLogNumFiles;
   // If true, jobs will validate proxy user against a list of valid proxy users.
   private final boolean validateProxyUser;
+  private final Method onIdle;
+  private final Method onBusy;
   private final ClusterRouter clusterRouter;
   private PollingService pollingService;
   private int threadPoolQueueSize = -1;
@@ -185,6 +190,22 @@ public class FlowRunnerManager implements EventListener<Event>,
     this.azkabanProps = props;
 
     this.azkabanEventReporter = azkabanEventReporter;
+
+    Method onIdle = null;
+    Method onBusy = null;
+    final String idleMonitorClass = props.getString("azkaban.idleMonitor.class", "");
+    if(null != idleMonitorClass && !idleMonitorClass.isEmpty()) {
+      try {
+        Class<?> idleMontorClass = this.getClass().getClassLoader().loadClass(idleMonitorClass);
+        onIdle = idleMontorClass.getMethod("onIdle");
+        onBusy = idleMontorClass.getMethod("onBusy");
+      } catch (NoSuchMethodException | ClassNotFoundException e) {
+        LOGGER.warn("Error initializing idle/busy monitor", e);
+      }
+    }
+    this.onIdle = onIdle;
+    this.onBusy = onBusy;
+
 
     this.executionDirectory = new File(props.getString("azkaban.execution.dir", "executions"));
     if (!this.executionDirectory.exists()) {
@@ -378,6 +399,7 @@ public class FlowRunnerManager implements EventListener<Event>,
           "Set active action ignored. Executor is already " + (isActive ? "active" : "inactive"));
     }
     this.active = isActive;
+    updateIdleState();
     if (!this.active) {
       // When deactivating this executor, this call will wait to return until every thread in {@link
       // #createFlowRunner} has finished. When deploying new executor, old running executor will be
@@ -392,6 +414,7 @@ public class FlowRunnerManager implements EventListener<Event>,
 
   public void setActiveInternal(final boolean isActive) {
     this.active = isActive;
+    updateIdleState();
   }
 
   /**
@@ -539,7 +562,7 @@ public class FlowRunnerManager implements EventListener<Event>,
   }
 
   private void submitFlowRunner(final FlowRunner runner) throws ExecutorManagerException {
-    this.runningFlows.put(runner.getExecutionId(), runner);
+    putFlowRunner(runner);
     try {
       // The executorService already has a queue.
       // The submit method below actually returns an instance of FutureTask,
@@ -551,7 +574,7 @@ public class FlowRunnerManager implements EventListener<Event>,
       // update the last submitted time.
       this.lastFlowSubmittedDate = System.currentTimeMillis();
     } catch (final RejectedExecutionException re) {
-      this.runningFlows.remove(runner.getExecutionId());
+      removeFlow(runner.getExecutionId());
       final StringBuffer errorMsg = new StringBuffer(
           "Azkaban executor can't execute any more flows. ");
       if (this.executorService.isShutdown()) {
@@ -560,6 +583,53 @@ public class FlowRunnerManager implements EventListener<Event>,
       throw new ExecutorManagerException(errorMsg.toString(), re);
     }
   }
+
+  private final AtomicBoolean isIdle = new AtomicBoolean(true);
+  private void onIdle() {
+    if(!FlowRunnerManager.this.active && !isIdle.getAndSet(true)) {
+      LOGGER.info("Executor is idle");
+      if(onIdle != null) {
+        try {
+          onIdle.invoke(null);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+          LOGGER.warn("Error calling onIdle", e);
+        }
+      }
+    }
+  }
+
+  private void putFlowRunner(FlowRunner runner) {
+    synchronized (this.runningFlows) {
+      if (this.runningFlows.isEmpty()) onBusy();
+      this.runningFlows.put(runner.getExecutionId(), runner);
+    }
+  }
+
+  private boolean isBusy() {
+    return !this.runningFlows.isEmpty();
+  }
+
+  private void onBusy() {
+        if(isIdle.getAndSet(false)) {
+            LOGGER.info("Executor is busy");
+            if(onBusy != null) {
+                try {
+                    onBusy.invoke(null);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                  LOGGER.warn("Error calling onBusy", e);
+                }
+            }
+        }
+    }
+
+    private FlowRunner removeFlow(int executionId) {
+        FlowRunner removed;
+        synchronized (this.runningFlows) {
+            removed = this.runningFlows.remove(executionId);
+            if(this.runningFlows.isEmpty()) onIdle();
+        }
+        return removed;
+    }
 
   /**
    * Configure Azkaban metrics tracking for a new flowRunner instance
@@ -690,7 +760,7 @@ public class FlowRunnerManager implements EventListener<Event>,
 
         LOGGER.info("Flow " + flow.getExecutionId()
             + " is finished. Adding it to recently finished flows list.");
-        this.runningFlows.remove(flow.getExecutionId());
+        removeFlow(flow.getExecutionId());
         this.deleteExecutionDir(flow.getExecutionId());
       } else if (event.getType() == EventType.FLOW_STARTED) {
         // add flow level SLA checker
@@ -1149,6 +1219,33 @@ public class FlowRunnerManager implements EventListener<Event>,
         }
       } else if (this.pollingCriteria.shouldPoll()) {
         try {
+          int queueSize = executorLoader.checkExecutionQueueSize(executorId, active);
+          if(queueSize > 0) {
+            onBusy();
+            try {
+              poll();
+            } finally {
+              updateIdleState();
+            }
+          }
+        } catch (final Exception e) {
+          FlowRunnerManager.LOGGER.error("Failed to submit flow ", e);
+          FlowRunnerManager.this.commonMetrics.markDispatchFail();
+          this.numRetries = this.numRetries + 1;
+          try {
+            // Implement exponential backoff retries when flow submission fails,
+            // i.e., sleep 1s, 2s, 4s, 8s ... before next retries.
+            Thread.sleep((long) (Math.pow(2, this.numRetries) * 1000));
+          } catch (final InterruptedException ie) {
+            FlowRunnerManager.LOGGER
+              .warn("Sleep after flow submission failure was interrupted - ignoring");
+          }
+        }
+      }
+    }
+
+    private void poll() throws ExecutorManagerException {
+      try {
           final int execId;
           if (FlowRunnerManager.this.azkabanProps
               .getBoolean(ConfigurationKeys.AZKABAN_POLLING_LOCK_ENABLED, false)) {
@@ -1189,11 +1286,20 @@ public class FlowRunnerManager implements EventListener<Event>,
           }
         }
       }
-    }
 
     public void shutdown() {
       this.scheduler.shutdown();
       this.scheduler.shutdownNow();
+    }
+  }
+
+  private void updateIdleState() {
+    synchronized (runningFlows) {
+      if(this.active || isBusy()) {
+        onBusy();
+      } else {
+        onIdle();
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ ext.versions = [hadoop: '2.10.0',
 
 ext.deps = [
     // External dependencies
+    awsEC2              : 'com.amazonaws:aws-java-sdk-ec2:1.11.922',
+    awsAutoscale        : 'com.amazonaws:aws-java-sdk-autoscaling:1.11.922',
     // restli 1.* had this one included transitively. restli 28.* doesn't. But we still need it:
     json                 : 'org.json:json:20170516',
     assertj              : 'org.assertj:assertj-core:3.8.0',


### PR DESCRIPTION
Our organization uses AWS EC2 autoscaling groups for our Azkaban execution cluster, and we have implemented a way of leveraging the “scale-in protection” feature so that we can scale down our execution clusters during deployments and after load spikes. We have implemented this in a generic way, adding the notion of idle and busy into the executor logic, and a configurable class provider can handle the specific logic of what to do when busy or idle.

To use this patch as originally designed when running executors on an ASG, set the following configuration property in the executors: `azkaban.idleMonitor.class=azkaban.execapp.EC2Util` - This will cause the EC2Util class to be notified of the busy/idle events.

Executors trigger the `busy` state event prior to claiming their first task for execution. In order to eliminate the race condition of claiming a task before marking itself as busy while also minimizing needless busy events, an extra database query is used to check the availability of queued tasks. In order to monitor the number of tasks currently running, calls to the `runningFlows` collection have been wrapped. Once busy, an executor only transitions to `idle` when it is both deactivated and its last flow has been completed.

This patch has been tested internally and has been deployed to production for some time, being actively used in many deployments. 