### PR TITLE
Fix hadoopSecurityManager on bare metal executor

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -422,6 +422,9 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
               logger.error("Failed to fetch extra metastore tokens from : " + thriftUrls, e);
             }
           }
+          if (0 == extraHcatTokenCount) {
+            throw new HadoopSecurityManagerException("No extra metastore token could be fetched.");
+          }
         } else {
           // Only if EXTRA_HCAT_CLUSTERS
           final List<String> extraHcatLocations =
@@ -444,10 +447,10 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
                 logger.error("Failed to fetch extra metastore tokens from : " + thriftUrl, e);
               }
             }
+            if (0 == extraHcatTokenCount) {
+              throw new HadoopSecurityManagerException("No extra metastore token could be fetched.");
+            }
           }
-        }
-        if (0 == extraHcatTokenCount) {
-          throw new HadoopSecurityManagerException("No extra metastore token could be fetched.");
         }
 
         logger.info("Hive metastore token(s) prefetched");


### PR DESCRIPTION
extraHcatTokenCound should only be checked when extra metastore token is requested. Tested changes on test cluster. 