### PR TITLE
Use fetchProperty instead of fetchProperties which is compute heavy and has memory leaks.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -153,6 +153,9 @@ public class Constants {
   // Overridable plugin load properties
   public static final String AZ_PLUGIN_LOAD_OVERRIDE_PROPS = "azkaban.plugin.load.override.props";
 
+  // File containing param override configs
+  public static final String PARAM_OVERRIDE_FILE = "param_override.properties";
+
   // Azkaban event reporter constants
   public static class EventReporterConstants {
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -15,6 +15,7 @@
  */
 package azkaban.executor;
 
+import azkaban.Constants;
 import azkaban.DispatchMethod;
 import azkaban.flow.Flow;
 import azkaban.imagemgmt.version.VersionSet;
@@ -486,26 +487,16 @@ public class ExecutableFlow extends ExecutableFlowBase {
    * @return Returns the flattened flow props overridden by flow params.
    */
   public void setFlowPropsAndParams(final ProjectLoader projectLoader) {
-    Props props = new Props();
-    // Fetch the flow properties
-    if (FlowLoaderUtils.isAzkabanFlowVersion20(this.azkabanFlowVersion)) {
-      props = FlowLoaderUtils.loadPropsFromYamlFile(projectLoader,
-          this, null);
-    } else {
-      final Map<String, Props> propsMap = projectLoader.
-          fetchProjectProperties(projectId, version);
-      if (null != propsMap) {
-        propsMap.values().forEach(props::putAll);
-      }
-    }
+    Props props = FlowLoaderUtils.isAzkabanFlowVersion20(this.azkabanFlowVersion) ?
+        FlowLoaderUtils.loadPropsFromYamlFile(projectLoader, this, null) :
+        projectLoader.fetchProjectProperty(projectId, version, Constants.PARAM_OVERRIDE_FILE);
 
-    // Filter out the properties to keep only the override ones.
-    Map<String, String> flowOverridePropsMap = props.getMapByPrefix(PARAM_OVERRIDE);
+    // Clone the props object and filter out the properties to keep only the override ones.
+    Map<String, String> flowOverridePropsMap = Props.clone(props).getMapByPrefix(PARAM_OVERRIDE);
 
     // Update the flow params with override props
     if (this.executionOptions != null) {
       this.executionOptions.addAllFlowParameters(flowOverridePropsMap);
     }
   }
-
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -526,9 +526,8 @@ public class KubernetesContainerizedImplTest {
     final Props flowProps = new Props();
     flowProps.put("param.override.image.version", "1.2.3");
     flowProps.put("regular.param", "4.5.6"); // Should be filtered out.
-    final Map<String, Props> propsMap = new HashMap<>();
-    propsMap.put("test", flowProps);
-    when(this.projectLoader.fetchProjectProperties(flow.getProjectId(), flow.getVersion())).thenReturn(propsMap);
+    when(this.projectLoader.fetchProjectProperty(
+        flow.getProjectId(), flow.getVersion(), Constants.PARAM_OVERRIDE_FILE)).thenReturn(flowProps);
     final ExecutionOptions executionOptions = new ExecutionOptions();
     flow.setExecutionOptions(executionOptions);
     final Map<String, String> flowParams = flow.getExecutionOptions().getFlowParameters();
@@ -552,9 +551,8 @@ public class KubernetesContainerizedImplTest {
     final Props flowProps = new Props();
     flowProps.put("param.override.image.version", "1.2.3");
     flowProps.put("regular.param", "4.5.6"); // Should be filtered out.
-    final Map<String, Props> propsMap = new HashMap<>();
-    propsMap.put("test", flowProps);
-    when(this.projectLoader.fetchProjectProperties(flow.getProjectId(), flow.getVersion())).thenReturn(propsMap);
+    when(this.projectLoader.fetchProjectProperty(
+        flow.getProjectId(), flow.getVersion(), Constants.PARAM_OVERRIDE_FILE)).thenReturn(flowProps);
     final ExecutionOptions executionOptions = new ExecutionOptions();
     flow.setExecutionOptions(executionOptions);
     final Map<String, String> flowParams = flow.getExecutionOptions().getFlowParameters();


### PR DESCRIPTION

This also adds requirement for users to create param_override.properties which will contain all override properties.
Updated the tests accordingly.