### PR TITLE
Instantiate OnExecutionEventListener for Containerization

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -31,6 +31,7 @@ import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutorManager;
 import azkaban.executor.ExecutorManagerAdapter;
+import azkaban.executor.OnExecutionEventListener;
 import azkaban.executor.container.ContainerCleanupManager;
 import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.flowtrigger.FlowTriggerService;
@@ -194,7 +195,8 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
       final ExecutionLogsCleaner executionLogsCleaner,
       final ObjectMapper objectMapper,
       final ContainerizationMetrics containerizationMetrics,
-      @Nullable final ContainerCleanupManager containerCleanupManager) {
+      @Nullable final ContainerCleanupManager containerCleanupManager,
+      @Nullable final OnExecutionEventListener onExecutionEventListener) {
     this.props = requireNonNull(props, "props is null.");
     this.server = requireNonNull(server, "server is null.");
     this.executorManagerAdapter = requireNonNull(executorManagerAdapter,
@@ -213,6 +215,10 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     this.objectMapper = objectMapper;
     this.containerizationMetrics = containerizationMetrics;
     this.containerCleanupManager = Optional.ofNullable(containerCleanupManager);
+    if (null != onExecutionEventListener) {
+      logger.info("Initialized onExecutionEventListener");
+      ExecutionControllerUtils.onExecutionEventListener = onExecutionEventListener;
+    }
 
     loadBuiltinCheckersAndActions();
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -136,6 +136,7 @@ public class AzkabanWebServerModule extends AbstractModule {
     bindImageManagementDependencies();
     bindContainerWatchDependencies();
     bindContainerCleanupManager();
+    bindOnExecutionEventListener();
   }
 
   private Class<? extends ContainerizationMetrics> resolveContainerMetricsClass() {
@@ -223,6 +224,15 @@ public class AzkabanWebServerModule extends AbstractModule {
     }
     log.info("Binding ContainerCleanupManager");
     bind(ContainerCleanupManager.class).in(Scopes.SINGLETON);
+  }
+
+  private void bindOnExecutionEventListener() {
+    if(!isContainerizedDispatchMethodEnabled()) {
+      bind(OnExecutionEventListener.class).toProvider(Providers.of(null));
+      return;
+    }
+    log.info("Binding OnExecutionEventListener");
+    bind(OnExecutionEventListener.class).to(OnContainerizedExecutionEventListener.class).in(Scopes.SINGLETON);
   }
 
   @Inject
@@ -328,18 +338,5 @@ public class AzkabanWebServerModule extends AbstractModule {
         Logger.getLogger("org.apache.velocity.Logger"));
     engine.setProperty("parser.pool.size", 3);
     return engine;
-  }
-
-  @Inject
-  @Singleton
-  @Provides
-  public OnExecutionEventListener createOnContainerizationExecutionEventListener (
-      final ExecutorLoader executorLoader,
-      final ExecutorManagerAdapter executorManagerAdapter,
-      final ProjectManager projectManager) {
-    OnExecutionEventListener listener = new OnContainerizedExecutionEventListener(executorLoader,
-        executorManagerAdapter, projectManager);
-    ExecutionControllerUtils.onExecutionEventListener = listener;
-    return listener;
   }
 }


### PR DESCRIPTION
The onExecutionEventListener was not getting initialized and hence when trying to restart the flow we were facing NPE.
This change fixes the issue by instantiating it at the start of the webserver.