### PR TITLE
Emit FLOW_FINISHED events for cancelled flow

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -526,6 +526,9 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
         final Pair<ExecutionReference, ExecutableFlow> pair = unfinishedFlows
             .get(exFlow.getExecutionId());
         handleCancelFlow(pair.getFirst(), exFlow, userId);
+        // Emit FLOW_FINISHED event
+        this.fireEventListeners(Event.create(exFlow,
+            EventType.FLOW_FINISHED, new EventData(exFlow)));
       } else {
         final ExecutorManagerException eme = new ExecutorManagerException("Execution "
             + exFlow.getExecutionId() + " of flow " + exFlow.getFlowId() + " isn't running.");

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -26,7 +26,6 @@ import azkaban.spi.AzkabanEventReporter;
 import azkaban.spi.ExecutorType;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -478,6 +478,11 @@ public class ContainerizedDispatchManagerTest {
         new WrappedExecutorApiClient(createContainerDispatchEnabledProps(this.props));
     ContainerizedDispatchManager dispatchManager = createDefaultDispatchWithGateway(apiClient);
     apiClient.setNextHttpPostResponse(WrappedExecutorApiClient.STATUS_SUCCESS_JSON);
+    // Verify FLOW_FINISHED event is emitted
+    dispatchManager.addListener((event) -> {
+      Event flowEvent = (Event) event;
+      Assert.assertEquals(EventType.FLOW_FINISHED, flowEvent.getType());
+    });
     dispatchManager.cancelFlow(flow1, this.user.getUserId());
     Assert.assertEquals(apiClient.getExpectedReverseProxyContainerizedURI(),
         apiClient.getLastBuildExecutorUriRespone());

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -224,6 +224,11 @@ public class ExecutionControllerTest {
     // Flow1 is not assigned to any executor and is in PREPARING status.
     submitFlow(this.flow1, this.ref1);
     this.flow1.setStatus(Status.PREPARING);
+    // Verify FLOW_FINISHED event is emitted
+    this.controller.addListener((event) -> {
+      Event flowEvent = (Event) event;
+      Assert.assertEquals(EventType.FLOW_FINISHED, flowEvent.getType());
+    });
     try {
       this.controller.cancelFlow(this.flow1, this.user.getUserId());
     } catch (ExecutorManagerException e) {

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -26,7 +26,10 @@ import azkaban.Constants.ConfigurationKeys;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.Constants.FlowParameters;
 import azkaban.DispatchMethod;
+import azkaban.event.Event;
+import azkaban.event.EventListener;
 import azkaban.executor.AlerterHolder;
+import azkaban.executor.DummyEventListener;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
@@ -39,6 +42,7 @@ import azkaban.executor.container.ContainerizedImpl;
 import azkaban.executor.container.watch.KubernetesWatch.PodWatchParams;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.spi.EventType;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
 import com.google.common.collect.ImmutableList;
@@ -125,6 +129,7 @@ public class KubernetesWatchTest {
       OnContainerizedExecutionEventListener.class);
   private Map<String, String> flowParam = ImmutableMap.of(FlowParameters
       .FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true");
+  private EventListener eventListener = new DummyEventListener();
 
   @Before
   public void setUp() throws Exception {
@@ -179,7 +184,7 @@ public class KubernetesWatchTest {
 
   private FlowStatusManagerListener flowStatusUpdatingListener(Props azkProps) {
     return new FlowStatusManagerListener(azkProps, mockedContainerizedImpl(),
-        mockedExecutorLoader(), mock(AlerterHolder.class), containerizationMetrics);
+        mockedExecutorLoader(), mock(AlerterHolder.class), containerizationMetrics, eventListener);
   }
 
   private AzPodStatusDrivingListener statusDriverWithListener(AzPodStatusListener listener) {
@@ -297,6 +302,12 @@ public class KubernetesWatchTest {
     // Setup a FlowUpdatingListener
     Props azkProps = new Props();
     FlowStatusManagerListener updatingListener = flowStatusUpdatingListener(azkProps);
+    // Verify EXECUTION_STOPPED flow life cycle event is emitted
+    updatingListener.addListener((event) -> {
+      Event flowEvent = (Event) event;
+      Assert.assertEquals(EventType.FLOW_FINISHED, flowEvent.getType());
+      Assert.assertEquals(Status.EXECUTION_STOPPED, flowEvent.getData().getStatus());
+    });
     AzPodStatusDrivingListener statusDriver = new AzPodStatusDrivingListener(azkProps);
     statusDriver.registerAzPodStatusListener(updatingListener);
 
@@ -328,6 +339,12 @@ public class KubernetesWatchTest {
     // Setup a FlowUpdatingListener
     Props azkProps = new Props();
     FlowStatusManagerListener updatingListener = flowStatusUpdatingListener(azkProps);
+    // Verify EXECUTION_STOPPED flow life cycle event is emitted
+    updatingListener.addListener((event) -> {
+      Event flowEvent = (Event) event;
+      Assert.assertEquals(EventType.FLOW_FINISHED, flowEvent.getType());
+      Assert.assertEquals(Status.EXECUTION_STOPPED, flowEvent.getData().getStatus());
+    });
     AzPodStatusDrivingListener statusDriver = new AzPodStatusDrivingListener(azkProps);
     statusDriver.registerAzPodStatusListener(updatingListener);
 
@@ -394,6 +411,12 @@ public class KubernetesWatchTest {
     // Setup a FlowUpdatingListener
     Props azkProps = new Props();
     FlowStatusManagerListener updatingListener = flowStatusUpdatingListener(azkProps);
+    // Verify EXECUTION_STOPPED flow life cycle event is emitted
+    updatingListener.addListener((event) -> {
+      Event flowEvent = (Event) event;
+      Assert.assertEquals(EventType.FLOW_FINISHED, flowEvent.getType());
+      Assert.assertEquals(Status.EXECUTION_STOPPED, flowEvent.getData().getStatus());
+    });
     AzPodStatusDrivingListener statusDriver = new AzPodStatusDrivingListener(azkProps);
     statusDriver.registerAzPodStatusListener(updatingListener);
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -24,7 +24,6 @@ import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
 import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutionController;
-import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManager;
 import azkaban.executor.ExecutorManagerAdapter;
@@ -63,7 +62,6 @@ import azkaban.imagemgmt.version.VersionSetLoader;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.ContainerizationMetricsImpl;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
-import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
 import azkaban.user.UserManager;
@@ -255,9 +253,10 @@ public class AzkabanWebServerModule extends AbstractModule {
       final Props azkProps,
       final ContainerizedImpl containerizedImpl,
       final ExecutorLoader executorLoader,
-      final AlerterHolder alerterHolder, final ContainerizationMetrics containerizationMetrics) {
+      final AlerterHolder alerterHolder, final ContainerizationMetrics containerizationMetrics,
+      final EventListener eventListener) {
     return new FlowStatusManagerListener(azkProps, containerizedImpl, executorLoader, alerterHolder,
-        containerizationMetrics);
+        containerizationMetrics, eventListener);
   }
 
   @Inject


### PR DESCRIPTION
From the events, especially EXECUTION_STOPPED status, analytics can be done on containerized executions.