### PR TITLE
Fix bug in canWriteInCurrentWorkingDirectory, delete TEMP_FILE user_can_write in current working directory if it exists

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -34,6 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -391,14 +392,15 @@ public class ProcessJob extends AbstractProcessJob {
       throws IOException {
     final ExecuteAsUser executeAsUser = new ExecuteAsUser(
         this.getSysProps().getString(AZKABAN_SERVER_NATIVE_LIB_FOLDER));
+    final Path tmpFilePath = Paths.get(getWorkingDirectory(), TEMP_FILE_NAME);
     final List<String> checkIfUserCanWriteCommand = Arrays
-        .asList(CREATE_FILE, getWorkingDirectory() + "/" + TEMP_FILE_NAME);
+        .asList(CREATE_FILE, tmpFilePath.toString());
     final int result = executeAsUser.execute(effectiveUser, checkIfUserCanWriteCommand);
     // If TEMP_FILE user_can_write is created, it should be deleted at the end of the function
     try {
-      Files.deleteIfExists(Paths.get(getWorkingDirectory() + "/" + TEMP_FILE_NAME));
+      Files.deleteIfExists(tmpFilePath);
     } catch (Exception e) {
-      info(String.format("Failed to delete %s in current working directory", TEMP_FILE_NAME));
+      warn(String.format("Failed to delete %s in current working directory", TEMP_FILE_NAME), e);
     }
     return result == SUCCESSFUL_EXECUTION;
   }

--- a/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/ProcessJob.java
@@ -394,12 +394,7 @@ public class ProcessJob extends AbstractProcessJob {
     final List<String> checkIfUserCanWriteCommand = Arrays
         .asList(CREATE_FILE, getWorkingDirectory() + "/" + TEMP_FILE_NAME);
     final int result = executeAsUser.execute(effectiveUser, checkIfUserCanWriteCommand);
-    // There's bug when traversing a special DAG like A->A->B->A, where A and B are different
-    // effective users. The CWD ownership would be A->A->B->B instead of A->A->B->A.
-    // This is Because the TEMP_FILE created in the second job would persist (which A always has
-    // write permission of this temp file) and violates the logic to check whether current effective
-    // user has write permission in CWD.
-    // Therefore, if TEMP_FILE is created, it should be destroyed at the end of the function
+    // If TEMP_FILE user_can_write is created, it should be deleted at the end of the function
     try {
       Files.deleteIfExists(Paths.get(getWorkingDirectory() + "/" + TEMP_FILE_NAME));
     } catch (Exception e) {


### PR DESCRIPTION
There's bug when traversing a special DAG like A->A->B->A, where A and B are different effective users. The CWD ownership would be A->A->B->B instead of A->A->B->A. This is because the TEMP_FILE created in the second job would persist (which A always has write permission to this temp file) and violates the logic to check whether current effective user has write permission in CWD.
Therefore, if TEMP_FILE is created, it should be destroyed at the end of the function.

A test has conducted with a flow DAG of job1(proxy user A)->job2(proxy user A)->job3(proxy user B)->job4(proxy user A).
In job4's log:
08-02-2022 23:27:35 PST job4 INFO - Changing current working directory ownership
08-02-2022 23:27:35 PST job4 INFO - Change ownership of /export/apps/azkaban/azkaban-exec-server/A/executions/1103257 to A:azkaban.
which indicates the fix is working. 

    

