### PR TITLE
Enable periodic bulk cleaning up stale containers in current Azkaban cluster and namespace via ContainerCleanupManager

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -715,6 +715,8 @@ public class Constants {
     // Periodicity of lookup and cleanup of stale executions.
     public static final String CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN =
         AZKABAN_CONTAINERIZED_PREFIX + "stale.execution.cleanup.interval.min";
+    public static final String CONTAINERIZED_STALE_CONTAINER_CLEANUP_INTERVAL_MIN =
+        AZKABAN_CONTAINERIZED_PREFIX + "stale.container.cleanup.interval.min";
 
     public static final String ENV_VERSION_SET_ID = "VERSION_SET_ID";
     public static final String ENV_FLOW_EXECUTION_ID = "FLOW_EXECUTION_ID";

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -204,7 +204,7 @@ public class ContainerCleanupManager {
       logger.info("Restarting cleaned up flow " + flow.getExecutionId());
       ExecutionControllerUtils.restartFlow(flow, originalStatus);
     } catch (RuntimeException re) {
-      logger.error("Unexpected RuntimeException while restarting flow during clean up." + re);
+      logger.error("Unexpected Exception while restarting flow during clean up." + re);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -83,8 +83,8 @@ public class ContainerCleanupManager {
             ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN,
             DEFAULT_STALE_EXECUTION_CLEANUP_INTERVAL.toMinutes());
     this.containerCleanupIntervalMin = azkProps.getLong(
-        ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_CONTAINER_CLEANUP_INTERVAL_MIN
-        , DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL.toMinutes());
+        ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_CONTAINER_CLEANUP_INTERVAL_MIN,
+        DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL.toMinutes());
     this.cleanupService = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("azk-container-cleanup").build());
     this.executorLoader = executorLoader;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -127,7 +127,7 @@ public class ContainerCleanupManager {
   public void cleanUpStaleContainers() {
     try {
       this.containerizedImpl.deleteAgedContainers(validityMap.get(Status.RUNNING).getFirst());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       logger.error("Exception occurred while cleaning up stale pods and services." + e);
     }
   }
@@ -194,7 +194,7 @@ public class ContainerCleanupManager {
           "Cleaning up stale flow " + flow.getExecutionId() + " in state " + originalStatus
               .name());
       this.containerizedDispatchManager.cancelFlow(flow, flow.getSubmitUser());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       logger.error("Unexpected Exception while canceling and finalizing flow during clean up." + e);
     }
   }
