### PR TITLE
Upgrade javax.mail to 1.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ ext.deps = [
     kafkaLog4jAppender   : 'org.apache.kafka:kafka-log4j-appender:0.10.0.0',
     k8sClient            : 'io.kubernetes:client-java:10.0.0',
     log4j                : 'log4j:log4j:1.2.16',
-    mail                 : 'javax.mail:mail:1.4.5',
+    mail                 : 'com.sun.mail:javax.mail:1.6.2',
     math3                : 'org.apache.commons:commons-math3:3.0',
     metricsCore          : 'io.dropwizard.metrics:metrics-core:3.2.6',
     metricsJvm           : 'io.dropwizard.metrics:metrics-jvm:3.2.6',


### PR DESCRIPTION
When running Azkaban on a new Ubuntu, email sending started failing like this:
```
2021/11/03 11:50:20.237 +0000 ERROR EmailMessage

Connecting to SMTP server failed, attempt: 4
javax.mail.MessagingException: Could not convert socket to TLS;
  nested exception is:
	javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
	at com.sun.mail.smtp.SMTPTransport.startTLS(SMTPTransport.java:1918)
	at com.sun.mail.smtp.SMTPTransport.protocolConnect(SMTPTransport.java:652)
	at javax.mail.Service.connect(Service.java:295)
	at azkaban.utils.JavaxMailSender.connect(JavaxMailSender.java:34)
	at azkaban.utils.EmailMessage.connectToSMTPServer(EmailMessage.java:222)
	at azkaban.utils.EmailMessage.retryConnectToSMTPServer(EmailMessage.java:232)
	at azkaban.utils.EmailMessage.sendEmail(EmailMessage.java:215)
	at azkaban.utils.Emailer.sendEmail(Emailer.java:254)
	at azkaban.utils.Emailer.alertOnSuccess(Emailer.java:163)
	at azkaban.executor.ExecutionControllerUtils.alertUserOnFlowFinished(ExecutionControllerUtils.java:144)
	at azkaban.executor.ExecutionFinalizer.finalizeFlow(ExecutionFinalizer.java:97)
	at azkaban.executor.RunningExecutionsUpdater.updateExecutions(RunningExecutionsUpdater.java:139)
	at azkaban.executor.RunningExecutionsUpdaterThread.run(RunningExecutionsUpdaterThread.java:54)
Caused by: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
	at sun.security.ssl.HandshakeContext.<init>(HandshakeContext.java:171)
	at sun.security.ssl.ClientHandshakeContext.<init>(ClientHandshakeContext.java:98)
	at sun.security.ssl.TransportContext.kickstart(TransportContext.java:220)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:428)
	at com.sun.mail.util.SocketFetcher.configureSSLSocket(SocketFetcher.java:548)
	at com.sun.mail.util.SocketFetcher.startTLS(SocketFetcher.java:485)
	at com.sun.mail.smtp.SMTPTransport.startTLS(SMTPTransport.java:1913)
	... 12 more
```

Upgrading javax.mail to 1.6.x fixes the error (it supports TLS 1.2). With this change alert emails are working again.