### PR TITLE
Make metrics reporting more open source friendly.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -290,13 +290,15 @@ public class Constants {
     public static final String AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST = "azkaban.server.logging.kafka.brokerList";
     public static final String AZKABAN_SERVER_LOGGING_KAFKA_TOPIC = "azkaban.server.logging.kafka.topic";
 
-    // Represent the class name of azkaban metrics reporter.
-    public static final String CUSTOM_METRICS_REPORTER_CLASS_NAME = "azkaban.metrics.reporter.name";
-
-    // Represent the metrics server URL.
-    public static final String METRICS_SERVER_URL = "azkaban.metrics.server.url";
-
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
+
+    // Web and Exec server properties to configure a custom metrics reporter.
+    // (Required) The fully qualified name of the reporter class.
+    public static final String CUSTOM_METRICS_REPORTER_CLASS_NAME = "azkaban.metrics.reporter.name";
+    // (Optional) The path to a file containing the reporter specific settings.
+    public static final String CUSTOM_METRICS_REPORTER_CONFIG_PATH =
+        "azkaban.metrics.reporter.config.path";
+
     public static final String MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = "azkaban.metrics"
         + ".min_age_for_classifying_a_flow_aged_minutes";
 

--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -17,7 +17,7 @@
 package azkaban.metrics;
 
 import static azkaban.Constants.ConfigurationKeys.CUSTOM_METRICS_REPORTER_CLASS_NAME;
-import static azkaban.Constants.ConfigurationKeys.METRICS_SERVER_URL;
+import static azkaban.Constants.ConfigurationKeys.CUSTOM_METRICS_REPORTER_CONFIG_PATH;
 
 import azkaban.utils.Props;
 import com.codahale.metrics.Counter;
@@ -33,13 +33,14 @@ import java.lang.reflect.Constructor;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * The singleton class, MetricsManager, is the place to have MetricRegistry and ConsoleReporter in
- * this class. Also, web servers and executors can call {@link #startReporting(String, Props)} to
- * start reporting AZ metrics to remote metrics server.
+ * this class. Also, web servers and executors can call {@link #startReporting(Props)} to start
+ * reporting AZ metrics to remote metrics server.
  */
 @Singleton
 public class MetricsManager {
@@ -114,27 +115,27 @@ public class MetricsManager {
    * reporting metrics to remote metrics collector. Note: this method must be synchronized, since
    * both web server and executor will call it during initialization.
    */
-  public synchronized void startReporting(final String reporterName, final Props props) {
+  public synchronized void startReporting(final Props props) {
     final String metricsReporterClassName = props.get(CUSTOM_METRICS_REPORTER_CLASS_NAME);
-    final String metricsServerURL = props.get(METRICS_SERVER_URL);
-    if (metricsReporterClassName != null && metricsServerURL != null) {
+    final String metricsReporterConfigPath =
+        props.get(CUSTOM_METRICS_REPORTER_CONFIG_PATH); // optional param
+    if (!StringUtils.isBlank(metricsReporterClassName)) {
       try {
-        log.info("metricsReporterClassName: " + metricsReporterClassName);
+        log.info("The class name of the custom metrics reporter is: {}", metricsReporterClassName);
         final Class<?> metricsClass = Class.forName(metricsReporterClassName);
 
-        final Constructor<?> ctor = metricsClass.getConstructor(reporterName.getClass(),
-            this.registry.getClass(), metricsServerURL.getClass(), boolean.class);
-        ctor.newInstance(reporterName, this.registry, metricsServerURL, true);
+        final Constructor<?> ctor = metricsClass.getConstructor(this.registry.getClass(),
+            metricsReporterConfigPath.getClass());
+        ctor.newInstance(this.registry, metricsReporterConfigPath);
 
       } catch (final Exception e) {
-        log.error("Encountered error while loading and instantiating "
-            + metricsReporterClassName, e);
-        throw new IllegalStateException("Encountered error while loading and instantiating "
-            + metricsReporterClassName, e);
+        final String errMsg = "Encountered an error while loading or instantiating the custom "
+            + "metrics reporter " + metricsReporterClassName;
+        log.error(errMsg, e);
+        throw new IllegalStateException(errMsg, e);
       }
     } else {
-      log.error(String.format("No value for property: %s or %s was found",
-          CUSTOM_METRICS_REPORTER_CLASS_NAME, METRICS_SERVER_URL));
+      log.error("No value for property: {} was found.", CUSTOM_METRICS_REPORTER_CLASS_NAME);
     }
   }
 }

--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -117,9 +117,9 @@ public class MetricsManager {
    */
   public synchronized void startReporting(final Props props) {
     final String metricsReporterClassName = props.get(CUSTOM_METRICS_REPORTER_CLASS_NAME);
-    final String metricsReporterConfigPath =
-        props.get(CUSTOM_METRICS_REPORTER_CONFIG_PATH); // optional param
     if (!StringUtils.isBlank(metricsReporterClassName)) {
+      final String metricsReporterConfigPath =
+          props.getString(CUSTOM_METRICS_REPORTER_CONFIG_PATH, ""); // optional param
       try {
         log.info("The class name of the custom metrics reporter is: {}", metricsReporterClassName);
         final Class<?> metricsClass = Class.forName(metricsReporterClassName);
@@ -129,8 +129,8 @@ public class MetricsManager {
         ctor.newInstance(this.registry, metricsReporterConfigPath);
 
       } catch (final Exception e) {
-        final String errMsg = "Encountered an error while loading or instantiating the custom "
-            + "metrics reporter " + metricsReporterClassName;
+        final String errMsg = "Encountered an error while loading or instantiating the custom metrics reporter "
+            + metricsReporterClassName;
         log.error(errMsg, e);
         throw new IllegalStateException(errMsg, e);
       }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -63,7 +63,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   @Override
   public synchronized void startReporting(Props props) {
     logger.info(String.format("Start reporting container metrics"));
-    this.metricsManager.startReporting("AZ-WEB", props);
+    this.metricsManager.startReporting(props);
     this.isInitialized = true;
   }
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -289,7 +289,7 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
 
   private void startReportingExecMetrics() {
     logger.info("starting reporting Executor Metrics");
-    this.metricsManager.startReporting("AZ-EXEC", this.props);
+    this.metricsManager.startReporting(this.props);
   }
 
   private void initActive() throws ExecutorManagerException {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/metrics/WebMetricsImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/metrics/WebMetricsImpl.java
@@ -63,7 +63,7 @@ public class WebMetricsImpl implements WebMetrics {
   @Override
   public void startReporting(final Props props) {
     logger.info("Start reporting Web Server metrics.");
-    this.metricsManager.startReporting("AZ-WEB", props);
+    this.metricsManager.startReporting(props);
   }
 
   /**


### PR DESCRIPTION
Azkaban uses the Dropwizard Metrics library to collect metrics to gauge how the app is doing. To report those metrics for proper storage and plotting for example, it allows custom reporters to be hooked in.
Before, to connect a custom reporter the fully qualified name of its class had to be provided in a config property and the class should have a constructor with the following signature: `(String reporterName, MetricRegistry registry, String metricsServerURL, Boolean someFlag)`

This approach leaks LinkedIn specific settings for reporting and forces users to implement a constructor with parameters that might not make sense to them. In addition, it's not extensible as to accommodate new configs, in the past the constructor signature has been modified making it a backward incompatible change.

To make the configuration of custom reporters more open source friendly (able to support reporter specific settings and can withstand changes) a constructor with the following signature can be used instead: `(MetricRegistry registry, String reporterConfigsPath)`
- A MetricRegistry should always be required as it contains all the app metrics.
- Optionally, the path to a file containing custom reporter specific settings can be specified. The file format and how to read it is up to the reporter implementation.