### PR TITLE
Enable periodic bulk cleaning up stale containers in current Azkaban cluster and namespace via ContainerCleanupManager

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -714,6 +714,8 @@ public class Constants {
     // Periodicity of lookup and cleanup of stale executions.
     public static final String CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN =
         AZKABAN_CONTAINERIZED_PREFIX + "stale.execution.cleanup.interval.min";
+    public static final String CONTAINERIZED_STALE_CONTAINER_CLEANUP_INTERVAL_MIN =
+        AZKABAN_CONTAINERIZED_PREFIX + "stale.container.cleanup.interval.min";
 
     public static final String ENV_VERSION_SET_ID = "VERSION_SET_ID";
     public static final String ENV_FLOW_EXECUTION_ID = "FLOW_EXECUTION_ID";

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
@@ -21,4 +21,5 @@ import azkaban.executor.ExecutorManagerException;
 public interface ContainerizedImpl {
   void createContainer(final int executionId) throws ExecutorManagerException;
   void deleteContainer(final ExecutableFlow flow) throws ExecutorManagerException;
+  void deleteContainers(final long containerValidity) throws ExecutorManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -61,6 +61,7 @@ import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -72,7 +73,9 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -83,7 +86,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,6 +131,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DISABLE_CLEANUP_LABEL_NAME = "cleanup-disabled";
   public static final String DEFAULT_AZKABAN_BASE_IMAGE_NAME = "azkaban-base";
   public static final String DEFAULT_AZKABAN_CONFIG_IMAGE_NAME = "azkaban-config";
+  public static final int DAY_TO_MILLISECOND_CONVERSION_FACTOR = 86400000;
 
   private final String namespace;
   private final ApiClient client;
@@ -402,9 +405,36 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   @Override
   public void deleteContainer(final ExecutableFlow flow) throws ExecutorManagerException {
-    deletePod(flow);
+    try { // if pod deletion is not successful, the service deletion can still be handled
+      deletePod(flow);
+    } catch (ExecutorManagerException e) {
+      logger.error("ExecId: {}, Unable to delete Pod in Kubernetes: {}", flow.getExecutionId(),
+          e.getMessage());
+    }
     if (isServiceRequired()) {
       deleteService(flow);
+    }
+  }
+
+  /**
+   * This method is used to delete invalid containers in batch
+   * @param containerValidity pod validity in milliseconds
+   * @throws ExecutorManagerException
+   */
+  @Override
+  public void deleteContainers(final long containerValidity) throws ExecutorManagerException {
+    logger.info(String.format("Cleaning up containers older than %d days",
+        containerValidity / DAY_TO_MILLISECOND_CONVERSION_FACTOR));
+    final List<String> podsToDelete = getStalePods(containerValidity);
+    for (String podName : podsToDelete) {
+      logger.info(String.format("Deleting stale pod %s", podName));
+      final int execId = getExecutionId(podName);
+      if (execId > 0) {
+        final ExecutableFlow flow = new ExecutableFlow();
+        flow.setStatus(Status.FAILED);
+        flow.setExecutionId(execId);
+        deleteContainer(flow);
+      }
     }
   }
 
@@ -1268,6 +1298,48 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
       return "";
     }
     return events;
+  }
+
+  /**
+   * This method is used to fetch all stale pods in the current az cluster and namespace
+   * @param containerValidity pod validity in milliseconds
+   * @return List of stale pods
+   */
+  private List<String> getStalePods(final long containerValidity) {
+    List<String> stalePodList = new ArrayList<>();
+    try {
+      final String label = "cluster=" + this.clusterName;
+      V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
+          null, null, null, label,
+          null, null, null, null);
+
+      // Get all pods whose age is older than Azkaban max flow running time (e.g. 10 days)
+      final Long validStartTimeStamp = System.currentTimeMillis() - containerValidity;
+      stalePodList =
+          items.getItems().stream()
+              .filter((pod) -> pod.getMetadata().getCreationTimestamp().getMillis() < validStartTimeStamp)
+              .map((pod) -> pod.getMetadata().getName()).collect(Collectors.toList());
+    } catch (ApiException e) {
+      logger.error(String.format("Unable to fetch stale pods in %s.", this.clusterName),
+          e.getResponseBody());
+    }
+    return stalePodList;
+  }
+
+  /**
+   * This method is used to extract execution id from pod mame
+   * @param podName
+   * @return execution id
+   */
+  private int getExecutionId(final String podName) {
+    int execId = -1;
+    try {
+      execId = Integer.valueOf(podName.replace(this.podPrefix + "-", "")
+          .replace(this.clusterName + "-", ""));
+    } catch (Exception e) {
+      logger.error("Failed to retrieve execution id from pod {}.", podName, e.getMessage());
+    }
+    return execId;
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -88,7 +88,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.AfterClass;


### PR DESCRIPTION
2022/02/24 07:05:10.161 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Cleaning up containers older than 10 days
2022/02/24 07:05:10.226 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Deleting stale pod fc-dep-XXXXXXX-439102
2022/02/24 07:05:10.226 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Getting Pod Events for execution Id 439102
2022/02/24 07:05:11.439 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] ExecId: 439102, Action: Pod Deletion, Pod Name: fc-dep-XXXXXXX-439102
2022/02/24 07:05:11.440 +0000  INFO [AzPodStatusDrivingListener] [Thread-16] [Azkaban] WatchEvent for pod fc-dep-XXXXXXX-439102 : AZ_POD_READY
2022/02/24 07:05:11.440 +0000  INFO [ContainerStatusMetricsListener] [azk-container-metrics-pool-0] [Azkaban] Event pod status is same as current AZ_POD_READY, for pod fc-dep-XXXXXXX-439102. Any updates will be skipped.
2022/02/24 07:05:11.453 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] ExecId: 439102, Action: Service Deletion, Service Name: fc-svc-XXXXXXX-439102, code: null, message: null