### PR TITLE
Remove ConsoleAppender from HadoopJavaJobRunnerMain 

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJavaJobRunnerMain.java
@@ -94,11 +94,6 @@ public class HadoopJavaJobRunnerMain {
     // Separate try catch for logger
     try {
       _logger = Logger.getRootLogger();
-      _logger.removeAllAppenders();
-      ConsoleAppender appender = new ConsoleAppender(DEFAULT_LAYOUT);
-      appender.activateOptions();
-      _logger.addAppender(appender);
-      _logger.setLevel(Level.INFO); //Explicitly setting level to INFO
     } catch (Exception e) {
       throw e;
     }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/JavaJobRunnerMain.java
@@ -88,10 +88,6 @@ public class JavaJobRunnerMain {
       String propsFile = System.getenv(ProcessJob.JOB_PROP_ENV);
 
       _logger = Logger.getRootLogger();
-      _logger.removeAllAppenders();
-      ConsoleAppender appender = new ConsoleAppender(DEFAULT_LAYOUT);
-      appender.activateOptions();
-      _logger.addAppender(appender);
 
       Properties props = new Properties();
       props.load(new BufferedReader(new FileReader(propsFile)));


### PR DESCRIPTION
Remove ConsoleAppender from HadoopJavaJobRunnerMain  as it is not needed anymore.

It breaks compatibility with applications using log4j2.