### PR TITLE
Adding a timeout for HTTP Ping. 

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -240,6 +240,7 @@ public class Constants {
     // Configures properties for Azkaban executor health check
     public static final String AZKABAN_EXECUTOR_HEALTHCHECK_INTERVAL_MIN = "azkaban.executor.healthcheck.interval.min";
     public static final String AZKABAN_EXECUTOR_MAX_FAILURE_COUNT = "azkaban.executor.max.failurecount";
+    public static final String AZKABAN_EXECUTOR_PING_TIMEOUT = "azkaban.executor.ping.timeout";
     public static final String AZKABAN_ADMIN_ALERT_EMAIL = "azkaban.admin.alert.email";
 
     // Configures Azkaban Flow Version in project YAML file

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorApiClient.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorApiClient.java
@@ -257,6 +257,7 @@ public class ExecutorApiClient extends RestfulApiClient<String> {
     // If in future tls support is added for POLL based model, then following condition
     // can be simplified
     if (isTlsEnabled && null != dispatchMethod && dispatchMethod == DispatchMethod.CONTAINERIZED) {
+      //TODO: Use a HTTP Client builder function rather than calling the client with default params.
       return this.httpsPost(uri, params);
     } else {
       return this.httpPost(uri, params);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorApiGatewayTest.java
@@ -187,5 +187,9 @@ public class ExecutorApiGatewayTest {
     protected String sendAndReturn(HttpUriRequest request) throws IOException {
       return SUCCESS_JSON;
     }
+    @Override
+    protected String sendAndReturnHttpForPing(HttpUriRequest request) throws IOException {
+      return SUCCESS_JSON;
+    }
   }
 }


### PR DESCRIPTION
Adding HTTP timeout for ping actions. 

Alternative approach would be adding a parameter for timeout to the following functions and passing it down the stack and modifying the following functions -->   callwithexecutionID, createHttpsClient, createHttpClient, doPost, sendAndReturnHttps, sendAndReturnHttp, callForJsonObjectMap, callForJsonString and all the test classes associated with calling the above mentioned functions. 

The benefits for following the approach in this PR over the above approach are as follows :

   *   This approach  tries to isolate this change for PING action, to avoid using any of the existing HTTP Post function calls used through Azkaban. We would require more extensive testing if we add did decide add the parameter just due to the number of functions it uses. 
   
   Note:
   *   The ideal approach would be  using a HTTP Client builder function for all requests at the doPost level rather than just before the request (the way it is currently)  can be added as a TODO and we can then add timeout as a parameter rather than using the default client used currently and just passing the timeout as a parameter the way the functions are defined currently. 
   