### PR TITLE
[Azkaban] -- Enable logging of underlying exception when fetching NameNodeToken

### DIFF
--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/HadoopSecurityManager_H_2_0.java
@@ -312,9 +312,9 @@ public class HadoopSecurityManager_H_2_0 extends AbstractHadoopSecurityManager {
               fsToken.getKind(), fsToken.getService()));
         }
       } catch (Exception e) {
-        logger.error("Failed to fetch DFS token for " + userToProxyFQN);
+        logger.error("Failed to fetch DFS token for " + userToProxyFQN, e);
         throw new HadoopSecurityManagerException(
-            "Failed to fetch DFS token for " + userToProxyFQN);
+            "Failed to fetch DFS token for " + userToProxyFQN, e);
       }
     } finally {
       if (fs != null) {


### PR DESCRIPTION
**Context**
---
We are seeing a quite high amount of errors during the fetching of name-node tokens and the exception does not present much information to perform RC analysis.

```
13-04-2022 10:01:16 PDT copy-latest INFO - Token service: thrift://ltx1-holdemhcat01.grid.linkedin.com:7552,thrift://ltx1-holdemhcat02.grid.linkedin.com:7552
13-04-2022 10:01:16 PDT copy-latest INFO - Hive metastore token(s) prefetched
13-04-2022 10:01:16 PDT copy-latest INFO - Pre-fetching JH token from job history server
13-04-2022 10:01:16 PDT copy-latest INFO - Connecting to HistoryServer at: ltx1-holdemjh01.grid.linkedin.com:10020
13-04-2022 10:01:16 PDT copy-latest INFO - JH token from job history server pre-fetched, token Kind: MR_DELEGATION_TOKEN, token service: ltx1-holdemjh01.grid.linkedin.com:10020
13-04-2022 10:01:16 PDT copy-latest INFO - Here is the props for obtain.namenode.token: true
13-04-2022 10:01:17 PDT copy-latest ERROR - Job run failed!
azkaban.security.commons.HadoopSecurityManagerException: Failed to get hadoop tokens! nullazkaban.security.commons.HadoopSecurityManagerException: Failed to fetch DFS token for dcoffline/az_ltx1-holdemaz05.grid.linkedin.com_61914650@GRID.LINKEDIN.COM
    at azkaban.security.AbstractHadoopSecurityManager.doPrefetch(AbstractHadoopSecurityManager.java:418)
    at azkaban.security.AbstractHadoopSecurityManager.prefetchToken(AbstractHadoopSecurityManager.java:381)
    at azkaban.jobtype.HadoopJobUtils.getHadoopTokens(HadoopJobUtils.java:165)
    at azkaban.jobtype.HadoopProxy.setupPropsForProxy(HadoopProxy.java:99)
    at azkaban.jobtype.HadoopShell.run(HadoopShell.java:49)
    at azkaban.execapp.JobRunner.runJob(JobRunner.java:991)
    at azkaban.execapp.JobRunner.doRun(JobRunner.java:708)
    at azkaban.execapp.JobRunner.run(JobRunner.java:658)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.UndeclaredThrowableException
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1911)
    at azkaban.security.HadoopSecurityManager_H_2_0.fetchAllHadoopTokens(HadoopSecurityManager_H_2_0.java:234)
    at azkaban.security.AbstractHadoopSecurityManager.doPrefetch(AbstractHadoopSecurityManager.java:404)
    ... 12 more
```

Hence, in this RB we are throwing the original exception as part of the stacktrace.