### PR TITLE
Add ability to execute the Polling cleanup logic in Containerized dispatch model

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -125,7 +125,7 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
     // include executor which were initially active and still has flows running
     try {
       for (final Pair<ExecutionReference, ExecutableFlow> running : this.executorLoader
-          .fetchActiveFlows().values()) {
+          .fetchActiveFlows(DispatchMethod.POLL).values()) {
         final ExecutionReference ref = running.getFirst();
         if (ref.getExecutor().isPresent()) {
           final Executor executor = ref.getExecutor().get();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorHealthChecker.java
@@ -16,6 +16,7 @@
 package azkaban.executor;
 
 import azkaban.Constants.ConfigurationKeys;
+import azkaban.DispatchMethod;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
@@ -201,7 +202,7 @@ public class ExecutorHealthChecker {
     final HashMap<Optional<Executor>, List<ExecutableFlow>> exFlowMap = new HashMap<>();
     try {
       for (final Pair<ExecutionReference, ExecutableFlow> runningFlow : this
-          .executorLoader.fetchActiveFlows().values()) {
+          .executorLoader.fetchActiveFlows(DispatchMethod.POLL).values()) {
         final Optional<Executor> executor = runningFlow.getFirst().getExecutor();
         List<ExecutableFlow> flows = exFlowMap.get(executor);
         if (flows == null) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -39,7 +39,7 @@ public interface ExecutorLoader {
   List<ExecutableFlow> fetchRecentlyFinishedFlows(Duration maxAge)
       throws ExecutorManagerException;
 
-  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows(DispatchMethod dispatchMethod)
       throws ExecutorManagerException;
 
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -356,7 +356,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
   private void loadRunningExecutions() throws ExecutorManagerException {
     logger.info("Loading running flows from database..");
     final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows = this.executorLoader
-        .fetchActiveFlows();
+        .fetchActiveFlows(DispatchMethod.PUSH);
     logger.info("Loaded " + activeFlows.size() + " running flows");
     this.runningExecutions.get().putAll(activeFlows);
   }

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -16,6 +16,7 @@
 
 package azkaban.executor;
 
+import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
 import azkaban.db.EncodingType;
 import azkaban.flow.Flow;
@@ -146,11 +147,11 @@ public class FetchActiveFlowDao {
    * @return active flows map
    * @throws ExecutorManagerException the executor manager exception
    */
-  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
-      throws ExecutorManagerException {
+  Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows(
+      final DispatchMethod dispatchMethod) throws ExecutorManagerException {
     try {
       return this.dbOperator.query(FetchActiveExecutableFlows.FETCH_ACTIVE_EXECUTABLE_FLOWS,
-          new FetchActiveExecutableFlows());
+          new FetchActiveExecutableFlows(), dispatchMethod.getNumVal());
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Error fetching active flows", e);
     }
@@ -204,7 +205,8 @@ public class FetchActiveFlowDao {
             + " FROM execution_flows ex"
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
-            + " WHERE ex.status NOT IN ("
+            + " WHERE dispatch_method = ? "
+            + " AND ex.status NOT IN ("
             + getTerminatingStatusesString() + ")"
             // exclude queued flows that haven't been assigned yet -- this is the opposite of
             // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -127,9 +127,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
-      throws ExecutorManagerException {
-    return this.fetchActiveFlowDao.fetchActiveFlows();
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows(
+      final DispatchMethod dispatchMethod) throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchActiveFlows(dispatchMethod);
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -21,6 +21,7 @@ import static azkaban.executor.ExecutorApiClientTest.REVERSE_PROXY_HOST;
 import static azkaban.executor.ExecutorApiClientTest.REVERSE_PROXY_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -69,10 +70,8 @@ public class ContainerizedDispatchManagerTest {
   private final CommonMetrics commonMetrics = new CommonMetrics(
       new MetricsManager(new MetricRegistry()));
   private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> activeFlows = new HashMap<>();
-  private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = new
-      HashMap<>();
-  private List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows = new
-      ArrayList<>();
+  private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = new HashMap<>();
+  private List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows = new ArrayList<>();
   private ExecutorLoader loader;
   private ExecutorApiGateway apiGateway;
   private ContainerizedImpl containerizedImpl;
@@ -140,7 +139,7 @@ public class ContainerizedDispatchManagerTest {
     this.activeFlows = ImmutableMap
         .of(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2),
             this.flow3.getExecutionId(), new Pair<>(this.ref3, this.flow3));
-    when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
+    when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
     when(this.loader.fetchActiveFlowByExecId(flow1.getExecutionId())).thenReturn(
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), DispatchMethod.CONTAINERIZED), flow1));
     this.queuedFlows = ImmutableList.of(new Pair<>(this.ref1, this.flow1));
@@ -408,7 +407,7 @@ public class ContainerizedDispatchManagerTest {
         new ContainerizedDispatchManager(this.props, this.loader,
         this.commonMetrics,
         this.apiGateway, this.containerizedImpl, null, null, this.eventListener,
-            this.containerizationMetrics);
+            this.containerizationMetrics, null);
   }
 
   @Test
@@ -532,7 +531,7 @@ public class ContainerizedDispatchManagerTest {
     ContainerizedDispatchManager dispatchManager =
         new ContainerizedDispatchManager(containerEnabledProps, this.loader,
             this.commonMetrics, apiGateway, this.containerizedImpl,null, null, this.eventListener,
-            this.containerizationMetrics);
+            this.containerizationMetrics, null);
     dispatchManager.start();
     return dispatchManager;
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -115,7 +115,7 @@ public class ExecutionControllerTest {
     this.activeFlows = ImmutableMap
         .of(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2),
             this.flow3.getExecutionId(), new Pair<>(this.ref3, this.flow3));
-    when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
+    when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
     this.queuedFlows = ImmutableList.of(new Pair<>(this.ref1, this.flow1));
     when(this.loader.fetchQueuedFlows()).thenReturn(this.queuedFlows);
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -70,7 +70,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
     this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props,
         this.executorLoader, this.commonMetrics, mock(ExecutorApiGateway.class),
         mock(ContainerizedImpl.class),null, null,
-        new DummyEventListener(), new DummyContainerizationMetricsImpl());
+        new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
     this.projectManager = mock(ProjectManager.class);
     when(this.projectManager.getProject(projectId)).thenReturn(this.project);
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
@@ -80,7 +80,7 @@ public class ExecutorHealthCheckerTest {
 
     this.executor1 = new Executor(1, "localhost", 12345, true);
     this.executor2 = new Executor(2, "localhost", 5678, true);
-    when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
+    when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
     when(this.alerterHolder.get("email")).thenReturn(this.mailAlerter);
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -625,7 +625,7 @@ public class ExecutorManagerTest {
     this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2, DispatchMethod.PUSH);
     this.activeFlows.put(this.flow1.getExecutionId(), new Pair<>(this.ref1, this.flow1));
     this.activeFlows.put(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2));
-    when(this.loader.fetchActiveFlows()).thenReturn(this.activeFlows);
+    when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
   }
 
   private ExecutableFlow waitFlowFinished(final ExecutableFlow flow) throws Exception {

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -78,8 +78,8 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows()
-      throws ExecutorManagerException {
+  public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows(
+      final DispatchMethod dispatchMethod) throws ExecutorManagerException {
     return this.activeFlows;
   }
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -132,7 +132,7 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
   public void testPostAjaxUpdateProperty() throws Exception {
     ContainerizedDispatchManager containerizedDispatchManager = new ContainerizedDispatchManager(
         new Props(), null, null, null, null, null, null, new DummyEventListener(),
-        new DummyContainerizationMetricsImpl());
+        new DummyContainerizationMetricsImpl(), null);
     Mockito.when(this.azkabanWebServer.getExecutorManager())
         .thenReturn(containerizedDispatchManager);
     this.executorServlet.init(this.servletConfig);


### PR DESCRIPTION
The transition to CONTAINERIZED dispatch model from POLL model can be done gradually by splitting the workload between the 2. In the scenario where both dispatch models are in use both of the logics to cleanup stuck executions are needed.

This PR adds a workaround to run the `ExecutorHealthChecker` thread from POLL dispatch when Containerization is enabled. The `ExecutorHealthChecker` thread will start only if the properties `azkaban.executor.healthcheck.interval.min` and `azkaban.executor.max.failurecount` are configured in the _azkaban.properties_ file.

A better solution would be to support multiple dispatch models in the web server instead of just one. 

Testing: 
-Added unit test to make sure the Polling cleanup logic processes executions with POLL dispatch method only.
-Verified that the `ExecutorHealthChecker` thread starts in a test Azkaban instance where containerization was enabled.