### PR TITLE
Log4j and Sl4j is upgraded because of CVE-2019-1751 vulnerability to …

### DIFF
--- a/az-core/src/main/java/azkaban/utils/Props.java
+++ b/az-core/src/main/java/azkaban/utils/Props.java
@@ -15,6 +15,8 @@
  */
 package azkaban.utils;
 
+import org.slf4j.Logger;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -35,7 +37,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
-import org.apache.log4j.Logger;
 
 
 /**

--- a/az-core/src/main/java/azkaban/utils/Utils.java
+++ b/az-core/src/main/java/azkaban/utils/Utils.java
@@ -40,9 +40,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -51,7 +52,7 @@ import org.quartz.CronExpression;
 public class Utils {
 
   private static final Random RANDOM = new Random();
-  private static final Logger logger = Logger.getLogger(Utils.class);
+  private static final Logger logger = LoggerFactory.getLogger(Utils.class);
 
   /**
    * Private constructor.

--- a/azkaban-exec-server/src/test/java/azkaban/dag/StatusChangeRecorder.java
+++ b/azkaban-exec-server/src/test/java/azkaban/dag/StatusChangeRecorder.java
@@ -16,16 +16,14 @@
 
 package azkaban.dag;
 
-
-import static org.assertj.core.api.Assertions.assertThat;
+import azkaban.utils.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
-import javafx.util.Pair;
 
-/**
- * Records the sequence of nodes and dag status change.
- */
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Records the sequence of nodes and dag status change. */
 class StatusChangeRecorder {
 
   private final List<Pair<String, Status>> sequence = new ArrayList<>();

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ ext.versions = [hadoop: '2.10.0',
                 hive  : '1.1.0',
                 pig   : '0.11.0',
                 restli: '29.16.0',
-                slf4j : '1.7.18',]
+                slf4j : '1.7.32',]
 
 ext.deps = [
     // External dependencies
@@ -108,9 +108,9 @@ ext.deps = [
     jopt                 : 'net.sf.jopt-simple:jopt-simple:5.0.3',
     jsr305               : 'com.google.code.findbugs:jsr305:3.0.2',
     junit                : 'junit:junit:4.12',
-    kafkaLog4jAppender   : 'org.apache.kafka:kafka-log4j-appender:0.10.0.0',
+    kafkaLog4jAppender   : 'org.apache.kafka:kafka-log4j-appender:3.0.0',
     k8sClient            : 'io.kubernetes:client-java:10.0.0',
-    log4j                : 'log4j:log4j:1.2.16',
+    log4j                : 'org.apache.logging.log4j:log4j-core:2.17.1',
     mail                 : 'javax.mail:mail:1.4.5',
     math3                : 'org.apache.commons:commons-math3:3.0',
     metricsCore          : 'io.dropwizard.metrics:metrics-core:3.2.6',


### PR DESCRIPTION
Log4j and sl4j upgraded because of CVE-2019-1751-vulnerability and also some errors fixed after build.


**Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data. This affects Log4j versions up to 1.2 up to 1.2.17.**

