### PR TITLE
Retry EXECUTION_STOPPED executions when allow.restart.on.execution.stopped:true is added to flow parameters/runtime properties

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -138,7 +138,8 @@ public class ExecutionControllerUtils {
       return;
     }
     final ExecutionOptions options = flow.getExecutionOptions();
-    if (options == null || options.isExecutionRetried()) { // flow can only be retried once
+    // flow can only be retried once
+    if (options == null || options.isExecutionRetried()) {
       return;
     }
     // If the original execution status is not EXECUTION_STOPPED, it can be retried

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -124,26 +124,32 @@ public class ExecutionControllerUtils {
 
   /**
    * This method tries to restart the flow for certain statuses otherwise simply return.
-   * If the flow is already retried once, then it won't be retried again.
-   * If the status is EXECUTION_STOPPED, then it will be retried only if
+   * There are three scenarios that this method is called: 1. a flow is cleaned up by
+   * ContainerCleanupManager; 2. a flow has dispatch failure; 3. a flow encounters pod failure
+   * Each flow execution can be retried once.
+   * If the original status is EXECUTION_STOPPED, then it will be retried only if
    * allow.restart.on.execution.stopped is set to true
    *
    * @param flow
    * @param originalStatus
    */
   public static void restartFlow(final ExecutableFlow flow, final Status originalStatus) {
-    if (!RESTARTABLE_STATUSES.contains(originalStatus) && flow.getStatus() != EXECUTION_STOPPED) {
+    if (!RESTARTABLE_STATUSES.contains(originalStatus)) {
       return;
     }
     final ExecutionOptions options = flow.getExecutionOptions();
-    if (options == null || options.isExecutionRetried()) {
+    if (options == null || options.isExecutionRetried()) { // flow can only be retried once
       return;
     }
+    // If the original execution status is not EXECUTION_STOPPED, it can be retried
     if (originalStatus != Status.EXECUTION_STOPPED) {
       logger.info("Submitted flow for restart: " + flow.getExecutionId());
       ExecutionControllerUtils.submitRestartFlow(flow);
       return;
     }
+    // If the original execution status is EXECUTION_STOPPED, which indicates the program
+    // detects there's an invalid pod state transition and flow is terminated before final states,
+    // the runtime properties (flow parameters) need to be checked.
     final Map<String, String> flowParams = options.getFlowParameters();
     if (flowParams == null || flowParams.isEmpty()) {
       return;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -167,7 +167,6 @@ public class ContainerCleanupManager {
       }
       Status originalStatus = flow.getStatus();
       cancelFlowQuietly(flow, originalStatus);
-      retryFlowQuietly(flow, originalStatus);
       deleteContainerQuietly(flow.getExecutionId());
     }
   }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -212,15 +212,6 @@ public class ContainerCleanupManager {
     }
   }
 
-  private void retryFlowQuietly(ExecutableFlow flow, Status originalStatus) {
-    try {
-      logger.info("Restarting cleaned up flow " + flow.getExecutionId());
-      ExecutionControllerUtils.restartFlow(flow, originalStatus);
-    } catch (final Exception e) {
-      logger.error("Unexpected Exception while restarting flow during clean up." + e);
-    }
-  }
-
   // Deletes the container specified by executionId while logging and consuming any exceptions.
   // Note that while this method is not async it's still expected to return 'quickly'. This is true
   // for Kubernetes as it's declarative API will only submit the request for deleting container

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -167,6 +167,7 @@ public class ContainerCleanupManager {
       }
       Status originalStatus = flow.getStatus();
       cancelFlowQuietly(flow, originalStatus);
+      retryFlowQuietly(flow, originalStatus);
       deleteContainerQuietly(flow.getExecutionId());
     }
   }
@@ -209,6 +210,20 @@ public class ContainerCleanupManager {
       this.containerizedDispatchManager.cancelFlow(flow, flow.getSubmitUser());
     } catch (final Exception e) {
       logger.error("Unexpected Exception while canceling and finalizing flow during clean up." + e);
+    }
+  }
+
+  /**
+   * Quietly retry flow if it is terminated in statuses prior to RUNNING
+   * @param flow
+   * @param originalStatus
+   */
+  private void retryFlowQuietly(ExecutableFlow flow, Status originalStatus) {
+    try {
+      logger.info("Restarting cleaned up flow " + flow.getExecutionId());
+      ExecutionControllerUtils.restartFlow(flow, originalStatus);
+    } catch (final Exception e) {
+      logger.error("Unexpected Exception while restarting flow during clean up." + e);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -278,7 +278,7 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
       // Emit EXECUTION_STOPPED flow event
       this.fireEventListeners(Event.create(executableFlow,
           EventType.FLOW_FINISHED, new EventData(executableFlow)));
-      ExecutionControllerUtils.restartFlow(executableFlow, Status.EXECUTION_STOPPED);
+      ExecutionControllerUtils.restartFlow(executableFlow, executableFlow.getStatus());
       // Log event for cases where the flow was not already in a final state
       WatchEventLogger.logWatchEvent(event, "WatchEvent for finalization of execution-id " + executionId);
     }

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -278,7 +278,7 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
       // Emit EXECUTION_STOPPED flow event
       this.fireEventListeners(Event.create(executableFlow,
           EventType.FLOW_FINISHED, new EventData(executableFlow)));
-      ExecutionControllerUtils.restartFlow(executableFlow, originalStatus);
+      ExecutionControllerUtils.restartFlow(executableFlow, Status.EXECUTION_STOPPED);
       // Log event for cases where the flow was not already in a final state
       WatchEventLogger.logWatchEvent(event, "WatchEvent for finalization of execution-id " + executionId);
     }

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -310,7 +310,10 @@ public class KubernetesWatchTest {
 
     // Mocked flow in RUNNING state. Init failure event will be processed for this execution.
     ExecutableFlow flow1 = createExecutableFlow(EXECUTION_ID_WITH_INIT_FAILURE, Status.PREPARING);
-
+    // set flow parameter to allow restart from EXECUTION_STOPPED
+    final ExecutionOptions options = flow1.getExecutionOptions();
+    options.addAllFlowParameters(flowParam);
+    flow1.setExecutionOptions(options);
     when(updatingListener.getExecutorLoader().fetchExecutableFlow(EXECUTION_ID_WITH_INIT_FAILURE))
         .thenReturn(flow1);
 
@@ -345,6 +348,10 @@ public class KubernetesWatchTest {
     // execution. The extracted AzPodStatus will be AZ_POD_APP_FAILURE.
     ExecutableFlow flow1 = createExecutableFlow(EXECUTION_ID_WITH_CREATE_CONTAINER_ERROR,
         Status.DISPATCHING);
+    // set flow parameter to allow restart from EXECUTION_STOPPED
+    final ExecutionOptions options = flow1.getExecutionOptions();
+    options.addAllFlowParameters(flowParam);
+    flow1.setExecutionOptions(options);
     when(updatingListener.getExecutorLoader()
         .fetchExecutableFlow(EXECUTION_ID_WITH_CREATE_CONTAINER_ERROR))
         .thenReturn(flow1);


### PR DESCRIPTION
Users can control whether to auto retry the EXECUTION_STOPPED flows. 