### PR TITLE
Adding update and delete APIs for imageType image management API

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -722,6 +722,8 @@ public class Constants {
     public static final String VERSION_STATE = "versionState";
     public static final String ID_KEY = "id";
     public static final String IMAGE_RAMPUP_PLAN = "imageRampupPlan";
+    public static final String IMAGE_UPDATE_ADD_USER = "addImageOwners";
+    public static final String IMAGE_UPDATE_REMOVE_USER = "removeImageOwners";
   }
 
   public static class FlowParameters {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDao.java
@@ -86,4 +86,21 @@ public interface ImageTypeDao {
    * @return ImageType
    */
   public ImageType getImageTypeWithOwnershipsById(String id);
+
+  /**
+   * Add an owner for a given image type.
+   *
+   * @param imageType - ImageType to be updated
+   * @return int - Id representing image type metadata
+   */
+  public int addOwnerOfImageType(ImageType imageType) throws ImageMgmtException;
+
+  /**
+   * Remove an owner for a given image type.
+   *
+   * @param imageType - ImageType to be updated
+   * @return int - Id representing image type metadata
+   */
+  public int removeOwnerOfImageType(ImageType imageType) throws ImageMgmtException;
+
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDao.java
@@ -93,7 +93,7 @@ public interface ImageTypeDao {
    * @param imageType - ImageType to be updated
    * @return int - Id representing image type metadata
    */
-  public int addOwnerOfImageType(ImageType imageType) throws ImageMgmtException;
+  public int addImageTypeOwner(ImageType imageType) throws ImageMgmtException;
 
   /**
    * Remove an owner for a given image type.
@@ -101,6 +101,6 @@ public interface ImageTypeDao {
    * @param imageType - ImageType to be updated
    * @return int - Id representing image type metadata
    */
-  public int removeOwnerOfImageType(ImageType imageType) throws ImageMgmtException;
+  public int removeImageTypeOwner(ImageType imageType) throws ImageMgmtException;
 
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDaoImpl.java
@@ -143,6 +143,11 @@ public class ImageTypeDaoImpl implements ImageTypeDao {
     }
     int imageTypeId =
         getImageTypeByName(imageType.getName()).map(BaseModel::getId).orElse(0);
+    if (imageTypeId < 1) {
+      log.error(String.format("Exception while updating image type due to invalid "
+          + "imageTypeId: %d.", imageTypeId));
+      throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while updating image ");
+    }
     final SQLTransaction<Integer> update = transOperator -> {
       final Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
       for (final ImageOwnership imageOwnership : newOwners) {
@@ -153,11 +158,6 @@ public class ImageTypeDaoImpl implements ImageTypeDao {
       transOperator.getConnection().commit();
       return 1;
     };
-    if (imageTypeId < 1) {
-      log.error(String.format("Exception while updating image type due to invalid "
-          + "imageTypeId: %d.", imageTypeId));
-      throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while updating image ");
-    }
     try {
       this.databaseOperator.transaction(update);
       log.info("Successfully Updated image ownerships for :" + imageType.getName());

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageTypeDaoImpl.java
@@ -23,6 +23,7 @@ import azkaban.db.SQLTransaction;
 import azkaban.imagemgmt.exception.ErrorCode;
 import azkaban.imagemgmt.exception.ImageMgmtDaoException;
 import azkaban.imagemgmt.exception.ImageMgmtException;
+import azkaban.imagemgmt.models.BaseModel;
 import azkaban.imagemgmt.models.ImageOwnership;
 import azkaban.imagemgmt.models.ImageOwnership.Role;
 import azkaban.imagemgmt.models.ImageType;
@@ -63,10 +64,27 @@ public class ImageTypeDaoImpl implements ImageTypeDao {
   static String INSERT_IMAGE_OWNERSHIP =
       "insert into image_ownerships ( type_id, owner, role, created_by, created_on, modified_by, "
           + "modified_on ) values (?, ?, ?, ?, ?, ?, ?)";
+  static String DELETE_IMAGE_OWNERSHIP =
+      "delete from image_ownerships where type_id=? AND owner=?";
 
   @Inject
   public ImageTypeDaoImpl(final DatabaseOperator databaseOperator) {
     this.databaseOperator = databaseOperator;
+  }
+
+  public void handleSqlException(final SQLException e){
+    String errorMessage = "";
+    // TODO: Find a better way to get the error message. Currently apache common dbutils
+    // throws sql exception for all the below error scenarios and error message contains
+    // complete query as well, hence generic error message is thrown.
+    if (e.getErrorCode() == SQL_ERROR_CODE_DUPLICATE_ENTRY) {
+      errorMessage = "Reason: Duplicate key provided for one or more column(s).";
+    }
+    if (e.getErrorCode() == SQL_ERROR_CODE_DATA_TOO_LONG) {
+      errorMessage = "Reason: Data too long for one or more column(s).";
+    }
+    throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception occurred while creating "
+        + "image type metadata. " + errorMessage);
   }
 
   @Override
@@ -106,20 +124,80 @@ public class ImageTypeDaoImpl implements ImageTypeDao {
       log.info("Created image type id :" + imageTypeId);
     } catch (final SQLException e) {
       log.error("Unable to create the image type metadata", e);
-      String errorMessage = "";
-      // TODO: Find a better way to get the error message. Currently apache common dbutils
-      // throws sql exception for all the below error scenarios and error message contains
-      // complete query as well, hence generic error message is thrown.
-      if (e.getErrorCode() == SQL_ERROR_CODE_DUPLICATE_ENTRY) {
-        errorMessage = "Reason: Duplicate key provided for one or more column(s).";
-      }
-      if (e.getErrorCode() == SQL_ERROR_CODE_DATA_TOO_LONG) {
-        errorMessage = "Reason: Data too long for one or more column(s).";
-      }
-      throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception occurred while creating "
-          + "image type metadata. " + errorMessage);
+      handleSqlException(e);
     }
     return imageTypeId;
+  }
+
+  @Override
+  public int addOwnerOfImageType(final ImageType imageType) {
+    final Set<ImageOwnership> currentOwners =
+        new HashSet<>(getImageTypeOwnership(imageType.getName()));
+    final Set<ImageOwnership> newOwners = new HashSet<>(imageType.getOwnerships());
+    newOwners.removeAll(currentOwners);
+    //Check if there are actually new owners added.
+    if (newOwners.isEmpty()) {
+      throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while updating image, "
+          + "specified no new owners");
+    }
+    int imageTypeId =
+        getImageTypeByName(imageType.getName()).map(BaseModel::getId).orElse(0);
+    final SQLTransaction<Integer> update = transOperator -> {
+      final Timestamp currentTimestamp = Timestamp.valueOf(LocalDateTime.now());
+      for (final ImageOwnership imageOwnership : newOwners) {
+        transOperator.update(INSERT_IMAGE_OWNERSHIP, imageTypeId, imageOwnership.getOwner(),
+            imageOwnership.getRole().name(), imageType.getCreatedBy(), currentTimestamp,
+            imageType.getModifiedBy(), currentTimestamp);
+      }
+      transOperator.getConnection().commit();
+      return 1;
+    };
+    try {
+      this.databaseOperator.transaction(update);
+      if (imageTypeId < 1) {
+        log.error(String.format("Exception while updating image type due to invalid "
+            + "imageTypeId: %d.", imageTypeId));
+        throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while updating image ");
+      }
+      log.info("Successfully Updated image ownerships for :" + imageType.getName());
+    } catch (final SQLException e) {
+      log.error("Unable to update the image type metadata", e);
+      handleSqlException(e);
+    }
+    return imageTypeId;
+  }
+
+  @Override
+  public int removeOwnerOfImageType(ImageType imageType) throws ImageMgmtException {
+    final Set<ImageOwnership> currentOwners =
+        new HashSet<>(getImageTypeOwnership(imageType.getName()));
+    final Set<ImageOwnership> ownersToRemove = new HashSet<>(imageType.getOwnerships());
+    ownersToRemove.retainAll(currentOwners);
+      //Check if it's removing all owners
+    if (ownersToRemove.size() >= currentOwners.size() - 1){
+        throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while deleting "
+            + " image owners, need greater than two owners to be present");
+      }
+      int imageTypeId =
+          getImageTypeByName(imageType.getName()).map(BaseModel::getId).orElse(0);
+
+    try {
+      if (imageTypeId < 1) {
+        log.error(String.format("Exception while removing owner due to invalid "
+            + "imageTypeId: %d.", imageTypeId));
+        throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "Exception while removing "
+            + "image owners. Invalid imageTypeId");
+      }
+      for (final ImageOwnership imageOwnership : ownersToRemove) {
+        this.databaseOperator.update(DELETE_IMAGE_OWNERSHIP, imageTypeId,
+            imageOwnership.getOwner());
+      }
+      log.info("Successfully removed owner(s) image type id :" + imageTypeId);
+    } catch (final SQLException e) {
+        log.error("Unable to update the image type metadata", e);
+        handleSqlException(e);
+      }
+      return imageTypeId;
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageTypeDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageTypeDTO.java
@@ -65,6 +65,7 @@ public class ImageTypeDTO extends BaseDTO {
   }
 
   public void setOwnerships(final List<ImageOwnershipDTO> ownerships) {
-    this.ownerships = ownerships;
+            ownerships.stream().forEach(o -> o.setName(getName()));
+            this.ownerships = ownerships;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageTypeDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageTypeDTO.java
@@ -65,7 +65,7 @@ public class ImageTypeDTO extends BaseDTO {
   }
 
   public void setOwnerships(final List<ImageOwnershipDTO> ownerships) {
-            ownerships.stream().forEach(o -> o.setName(getName()));
+            ownerships.forEach(o -> o.setName(getName()));
             this.ownerships = ownerships;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageOwnership.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageOwnership.java
@@ -20,6 +20,8 @@ import azkaban.user.Permission.Type;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -109,5 +111,29 @@ public class ImageOwnership extends BaseModel {
         ", modifiedBy='" + this.modifiedBy + '\'' +
         ", modifiedOn='" + this.modifiedOn + '\'' +
         '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 31).
+        append(this.name).
+        append(this.owner).
+        append(this.role).
+        toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ImageOwnership))
+      return false;
+    if (obj == this)
+      return true;
+
+    ImageOwnership imageOwner = (ImageOwnership) obj;
+    return new EqualsBuilder().
+            append(name, imageOwner.name).
+            append(owner, imageOwner.owner).
+            append(role, imageOwner.role).
+            isEquals();
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeService.java
@@ -56,10 +56,20 @@ public interface ImageTypeService {
   /**
    * Method for processing and delegation of image type creation/registration.
    *
-   * @param imageType - DTO which encaptulates  and transfers the create request details
+   * @param imageType - DTO which encapsulates  and transfers the create request details
    * @return int - id of the image type metadata record created
    * @throws IOException
    * @throws ImageMgmtException
    */
   public int createImageType(ImageTypeDTO imageType) throws ImageMgmtException;
+
+  /**
+   * Method for updating image types.
+   *
+   * @param imageType - DTO which encapsulates  and transfers the update request details
+   * @return int - id of the image type metadata record updated
+   * @throws IOException
+   * @throws ImageMgmtException
+   */
+  public int updateImageType(ImageTypeDTO imageType, String updateOp) throws ImageMgmtException;
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeServiceImpl.java
@@ -16,6 +16,8 @@
 package azkaban.imagemgmt.services;
 
 import static azkaban.Constants.ImageMgmtConstants.IMAGE_TYPE;
+import static azkaban.Constants.ImageMgmtConstants.IMAGE_UPDATE_ADD_USER;
+import static azkaban.Constants.ImageMgmtConstants.IMAGE_UPDATE_REMOVE_USER;
 
 import azkaban.imagemgmt.converters.Converter;
 import azkaban.imagemgmt.daos.ImageTypeDao;
@@ -107,6 +109,22 @@ public class ImageTypeServiceImpl implements ImageTypeService {
     // Validate ownership metadata
     validateOwnership(imageType);
     return this.imageTypeDao.createImageType(this.converter.convertToDataModel(imageType));
+  }
+
+  @Override
+  public int updateImageType(final ImageTypeDTO imageType,
+                             final String updateOp) throws ImageMgmtException {
+    // Check if update operation is valid
+    if (updateOp.equals(IMAGE_UPDATE_ADD_USER)) {
+      return this.imageTypeDao.addOwnerOfImageType(this.converter.convertToDataModel(imageType));
+    }
+    if (updateOp.equals(IMAGE_UPDATE_REMOVE_USER)) {
+      return this.imageTypeDao.removeOwnerOfImageType(this.converter.convertToDataModel(imageType));
+    }
+    else{
+      throw new ImageMgmtValidationException(ErrorCode.BAD_REQUEST, String.format("Provide valid "
+          + "input for image update operation"));
+    }
   }
 
   /**

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageTypeServiceImpl.java
@@ -116,10 +116,10 @@ public class ImageTypeServiceImpl implements ImageTypeService {
                              final String updateOp) throws ImageMgmtException {
     // Check if update operation is valid
     if (updateOp.equals(IMAGE_UPDATE_ADD_USER)) {
-      return this.imageTypeDao.addOwnerOfImageType(this.converter.convertToDataModel(imageType));
+      return this.imageTypeDao.addImageTypeOwner(this.converter.convertToDataModel(imageType));
     }
     if (updateOp.equals(IMAGE_UPDATE_REMOVE_USER)) {
-      return this.imageTypeDao.removeOwnerOfImageType(this.converter.convertToDataModel(imageType));
+      return this.imageTypeDao.removeImageTypeOwner(this.converter.convertToDataModel(imageType));
     }
     else{
       throw new ImageMgmtValidationException(ErrorCode.BAD_REQUEST, String.format("Provide valid "

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageTypeServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageTypeServiceImplTest.java
@@ -89,11 +89,11 @@ public class ImageTypeServiceImplTest {
     final ImageTypeDTO imageTypeDTO = converterUtils.convertToDTO(jsonPayload, ImageTypeDTO.class);
     imageTypeDTO.setCreatedBy("azkaban");
     imageTypeDTO.setModifiedBy("azkaban");
-    when(this.imageTypeDao.addOwnerOfImageType(any(ImageType.class))).thenReturn(200);
+    when(this.imageTypeDao.addImageTypeOwner(any(ImageType.class))).thenReturn(200);
     final int imageTypeId = this.imageTypeService.updateImageType(imageTypeDTO, "addImageOwners");
     final ArgumentCaptor<ImageType> imageTypeArgumentCaptor =
         ArgumentCaptor.forClass(ImageType.class);
-    verify(this.imageTypeDao, times(1)).addOwnerOfImageType(imageTypeArgumentCaptor.capture());
+    verify(this.imageTypeDao, times(1)).addImageTypeOwner(imageTypeArgumentCaptor.capture());
     final ImageType capturedImageType = imageTypeArgumentCaptor.getValue();
     Assert.assertEquals("kafka_push_job", capturedImageType.getName());
     Assert.assertEquals("azkaban", capturedImageType.getCreatedBy());
@@ -109,12 +109,12 @@ public class ImageTypeServiceImplTest {
     final ImageTypeDTO imageTypeDTO = converterUtils.convertToDTO(jsonPayload, ImageTypeDTO.class);
     imageTypeDTO.setCreatedBy("azkaban");
     imageTypeDTO.setModifiedBy("azkaban");
-    when(this.imageTypeDao.removeOwnerOfImageType(any(ImageType.class))).thenReturn(300);
+    when(this.imageTypeDao.removeImageTypeOwner(any(ImageType.class))).thenReturn(300);
     final int imageTypeId = this.imageTypeService.updateImageType(imageTypeDTO,
         "removeImageOwners");
     final ArgumentCaptor<ImageType> imageTypeArgumentCaptor =
         ArgumentCaptor.forClass(ImageType.class);
-    verify(this.imageTypeDao, times(1)).removeOwnerOfImageType(imageTypeArgumentCaptor.capture());
+    verify(this.imageTypeDao, times(1)).removeImageTypeOwner(imageTypeArgumentCaptor.capture());
     final ImageType capturedImageType = imageTypeArgumentCaptor.getValue();
     Assert.assertEquals("kafka_push_job", capturedImageType.getName());
     Assert.assertEquals("azkaban", capturedImageType.getCreatedBy());

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageTypeServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageTypeServiceImplTest.java
@@ -84,6 +84,47 @@ public class ImageTypeServiceImplTest {
   }
 
   @Test
+  public void testAddOwnerToImageType() throws Exception {
+    final String jsonPayload = JSONUtils.readJsonFileAsString("image_management/image_type.json");
+    final ImageTypeDTO imageTypeDTO = converterUtils.convertToDTO(jsonPayload, ImageTypeDTO.class);
+    imageTypeDTO.setCreatedBy("azkaban");
+    imageTypeDTO.setModifiedBy("azkaban");
+    when(this.imageTypeDao.addOwnerOfImageType(any(ImageType.class))).thenReturn(200);
+    final int imageTypeId = this.imageTypeService.updateImageType(imageTypeDTO, "addImageOwners");
+    final ArgumentCaptor<ImageType> imageTypeArgumentCaptor =
+        ArgumentCaptor.forClass(ImageType.class);
+    verify(this.imageTypeDao, times(1)).addOwnerOfImageType(imageTypeArgumentCaptor.capture());
+    final ImageType capturedImageType = imageTypeArgumentCaptor.getValue();
+    Assert.assertEquals("kafka_push_job", capturedImageType.getName());
+    Assert.assertEquals("azkaban", capturedImageType.getCreatedBy());
+    Assert.assertEquals("image", capturedImageType.getDeployable().getName());
+    Assert.assertNotNull(capturedImageType.getOwnerships());
+    Assert.assertEquals(2, capturedImageType.getOwnerships().size());
+    Assert.assertEquals(200, imageTypeId);
+  }
+
+  @Test
+  public void testRemoveOwnerFromImageType() throws Exception {
+    final String jsonPayload = JSONUtils.readJsonFileAsString("image_management/image_type.json");
+    final ImageTypeDTO imageTypeDTO = converterUtils.convertToDTO(jsonPayload, ImageTypeDTO.class);
+    imageTypeDTO.setCreatedBy("azkaban");
+    imageTypeDTO.setModifiedBy("azkaban");
+    when(this.imageTypeDao.removeOwnerOfImageType(any(ImageType.class))).thenReturn(300);
+    final int imageTypeId = this.imageTypeService.updateImageType(imageTypeDTO,
+        "removeImageOwners");
+    final ArgumentCaptor<ImageType> imageTypeArgumentCaptor =
+        ArgumentCaptor.forClass(ImageType.class);
+    verify(this.imageTypeDao, times(1)).removeOwnerOfImageType(imageTypeArgumentCaptor.capture());
+    final ImageType capturedImageType = imageTypeArgumentCaptor.getValue();
+    Assert.assertEquals("kafka_push_job", capturedImageType.getName());
+    Assert.assertEquals("azkaban", capturedImageType.getCreatedBy());
+    Assert.assertEquals("image", capturedImageType.getDeployable().getName());
+    Assert.assertNotNull(capturedImageType.getOwnerships());
+    Assert.assertEquals(2, capturedImageType.getOwnerships().size());
+    Assert.assertEquals(300, imageTypeId);
+  }
+
+  @Test
   public void testGetAllImageTypesWithOwnerships() throws Exception {
     List<ImageType> imageTypes = getImageTypeList();
     ImageTypeDTO expected = getImageTypeDTO();


### PR DESCRIPTION
Adding image management APIs for updating and deleting.

**_Query Params for POST Request:_**
session.id = "Insert session id from browser here"
updateImageOwners = "removeImageOwners OR addImageOwners"

**_Body for POST Request (Required Parameters):_**

```
{
"imageType": "utktest",
"ownerships":[{"owner": "jakhani", "role": "ADMIN"},
{"owner": "djaiswal", "role": "ADMIN"}]
}
```