### PR TITLE
Use ".override" instead of "param.override" to remove c14n properties from pig properties

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -173,7 +173,6 @@ public class Constants {
    * (b). foo_a.properties precedence will be higher than that of basic.properties.
    */
   public static final String PARAM_OVERRIDE_FILE = "param_override.properties";
-  public static final String PARAM_OVERRIDE = "param.override.";
 
   // Azkaban event reporter constants
   public static class EventReporterConstants {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopPigJob.java
@@ -55,6 +55,8 @@ public class HadoopPigJob extends AbstractHadoopJavaProcessJob {
   private static final String PIG_ADDITIONAL_JARS = "pig.additional.jars";
   private static final String DEFAULT_PIG_ADDITIONAL_JARS = "default.pig.additional.jars";
   private static final String PIG_PARAM_PREFIX = "param.";
+  // This param override is used for containerized executions and conflicts with pig params.
+  private static final String PARAM_OVERRIDE_PREFIX = "override.";
   private static final String PIG_PARAM_FILES = "paramfile";
   private static final String HADOOP_UGI = "hadoop.job.ugi";
   private static final String DEBUG = "debug";
@@ -360,9 +362,10 @@ public class HadoopPigJob extends AbstractHadoopJavaProcessJob {
   private Map<String, String> getPigParams() {
     final Map<String, String> paramMap = getJobProps().getMapByPrefix(PIG_PARAM_PREFIX);
     // This map may also contain certain configs which are meant for flow execution on containers.
-    // These configs start with "param.override.". Remove any such property.
+    // These configs start with "param.override.". The "param." is removed by getMapByPrefix.
+    // Remove any such property.
     for (final String key : paramMap.keySet()) {
-      if (key.startsWith(Constants.PARAM_OVERRIDE)) {
+      if (key.startsWith(PARAM_OVERRIDE_PREFIX)) {
         paramMap.remove(key);
       }
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -60,7 +60,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String VERSIONSET_JSON_PARAM = "versionSetJson";
   public static final String VERSIONSET_MD5HEX_PARAM = "versionSetMd5Hex";
   public static final String VERSIONSET_ID_PARAM = "versionSetId";
-
+  private static final String PARAM_OVERRIDE = "param.override.";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
@@ -494,7 +494,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
       return;
     }
     // Clone the props object and filter out the properties to keep only the override ones.
-    Map<String, String> flowOverridePropsMap = Props.clone(props).getMapByPrefix(Constants.PARAM_OVERRIDE);
+    Map<String, String> flowOverridePropsMap = Props.clone(props).getMapByPrefix(PARAM_OVERRIDE);
 
     // Update the flow params with override props
     if (this.executionOptions != null) {


### PR DESCRIPTION
Use ".override" instead of "param.override" to remove c14n properties from pig properties