### PR TITLE
When using cluster routing method to execute jobs, some properties need to be overridden.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -150,6 +150,9 @@ public class Constants {
   // Flow restart action on EXECUTION_STOPPED
   public static final String RESTART_FLOW = "Restart Flow";
 
+  // Overridable plugin load properties
+  public static final String AZ_PLUGIN_LOAD_OVERRIDE_PROPS = "azkaban.plugin.load.override.props";
+
   // Azkaban event reporter constants
   public static class EventReporterConstants {
 

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -439,17 +439,18 @@ public class JobTypeManager {
       }
 
       // Override any plugin load props if specified.
-      Props pluginLoadPropsCopy = pluginLoadProps;
+      // Make a clone of pluginLoadProps to ensure the original object is not corrupted.
+      // Use the cloned object from here on.
+      final Props pluginLoadPropsCopy = Props.clone(pluginLoadProps);
       if (pluginLoadOverrideProps != null) {
-        // Make a clone of pluginLoadProps
-        pluginLoadPropsCopy = Props.clone(pluginLoadProps);
         final String[] propsList = pluginLoadOverrideProps.split(",");
         for (final String prop : propsList) {
           final String value = clusterSpecificProps.getString(prop, null);
           if (value == null) {
             // The property must be present in cluster specific props
-            throw new JobExecutionException(String.format("Required cluster property %s "
-            + " is not present in ClusterSpecific Properties", prop));
+            logger.warn(String.format("Expected override property %s is not "
+            + " present in ClusterSpecific Properties, ignoring it.", prop));
+            continue;
           }
           pluginLoadPropsCopy.put(prop, value);
         }

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -64,19 +64,23 @@ public class JobTypeManager {
   private JobTypePluginSet pluginSet;
   // Only used to load keyStore.
   private Props cachedCommonPluginLoadProps;
+  // Overridable plugin load properties
+  private final String pluginLoadOverrideProps;
 
   @VisibleForTesting
   public JobTypeManager(final String jobtypePluginDir, final Props globalProperties,
       final ClassLoader parentClassLoader) {
-    this(jobtypePluginDir, globalProperties, parentClassLoader, new DisabledClusterRouter());
+    this(jobtypePluginDir, globalProperties, parentClassLoader, new DisabledClusterRouter(), null);
   }
 
   public JobTypeManager(final String jobtypePluginDir, final Props globalProperties,
-    final ClassLoader parentClassLoader, ClusterRouter clusterRouter) {
+    final ClassLoader parentClassLoader, final ClusterRouter clusterRouter,
+    final String pluginLoadOverrideProps  ) {
     this.jobTypePluginDir = jobtypePluginDir;
     this.parentLoader = parentClassLoader;
     this.globalProperties = globalProperties;
     this.clusterRouter = clusterRouter;
+    this.pluginLoadOverrideProps = pluginLoadOverrideProps;
     loadPlugins();
   }
 
@@ -433,6 +437,24 @@ public class JobTypeManager {
           jobProps.put(key, clusterSpecificProps.get(key));
         }
       }
+
+      // Override any plugin load props if specified.
+      Props pluginLoadPropsCopy = pluginLoadProps;
+      if (pluginLoadOverrideProps != null) {
+        // Make a clone of pluginLoadProps
+        pluginLoadPropsCopy = Props.clone(pluginLoadProps);
+        final String[] propsList = pluginLoadOverrideProps.split(",");
+        for (final String prop : propsList) {
+          final String value = clusterSpecificProps.getString(prop, null);
+          if (value == null) {
+            // The property must be present in cluster specific props
+            throw new JobExecutionException(String.format("Required cluster property %s "
+            + " is not present in ClusterSpecific Properties", prop));
+          }
+          pluginLoadPropsCopy.put(prop, value);
+        }
+      }
+
       Props nonOverriddableClusterProps = getClusterSpecificNonOverridableJobProps(clusterSpecificProps);
       // CAUTION: ADD ROUTER-SPECIFIC PROPERTIES THAT ARE CRITICAL FOR JOB EXECUTION AS THE LAST
       // STEP TO STOP THEM FROM BEING ACCIDENTALLY OVERRIDDEN BY JOB PROPERTIES
@@ -440,7 +462,7 @@ public class JobTypeManager {
       jobProps = PropsUtils.resolveProps(jobProps);
 
       return new JobParams(jobTypeClass, jobProps, pluginSet.getPluginPrivateProps(jobType),
-          pluginLoadProps, jobContextClassLoader);
+          pluginLoadPropsCopy, jobContextClassLoader);
     } catch (final Exception e) {
       logger.error("Failed to build job executor for job " + jobId
           + e.getMessage());

--- a/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerWithDynamicClusterTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerWithDynamicClusterTest.java
@@ -25,6 +25,7 @@ import azkaban.cluster.ClusterRouter;
 import azkaban.cluster.DefaultClusterRouter;
 import azkaban.flow.CommonJobProperties;
 import azkaban.jobExecutor.Job;
+import azkaban.jobExecutor.utils.JobExecutionException;
 import azkaban.jobtype.JobTypeManager.JobParams;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
@@ -79,6 +80,7 @@ public class JobTypeManagerWithDynamicClusterTest {
     clusterProps.put(PIG_HOME, "/cluster/pig/path");
     clusterProps.put("PropA", "${PropB}");
     clusterProps.put("PropB", "valB");
+    clusterProps.put("PropC", "valC");
 
     return new Cluster("default", clusterProps);
   }
@@ -108,7 +110,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobTypeManagerJobSetupWithoutJobComponentDependency() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "anothertestjob");
@@ -137,7 +139,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobTypeManagerJobSetupWithJobComponentDependency() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "anothertestjob");
@@ -168,7 +170,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobTypeManagerJobSetupWithoutJobtypeComponentDependency() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "testjob");
@@ -199,7 +201,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test (expected = JobTypeManagerException.class)
   public void testJobTypeManagerJobSetupWithUnknownClusterComponents() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     final Props jobProps = new Props();
     jobProps.put("type", "anothertestjob");
