### PR TITLE
Add logic to load certain flow properties and merge flow parameters on top of it.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -508,7 +508,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     }
 
     // Filter out the properties to keep only the override ones.
-    final Props flowProps =
+    final Props flowOverrideProps =
         new Props(null, props.getMapByPrefix(PARAM_OVERRIDE));
 
     // Fetch the flow parameters
@@ -517,9 +517,9 @@ public class ExecutableFlow extends ExecutableFlowBase {
       flowParam = this.executionOptions.getFlowParameters();
     }
     // Always put flow params AFTER the flow properties as flow params always take precedence
-    this.flattenedFlowPropsAndParams = flowProps;
+    this.flattenedFlowPropsAndParams = flowOverrideProps;
     if (flowParam != null && !flowParam.isEmpty()) {
-      this.flattenedFlowPropsAndParams = new Props(flowProps, flowParam);
+      this.flattenedFlowPropsAndParams = new Props(flowOverrideProps, flowParam);
     }
     return this.flattenedFlowPropsAndParams;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -503,19 +503,13 @@ public class ExecutableFlow extends ExecutableFlowBase {
       final Map<String, Props> propsMap = projectLoader.
           fetchProjectProperties(projectId, version);
       if (null != propsMap) {
-        Props finalProps = props;
-        propsMap.values().forEach(finalProps::putAll);
-        props = finalProps;
+        propsMap.values().forEach(props::putAll);
       }
     }
 
     // Filter out the properties to keep only the override ones.
-    final Map<String, String> filteredProps = props.getMapByPrefix(PARAM_OVERRIDE);
-    final Props flowProps = new Props(null, filteredProps);
-    /*filteredProps.forEach((key, value) -> {
-      final String newKey = key.substring(PARAM_OVERRIDE.length() + 1);
-      flowProps.put(newKey, value);
-    });*/
+    final Props flowProps =
+        new Props(null, props.getMapByPrefix(PARAM_OVERRIDE));
 
     // Fetch the flow parameters
     Map<String, String> flowParam = null;
@@ -523,11 +517,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
       flowParam = this.executionOptions.getFlowParameters();
     }
     // Always put flow params AFTER the flow properties as flow params always take precedence
-    Props combinedProps = flowProps;
+    this.flattenedFlowPropsAndParams = flowProps;
     if (flowParam != null && !flowParam.isEmpty()) {
-      combinedProps = new Props(flowProps, flowParam);
+      this.flattenedFlowPropsAndParams = new Props(flowProps, flowParam);
     }
-    this.flattenedFlowPropsAndParams = combinedProps;
     return this.flattenedFlowPropsAndParams;
   }
 

--- a/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
+++ b/azkaban-common/src/main/java/azkaban/project/FlowLoaderUtils.java
@@ -16,14 +16,17 @@
 package azkaban.project;
 
 import azkaban.Constants;
+import azkaban.executor.ExecutableFlow;
 import azkaban.flow.CommonJobProperties;
 import azkaban.flow.Flow;
+import azkaban.flow.FlowProps;
 import azkaban.jobcallback.JobCallbackValidator;
 import azkaban.project.validator.ValidationReport;
 import azkaban.utils.MemConfValue;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
 import azkaban.utils.Utils;
