### PR TITLE
Get event data distinguishable for flow retries

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -193,6 +193,7 @@ public class Constants {
     public static final String FLOW_KILL_DURATION = "flowKillDuration";
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
+    public static final String EXECUTION_RETRY_BY_AZKABAN = "executionRetryByAzkaban";
     public static final String SLA_OPTIONS = "slaOptions";
     public static final String VERSION_SET = "versionSet";
     public static final String EXECUTOR_TYPE = "executorType";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -194,6 +194,8 @@ public class Constants {
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
     public static final String EXECUTION_RETRY_BY_AZKABAN = "executionRetryByAzkaban";
+    public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =
+        "originalFlowExecutionIdBeforeRetry";
     public static final String SLA_OPTIONS = "slaOptions";
     public static final String VERSION_SET = "versionSet";
     public static final String EXECUTOR_TYPE = "executorType";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -193,7 +193,7 @@ public class Constants {
     public static final String FLOW_KILL_DURATION = "flowKillDuration";
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
-    public static final String EXECUTION_RETRY_BY_AZKABAN = "executionRetryByAzkaban";
+    public static final String EXECUTION_RETRIED_BY_AZKABAN = "executionRetriedByAzkaban";
     public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =
         "originalFlowExecutionIdBeforeRetry";
     public static final String SLA_OPTIONS = "slaOptions";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -16,6 +16,8 @@
 
 package azkaban.executor;
 
+import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
+
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.sla.SlaOption;
 import azkaban.utils.TypedMapWrapper;
@@ -63,8 +65,6 @@ public class ExecutionOptions {
   public static final String FAILURE_ACTION_OVERRIDE = "failureActionOverride";
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
-  // Flow restartability check
-  private static final String EXECUTION_RETRY_BY_AZKABAN = "executionRetryByAzkaban";
   private boolean isExecutionRetried = false;
 
   private boolean notifyOnFirstFailure = true;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -16,7 +16,7 @@
 
 package azkaban.executor;
 
-import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
+import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN;
 import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
 
 import azkaban.executor.mail.DefaultMailCreator;
@@ -159,7 +159,7 @@ public class ExecutionOptions {
     // separately for the original JSON format. New formats should include slaOptions as
     // part of execution options.
 
-    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRY_BY_AZKABAN, false));
+    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRIED_BY_AZKABAN, false));
     options.setOriginalFlowExecutionIdBeforeRetry(wrapper.getInt(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
         options.originalFlowExecutionIdBeforeRetry));
 
@@ -337,7 +337,7 @@ public class ExecutionOptions {
     flowOptionObj.put(FAILURE_ACTION_OVERRIDE, this.failureActionOverride);
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
-    flowOptionObj.put(EXECUTION_RETRY_BY_AZKABAN, this.isExecutionRetried);
+    flowOptionObj.put(EXECUTION_RETRIED_BY_AZKABAN, this.isExecutionRetried);
     flowOptionObj.put(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY, this.originalFlowExecutionIdBeforeRetry);
     return flowOptionObj;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
+import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
 
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.sla.SlaOption;
@@ -66,6 +67,7 @@ public class ExecutionOptions {
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
   private boolean isExecutionRetried = false;
+  private Integer originalFlowExecutionIdBeforeRetry = null;
 
   private boolean notifyOnFirstFailure = true;
   private boolean notifyOnLastFailure = false;
@@ -158,6 +160,8 @@ public class ExecutionOptions {
     // part of execution options.
 
     options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRY_BY_AZKABAN, false));
+    options.setOriginalFlowExecutionIdBeforeRetry(wrapper.getInt(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
+        options.originalFlowExecutionIdBeforeRetry));
 
     return options;
   }
@@ -308,6 +312,11 @@ public class ExecutionOptions {
   public void setExecutionRetried(boolean executionRetried) { this.isExecutionRetried =
       executionRetried; }
 
+  public Integer getOriginalFlowExecutionIdBeforeRetry() { return originalFlowExecutionIdBeforeRetry; }
+
+  public void setOriginalFlowExecutionIdBeforeRetry(Integer originalFlowExecutionIdBeforeRetry) { this.originalFlowExecutionIdBeforeRetry =
+      originalFlowExecutionIdBeforeRetry; }
+
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
@@ -329,6 +338,7 @@ public class ExecutionOptions {
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
     flowOptionObj.put(EXECUTION_RETRY_BY_AZKABAN, this.isExecutionRetried);
+    flowOptionObj.put(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY, this.originalFlowExecutionIdBeforeRetry);
     return flowOptionObj;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -64,7 +64,7 @@ public class ExecutionOptions {
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
   // Flow restartability check
-  private static final String EXECUTION_RETRY = "executionRetryByAzkaban";
+  private static final String EXECUTION_RETRY_BY_AZKABAN = "executionRetryByAzkaban";
   private boolean isExecutionRetried = false;
 
   private boolean notifyOnFirstFailure = true;
@@ -157,7 +157,7 @@ public class ExecutionOptions {
     // separately for the original JSON format. New formats should include slaOptions as
     // part of execution options.
 
-    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRY, false));
+    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRY_BY_AZKABAN, false));
 
     return options;
   }
