### PR TITLE
Fixed dispatch stuck bug when no active version and user uses pinned image

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -65,7 +65,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -511,8 +510,8 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         final Map<String, VersionInfo> versionMap =
             this.imageRampupManager.getVersionByImageTypes(executableFlow, imageTypesUsedInFlow,
                 overlayMap.keySet());
-        versionMap.putAll(overlayMap);
         final VersionSetBuilder versionSetBuilder = new VersionSetBuilder(this.versionSetLoader);
+        versionSetBuilder.addElements(overlayMap);
         versionSet = versionSetBuilder.addElements(versionMap).build();
       }
     } catch (final IOException e) {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManager.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManager.java
@@ -46,7 +46,7 @@ public interface ImageRampupManager {
    * @throws ImageMgmtException
    */
   public Map<String, VersionInfo> getVersionByImageTypes(ExecutableFlow flow,
-      Set<String> imageTypes)
+      Set<String> imageTypes, Set<String> overlayImageTypes)
       throws ImageMgmtException;
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -246,7 +246,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(1);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class)))
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class), any(Set.class)))
         .thenReturn(getVersionMap());
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     final Set<String> dependencyTypes = ImmutableSet.of(DEPENDENCY1);
@@ -280,7 +280,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class)))
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class), any(Set.class)))
         .thenReturn(getVersionMap());
     when(imageRampupManager
         .getVersionInfo(any(String.class), any(String.class), any(Set.class)))
@@ -350,7 +350,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class)))
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class), any(Set.class)))
         .thenReturn(getVersionMap());
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);
     final Set<String> dependencyTypes = ImmutableSet.of(DEPENDENCY1);
@@ -394,7 +394,7 @@ public class KubernetesContainerizedImplTest {
     final ExecutableFlow flow = createFlowWithMultipleJobtypes();
     flow.setExecutionId(2);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
-    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class)))
+    when(imageRampupManager.getVersionByImageTypes(any(), any(Set.class), any(Set.class)))
         .thenReturn(getVersionMap());
 
     final TreeSet<String> jobTypes = ContainerImplUtils.getJobTypesForFlow(flow);

--- a/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/imagemgmt/rampup/ImageRampupManagerImplTest.java
@@ -42,6 +42,7 @@ import azkaban.imagemgmt.version.VersionInfo;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.TestUtils;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -110,7 +111,7 @@ public class ImageRampupManagerImplTest {
     final ExecutableFlow flow = TestUtils
         .createTestExecutableFlow("exectest1", "exec1", DispatchMethod.CONTAINERIZED);
     Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
-        .getVersionByImageTypes(flow, imageTypes);
+        .getVersionByImageTypes(flow, imageTypes, new HashSet<>());
     Assert.assertEquals("3.6.5", imageTypeVersionMap.get("azkaban_config").getVersion());
     Assert.assertEquals("3.6.2", imageTypeVersionMap.get("azkaban_core").getVersion());
     Assert.assertEquals("1.8.2", imageTypeVersionMap.get("azkaban_exec").getVersion());
@@ -156,7 +157,7 @@ public class ImageRampupManagerImplTest {
     when(this.imageVersionDao.getActiveVersionByImageTypes(any(Set.class)))
         .thenReturn(activeImageVersions);
     final Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
-        .getVersionByImageTypes(null, imageTypes);
+        .getVersionByImageTypes(null, imageTypes, new HashSet<>());
     Assert.assertNotNull(imageTypeVersionMap);
     // Below image type versions are obtained from active ramp up. Version is selected randomly
     // based on rampup percentage.
@@ -174,7 +175,7 @@ public class ImageRampupManagerImplTest {
 
   /**
    * For the given image types some of the versions are from active rampups, some of the versions
-   * are based on active image version. But there are some image types for which there is neighter
+   * are based on active image version. But there are some image types for which there is neither
    * active rampups nor active image version, hence throws exception.
    *
    * @throws Exception
@@ -211,8 +212,10 @@ public class ImageRampupManagerImplTest {
     when(this.imageVersionDao.findImageVersions(any(ImageMetadataRequest.class))).thenReturn(newAndRampupImageVersions);
     when(this.imageVersionDao.getActiveVersionByImageTypes(any(Set.class)))
         .thenReturn(activeImageVersions);
+    final Set<String> overlaySet = new HashSet<>();
+    overlaySet.add("kabootar_job");
     final Map<String, VersionInfo> imageTypeVersionMap = this.imageRampupManger
-        .getVersionByImageTypes(null, imageTypes);
+        .getVersionByImageTypes(null, imageTypes, new HashSet<>());
     Assert.assertNotNull(imageTypeVersionMap);
     // Below image type versions are obtained from active ramp up. Version is selected randomly
     // based on rampup percentage.


### PR DESCRIPTION
Context:
The IMAGE-A is new so there is no active version or ramp-up plan. It seems dispatch looks for those and errors out like this:
```
2021/08/25 17:31:46.533 +0000  INFO [ImageRampupManagerImpl] [pool-15-thread-7] [Azkaban] After fetching version using ramp up and based on active image version the image types remaining: [image-a]
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban] Exception in thread "pool-15-thread-7"
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban] azkaban.imagemgmt.exception.ImageMgmtException: Could not fetch version for below image types. Reasons:  1. There is no active rampup plan in the image_rampup_plan table. 2. There is no  active version in the image_versions table. Image Types: [image-a]
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at azkaban.imagemgmt.rampup.ImageRampupManagerImpl.getVersionByImageTypes(ImageRampupManagerImpl.java:176)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at azkaban.executor.container.KubernetesContainerizedImpl.fetchVersionSet(KubernetesContainerizedImpl.java:457)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at azkaban.executor.container.KubernetesContainerizedImpl.createPod(KubernetesContainerizedImpl.java:713)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at azkaban.executor.container.KubernetesContainerizedImpl.createContainer(KubernetesContainerizedImpl.java:334)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at azkaban.executor.container.ContainerizedDispatchManager$ExecutionDispatcher.run(ContainerizedDispatchManager.java:421)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2021/08/25 17:31:46.533 +0000 ERROR [StdOutErrRedirect] [pool-15-thread-7] [Azkaban]    at java.lang.Thread.run(Thread.java:748)
```
The fix set up overlay map (contains pinned image from flow parameter) first, then provide overlay map key set as argument to ImagerampupManagerImpl::getVersionByImageTypes, so that pinned images can be taken care of.

Tests done: tested on containerization cluster, no signs of dispatch stuck using the same flow and image-a was set not active. 