+import com.google.common.collect.ImmutableList;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileFilter;
@@ -339,5 +342,64 @@ public class FlowLoaderUtils {
     public boolean accept(final File pathname) {
       return pathname.isDirectory();
     }
+  }
+
+  /**
+   * Loads flow/job properties from the flow's YAML file. If path is null
+   * then it loads the flow's properties, otherwise it loads the property
+   * of the job at the path. The caller is responsible for providing the
+   * correct path
+   * @param projectLoader Used to fetch file from DB.
+   * @param executableFlow The executable flow of which properties are
+   *                       being loaded.
+   * @param path Path to job file. NULL for flow properties.
+   * @return return Props object with flow/job properties.
+   */
+  public static Props loadPropsFromYamlFile(final ProjectLoader projectLoader,
+      final ExecutableFlow executableFlow, final String path) {
+    File tempDir = null;
+    Props props = null;
+    try {
+      tempDir = com.google.common.io.Files.createTempDir();
+      props = FlowLoaderUtils.getPropsFromYamlFile(
+          path == null ? executableFlow.getId() : path,
+          getFlowFile(tempDir, projectLoader, executableFlow));
+    } catch (final Exception e) {
+      logger.error("Failed to get props from flow file. " + e);
+    } finally {
+      if (tempDir != null && tempDir.exists()) {
+        try {
+          FileUtils.deleteDirectory(tempDir);
+        } catch (final IOException e) {
+          logger.error("Failed to delete temp directory." + e);
+          tempDir.deleteOnExit();
+        }
+      }
+    }
+    return props;
+  }
+
+  /**
+   * This function fetches the flow file and puts it in tempDir
+   * @param tempDir location where the flow file is put
+   * @param projectLoader Used to fetch from DB
+   * @param flow the executable flow
+   * @return returns the flow file from db.
+   * @throws Exception
+   */
+  private static File getFlowFile(final File tempDir, final ProjectLoader projectLoader,
+      final ExecutableFlow flow) throws Exception {
+    final List<FlowProps> flowPropsList = ImmutableList.copyOf(flow.getFlowProps());
+    // There should be exact one source (file name) for each flow file.
+    if (flowPropsList.isEmpty() || flowPropsList.get(0) == null) {
+      throw new ProjectManagerException(
+          "Failed to get flow file source. Flow props is empty for " + flow.getId());
+    }
+    final String source = flowPropsList.get(0).getSource();
+    final int flowVersion = projectLoader
+        .getLatestFlowVersion(flow.getProjectId(), flow.getVersion(), source);
+    return projectLoader
+        .getUploadedFlowFile(flow.getProjectId(), flow.getVersion(), source,
+            flowVersion, tempDir);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -64,6 +64,7 @@ import azkaban.imagemgmt.version.VersionSetBuilder;
 import azkaban.imagemgmt.version.VersionSetLoader;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.project.FlowLoaderUtils;
 import azkaban.project.ProjectLoader;
 import azkaban.test.Utils;
 import azkaban.utils.JSONUtils;
@@ -436,14 +437,16 @@ public class KubernetesContainerizedImplTest {
    */
   @Test
   public void testFlowPropertyAndParamsMerge() throws Exception {
-    final ExecutableFlow flow = createFlowWithMultipleJobtypes();
+    final ExecutableFlow flow = createTestFlow();
     flow.setExecutionId(3);
     final Props flowProps = new Props();
-    flowProps.put("image.version", "1.2.3");
+    flowProps.put("param.override.image.version", "1.2.3");
+    flowProps.put("regular.param", "4.5.6"); // Should be filtered out.
     final Map<String, Props> propsMap = new HashMap<>();
     propsMap.put("test", flowProps);
     when(this.projectLoader.fetchProjectProperties(flow.getProjectId(), flow.getVersion())).thenReturn(propsMap);
-    //when(flow.getExecutionOptions().getFlowParameters()).thenReturn(flowParam);
+    //when(FlowLoaderUtils.loadPropsFromYamlFile(this.projectLoader, flow, null)).thenReturn(flowProps);
+    //doReturn(flowProps).when(FlowLoaderUtils.loadPropsFromYamlFile(this.projectLoader, flow, null));
     final ExecutionOptions executionOptions = new ExecutionOptions();
     flow.setExecutionOptions(executionOptions);
     final Map<String, String> flowParams = flow.getExecutionOptions().getFlowParameters();
@@ -460,14 +463,14 @@ public class KubernetesContainerizedImplTest {
    */
   @Test
   public void testFlowPropertyAndParamsMergeWithOverwrite() throws Exception {
-    final ExecutableFlow flow = createFlowWithMultipleJobtypes();
+    final ExecutableFlow flow = createTestFlow();
     flow.setExecutionId(3);
     final Props flowProps = new Props();
-    flowProps.put("image.version", "1.2.3");
+    flowProps.put("param.override.image.version", "1.2.3");
+    flowProps.put("regular.param", "4.5.6"); // Should be filtered out.
     final Map<String, Props> propsMap = new HashMap<>();
     propsMap.put("test", flowProps);
     when(this.projectLoader.fetchProjectProperties(flow.getProjectId(), flow.getVersion())).thenReturn(propsMap);
-    //when(flow.getExecutionOptions().getFlowParameters()).thenReturn(flowParam);
     final ExecutionOptions executionOptions = new ExecutionOptions();
     flow.setExecutionOptions(executionOptions);
     final Map<String, String> flowParams = flow.getExecutionOptions().getFlowParameters();


### PR DESCRIPTION
Add logic to load certain flow properties and merge flow parameters on top of it.

The logic to load flow properties from YAML file is refactored from FlowRunner to FlowLoaderUtils for reuse.
It is used to add support for flow2.0.

Only flow properties with prefix "param.override" are filtered and then flow params are added.