### PR TITLE
[Documentation] Corrected the indentation for code sample.

### DIFF
--- a/docs/ajaxApi.rst
+++ b/docs/ajaxApi.rst
@@ -1830,17 +1830,17 @@ A response sample:
 
 .. code-block:: guess
 
-{
-  "columns" : [ "user", "time", "type", "message" ],
-  "logData" : [ 
-    [ "test_user1", 1543615522936, "PROPERTY_OVERRIDE", "Modified Properties: .... " ],
-    [ "test_user2", 1542346639933, "UPLOADED", "Uploaded project files zip " ],
-    [ "test_user3", 1519908889338, "CREATED", null ],
-    ... 
-  ],
-  "project" : "azkaban-test-project",
-  "projectId" : 1
-}
+  {
+    "columns" : [ "user", "time", "type", "message" ],
+    "logData" : [ 
+      [ "test_user1", 1543615522936, "PROPERTY_OVERRIDE", "Modified Properties: .... " ],
+      [ "test_user2", 1542346639933, "UPLOADED", "Uploaded project files zip " ],
+      [ "test_user3", 1519908889338, "CREATED", null ],
+      ... 
+    ],
+    "project" : "azkaban-test-project",
+    "projectId" : 1
+  }
 
 .. _api-image-management-api:
 


### PR DESCRIPTION
Corrected the indentation for the code sample, due to which it was not showing up correctly in the documentation.
Have tested locally as well. Attaching images for before and after.