### PR TITLE
Adding a way to add group and user in case environment doesn't provide it by default. It is controlled by property.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -319,6 +319,10 @@ public class Constants {
     // Path name of execute-as-user executable
     public static final String AZKABAN_SERVER_NATIVE_LIB_FOLDER = "azkaban.native.lib";
 
+    // Add group and user on linux machine for effective user before job process starts
+    public static final String AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER =
+        "azkaban.add.group.and.user.for.effective.user";
+
     // Name of *nix group associated with the process running Azkaban
     public static final String AZKABAN_SERVER_GROUP_NAME = "azkaban.group.name";
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -563,7 +563,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     // Get CPU and memory requested for a flow container
     final String flowContainerCPURequest = getFlowContainerCPURequest(flowParam);
     final String flowContainerMemoryRequest = getFlowContainerMemoryRequest(flowParam);
-
+    logger.info("Creating pod for : " + executionId);
     final AzKubernetesV1SpecBuilder v1SpecBuilder =
         new AzKubernetesV1SpecBuilder(this.clusterEnv, Optional.empty())
             .addFlowContainer(this.flowContainerName,

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -563,7 +563,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     // Get CPU and memory requested for a flow container
     final String flowContainerCPURequest = getFlowContainerCPURequest(flowParam);
     final String flowContainerMemoryRequest = getFlowContainerMemoryRequest(flowParam);
-    logger.info("Creating pod for : " + executionId);
+    logger.info("Creating pod for execution-id: " + executionId);
     final AzKubernetesV1SpecBuilder v1SpecBuilder =
         new AzKubernetesV1SpecBuilder(this.clusterEnv, Optional.empty())
             .addFlowContainer(this.flowContainerName,

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -15,7 +15,6 @@
  */
 package azkaban.jobExecutor;
 
-import static azkaban.Constants.ConfigurationKeys.AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_GROUP_NAME;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -27,7 +26,6 @@ import azkaban.jobExecutor.utils.process.AzkabanProcess;
 import azkaban.jobExecutor.utils.process.AzkabanProcessBuilder;
 import azkaban.metrics.CommonMetrics;
 import azkaban.utils.ExecuteAsUser;
-import azkaban.utils.ExecuteAsUserUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.SystemMemoryInfo;
@@ -251,19 +249,9 @@ public class ProcessJob extends AbstractProcessJob {
         );
       }
 
-      final boolean addGroupAndUserForEffectiveUser =
-          this.getSysProps().getBoolean(AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER, false);
-      if (addGroupAndUserForEffectiveUser) {
-        // If linux group and user needs to be added for effectiveUser before job process starts
-        // then set it up before effective user is used to set permission for any file.
-        info("Adding group and user for effective user: " + effectiveUser);
-        final ExecuteAsUser executeAsUser = new ExecuteAsUser(
-            this.getSysProps().getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER));
-        ExecuteAsUserUtils.addGroupAndUserForEffectiveUser(executeAsUser, effectiveUser);
-      }
-
       // Set parent directory permissions to <uid>:azkaban so user can write in their execution directory
