### PR TITLE
Set finalized flow finalFlowStatus so that Azkaban event reporter can report correct flow status

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -103,6 +103,8 @@ public class ExecutionControllerUtils {
           failEverything(dsFlow, finalFlowStatus);
           executorLoader.updateExecutableFlow(dsFlow);
         }
+        // flow will be used for event reporter afterwards, thus the final status needs to be set
+        flow.setStatus(finalFlowStatus);
       }
 
       if (flow.getEndTime() == -1) {


### PR DESCRIPTION
Verified flow status reported in the flow life cycle event. 