### PR TITLE
Thread safe kubernetes containerized impl

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -1080,10 +1080,6 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     return selectorBuilder.toString();
   }
 
-  public String getNamespace() {
-    return this.namespace;
-  }
-
   /**
    * TODO: Add implementation to get annotations for Pod.
    *
@@ -1213,7 +1209,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    * @param executionId
    * @throws ExecutorManagerException
    */
-  public void deleteService(final int executionId) throws ExecutorManagerException {
+  private void deleteService(final int executionId) throws ExecutorManagerException {
     final String serviceName = getServiceName(executionId);
     try {
       final V1Status deleteResult = this.coreV1Api.deleteNamespacedService(

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -379,7 +379,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    * @throws ExecutorManagerException
    */
   @Override
-  public void createContainer(final int executionId) throws ExecutorManagerException {
+  public synchronized void createContainer(final int executionId) throws ExecutorManagerException {
     createPod(executionId);
     if (isServiceRequired()) {
       createService(executionId);
@@ -395,7 +395,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    * @throws ExecutorManagerException
    */
   @Override
-  public void deleteContainer(final int executionId) throws ExecutorManagerException {
+  public synchronized void deleteContainer(final int executionId) throws ExecutorManagerException {
     try { // if pod deletion is not successful, the service deletion can still be handled
       deletePod(executionId);
     } finally {
@@ -411,7 +411,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    * @throws ExecutorManagerException
    */
   @Override
-  public void deleteAgedContainers(final Duration containerValidity) throws ExecutorManagerException {
+  public synchronized void deleteAgedContainers(final Duration containerValidity) throws ExecutorManagerException {
     logger.info(String.format("Cleaning up containers older than %d days",
         containerValidity.toDays()));
     final Set<Integer> containersToDelete = getStaleContainers(containerValidity);


### PR DESCRIPTION
Currently public methods of the class `KubernetesContainerizedImpl` do not gurantee any thread-safety. Method `deleteContainer` in particular is executed from several different threads. Arguably 'createContainer` can also be executed from different threads (depending on the exact dispatch logic)

Among synchronized, BlockingQueue, atomic variables and stateless design, synchronized keyword seems to be the best way to go considering that:
1. It is recommended to use coreV1Api class per thread: coreV1Api class is not thread-safe from this github [page](https://github.com/kubernetes-client/java/issues/100).
2. In CreatePod method, we access sql db multiple times and do read+write operations. Guarantee the read-write ordering is much safer (no need to think through the side-effect of out-of-order read-writes in multi-threading) using synchronized method.