### PR TITLE
Allow only one ACTIVE image version for a given image type.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageVersionDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageVersionDaoImpl.java
@@ -354,8 +354,27 @@ public class ImageVersionDaoImpl implements ImageVersionDao {
       queryBuilder.append(" where iv.id = ? and iv.type_id = it.id and it.name = ?");
       params.add(imageVersionRequest.getId());
       params.add(imageVersionRequest.getName());
-      final int updateCount = this.databaseOperator.update(queryBuilder.toString(),
-          Iterables.toArray(params, Object.class));
+      int updateCount = 0;
+      if (imageVersionRequest.getState() != State.ACTIVE) {
+        updateCount = this.databaseOperator.update(queryBuilder.toString(),
+            Iterables.toArray(params, Object.class));
+      } else {
+        // If the state is being set to ACTIVE then only the current image version can be set
+        // to ACTIVE and the rest of the image versions with ACTIVE state must be set to STABLE.
+        final SQLTransaction<Integer> setCurrentVersionActive = transOperator -> {
+          // Set all the current active versions to STABLE
+          final String setStable = String.format("update image_versions iv, image_types it " +
+              " set iv.state = 'STABLE' where iv.type_id = it.id and it.name = '%s' "
+              + " and iv.state = 'active'", imageVersionRequest.getName());
+          transOperator.update(setStable);
+          // Now set the current version to ACTIVE
+          final int count = transOperator.update(queryBuilder.toString(),
+              Iterables.toArray(params, Object.class));
+          transOperator.getConnection().commit();
+          return count;
+        };
+        updateCount = this.databaseOperator.transaction(setCurrentVersionActive);
+      }
       if (updateCount < 1) {
         log.error(String.format("Exception while updating image version due to invalid input, "
             + "updateCount: %d.", updateCount));

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
@@ -117,13 +117,16 @@ public class ImageVersion extends BaseModel {
    * table. DEPRECATED - An image type version which is no longer in use is marked as DEPRECATED
    * TEST - This is to represent a TEST version of the image and once the version is tested it can
    * be marked as NEW.
+   * STABLE - When an image version is marked as ACTIVE, the other ACTIVE version(s) are marked as
+   * STABLE as there can be only 1 ACTIVE version at a time.
    */
   public enum State {
     NEW("new"),
     ACTIVE("active"),
     UNSTABLE("unstable"),
     DEPRECATED("deprecated"),
-    TEST("test");
+    TEST("test"),
+    STABLE("stable");
     private final String stateValue;
 
     private State(final String stateValue) {

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
@@ -199,8 +199,7 @@ public class ImageVersionServlet extends LoginAbstractAzkabanServlet {
 
   private void handleUpdateImageVersion(final HttpServletRequest req,
       final HttpServletResponse resp, final Session session,
-      final Map<String, String> templateVariableToValue) throws ServletException,
-      IOException {
+      final Map<String, String> templateVariableToValue) throws IOException {
     try {
       final String idString = templateVariableToValue.get(IMAGE_VERSION_ID_KEY);
       final Integer id = Ints.tryParse(idString);


### PR DESCRIPTION
The Image Management APIs allow multiple image versions of same type to remain in ACTIVE state.

This leads to unexpected behavior of getting incorrect version among the ACTIVE ones for executing flows.
Introducing new image version state STABLE.
If an image is set as ACTIVE using the ACTIVATE API, all the other image versions which are currently
set to ACTIVE will be set to STABLE state.