@@ -203,8 +203,8 @@ public class ContainerCleanupManager {
     try {
       logger.info("Restarting cleaned up flow " + flow.getExecutionId());
       ExecutionControllerUtils.restartFlow(flow, originalStatus);
-    } catch (RuntimeException re) {
-      logger.error("Unexpected Exception while restarting flow during clean up." + re);
+    } catch (final Exception e) {
+      logger.error("Unexpected Exception while restarting flow during clean up." + e);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -126,9 +126,11 @@ public class ContainerCleanupManager {
    */
   public void cleanUpStaleContainers() {
     try {
-      this.containerizedImpl.deleteContainers(validityMap.get(Status.RUNNING).getFirst().toMillis());
-    } catch (ExecutorManagerException e) {
-      logger.error("Exception occurred while deleting stale pods and services." + e);
+      this.containerizedImpl.deleteAgedContainers(validityMap.get(Status.RUNNING).getFirst());
+    } catch (ExecutorManagerException eme) {
+      logger.error("ExecutorManagerException occurred while deleting stale pods and services." + eme);
+    } catch (RuntimeException re) {
+      logger.error("Unexpected RuntimeException while finalizing flow during clean up." + re);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -217,7 +217,7 @@ public class ContainerCleanupManager {
     try {
       this.containerizedImpl.deleteContainer(executionId);
     } catch (final Exception e) {
-      logger.error("Unexpected RuntimeException while deleting container.", e);
+      logger.error("Unexpected exception while deleting container.", e);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -127,10 +127,8 @@ public class ContainerCleanupManager {
   public void cleanUpStaleContainers() {
     try {
       this.containerizedImpl.deleteAgedContainers(validityMap.get(Status.RUNNING).getFirst());
-    } catch (ExecutorManagerException eme) {
-      logger.error("ExecutorManagerException occurred while deleting stale pods and services." + eme);
-    } catch (RuntimeException re) {
-      logger.error("Unexpected RuntimeException while finalizing flow during clean up." + re);
+    } catch (Exception e) {
+      logger.error("Exception occurred while cleaning up stale pods and services." + e);
     }
   }
 
@@ -196,10 +194,8 @@ public class ContainerCleanupManager {
           "Cleaning up stale flow " + flow.getExecutionId() + " in state " + originalStatus
               .name());
       this.containerizedDispatchManager.cancelFlow(flow, flow.getSubmitUser());
-    } catch (ExecutorManagerException eme) {
-      logger.error("ExecutorManagerException while cancelling flow.", eme);
-    } catch (RuntimeException re) {
-      logger.error("Unexpected RuntimeException while finalizing flow during clean up." + re);
+    } catch (Exception e) {
+      logger.error("Unexpected Exception while canceling and finalizing flow during clean up." + e);
     }
   }
 
@@ -220,10 +216,8 @@ public class ContainerCleanupManager {
   private void deleteContainerQuietly(final int executionId) {
     try {
       this.containerizedImpl.deleteContainer(executionId);
-    } catch (final ExecutorManagerException eme) {
-      logger.error("ExecutorManagerException while deleting container.", eme);
-    } catch (final RuntimeException re) {
-      logger.error("Unexpected RuntimeException while deleting container.", re);
+    } catch (final Exception e) {
+      logger.error("Unexpected RuntimeException while deleting container.", e);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -54,8 +54,10 @@ public class ContainerCleanupManager {
 
   public static final int DEFAULT_AZKABAN_MAX_FLOW_RUNNING_MINS = -1;
   private static final Logger logger = LoggerFactory.getLogger(ContainerCleanupManager.class);
-  private static final Duration DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL = Duration.ofMinutes(10);
-  private final long cleanupIntervalMin;
+  private static final Duration DEFAULT_STALE_EXECUTION_CLEANUP_INTERVAL = Duration.ofMinutes(10);
+  private static final Duration DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL = Duration.ofMinutes(60);
+  private final long executionCleanupIntervalMin;
+  private final long containerCleanupIntervalMin;
   private final ScheduledExecutorService cleanupService;
   private final ExecutorLoader executorLoader;
   private final ContainerizedImpl containerizedImpl;
@@ -76,10 +78,13 @@ public class ContainerCleanupManager {
   public ContainerCleanupManager(final Props azkProps, final ExecutorLoader executorLoader,
       final ContainerizedImpl containerizedImpl,
       final ContainerizedDispatchManager containerizedDispatchManager) {
-    this.cleanupIntervalMin = azkProps
+    this.executionCleanupIntervalMin = azkProps
         .getLong(
             ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_EXECUTION_CLEANUP_INTERVAL_MIN,
-            DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL.toMinutes());
+            DEFAULT_STALE_EXECUTION_CLEANUP_INTERVAL.toMinutes());
+    this.containerCleanupIntervalMin = azkProps.getLong(
+        ContainerizedDispatchManagerProperties.CONTAINERIZED_STALE_CONTAINER_CLEANUP_INTERVAL_MIN
+        , DEFAULT_STALE_CONTAINER_CLEANUP_INTERVAL.toMinutes());
     this.cleanupService = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("azk-container-cleanup").build());
     this.executorLoader = executorLoader;
@@ -114,6 +119,17 @@ public class ContainerCleanupManager {
   public void cleanUpStaleFlows() {
     this.validityMap.entrySet().stream().filter(e -> !e.getValue().getFirst().isNegative()).map(
         Entry::getKey).forEach(this::cleanUpStaleFlows);
+  }
+
+  /**
+   * Try to clean the stale containers that are older than maximum azkaban flow running time
+   */
+  public void cleanUpStaleContainers() {
+    try {
+      this.containerizedImpl.deleteContainers(validityMap.get(Status.RUNNING).getFirst().toMillis());
+    } catch (ExecutorManagerException e) {
+      logger.error("Exception occurred while deleting stale pods and services." + e);
+    }
   }
 
   /**
@@ -215,8 +231,11 @@ public class ContainerCleanupManager {
   @SuppressWarnings("FutureReturnValueIgnored")
   public void start() {
     logger.info("Start container cleanup service");
+    // Default execution clean up interval is 10 min, container clean up interval is 60 min
     this.cleanupService.scheduleAtFixedRate(this::cleanUpStaleFlows, 0L,
-        this.cleanupIntervalMin, TimeUnit.MINUTES);
+        this.executionCleanupIntervalMin, TimeUnit.MINUTES);
+    this.cleanupService.scheduleAtFixedRate(this::cleanUpStaleContainers, 0L,
+        this.containerCleanupIntervalMin, TimeUnit.MINUTES);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
@@ -20,4 +20,5 @@ import azkaban.executor.ExecutorManagerException;
 public interface ContainerizedImpl {
   void createContainer(final int executionId) throws ExecutorManagerException;
   void deleteContainer(final int executionId) throws ExecutorManagerException;
+  void deleteContainers(final long containerValidity) throws ExecutorManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
@@ -16,9 +16,10 @@
 package azkaban.executor.container;
 
 import azkaban.executor.ExecutorManagerException;
+import java.time.Duration;
 
 public interface ContainerizedImpl {
   void createContainer(final int executionId) throws ExecutorManagerException;
   void deleteContainer(final int executionId) throws ExecutorManagerException;
-  void deleteContainers(final long containerValidity) throws ExecutorManagerException;
+  void deleteAgedContainers(final Duration containerValidity) throws ExecutorManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -414,15 +414,15 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
 
   /**
    * This method is used to delete invalid containers in batch
-   * @param containerValidity pod validity in milliseconds
+   * @param containerValidity container valid duration
    * @throws ExecutorManagerException
    */
   @Override
-  public void deleteAgedContainers(Duration containerValidity) throws ExecutorManagerException {
+  public void deleteAgedContainers(final Duration containerValidity) throws ExecutorManagerException {
     logger.info(String.format("Cleaning up containers older than %d days",
         containerValidity.toDays()));
     final Set<Integer> containersToDelete = getStaleContainers(containerValidity);
-    for (int execId : containersToDelete) {
+    for (final int execId : containersToDelete) {
       if (execId > 0) {
         logger.info(String.format("Deleting stale pod %s and service %s", getPodName(execId),
             getServiceName(execId)));
@@ -438,20 +438,20 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
 
   /**
    * This method is used to fetch all stale pods in the current az cluster and namespace
-   * @param containerValidity container validity in milliseconds
+   * @param containerValidity container valid duration
    * @return Set of stale container's execution ids
    */
   private Set<Integer> getStaleContainers(final Duration containerValidity) throws ExecutorManagerException {
     try {
       // Select pods only from current Azkaban cluster and namespace
       final String label = CLUSTER_LABEL_NAME + "=" + this.clusterName + "," + LABEL_POSTFIX;
-      V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
+      final V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
           null, null, null, label,
           null, null, null, null);
 
       // Get all execution ids of the pods whose age is older than Azkaban max flow running time
       // (e.g. 10 days)
-      final Long validStartTimeStamp = System.currentTimeMillis() - containerValidity.toMillis();
+      final long validStartTimeStamp = System.currentTimeMillis() - containerValidity.toMillis();
       return getExecutionIdFromPodList(items, validStartTimeStamp);
     } catch (ApiException ae) {
       logger.error(String.format("Unable to fetch stale pods in %s.", this.clusterName),
@@ -468,8 +468,8 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   @VisibleForTesting
   Set<Integer> getExecutionIdFromPodList (final V1PodList podList, final long validStartTimeStamp) {
-    Set<Integer> staleContainerExecIdSet = new HashSet<>();
-    for (V1Pod pod: podList.getItems()) {
+    final Set<Integer> staleContainerExecIdSet = new HashSet<>();
+    for (final V1Pod pod: podList.getItems()) {
       if (pod.getMetadata().getCreationTimestamp().getMillis() < validStartTimeStamp) {
         final String execIdLabel =
             pod.getMetadata().getLabels().getOrDefault(EXECUTION_ID_LABEL_NAME,

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -422,15 +422,13 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         containerValidity.toDays()));
     final Set<Integer> containersToDelete = getStaleContainers(containerValidity);
     for (final int execId : containersToDelete) {
-      if (execId > 0) {
-        logger.info(String.format("Deleting stale pod %s and service %s", getPodName(execId),
-            getServiceName(execId)));
-        try {
-          deleteContainer(execId);
-        } catch (final ExecutorManagerException e) {
-          logger.error(String.format("Unable to delete stale pod and service of exec-id %d",
-              execId), e.getMessage());
-        }
+      logger.info(String.format("Deleting stale pod %s and service %s", getPodName(execId),
+          getServiceName(execId)));
+      try {
+        deleteContainer(execId);
+      } catch (final ExecutorManagerException e) {
+        logger.error(String.format("Unable to delete stale pod and service of exec-id %d",
+            execId), e.getMessage());
       }
     }
   }
@@ -478,7 +476,10 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         try {
           final String execId = execIdLabel.substring(execIdLabel.indexOf(
               EXECUTION_ID_LABEL_PREFIX) + EXECUTION_ID_LABEL_PREFIX.length());
-          staleContainerExecIdSet.add(Integer.valueOf(execId));
+          final int id = Integer.valueOf(execId);
+          if (id > 0) {
+            staleContainerExecIdSet.add(id);
+          }
         } catch (final Exception e) {
           logger.error(String.format("Unable to retrieve execution id from pod %s",
               podMetadata.getName()), e.getMessage());

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -453,7 +453,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
               .map((pod) -> pod.getMetadata().getLabels().getOrDefault(EXECUTION_ID_LABEL_NAME,
                   EXECUTION_ID_LABEL_PREFIX + DEFAULT_EXECUTION_ID))
               .map((str) -> str.substring(str.indexOf(
-                  EXECUTION_ID_LABEL_PREFIX) + EXECUTION_ID_LABEL_NAME.length()))
+                  EXECUTION_ID_LABEL_PREFIX) + EXECUTION_ID_LABEL_PREFIX.length()))
               .map((execId) -> Integer.valueOf(execId))
               .collect(Collectors.toSet());
     } catch (ApiException ae) {

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -129,7 +129,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DEFAULT_AZKABAN_BASE_IMAGE_NAME = "azkaban-base";
   public static final String DEFAULT_AZKABAN_CONFIG_IMAGE_NAME = "azkaban-config";
   private static final int DEFAULT_EXECUTION_ID = -1;
-  private static final String EQUAL_TO = "=";
+  private static final String EQUALS_TO = "=";
 
   private final String namespace;
   private final ApiClient client;
@@ -439,7 +439,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private Set<Integer> getStaleContainers(final Duration containerValidity) throws ExecutorManagerException {
     Set<Integer> staleContainerExecIdSet = new HashSet<>();
     try {
-      final String label = CLUSTER_LABEL_NAME + EQUAL_TO + this.clusterName;
+      final String label = CLUSTER_LABEL_NAME + EQUALS_TO + this.clusterName;
       V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
           null, null, null, label,
           null, null, null, null);

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -59,6 +59,7 @@ import io.kubernetes.client.openapi.models.V1DeleteOptions;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -70,7 +71,9 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -125,6 +128,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DISABLE_CLEANUP_LABEL_NAME = "cleanup-disabled";
   public static final String DEFAULT_AZKABAN_BASE_IMAGE_NAME = "azkaban-base";
   public static final String DEFAULT_AZKABAN_CONFIG_IMAGE_NAME = "azkaban-config";
+  public static final int DAY_TO_MILLISECOND_CONVERSION_FACTOR = 86400000;
 
   private final String namespace;
   private final ApiClient client;
@@ -398,10 +402,76 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   @Override
   public void deleteContainer(final int executionId) throws ExecutorManagerException {
-    deletePod(executionId);
+    try { // if pod deletion is not successful, the service deletion can still be handled
+      deletePod(executionId);
+    } catch (ExecutorManagerException e) {
+      logger.error("ExecId: {}, Unable to delete Pod in Kubernetes: {}", executionId,
+          e.getMessage());
+    }
     if (isServiceRequired()) {
       deleteService(executionId);
     }
+  }
+
+  /**
+   * This method is used to delete invalid containers in batch
+   * @param containerValidity pod validity in milliseconds
+   * @throws ExecutorManagerException
+   */
+  @Override
+  public void deleteContainers(long containerValidity) throws ExecutorManagerException {
+    logger.info(String.format("Cleaning up containers older than %d days",
+        containerValidity / DAY_TO_MILLISECOND_CONVERSION_FACTOR));
+    final List<String> podsToDelete = getStalePods(containerValidity);
+    for (String podName : podsToDelete) {
+      logger.info(String.format("Deleting stale pod %s", podName));
+      final int execId = getExecutionId(podName);
+      if (execId > 0) {
+        deleteContainer(execId);
+      }
+    }
+  }
+
+  /**
+   * This method is used to fetch all stale pods in the current az cluster and namespace
+   * @param containerValidity pod validity in milliseconds
+   * @return List of stale pods
+   */
+  private List<String> getStalePods(final long containerValidity) {
+    List<String> stalePodList = new ArrayList<>();
+    try {
+      final String label = "cluster=" + this.clusterName;
+      V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
+          null, null, null, label,
+          null, null, null, null);
+
+      // Get all pods whose age is older than Azkaban max flow running time (e.g. 10 days)
+      final Long validStartTimeStamp = System.currentTimeMillis() - containerValidity;
+      stalePodList =
+          items.getItems().stream()
+              .filter((pod) -> pod.getMetadata().getCreationTimestamp().getMillis() < validStartTimeStamp)
+              .map((pod) -> pod.getMetadata().getName()).collect(Collectors.toList());
+    } catch (ApiException e) {
+      logger.error(String.format("Unable to fetch stale pods in %s.", this.clusterName),
+          e.getResponseBody());
+    }
+    return stalePodList;
+  }
+
+  /**
+   * This method is used to extract execution id from pod mame
+   * @param podName
+   * @return execution id
+   */
+  private int getExecutionId(final String podName) {
+    int execId = -1;
+    try {
+      execId = Integer.valueOf(podName.replace(this.podPrefix + "-", "")
+          .replace(this.clusterName + "-", ""));
+    } catch (Exception e) {
+      logger.error("Failed to retrieve execution id from pod {}.", podName, e.getMessage());
+    }
+    return execId;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -427,7 +427,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
             getServiceName(execId)));
         try {
           deleteContainer(execId);
-        } catch (ExecutorManagerException e) {
+        } catch (final ExecutorManagerException e) {
           logger.error(String.format("Unable to delete stale pod and service of exec-id %d",
               execId), e.getMessage());
         }
@@ -453,7 +453,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
       // (e.g. 10 days)
       final long validStartTimeStamp = System.currentTimeMillis() - containerValidity.toMillis();
       return getExecutionIdsFromPodList(items, validStartTimeStamp);
-    } catch (ApiException ae) {
+    } catch (final ApiException ae) {
       logger.error(String.format("Unable to fetch stale pods in %s.", this.clusterName),
           ae.getResponseBody());
       throw new ExecutorManagerException(ae);
@@ -462,8 +462,8 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
 
   /**
    * Obtain a set of execution ids from stale pod list
-   * @param podList
-   * @param validStartTimeStamp
+   * @param podList a stable pod list fetched from current az cluster and namespace
+   * @param validStartTimeStamp earliest creation timestamp for a valid pod
    * @return
    */
   @VisibleForTesting
@@ -479,7 +479,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
           final String execId = execIdLabel.substring(execIdLabel.indexOf(
               EXECUTION_ID_LABEL_PREFIX) + EXECUTION_ID_LABEL_PREFIX.length());
           staleContainerExecIdSet.add(Integer.valueOf(execId));
-        } catch (Exception e) {
+        } catch (final Exception e) {
           logger.error(String.format("Unable to retrieve execution id from pod %s",
               podMetadata.getName()), e.getMessage());
         }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -63,7 +63,6 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1Status;
-import io.kubernetes.client.proto.V1beta1Extensions.Ingress;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.Yaml;
@@ -130,7 +129,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DEFAULT_AZKABAN_BASE_IMAGE_NAME = "azkaban-base";
   public static final String DEFAULT_AZKABAN_CONFIG_IMAGE_NAME = "azkaban-config";
   private static final int DEFAULT_EXECUTION_ID = -1;
-  private static final String EQUAL_SIGN = "=";
+  private static final String EQUAL_TO = "=";
 
   private final String namespace;
   private final ApiClient client;
@@ -440,7 +439,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private Set<Integer> getStaleContainers(final Duration containerValidity) throws ExecutorManagerException {
     Set<Integer> staleContainerExecIdSet = new HashSet<>();
     try {
-      final String label = CLUSTER_LABEL_NAME + EQUAL_SIGN + this.clusterName;
+      final String label = CLUSTER_LABEL_NAME + EQUAL_TO + this.clusterName;
       V1PodList items= this.coreV1Api.listNamespacedPod(this.namespace, null,
           null, null, null, label,
           null, null, null, null);
@@ -452,8 +451,9 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
           items.getItems().stream()
               .filter((pod) -> pod.getMetadata().getCreationTimestamp().getMillis() < validStartTimeStamp)
               .map((pod) -> pod.getMetadata().getLabels().getOrDefault(EXECUTION_ID_LABEL_NAME,
-                  EXECUTION_ID_LABEL_PREFIX + DEFAULT_EXECUTION_ID)
-                  .replace(EXECUTION_ID_LABEL_PREFIX, ""))
+                  EXECUTION_ID_LABEL_PREFIX + DEFAULT_EXECUTION_ID))
+              .map((str) -> str.substring(str.indexOf(
+                  EXECUTION_ID_LABEL_PREFIX) + EXECUTION_ID_LABEL_NAME.length()))
               .map((execId) -> Integer.valueOf(execId))
               .collect(Collectors.toSet());
     } catch (ApiException ae) {

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -32,6 +32,7 @@ import azkaban.executor.ExecutorLoader;
 import azkaban.executor.OnContainerizedExecutionEventListener;
 import azkaban.executor.Status;
 import azkaban.utils.Props;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
@@ -46,12 +47,13 @@ public class ContainerCleanupManagerTest {
   private ContainerizedImpl containerImpl;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private ContainerCleanupManager cleaner;
+  private static long MAX_FLOW_RUNNING_MIN = 14400;
 
   @Before
   public void setup() throws Exception {
     this.props = new Props();
     // 10 days
-    this.props.put(AZKABAN_MAX_FLOW_RUNNING_MINS, 14400);
+    this.props.put(AZKABAN_MAX_FLOW_RUNNING_MINS, MAX_FLOW_RUNNING_MIN);
     this.executorLoader = mock(ExecutorLoader.class);
     this.containerImpl = mock(ContainerizedImpl.class);
     this.containerizedDispatchManager = mock(ContainerizedDispatchManager.class);
@@ -125,5 +127,11 @@ public class ContainerCleanupManagerTest {
     verify(this.containerImpl).deleteContainer(flow.getExecutionId());
     // Verify that the flow is indeed retried.
     verify(onExecutionEventListener).onExecutionEvent(flow, Constants.RESTART_FLOW);
+  }
+
+  @Test
+  public void testCleanUpStaleContainers() throws Exception {
+    this.cleaner.cleanUpStaleContainers();
+    verify(this.containerImpl).deleteContainers(Duration.ofMinutes(MAX_FLOW_RUNNING_MIN + 60).toMillis());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -47,7 +47,8 @@ public class ContainerCleanupManagerTest {
   private ContainerizedImpl containerImpl;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private ContainerCleanupManager cleaner;
-  private static long MAX_FLOW_RUNNING_MIN = 14400;
+  private static long MAX_FLOW_RUNNING_MIN = 60 * 24 * 10; // 10 days
+  private static long EXTRA_HOUR_MIN = 60;
 
   @Before
   public void setup() throws Exception {
@@ -132,6 +133,6 @@ public class ContainerCleanupManagerTest {
   @Test
   public void testCleanUpStaleContainers() throws Exception {
     this.cleaner.cleanUpStaleContainers();
-    verify(this.containerImpl).deleteAgedContainers(Duration.ofMinutes(MAX_FLOW_RUNNING_MIN + 60));
+    verify(this.containerImpl).deleteAgedContainers(Duration.ofMinutes(MAX_FLOW_RUNNING_MIN + EXTRA_HOUR_MIN));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -132,6 +132,6 @@ public class ContainerCleanupManagerTest {
   @Test
   public void testCleanUpStaleContainers() throws Exception {
     this.cleaner.cleanUpStaleContainers();
-    verify(this.containerImpl).deleteContainers(Duration.ofMinutes(MAX_FLOW_RUNNING_MIN + 60).toMillis());
+    verify(this.containerImpl).deleteAgedContainers(Duration.ofMinutes(MAX_FLOW_RUNNING_MIN + 60));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -78,6 +78,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.util.Yaml;
 import java.io.IOException;
@@ -91,6 +92,7 @@ import java.util.TreeSet;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -634,6 +636,51 @@ public class KubernetesContainerizedImplTest {
     Assert.assertEquals(1, mergedFlowPropsAndParams.size());
     Assert.assertTrue(mergedFlowPropsAndParams.containsKey("image.version"));
     Assert.assertEquals("2.3.4", mergedFlowPropsAndParams.get("image.version"));
+  }
+
+  /**
+   * Test get execution id set from pod list
+   * @throws Exception
+   */
+  @Test
+  public  void testGetExecutionIdFromPodList() throws Exception{
+    final V1PodList podList = new V1PodList();
+    final long validStartTimeStamp = System.currentTimeMillis();
+
+    // stale pod 1 with execution id information
+    final V1ObjectMeta podMetadata1 = new V1ObjectMeta();
+    ImmutableMap<String, String> label1 = ImmutableMap.of(
+        "execution-id", "execid-123");
+    podMetadata1.setLabels(label1);
+    podMetadata1.setCreationTimestamp(new DateTime(validStartTimeStamp - 1));
+    V1Pod pod1 = new AzKubernetesV1PodBuilder(podMetadata1, null).build();
+
+    // stale pod 2 without execution id information
+    final V1ObjectMeta podMetadata2 = new V1ObjectMeta();
+    ImmutableMap<String, String> label2 = ImmutableMap.of(
+        "key2", "val2");
+    podMetadata2.setLabels(label2);
+    podMetadata2.setCreationTimestamp(new DateTime(validStartTimeStamp - 1));
+    V1Pod pod2 = new AzKubernetesV1PodBuilder(podMetadata2, null).build();
+
+    // valid pod 3 with execution id information
+    final V1ObjectMeta podMetadata3 = new V1ObjectMeta();
+    ImmutableMap<String, String> label3 = ImmutableMap.of(
+        "execution-id", "execid-12345");
+    podMetadata3.setLabels(label3);
+    podMetadata3.setCreationTimestamp(new DateTime(validStartTimeStamp + 1 ));
+    V1Pod pod3 = new AzKubernetesV1PodBuilder(podMetadata3, null).build();
+
+    podList.addItemsItem(pod1);
+    podList.addItemsItem(pod2);
+    podList.addItemsItem(pod3);
+
+    Set<Integer> staleContainerExecIdSet =
+        this.kubernetesContainerizedImpl.getExecutionIdFromPodList(podList,
+        validStartTimeStamp);
+    Assert.assertTrue(staleContainerExecIdSet.contains(123));
+    Assert.assertTrue(staleContainerExecIdSet.contains(-1));
+    Assert.assertFalse(staleContainerExecIdSet.contains(12345));
   }
 
   private ExecutableFlow createTestFlow() throws Exception {

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -678,7 +678,7 @@ public class KubernetesContainerizedImplTest {
         this.kubernetesContainerizedImpl.getExecutionIdsFromPodList(podList,
         validStartTimeStamp);
     Assert.assertTrue(staleContainerExecIdSet.contains(123));
-    Assert.assertTrue(staleContainerExecIdSet.contains(-1));
+    Assert.assertFalse(staleContainerExecIdSet.contains(-1));
     Assert.assertFalse(staleContainerExecIdSet.contains(12345));
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -89,7 +89,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.joda.time.DateTime;
@@ -676,7 +675,7 @@ public class KubernetesContainerizedImplTest {
     podList.addItemsItem(pod3);
 
     final Set<Integer> staleContainerExecIdSet =
-        this.kubernetesContainerizedImpl.getExecutionIdFromPodList(podList,
+        this.kubernetesContainerizedImpl.getExecutionIdsFromPodList(podList,
         validStartTimeStamp);
     Assert.assertTrue(staleContainerExecIdSet.contains(123));
     Assert.assertTrue(staleContainerExecIdSet.contains(-1));

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -649,33 +649,33 @@ public class KubernetesContainerizedImplTest {
 
     // stale pod 1 with execution id information
     final V1ObjectMeta podMetadata1 = new V1ObjectMeta();
-    ImmutableMap<String, String> label1 = ImmutableMap.of(
+    final ImmutableMap<String, String> label1 = ImmutableMap.of(
         "execution-id", "execid-123");
     podMetadata1.setLabels(label1);
     podMetadata1.setCreationTimestamp(new DateTime(validStartTimeStamp - 1));
-    V1Pod pod1 = new AzKubernetesV1PodBuilder(podMetadata1, null).build();
+    final V1Pod pod1 = new AzKubernetesV1PodBuilder(podMetadata1, null).build();
 
     // stale pod 2 without execution id information
     final V1ObjectMeta podMetadata2 = new V1ObjectMeta();
-    ImmutableMap<String, String> label2 = ImmutableMap.of(
+    final ImmutableMap<String, String> label2 = ImmutableMap.of(
         "key2", "val2");
     podMetadata2.setLabels(label2);
     podMetadata2.setCreationTimestamp(new DateTime(validStartTimeStamp - 1));
-    V1Pod pod2 = new AzKubernetesV1PodBuilder(podMetadata2, null).build();
+    final V1Pod pod2 = new AzKubernetesV1PodBuilder(podMetadata2, null).build();
 
     // valid pod 3 with execution id information
     final V1ObjectMeta podMetadata3 = new V1ObjectMeta();
-    ImmutableMap<String, String> label3 = ImmutableMap.of(
+    final ImmutableMap<String, String> label3 = ImmutableMap.of(
         "execution-id", "execid-12345");
     podMetadata3.setLabels(label3);
     podMetadata3.setCreationTimestamp(new DateTime(validStartTimeStamp + 1 ));
-    V1Pod pod3 = new AzKubernetesV1PodBuilder(podMetadata3, null).build();
+    final V1Pod pod3 = new AzKubernetesV1PodBuilder(podMetadata3, null).build();
 
     podList.addItemsItem(pod1);
     podList.addItemsItem(pod2);
     podList.addItemsItem(pod3);
 
-    Set<Integer> staleContainerExecIdSet =
+    final Set<Integer> staleContainerExecIdSet =
         this.kubernetesContainerizedImpl.getExecutionIdFromPodList(podList,
         validStartTimeStamp);
     Assert.assertTrue(staleContainerExecIdSet.contains(123));


### PR DESCRIPTION
Verified in test cluster:
```
2022/02/24 07:05:10.161 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Cleaning up containers older than 10 days
2022/02/24 07:05:10.226 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Deleting stale pod fc-dep-xxxxxxx-439102
2022/02/24 07:05:10.226 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] Getting Pod Events for execution Id 439102
2022/02/24 07:05:11.439 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] ExecId: 439102, Action: Pod Deletion, Pod Name: fc-dep-xxxxxxx-439102
2022/02/24 07:05:11.440 +0000  INFO [AzPodStatusDrivingListener] [Thread-16] [Azkaban] WatchEvent for pod fc-dep-xxxxxxx-439102 : AZ_POD_READY
2022/02/24 07:05:11.440 +0000  INFO [ContainerStatusMetricsListener] [azk-container-metrics-pool-0] [Azkaban] Event pod status is same as current AZ_POD_READY, for pod fc-dep-xxxxxxx-439102. Any updates will be skipped.
2022/02/24 07:05:11.453 +0000  INFO [KubernetesContainerizedImpl] [azk-container-cleanup] [Azkaban] ExecId: 439102, Action: Service Deletion, Service Name: fc-svc-xxxxxxx-439102, code: null, message: null
```