### PR TITLE
Use local path instead of name for adding hadoop configuration

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/cluster/ClusterModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/cluster/ClusterModule.java
@@ -10,6 +10,7 @@ import com.google.inject.name.Named;
 import java.io.File;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 public class ClusterModule extends AbstractModule {
 
@@ -46,7 +47,7 @@ public class ClusterModule extends AbstractModule {
     }
     final String routerConfPath = props.getString(AzkabanExecutorServer.CLUSTER_ROUTER_CONF,
         "router-conf.xml");
-    configuration.addResource(routerConfPath);
+    configuration.addResource(new Path(routerConfPath));
     return configuration;
   }
 }


### PR DESCRIPTION
In the past, routerConfPath should be relative to classpath but it is not what we want when we first look at the code -- error-prune. Changing this to a local file path instead: i.e. relative to the current program execution path.

![Screen Shot 2022-03-30 at 6 37 12 PM](https://user-images.githubusercontent.com/18157653/160958696-86b0c8c2-3cc7-4644-8904-2601a55e6585.png)
