### PR TITLE
Kill button should finalize the flow even when execution is unreachable

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -60,7 +60,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   protected final ExecutorLoader executorLoader;
   protected final CommonMetrics commonMetrics;
   protected final ExecutorApiGateway apiGateway;
-  private final AlerterHolder alerterHolder;
+  protected final AlerterHolder alerterHolder;
   private final int maxConcurrentRunsOneFlow;
   private final Map<Pair<String, String>, Integer> maxConcurrentRunsPerFlowMap;
   private static final Duration RECENTLY_FINISHED_LIFETIME = Duration.ofMinutes(10);
@@ -510,11 +510,14 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   }
 
   /**
-   * If a flow is already dispatched to an executor, cancel by calling Executor. Else if it's still
-   * queued in DB, remove it from DB queue and finalize. {@inheritDoc}
+   * Cancel or kill or finalize the flow if it is not finished, and update the status in the DB.
+   *
+   * @param exFlow
+   * @param userId
+   * @throws ExecutorManagerException
    */
   @Override
-  public void cancelFlow(final ExecutableFlow exFlow, final String userId)
+  public void cancelFlow(ExecutableFlow exFlow, String userId)
       throws ExecutorManagerException {
     synchronized (exFlow) {
       final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = this.executorLoader
@@ -522,20 +525,76 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       if (unfinishedFlows.containsKey(exFlow.getExecutionId())) {
         final Pair<ExecutionReference, ExecutableFlow> pair = unfinishedFlows
             .get(exFlow.getExecutionId());
-        if (pair.getFirst().getExecutor().isPresent()) {
-          // Flow is already dispatched to an executor, so call that executor to cancel the flow.
-          this.apiGateway
-              .callWithReferenceByUser(pair.getFirst(), ConnectorParams.CANCEL_ACTION, userId);
-        } else {
-          // Flow is still queued, need to finalize it and update the status in DB.
-          ExecutionControllerUtils.finalizeFlow(this.executorLoader, this.alerterHolder, exFlow,
-              "Cancelled before dispatching to executor", null);
-        }
+        handleCancelFlow(pair.getFirst(), exFlow, userId);
       } else {
-        throw new ExecutorManagerException("Execution "
-            + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId()
-            + " isn't running.");
+        final ExecutorManagerException eme = new ExecutorManagerException("Execution "
+            + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId() + " isn't running.");
+        logger.error("Exception while cancelling flow. ", eme);
+        throw eme;
       }
+    }
+  }
+
+  /**
+   * Handles the cancelling of the flow.
+   * If the flow is unreachable, then try to finalize the flow.
+   * If the flow is reachable, but cancel is not successful, then try to finalize the flow.
+   * If the flow is reachable and cancel is successful, then return.
+   *
+   * @param executionReference
+   * @param executableFlow
+   * @param userId
+   */
+  protected void handleCancelFlow(ExecutionReference executionReference,
+      ExecutableFlow executableFlow,
+      String userId) throws ExecutorManagerException {
+    final Status finalizingStatus =
+        executionReference.getDispatchMethod() == DispatchMethod.CONTAINERIZED ? Status.KILLED :
+            Status.FAILED;
+    if (!isExecutionReachable(executionReference, userId)) {
+      logger.info("Finalizing executable flow as execution is unreachable: " + executionReference
+          .getExecId());
+      ExecutionControllerUtils.finalizeFlow(this.executorLoader, this.alerterHolder,
+          executableFlow, "Cancel action has been called but the flow is unreachable.", null,
+          finalizingStatus);
+      // Throwing exception to make the reason appear on the UI.
+      throw new ExecutorManagerException("Flow execution is unreachable. Finalizing the flow.");
+    }
+
+    try {
+      this.apiGateway.callWithReferenceByUser(executionReference, ConnectorParams.CANCEL_ACTION,
+          userId);
+    } catch (Exception e) {
+      logger
+          .error("Exception occurred while cancelling flow: " + executionReference.getExecId(), e);
+      logger.info("Finalizing executable flow: " + executionReference.getExecId());
+      final String finalizingReason = "Unable to gracefully kill the flow execution.";
+      ExecutionControllerUtils.finalizeFlow(this.executorLoader, this.alerterHolder,
+          executableFlow, finalizingReason, e, finalizingStatus);
+      // Throwing exception to make the reason appear on the UI.
+      throw new ExecutorManagerException(finalizingReason
+          + " Finalizing the flow.");
+    }
+  }
+
+  /**
+   * @param executionReference
+   * @param userId
+   * @return True if the flow execution is reachable, i.e., ping is successful, otherwise, return
+   * False. Any exception caught will be logged and False is returned.
+   */
+  protected boolean isExecutionReachable(ExecutionReference executionReference, String userId) {
+    if (executionReference.getDispatchMethod() == DispatchMethod.POLL && !executionReference
+        .getExecutor().isPresent()) {
+      return false;
+    }
+    try {
+      this.apiGateway.callWithReferenceByUser(executionReference, ConnectorParams.PING_ACTION,
+          userId);
+      return true;
+    } catch (Exception e) {
+      logger.warn("ExecutableFlow is unreachable: " + executionReference.getExecId(), e);
+      return false;
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
@@ -69,7 +69,7 @@ public class ExecutionFinalizer {
         // then mark it finished.
         if (!ExecutionControllerUtils.isFinished(dsFlow)) {
           this.updaterStage.set("finalizing flow " + execId + " failing the flow");
-          ExecutionControllerUtils.failEverything(dsFlow);
+          ExecutionControllerUtils.failEverything(dsFlow, Status.FAILED);
           this.executorLoader.updateExecutableFlow(dsFlow);
         }
       }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
@@ -184,7 +184,8 @@ public class ExecutorHealthChecker {
           String.format("Finalizing execution %s, %s", flow.getExecutionId(), finalizeReason));
       try {
         ExecutionControllerUtils
-            .finalizeFlow(this.executorLoader, this.alerterHolder, flow, finalizeReason, null);
+            .finalizeFlow(this.executorLoader, this.alerterHolder, flow, finalizeReason, null,
+                Status.FAILED);
       } catch (RuntimeException e) {
         logger.error("Unchecked exception while finalizing execution: " + flow.getExecutionId(), e);
       }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -458,27 +458,6 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
     }
   }
 
