### PR TITLE
Removing EXECUTION_STOPPED from container cleanup manager states as i…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -124,7 +124,6 @@ public class ContainerCleanupManager {
         .put(Status.RUNNING, new Pair<>(Duration.ofMinutes(runningFlowValidity), START_TIME))
         .put(Status.PAUSED, new Pair<>(Duration.ofMinutes(runningFlowValidity), START_TIME))
         .put(Status.KILLING, new Pair<>(Duration.ofMinutes(maxKillingValidity), UPDATE_TIME))
-        .put(Status.EXECUTION_STOPPED, new Pair<>(Duration.ofMinutes(maxExecStoppedValidity), UPDATE_TIME))
         .put(Status.FAILED_FINISHING, new Pair<>(Duration.ofMinutes(runningFlowValidity), START_TIME))
         .build();
 
@@ -222,10 +221,6 @@ public class ContainerCleanupManager {
    * @param originalStatus
    */
   private void retryFlowQuietly(ExecutableFlow flow, Status originalStatus) {
-    // EXECUTION_STOPPED flows should not be retried in CleanUpManager periodically
-    if (originalStatus == Status.EXECUTION_STOPPED) {
-      return;
-    }
     try {
       logger.info("Restarting cleaned up flow " + flow.getExecutionId());
       ExecutionControllerUtils.restartFlow(flow, originalStatus);

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -75,8 +75,6 @@ public class ContainerCleanupManagerTest {
     verify(this.executorLoader)
         .fetchStaleFlowsForStatus(Status.KILLING, this.cleaner.getValidityMap());
     verify(this.executorLoader)
-        .fetchStaleFlowsForStatus(Status.EXECUTION_STOPPED, this.cleaner.getValidityMap());
-    verify(this.executorLoader)
         .fetchStaleFlowsForStatus(Status.FAILED_FINISHING, this.cleaner.getValidityMap());
     verifyZeroInteractions(this.containerImpl);
   }


### PR DESCRIPTION
…t is a final state. Reverting 32637fdbecf81 due to this change as it's not required.
We have all the flows in cleanUpStaleFlows under EXECUTION_STOPPED being attempted to be deleted on K8s. This is inaccurate as EXECUTION_STOPPED is a final state. We have FlowStatusManagerListener.lambda$onPodCompleted  & cleanUpStaleContainers to take care of completed Pods. 

Having this in place floods our logs with 404 Not Found APiexceptions from K8s as these pods don't exist.