@@ -215,7 +217,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobTypeManagerJobSetupWithoutAnyComponentDependency() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "testjob");
@@ -234,7 +236,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobParamsPrecedenceOverClusterParams() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "testjob");
@@ -257,7 +259,7 @@ public class JobTypeManagerWithDynamicClusterTest {
   @Test
   public void testJobRunnerObservesClusterSpecificParams() {
     final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
-        this.getClass().getClassLoader(), this.clusterRouter);
+        this.getClass().getClassLoader(), this.clusterRouter, null);
 
     Props jobProps = new Props();
     jobProps.put("type", "anothertestjob");
@@ -266,5 +268,61 @@ public class JobTypeManagerWithDynamicClusterTest {
     // verify the jobProps also observe the parameters injected in JobTypeManager
     jobProps = PropsUtils.resolveProps(jobProps);
     Assert.assertEquals("valB", jobProps.getString("PropA"));
+  }
+
+  /**
+   * Verify that overidden plugin load props are indeed overridden.
+   */
+  @Test
+  public void testPluginLoadPropsOverrideByClusterSpecificParams() {
+    final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
+        this.getClass().getClassLoader(), this.clusterRouter, null);
+
+    Props jobProps = new Props();
+    jobProps.put("type", "testjob");
+    jobProps.put(PIG_HOME, "/user/pig/path");
+    jobProps.put(CommonJobProperties.JOB_CLUSTER_COMPONENTS_DEPENDENCIES, "hadoop");
+
+    final JobParams jobParams = manager.createJobParams("testjob", jobProps, LOG);
+    Assert.assertTrue(
+        jobParams.contextClassLoader instanceof HadoopSecurityManagerClassLoader);
+
+    final Job job = JobTypeManager.createJob("testjob", jobParams, LOG);
+    Props sysProps = ((FakeJavaJob2) job).getSysProps();
+    Assert.assertEquals(null, sysProps.get("PropA"));
+
+    // Create JobTypeManager again but with pluginOverrideProps this time.
+    final String pluginLoadOverrideProps = "PropC,PropB";
+    final JobTypeManager manager1 = new JobTypeManager(this.testPluginDirPath, null,
+        this.getClass().getClassLoader(), this.clusterRouter, pluginLoadOverrideProps);
+    final JobParams jobParams1 = manager1.createJobParams("testjob", jobProps, LOG);
+    final Job job1 = JobTypeManager.createJob("testjob", jobParams1, LOG);
+    sysProps = ((FakeJavaJob2) job1).getSysProps();
+    Assert.assertEquals("valC", sysProps.get("PropC"));
+    Assert.assertEquals("valB", sysProps.get("PropB"));
+  }
+
+  /**
+   * Verify that overidden plugin load props throws exception if a required property
+   * is missing.
+   */
+  @Test (expected = JobTypeManagerException.class)
+  public void testPluginLoadPropsOverrideByClusterSpecificParamsNegative() {
+
+    final Props jobProps = new Props();
+    jobProps.put("type", "testjob");
+    jobProps.put(PIG_HOME, "/user/pig/path");
+    jobProps.put(CommonJobProperties.JOB_CLUSTER_COMPONENTS_DEPENDENCIES, "hadoop");
+
+    // Create JobTypeManager with pluginOverrideProps, however, add propD which
+    // is not a valid property in cluster props.
+    final String pluginLoadOverrideProps = "PropC,PropD";
+    final JobTypeManager manager = new JobTypeManager(this.testPluginDirPath, null,
+        this.getClass().getClassLoader(), this.clusterRouter, pluginLoadOverrideProps);
+    final JobParams jobParams = manager.createJobParams("testjob", jobProps, LOG);
+    final Job job = JobTypeManager.createJob("testjob", jobParams, LOG);
+    final Props sysProps = ((FakeJavaJob2) job).getSysProps();
+    Assert.assertEquals("valC", sysProps.get("PropC"));
+    Assert.assertEquals(null, sysProps.get("PropD"));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerWithDynamicClusterTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobtype/JobTypeManagerWithDynamicClusterTest.java
@@ -303,10 +303,10 @@ public class JobTypeManagerWithDynamicClusterTest {
   }
 
   /**
-   * Verify that overidden plugin load props throws exception if a required property
+   * Verify that overidden plugin load props and ignores if a property
    * is missing.
    */
-  @Test (expected = JobTypeManagerException.class)
+  @Test
   public void testPluginLoadPropsOverrideByClusterSpecificParamsNegative() {
 
     final Props jobProps = new Props();

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -212,7 +212,8 @@ public class FlowContainer implements IMBeanRegistrable, EventListener<Event> {
         new JobTypeManager(
             this.azKabanProps.getString(AzkabanExecutorServer.JOBTYPE_PLUGIN_DIR,
                 PluginManager.JOBTYPE_DEFAULTDIR),
-            this.globalProps, getClass().getClassLoader(), clusterRouter);
+            this.globalProps, getClass().getClassLoader(), clusterRouter,
+            this.azKabanProps.getString(Constants.AZ_PLUGIN_LOAD_OVERRIDE_PROPS, null));
 
     this.numJobThreadPerFlow = props.getInt(JOB_THREAD_COUNT, DEFAULT_JOB_TREAD_COUNT);
     if (this.azKabanProps.getBoolean(Constants.USE_IN_MEMORY_KEYSTORE,

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -229,7 +229,8 @@ public class FlowRunnerManager implements EventListener<Event>,
     this.jobtypeManager =
         new JobTypeManager(props.getString(AzkabanExecutorServer.JOBTYPE_PLUGIN_DIR,
             Constants.PluginManager.JOBTYPE_DEFAULTDIR), this.globalProps,
-            getClass().getClassLoader(), this.clusterRouter);
+            getClass().getClassLoader(), this.clusterRouter,
+            props.getString(Constants.AZ_PLUGIN_LOAD_OVERRIDE_PROPS, null));
 
     ProjectCacheCleaner cleaner = null;
     this.LOGGER.info("Configuring Project Cache");


### PR DESCRIPTION
When using cluster routing method to execute jobs, some properties required to fetch token from HadoopSecurityManager

are overridden. It happens because the cluster routing properties which contain the specific property become part of jobProps,
whereas the default cluster routing property is part of the job's sysProps.
These properties are merged in AbstractProcessJob.getAllProps() where the default property in sysProps overrides the correct
property from jobProps.
This patch uses azkaban property AZ_PLUGIN_LOAD_OVERRIDE_PROPS to fetch list of properties which must be overridden
using cluster router properties into sysProps.
However, the sysProps object is unique per jobtype so it is cloned and the cloned copy is used thereafter thus preserving the
original copy of pluginLoadProps.