-  @Override
-  public void cancelFlow(ExecutableFlow exFlow, String userId)
-      throws ExecutorManagerException {
-    synchronized (exFlow) {
-      final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = this.executorLoader
-          .fetchUnfinishedFlows();
-      if (unfinishedFlows.containsKey(exFlow.getExecutionId())) {
-        final Pair<ExecutionReference, ExecutableFlow> pair = unfinishedFlows
-            .get(exFlow.getExecutionId());
-        // Note that ExecutionReference may have the 'executor' as null. ApiGateway call is expected
-        // to handle this scenario.
-        this.apiGateway.callWithReferenceByUser(pair.getFirst(), ConnectorParams.CANCEL_ACTION, userId);
-      } else {
-        final ExecutorManagerException eme = new ExecutorManagerException("Execution "
-            + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId() + " isn't running.");
-        logger.warn("Exception while cancelling flow. ", eme);
-        throw eme;
-      }
-    }
-  }
-
   //TODO: BDP-3642 Add a way to call Flow container APIs using apiGateway
   @Override
   public void resumeFlow(ExecutableFlow exFlow, String userId) throws ExecutorManagerException {

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -268,7 +268,7 @@ public class FlowStatusManagerListener implements AzPodStatusListener {
         executableFlow.setStatus(finalStatus.get());
       }
       ExecutionControllerUtils.finalizeFlow(executorLoader, alerterHolder, executableFlow, reason,
-          null);
+          null, Status.FAILED);
       // Log event for cases where the flow was not already in a final state
       WatchEventLogger.logWatchEvent(event, "WatchEvent for finalization of execution-id " + executionId);
     }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -224,7 +224,11 @@ public class ExecutionControllerTest {
     // Flow1 is not assigned to any executor and is in PREPARING status.
     submitFlow(this.flow1, this.ref1);
     this.flow1.setStatus(Status.PREPARING);
-    this.controller.cancelFlow(this.flow1, this.user.getUserId());
+    try {
+      this.controller.cancelFlow(this.flow1, this.user.getUserId());
+    } catch (ExecutorManagerException e) {
+      // Ignore if there is an exception.
+    }
     // Verify that the status of flow1 is finalized.
     assertThat(this.flow1.getStatus()).isEqualTo(Status.FAILED);
     this.flow1.getExecutableNodes().forEach(node -> {

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -218,8 +218,11 @@ azkaban.FlowTabView = Backbone.View.extend({
     } else if (data.status == "KILLED") {
       $("#executebtn").show();
     } else if (data.status == "KILLING") {
+      $("#cancelbtn").show();
     } else if (data.status == "EXECUTION_STOPPED") {
       $("#executebtn").show();
+    } else if (data.status == "DISPATCHING") {
+      $("#cancelbtn").show();
     }
   },
 


### PR DESCRIPTION
Changed azkaban-web-server/src/web/js/azkaban/view/exflow.js to show Kill button when flow status is Dispatching or Killing as there may be cases where flow is stuck in those states.

Updated cancelFlow() method in azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java  which is also leveraged by the ConatinerizedExecutorManager class. This method tries to kill the flow execution if it is reachable, otherwise, it will finalize the flow and display the message on the UI.

Updated finalizeFlow() method in azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java to accept one more parameter which will be used to set the final status of the flow. For containerized executions, it will be marked as Killed.

Added tests to azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java

Example screenshot of killing preparing flow execution:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/20373170/137182728-554c4a96-df77-427b-a714-8fddf2875634.png">
