### PR TITLE
Added attachment file size logging for reportal emails LIHADOOP-61138

### DIFF
--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalMailCreator.java
@@ -373,6 +373,7 @@ public class ReportalMailCreator implements MailCreator {
                   "It is too big to be attached in this message. Please use the link above titled Result Data to download the reports</tr>");
     }
     message.println("</body>").println("</html>");
+    logger.info("Total size of attached files is " + totalFileSize/1024/1024 + "MB");
 
     return true;
   }


### PR DESCRIPTION
Logging attached file size due to large file attachment errors in Azkaban web server logs.