-      // if the directory is not permission correctly already (should happen once per execution)
+      // if the directory does not have correct permission already (should happen once per
+      // execution)
       if (!canWriteInCurrentWorkingDirectory(effectiveUser)) {
         info("Changing current working directory ownership");
         assignUserFileOwnership(effectiveUser, getWorkingDirectory());

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
@@ -26,32 +26,22 @@ public class ExecuteAsUserUtils {
       final String effectiveUser) throws Exception {
     List<String> commands = Arrays.asList(ADD_GROUP_PATH, effectiveUser);
     int result = executeAsUser.execute("root", commands);
-    if (result == 0) {
+    if (result == 0 || result == 9) {
       logger.info("Group is added successfully.");
       commands = Arrays
           .asList(ADD_USER_PATH, "-l", "-m", effectiveUser, "-g", effectiveUser);
       result = executeAsUser.execute("root", commands);
-      if (result == 0) {
+      if (result == 0 || result == 9) {
         logger.info("User is added successfully.");
       } else {
-        if (result == 9) {
-          logger.info("User already exist for " + effectiveUser);
-        } else {
-          final String errorMessage = "Failed to add user: " + result;
-          logger.error(errorMessage);
-          throw new JobExecutionException(errorMessage);
-        }
-      }
-    } else {
-      //If group already exist then it will return error code 9. Log the info and don't raise any
-      // exception in that case.
-      if (result == 9) {
-        logger.info("Group already exist for " + effectiveUser);
-      } else {
-        final String errorMessage = "Failed to add group: " + result;
+        final String errorMessage = "Failed to add user: " + result;
         logger.error(errorMessage);
         throw new JobExecutionException(errorMessage);
       }
+    } else {
+      final String errorMessage = "Failed to add group: " + result;
+      logger.error(errorMessage);
+      throw new JobExecutionException(errorMessage);
     }
   }
 }

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
@@ -1,0 +1,42 @@
+package azkaban.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used as utility class for ExecuteAsUser script.
+ */
+public class ExecuteAsUserUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ExecuteAsUserUtils.class);
+  private static final String ADD_GROUP_COMMAND = "/usr/sbin/groupadd";
+  private static final String ADD_USER_COMMAND = "/usr/sbin/useradd";
+
+  /**
+   * Add group and user on environment where job will run before job process starts.
+   *
+   * @param effectiveUser
+   * @throws Exception
+   */
+  public static void addGroupAndUserForEffectiveUser(final ExecuteAsUser executeAsUser,
+      final String effectiveUser) throws Exception {
+    List<String> commands = Arrays.asList(ADD_GROUP_COMMAND, effectiveUser);
+    int result = executeAsUser.execute("root", commands);
+    if (result != 0) {
+      final String errorMessage = "Failed to add group: " + result;
+      //Log the error message and don't throw exception as this method is called for every job.
+      //If all the jobs have same effective user then first time, adding group and user will pass
+      //but for second time, it will fail. So fail silently.
+      logger.error(errorMessage);
+    }
+    commands =Arrays
+        .asList(ADD_USER_COMMAND, "-l", "-m", effectiveUser, "-g", effectiveUser);
+    result = executeAsUser.execute("root", commands);
+    if (result != 0) {
+      final String errorMessage = "Failed to add user: " + result;
+      logger.error(errorMessage);
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
@@ -26,20 +26,25 @@ public class ExecuteAsUserUtils {
       final String effectiveUser) throws Exception {
     List<String> commands = Arrays.asList(ADD_GROUP_PATH, effectiveUser);
     int result = executeAsUser.execute("root", commands);
+    // If group is added successfully, it will return code 0.
+    // If group is already added then it will return code 9.
     if (result == 0 || result == 9) {
       logger.info("Group is added successfully.");
       commands = Arrays
           .asList(ADD_USER_PATH, "-l", "-m", effectiveUser, "-g", effectiveUser);
       result = executeAsUser.execute("root", commands);
+      // If user is added successfully, it will return code 0.
+      // If user is already added then it will return code 9.
       if (result == 0 || result == 9) {
         logger.info("User is added successfully.");
       } else {
-        final String errorMessage = "Failed to add user: " + result;
+        final String errorMessage =
+            "Failed to add user:" + effectiveUser + "Return value was: " + result;
         logger.error(errorMessage);
         throw new JobExecutionException(errorMessage);
       }
     } else {
-      final String errorMessage = "Failed to add group: " + result;
+      final String errorMessage = "Failed to add group:" + effectiveUser + "Return value was: " + result;
       logger.error(errorMessage);
       throw new JobExecutionException(errorMessage);
     }

--- a/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/ExecuteAsUserUtils.java
@@ -1,5 +1,6 @@
 package azkaban.utils;
 
+import azkaban.jobExecutor.utils.JobExecutionException;
 import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
@@ -11,32 +12,46 @@ import org.slf4j.LoggerFactory;
 public class ExecuteAsUserUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(ExecuteAsUserUtils.class);
-  private static final String ADD_GROUP_COMMAND = "/usr/sbin/groupadd";
-  private static final String ADD_USER_COMMAND = "/usr/sbin/useradd";
+  private static final String ADD_GROUP_PATH = "/usr/sbin/groupadd";
+  private static final String ADD_USER_PATH = "/usr/sbin/useradd";
 
   /**
-   * Add group and user on environment where job will run before job process starts.
+   * Add group and user on environment where job will run before job process starts. These commands
+   * can only be executed by root user.
    *
    * @param effectiveUser
    * @throws Exception
    */
   public static void addGroupAndUserForEffectiveUser(final ExecuteAsUser executeAsUser,
       final String effectiveUser) throws Exception {
-    List<String> commands = Arrays.asList(ADD_GROUP_COMMAND, effectiveUser);
+    List<String> commands = Arrays.asList(ADD_GROUP_PATH, effectiveUser);
     int result = executeAsUser.execute("root", commands);
-    if (result != 0) {
-      final String errorMessage = "Failed to add group: " + result;
-      //Log the error message and don't throw exception as this method is called for every job.
-      //If all the jobs have same effective user then first time, adding group and user will pass
-      //but for second time, it will fail. So fail silently.
-      logger.error(errorMessage);
-    }
-    commands =Arrays
-        .asList(ADD_USER_COMMAND, "-l", "-m", effectiveUser, "-g", effectiveUser);
-    result = executeAsUser.execute("root", commands);
-    if (result != 0) {
-      final String errorMessage = "Failed to add user: " + result;
-      logger.error(errorMessage);
+    if (result == 0) {
+      logger.info("Group is added successfully.");
+      commands = Arrays
+          .asList(ADD_USER_PATH, "-l", "-m", effectiveUser, "-g", effectiveUser);
+      result = executeAsUser.execute("root", commands);
+      if (result == 0) {
+        logger.info("User is added successfully.");
+      } else {
+        if (result == 9) {
+          logger.info("User already exist for " + effectiveUser);
+        } else {
+          final String errorMessage = "Failed to add user: " + result;
+          logger.error(errorMessage);
+          throw new JobExecutionException(errorMessage);
+        }
+      }
+    } else {
+      //If group already exist then it will return error code 9. Log the info and don't raise any
+      // exception in that case.
+      if (result == 9) {
+        logger.info("Group already exist for " + effectiveUser);
+      } else {
+        final String errorMessage = "Failed to add group: " + result;
+        logger.error(errorMessage);
+        throw new JobExecutionException(errorMessage);
+      }
     }
   }
 }

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
@@ -15,7 +15,6 @@
  */
 package azkaban.security;
 
-import static azkaban.Constants.ConfigurationKeys.AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
@@ -28,7 +27,6 @@ import azkaban.executor.KeyStoreManager;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.ExecuteAsUser;
-import azkaban.utils.ExecuteAsUserUtils;
 import azkaban.utils.Props;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -394,20 +392,6 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
    */
   protected void doPrefetch(final File tokenFile, final Props props, final Logger logger,
       final String userToProxy) throws HadoopSecurityManagerException {
-    final boolean addGroupAndUserForEffectiveUser =
-        props.getBoolean(AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER, false);
-    if (addGroupAndUserForEffectiveUser) {
-      // If linux group and user needs to be added for effectiveUser before job process starts
-      // then set it up before effective user is used to set permission for any file.
-      logger.info("Adding group and user for effective user: " + userToProxy);
-      try {
-        ExecuteAsUserUtils.addGroupAndUserForEffectiveUser(executeAsUser, userToProxy);
-      } catch (Exception e) {
-        throw new HadoopSecurityManagerException(
-            "Failed to add group and user for effective user: " + userToProxy + ". Error: " + e);
-      }
-    }
-
     // Create suffix to be added to kerberos principal
     final String suffix = getFQNSuffix(props);
 

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/AbstractHadoopSecurityManager.java
@@ -15,6 +15,7 @@
  */
 package azkaban.security;
 
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
@@ -27,6 +28,7 @@ import azkaban.executor.KeyStoreManager;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.ExecuteAsUser;
+import azkaban.utils.ExecuteAsUserUtils;
 import azkaban.utils.Props;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -392,6 +394,20 @@ public abstract class AbstractHadoopSecurityManager extends HadoopSecurityManage
    */
   protected void doPrefetch(final File tokenFile, final Props props, final Logger logger,
       final String userToProxy) throws HadoopSecurityManagerException {
+    final boolean addGroupAndUserForEffectiveUser =
+        props.getBoolean(AZKABAN_ADD_GROUP_AND_USER_FOR_EFFECTIVE_USER, false);
+    if (addGroupAndUserForEffectiveUser) {
+      // If linux group and user needs to be added for effectiveUser before job process starts
+      // then set it up before effective user is used to set permission for any file.
+      logger.info("Adding group and user for effective user: " + userToProxy);
+      try {
+        ExecuteAsUserUtils.addGroupAndUserForEffectiveUser(executeAsUser, userToProxy);
+      } catch (Exception e) {
+        throw new HadoopSecurityManagerException(
+            "Failed to add group and user for effective user: " + userToProxy + ". Error: " + e);
+      }
+    }
+
     // Create suffix to be added to kerberos principal
     final String suffix = getFQNSuffix(props);
 


### PR DESCRIPTION
Where this change will help? 
In case of containers running in Kubernetes, we might not have linux users and groups available. In that case, Azkaban jobs will start failing. With the help of this change, it will add user and group for effective user before any job starts.
How to enable group and user addition for any flow execution?
The property introduced to enable group and user addition is: azkaban.add.group.and.user.for.effective.user. Set this property in commonprivate.properties to true and it will enable group and user addition prior to start of any user job process.