@@ -328,7 +328,7 @@ public class ExecutionOptions {
     flowOptionObj.put(FAILURE_ACTION_OVERRIDE, this.failureActionOverride);
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
-    flowOptionObj.put(EXECUTION_RETRY, this.isExecutionRetried);
+    flowOptionObj.put(EXECUTION_RETRY_BY_AZKABAN, this.isExecutionRetried);
     return flowOptionObj;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -76,6 +76,8 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
     metaData.put(EventReporterConstants.FLOW_VERSION, String.valueOf(flow.getAzkabanFlowVersion()));
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
+    metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
+        String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
     if (flow.getVersionSet() != null) { // Save version set information
       metaData.put(EventReporterConstants.VERSION_SET,
           getVersionSetJsonString(flow.getVersionSet()));

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -78,6 +78,11 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
     metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
         String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
+    if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
+      // original flow execution id is set when there is one
+      metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
+          String.valueOf(flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
+    }
     if (flow.getVersionSet() != null) { // Save version set information
       metaData.put(EventReporterConstants.VERSION_SET,
           getVersionSetJsonString(flow.getVersionSet()));

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -76,7 +76,7 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
     metaData.put(EventReporterConstants.FLOW_VERSION, String.valueOf(flow.getAzkabanFlowVersion()));
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
-    metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
+    metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
         String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
     if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
       // original flow execution id is set when there is one

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -67,6 +67,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     options.setMailCreator(flow.getMailCreator());
     // Update the flow options so that the flow will be not retried again by Azkaban
     options.setExecutionRetried(true);
+    options.setOriginalFlowExecutionIdBeforeRetry(exFlow.getExecutionId());
     executableFlow.setExecutionOptions(options);
     // Submit new flow for execution
     try {

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -67,7 +67,11 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     options.setMailCreator(flow.getMailCreator());
     // Update the flow options so that the flow will be not retried again by Azkaban
     options.setExecutionRetried(true);
-    options.setOriginalFlowExecutionIdBeforeRetry(exFlow.getExecutionId());
+    // If a retried flow A gets retried again with a new execution id flow B, the original flow
+    // execution id of flow B should be the same as flow A's original flow execution id.
+    if (options.getOriginalFlowExecutionIdBeforeRetry() == null) {
+      options.setOriginalFlowExecutionIdBeforeRetry(exFlow.getExecutionId());
+    }
     executableFlow.setExecutionOptions(options);
     // Submit new flow for execution
     try {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1656,7 +1656,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(flow.getExecutionId()));
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
-      metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
+      metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
           String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
       if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
         // original flow execution id is set when there is one

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1658,6 +1658,11 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
       metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
           String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
+      if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
+        // original flow execution id is set when there is one
+        metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
+            String.valueOf(flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
+      }
       // Flow_Status_Changed event attributes: flowVersion, failedJobId, modifiedBy
       metaData.put(EventReporterConstants.FLOW_VERSION,
           String.valueOf(flow.getAzkabanFlowVersion()));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1656,6 +1656,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(flow.getExecutionId()));
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
+      metaData.put(EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN,
+          String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
       // Flow_Status_Changed event attributes: flowVersion, failedJobId, modifiedBy
       metaData.put(EventReporterConstants.FLOW_VERSION,
           String.valueOf(flow.getAzkabanFlowVersion()));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -18,7 +18,7 @@ package azkaban.execapp;
 
 import static azkaban.Constants.EventReporterConstants.AZ_HOST;
 import static azkaban.Constants.EventReporterConstants.AZ_WEBSERVER;
-import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
+import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN;
 import static azkaban.Constants.EventReporterConstants.EXECUTOR_TYPE;
 import static azkaban.Constants.EventReporterConstants.FLOW_NAME;
 import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
@@ -375,7 +375,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     Assert.assertEquals("Event metadata not created as expected", "BAREMETAL",
         flowMetadata.get(EXECUTOR_TYPE)); // Checks executor type
     Assert.assertEquals("Event metadata not created as expected.", "false",
-        flowMetadata.get(EXECUTION_RETRY_BY_AZKABAN));
+        flowMetadata.get(EXECUTION_RETRIED_BY_AZKABAN));
     Assert.assertNull("Event metadata not created as expected.",
         flowMetadata.get(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY));
   }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -18,6 +18,7 @@ package azkaban.execapp;
 
 import static azkaban.Constants.EventReporterConstants.AZ_HOST;
 import static azkaban.Constants.EventReporterConstants.AZ_WEBSERVER;
+import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
 import static azkaban.Constants.EventReporterConstants.EXECUTOR_TYPE;
 import static azkaban.Constants.EventReporterConstants.FLOW_NAME;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_NAME;
@@ -372,6 +373,8 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
         ServerUtils.getVersionSetJsonString(versionSet), flowMetadata.get(VERSION_SET)); // Checks version set
     Assert.assertEquals("Event metadata not created as expected", "BAREMETAL",
         flowMetadata.get(EXECUTOR_TYPE)); // Checks executor type
+    Assert.assertEquals("Event metadata not created as expected.", "false",
+        flowMetadata.get(EXECUTION_RETRY_BY_AZKABAN));
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -21,6 +21,7 @@ import static azkaban.Constants.EventReporterConstants.AZ_WEBSERVER;
 import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRY_BY_AZKABAN;
 import static azkaban.Constants.EventReporterConstants.EXECUTOR_TYPE;
 import static azkaban.Constants.EventReporterConstants.FLOW_NAME;
+import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_NAME;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_UPLOADER_IP_ADDR;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_UPLOAD_TIME;
@@ -375,6 +376,8 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
         flowMetadata.get(EXECUTOR_TYPE)); // Checks executor type
     Assert.assertEquals("Event metadata not created as expected.", "false",
         flowMetadata.get(EXECUTION_RETRY_BY_AZKABAN));
+    Assert.assertNull("Event metadata not created as expected.",
+        flowMetadata.get(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY));
   }
 
   @Test


### PR DESCRIPTION
In containerized azkaban executions, auto restart is enabled for flow failed due to Kubernetes failures in PREPARING stage. Right now the Azkaban flow life cycle events emitted for original and retry are the same. There needs to be a way to distinguish between retries and originally failed flow execution in the azkaban events.

Validation: 
![Picture1](https://user-images.githubusercontent.com/18157653/155603494-9deff68c-ea1d-4486-a03f-aea577227802.png)

