### PR TITLE
Adding UserPermissions and GroupPermissions to the Permission Change Event

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -35,6 +35,7 @@ import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
@@ -432,6 +433,19 @@ public class ProjectManager {
       eventData.put("updatedUser", name);
       eventData.put("updatedGroup", "null");
     }
+
+    //Getting updated user and Group permissions as String
+    Map<String, String> updatedUserPermissionMap = new HashMap<>();
+    Map<String, String> updatedGroupPermissionMap = new HashMap<>();
+
+    project.getUserPermissions().forEach(el -> updatedUserPermissionMap.put(el.getFirst(), el.getSecond().toString()));
+    project.getGroupPermissions().forEach(el -> updatedGroupPermissionMap.put(el.getFirst(), el.getSecond().toString()));
+
+    String userPermissionMapAsString = Joiner.on(":").withKeyValueSeparator("=").join(updatedUserPermissionMap);
+    String groupPermissionMapAsString = Joiner.on(":").withKeyValueSeparator("=").join(updatedGroupPermissionMap);
+
+    eventData.put("updatedUserPermissions", userPermissionMapAsString);
+    eventData.put("updatedGroupPermissions", groupPermissionMapAsString);
 
     String errorMessage = null;
     try {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -435,8 +435,8 @@ public class ProjectManager {
     }
 
     //Getting updated user and Group permissions as String
-    Map<String, String> updatedUserPermissionMap = new HashMap<>();
-    Map<String, String> updatedGroupPermissionMap = new HashMap<>();
+    final Map<String, String> updatedUserPermissionMap = new HashMap<>(project.getUserPermissions().size());
+    final Map<String, String> updatedGroupPermissionMap = new HashMap<>(project.getGroupPermissions().size());
 
     project.getUserPermissions().forEach(el -> updatedUserPermissionMap.put(el.getFirst(), el.getSecond().toString()));
     project.getGroupPermissions().forEach(el -> updatedGroupPermissionMap.put(el.getFirst(), el.getSecond().toString()));

--- a/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
@@ -243,6 +243,13 @@ public class ProjectManagerTest {
       Assert.assertEquals("Event metadata not created as expected.", "ADMIN", projectEvent.getEventData().get("permission"));
       Assert.assertEquals("Event metadata not created as expected.", "SUCCESS", projectEvent.getEventData().get("projectEventStatus"));
       Assert.assertEquals("Event metadata not created as expected.", "null", projectEvent.getEventData().get("errorMessage"));
+
+      String updatedGroupPermissions = (String) projectEvent.getEventData().get("updatedGroupPermissions");
+      Assert.assertNotNull("Event metadata not created as expected.", updatedGroupPermissions);
+      Assert.assertTrue("Event metadata not created as expected.", updatedGroupPermissions.matches("((\\w+)=(\\w+,?)+:?)+"));
+      Assert.assertTrue("Event metadata not created as expected.", updatedGroupPermissions.contains("READ")
+          && updatedGroupPermissions.contains("WRITE") && updatedGroupPermissions.contains("EXECUTE"));
+      Assert.assertEquals("Event metadata not created as expected.", "", projectEvent.getEventData().get("updatedUserPermissions"));
     });
     project.addListener(listener1);
     // Add a user permission


### PR DESCRIPTION
This change is done to pass on the additional information related to updated UserPermissions and GroupPermissions after a change in permission is made. Since the metadata that is provided to KafkaEvent reporter is of type String so tried to convert the Hashmap's value to a string which can be then split back into String by event reporter later.

**How change is tested:**
Added respective test cases.