### PR TITLE
Updated ContainerCleaupManager to cleanup flows running beyond valid duration

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -242,14 +242,13 @@ public interface ExecutorLoader {
       throws ExecutorManagerException;
 
   /**
-   * Fetch stale flows. A flow is considered stale if it was started more than {@code
-   * executionDuration} ago and is not yet in a final state.
-   *
-   * @param executionDuration
+   * This method is used to get those flows which are stale. Staleness is determined based on the
+   * validity of the status as defined in {@link Status#validityMap}.
+   * @param status
    * @return
    * @throws ExecutorManagerException
    */
-  public List<ExecutableFlow> fetchStaleFlows(final Duration executionDuration)
+  List<ExecutableFlow> fetchStaleFlowsForStatus(final Status status)
       throws ExecutorManagerException;
 
   List<ExecutableFlow> fetchAgedQueuedFlows(

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -102,9 +102,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public List<ExecutableFlow> fetchStaleFlows(Duration executionDuration)
+  public List<ExecutableFlow> fetchStaleFlowsForStatus(final Status status)
       throws ExecutorManagerException {
-    return this.executionFlowDao.fetchStaleFlows(executionDuration);
+    return this.executionFlowDao.fetchStaleFlowsForStatus(status);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -450,7 +450,7 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public List<ExecutableFlow> fetchStaleFlows(Duration executionDuration)
+  public List<ExecutableFlow> fetchStaleFlowsForStatus(final Status status)
       throws ExecutorManagerException {
     throw new ExecutorManagerException("Method Not Implemented!");
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -30,6 +30,7 @@ import azkaban.executor.ExecutorManager;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.OnContainerizedExecutionEventListener;
 import azkaban.executor.OnExecutionEventListener;
+import azkaban.executor.container.ContainerCleanupManager;
 import azkaban.executor.container.ContainerizedWatch;
 import azkaban.executor.FlowStatusChangeEventListener;
 import azkaban.executor.container.watch.AzPodStatusDrivingListener;
@@ -134,6 +135,7 @@ public class AzkabanWebServerModule extends AbstractModule {
     // Following bindings will be present if and only if containerized dispatch is enabled.
     bindImageManagementDependencies();
     bindContainerWatchDependencies();
+    bindContainerCleanupManager();
   }
 
   private Class<? extends ContainerizationMetrics> resolveContainerMetricsClass() {
@@ -212,6 +214,15 @@ public class AzkabanWebServerModule extends AbstractModule {
     }
     log.info("Binding kubernetes watch dependencies");
     bind(KubernetesWatch.class).in(Scopes.SINGLETON);
+  }
+
+  private void bindContainerCleanupManager() {
+    if(!isContainerizedDispatchMethodEnabled()) {
+      bind(ContainerCleanupManager.class).toProvider(Providers.of(null));
+      return;
+    }
+    log.info("Binding ContainerCleanupManager");
+    bind(ContainerCleanupManager.class).in(Scopes.SINGLETON);
   }
 
   @Inject


### PR DESCRIPTION
Validity is defined for certain statuses in azkaban-common/src/main/java/azkaban/executor/Status.java containing validityDuration and validityFrom.

Updated azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java to fetchStaleFlowsForStatus, which utilizes the above validity for statuses and returns the list of stale flow executions.

Updated azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java to now clean up stale flow executions for various statuses. Cleanup consists of cancelling/finalizing the flows along with deletion of the pod. ContainerCleanupManager runs as a background thread every 10 minutes. 

Updated  azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java to bind the ContainerCleanupManager. 
Updated azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java for graceful start and shutdown of ContainerCleanupManager

Added unit tests.
