### PR TITLE
Don't use synchronous Ajax call to get flow logs.

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -35,7 +35,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1579310616"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1646723409"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -349,7 +349,6 @@ azkaban.FlowLogView = Backbone.View.extend({
     console.log("fetchLogs offset is " + offset)
 
     $.ajax({
-      async: false,
       url: requestURL,
       data: {
         "execid": execId,


### PR DESCRIPTION
Currently the Flow Execution page loading hangs (especially in Chrome) if the `fetchExecFlowLogs` api is slow or doesn't return. This is because the ajax call is synchronous and stops execution of further Javascript code until the ajax returns.