### PR TITLE
Adding null check for labels and annotations for Pod spec

### DIFF
--- a/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/PodTemplateMergeUtils.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -284,14 +285,20 @@ public class PodTemplateMergeUtils {
    */
   public static void mergePodMetadata(V1ObjectMeta podMetadata,
       V1ObjectMeta podMetadataFromTemplate) {
-    final Map<String, String> labels = podMetadata.getLabels();
+    final Map<String, String> labels = podMetadata.getLabels() != null ?
+        podMetadata.getLabels() : new HashMap<>();
     // if the same label exists in both metadata objects the template value has precedence.
-    labels.putAll(podMetadataFromTemplate.getLabels());
+    if (podMetadataFromTemplate.getLabels() != null) {
+      labels.putAll(podMetadataFromTemplate.getLabels());
+    }
     podMetadata.setLabels(labels);
 
-    final Map<String, String> annotations = podMetadata.getAnnotations();
+    final Map<String, String> annotations = podMetadata.getAnnotations() != null ?
+        podMetadata.getAnnotations() : new HashMap<>();
     // if the same annotation key exists in both metadata objects the template value has precedence.
-    annotations.putAll(podMetadataFromTemplate.getAnnotations());
+    if (podMetadataFromTemplate.getAnnotations() != null) {
+      annotations.putAll(podMetadataFromTemplate.getAnnotations());
+    }
     podMetadata.setAnnotations(annotations);
   }
 }


### PR DESCRIPTION
When pod spec template does not have labels or annotation in metadata, it will fail without the null check added in this PR. For safety reasons, I have also added null check for labels and annotation metadata for dynamic pod spec as well.