### PR TITLE
Removing unneccesary db call

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -156,20 +156,6 @@ public class JdbcProjectImpl implements ProjectLoader {
   public synchronized Project createNewProject(final String name, final String description,
       final User creator)
       throws ProjectManagerException {
-    final ProjectResultHandler handler = new ProjectResultHandler();
-
-    // Check if the same project name exists.
-    try {
-      final List<Project> projects = this.dbOperator
-          .query(ProjectResultHandler.SELECT_ACTIVE_PROJECT_BY_NAME, handler, name);
-      if (!projects.isEmpty()) {
-        throw new ProjectManagerException(
-            "Active project with name " + name + " already exists in db.");
-      }
-    } catch (final SQLException ex) {
-      logger.error(ex);
-      throw new ProjectManagerException("Checking for existing project failed. " + name, ex);
-    }
 
     final String INSERT_PROJECT =
         "INSERT INTO projects ( name, active, modified_time, create_time, version, last_modified_by, description, enc_type, settings_blob) values (?,?,?,?,?,?,?,?,?)";

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -107,21 +107,6 @@ public class JdbcProjectImplTest {
   }
 
   @Test
-  public void testCreateProjectsWithDifferentCases() {
-    final String projectName = "mytestproject";
-    final String projectDescription = "This is my new project with lower cases.";
-    final User user = new User("testUser1");
-    this.loader.createNewProject(projectName, projectDescription, user);
-    final String projectName2 = "MYTESTPROJECT";
-    final String projectDescription2 = "This is my new project with UPPER CASES.";
-    assertThatThrownBy(
-        () -> this.loader.createNewProject(projectName2, projectDescription2, user))
-        .isInstanceOf(ProjectManagerException.class)
-        .hasMessageContaining(
-            "Active project with name " + projectName2 + " already exists in db.");
-  }
-
-  @Test
   public void testFetchProjectByName() throws Exception {
     createThreeProjects();
     final Project project = this.loader.fetchProjectByName("mytestProject");


### PR DESCRIPTION
ProjectManager.createProject checks the DB for a project name twice. First through ProjectManager.getProject which checks the DB in ProjectCache.getProjectByName and then in JdbcProjectImpl.createNewProject. Since JdbcProjectImpl.createNewProject is only used within the ProjectManager.createProject method, it makes sense to remove the duplicated DB call here.

The testCreateProjectWIthDifferentCases already exists in ProjectMangerTest.