### PR TITLE
Load project white list .xml file in FlowRunnerManager and FlowContainer

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/ProjectWhitelist.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectWhitelist.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -37,11 +38,16 @@ public class ProjectWhitelist {
   private static final String PROJECT_TAG = "project";
   private static final String PROJECTID_ATTR = "projectid";
 
+  private static AtomicBoolean xmlFileLoaded = new AtomicBoolean(false);
+  public static boolean isXmlFileLoaded() {
+    return xmlFileLoaded.get();
+  }
   private static final AtomicReference<Map<WhitelistType, Set<Integer>>> projectsWhitelisted =
       new AtomicReference<>();
 
-  static void load(final Props props) {
+  public static void load(final Props props) {
     final String xmlFile = props.getString(XML_FILE_PARAM);
+    xmlFileLoaded.set(true);
     parseXMLFile(xmlFile);
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -505,9 +505,13 @@ public class FlowRunnerManager implements EventListener<Event>,
     int numJobThreads = this.numJobThreadPerFlow;
     if (options.getFlowParameters().containsKey(FLOW_NUM_JOB_THREADS)) {
       try {
+        if (!ProjectWhitelist.isXmlFileLoaded()) {
+          ProjectWhitelist.load(azkabanProps);
+        }
         final int numJobs =
             Integer.valueOf(options.getFlowParameters().get(
                 FLOW_NUM_JOB_THREADS));
+        LOGGER.info("Num of job threads read from flow parameter is " + numJobs);
         if (numJobs > 0 && (numJobs <= numJobThreads || ProjectWhitelist
             .isProjectWhitelisted(flow.getProjectId(),
                 WhitelistType.NumJobPerFlow))) {


### PR DESCRIPTION
Users reported that setting flow.num.job.threads = 128 in the runtime properties does not spin up a flow with  128 concurrently running jobs, even the project is added to the white list .xml in executor  server conf/ directory. 
This bug is caused by project white list file not loaded, because ProjectManager (which is responsible for loading this file) may not instantiate in executor server. 
Therefore, this bug fix aims to load project white list file in FlowRunnerManager (bare metal execution) or FlowContainer (containerized execution). 
