### PR TITLE
Added a way to support custom hostname to emit metrics

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -289,6 +289,12 @@ public class Constants {
 
     // Represent the class name of azkaban metrics reporter.
     public static final String CUSTOM_METRICS_REPORTER_CLASS_NAME = "azkaban.metrics.reporter.name";
+    /**
+     * In environments where hostnames keep changing, for example, Kubernates ecosystem,
+     * we can use this config to pass a custom hostname which will be used to store,
+     * and reference metrics.
+     */
+    public static final String CUSTOM_METRICS_HOSTNAME = "azkaban.metrics.hostname";
 
     // Represent the metrics server URL.
     public static final String METRICS_SERVER_URL = "azkaban.metrics.server.url";


### PR DESCRIPTION
This change will enable us to pass custom hostname (usually a fixed one) to emit and refer metrics in containerized Azkaban web server.

Tested this change in conjunction with AmfReporter library update, and observed that metrics got emitted.