### PR TITLE
Fix the pod status mismatch when pod is running but container is not ready

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusExtractor.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusExtractor.java
@@ -366,6 +366,7 @@ public class AzPodStatusExtractor {
       logger.debug("ContainerStarting false as container status is null or empty");
       return false;
     }
+    // All containers shouldn't be waiting and container should be ready
     boolean allContainersWaiting =
         containerStatuses.stream().allMatch(status -> status.getStarted() == false);
     if (!allContainersWaiting && this.containersReadyConditionStatus.isPresent() &&

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusExtractor.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusExtractor.java
@@ -368,8 +368,9 @@ public class AzPodStatusExtractor {
     }
     boolean allContainersWaiting =
         containerStatuses.stream().allMatch(status -> status.getStarted() == false);
-    if (!allContainersWaiting) {
-      logger.debug("ContainerStarting false as all containers are not waiting");
+    if (!allContainersWaiting && this.containersReadyConditionStatus.isPresent() &&
+        this.containersReadyConditionStatus.get() == PodConditionStatus.True) {
+      logger.debug("ContainerStarting false as all containers are not waiting and container is ready");
       return false;
     }
     logger.debug("ContainerStarting is true");


### PR DESCRIPTION
Since the pod goes into Running status very quick in AKS, so when the pod is running, the container is not ready yet, which cause https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/executor/container/watch/AzPodStatusExtractor.java#L578 fall into AZ_POD_UNEXPECTED.
In this case,  it make more sense to let it move to AZ_POD_APP_CONTAINERS_STARTING status. 