### PR TITLE
Utilize azkaban.cluster.env property to set the AZ_CLUSTER ENV variable for containerization

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -196,6 +196,7 @@ public class Constants {
   public static class ConfigurationKeys {
 
     public static final String AZKABAN_CLUSTER_NAME = "azkaban.cluster.name";
+    public static final String AZKABAN_CLUSTER_ENV = "azkaban.cluster.env";
     public static final String AZKABAN_GLOBAL_PROPERTIES_EXT_PATH = "executor.global.properties";
     // Property to enable appropriate dispatch model
     public static final String AZKABAN_EXECUTION_DISPATCH_METHOD = "azkaban.execution.dispatch.method";

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -125,6 +125,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private final String podPrefix;
   private final String servicePrefix;
   private final String clusterName;
+  private final String clusterEnv;
   private final String flowContainerName;
   private final String cpuLimit;
   private final String cpuRequest;
@@ -189,6 +190,9 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
             DEFAULT_SERVICE_NAME_PREFIX);
     this.clusterName = this.azkProps.getString(ConfigurationKeys.AZKABAN_CLUSTER_NAME,
         DEFAULT_CLUSTER_NAME);
+    // This is utilized to set AZ_CLUSTER ENV variable to the POD containers.
+    this.clusterEnv = this.azkProps.getString(ConfigurationKeys.AZKABAN_CLUSTER_ENV,
+        this.clusterName);
     this.cpuLimit = this.azkProps
         .getString(ContainerizedDispatchManagerProperties.KUBERNETES_FLOW_CONTAINER_CPU_LIMIT,
             CPU_LIMIT);
@@ -535,7 +539,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     final String flowContainerCPURequest = getFlowContainerCPURequest(flowParam);
     final String flowContainerMemoryRequest = getFlowContainerMemoryRequest(flowParam);
     final AzKubernetesV1SpecBuilder v1SpecBuilder =
-        new AzKubernetesV1SpecBuilder(this.clusterName, Optional.empty())
+        new AzKubernetesV1SpecBuilder(this.clusterEnv, Optional.empty())
             .addFlowContainer(this.flowContainerName,
                 azkabanBaseImageFullPath, ImagePullPolicy.IF_NOT_PRESENT, azkabanConfigVersion)
             .withResources(this.cpuLimit, flowContainerCPURequest, this.memoryLimit,


### PR DESCRIPTION
clusterEnv is the class variable that will be set using property azkaban.cluster.env, which defaults to class variable clusterName for backward compatibility.