### PR TITLE
enable Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt update
   - sudo apt install openjfx
 
-script: ./gradlew clean build --scan --no-daemon --info
+script: ./gradlew clean build --scan  --info
 
 # see https://docs.travis-ci.com/user/languages/java/#Projects-Using-Gradle
 before_cache:
@@ -32,5 +32,5 @@ env:
     - GRADLE_OPTS="-Xms128m"
 
 after_success:
-  - ./gradlew coveralls --no-daemon
+  - ./gradlew coveralls 
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`
