### PR TITLE
Removing method doRampActions from ContainerizedDispatchManager and utilize super method

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -531,12 +531,6 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   @Override
-  public Map<String, String> doRampActions(List<Map<String, Object>> rampAction)
-      throws ExecutorManagerException {
-    throw new UnsupportedOperationException("Unsupported Method");
-  }
-
-  @Override
   public Set<String> getAllActiveExecutorServerHosts() {
     throw new UnsupportedOperationException("Unsupported Method");
   }


### PR DESCRIPTION
Parent class AbstractExecutorManagerAdapter does implement the doRampActions method which allows making rampup changes for the executors. 

Once containerization is enabled, ContainerizedDispatchManager is utilized. Hence even if the rampup is not 100%, we see UnsupportedOperationException which shouldn't be the case.