### PR TITLE
Adding information about EXECUTION_SOURCE in FlowStatusChangeEvent's metadata

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -212,6 +212,7 @@ public class Constants {
     public static final String EFFECTIVE_USERS = "effectiveUsers";
     public static final String CPU_UTILIZED = "cpuUtilized";
     public static final String MEMORY_UTILIZED_IN_BYTES = "memoryUtilizedInBytes";
+    public static final String EXECUTION_SOURCE = "executionSource";
   }
 
   public static class ConfigurationKeys {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1681,6 +1681,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       } else {
         metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.BAREMETAL));
       }
+      //Flow Trigger Information
+      metaData.put(EventReporterConstants.EXECUTION_SOURCE, flow.getExecutionSource());
 
       // Project upload info
       final ProjectFileHandler handler = flowRunner.projectFileHandler;


### PR DESCRIPTION
This change is done to pass on the additional information related to the source or trigger of Flow's execution to the FlowStatusChangedEvent's metadata.