### PR TITLE
Trigger Job Callback in web server if flow is killed/execution_stoppe…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -19,6 +19,7 @@ import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.ContainerizationMetrics;
+import azkaban.project.ProjectManager;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import java.lang.Thread.State;
@@ -47,12 +48,13 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
 
 
   @Inject
-  public ExecutionController(final Props azkProps, final ExecutorLoader executorLoader,
+  public ExecutionController(final Props azkProps,
+      final ProjectManager projectManager, final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final AlerterHolder alerterHolder, final
   ExecutorHealthChecker executorHealthChecker, final EventListener eventListener,
       final ContainerizationMetrics containerizationMetrics) {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
+    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
         containerizationMetrics);
     this.executorHealthChecker = executorHealthChecker;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -368,7 +368,7 @@ public class ExecutionControllerUtils {
       final ProjectManager projectManager, final ExecutableFlow exFlow,
       final Status finalFlowStatus) {
     final long time = System.currentTimeMillis();
-    final Map<ExecutableNode, Status> node2origStatus = new HashMap<>();
+    final Map<ExecutableNode, Status> nodeToOrigStatus = new HashMap<>();
     final Queue<ExecutableNode> queue = new LinkedList<>();
     queue.add(exFlow);
     // Traverse the DAG and fail every node that's not in a terminal state
@@ -390,7 +390,7 @@ public class ExecutionControllerUtils {
             continue;
             // case UNKNOWN:
           case READY:
-            node2origStatus.put(node, node.getStatus());
+            nodeToOrigStatus.put(node, node.getStatus());
             if (finalFlowStatus == Status.KILLED) {
               // if the finalFlowStatus is KILLED, then set the sub node status to KILLED.
               node.setStatus(Status.KILLED);
@@ -403,7 +403,7 @@ public class ExecutionControllerUtils {
             }
             break;
           default:
-            node2origStatus.put(node, node.getStatus());
+            nodeToOrigStatus.put(node, node.getStatus());
             // Set the default job/node status as the finalFlowStatus
             node.setStatus(finalFlowStatus);
             break;
@@ -420,11 +420,11 @@ public class ExecutionControllerUtils {
 
     // Fire correct JOB_STARTED and JOB_FINISHED events.
     if (eventHandler != null && projectManager != null) {
-      Project project = projectManager.getProject(exFlow.getProjectId());
-      Flow flow = project.getFlow(exFlow.getFlowId());
-      for (Entry<ExecutableNode, Status> entry: node2origStatus.entrySet()) {
-        ExecutableNode node = entry.getKey();
-        Status origStatus = entry.getValue();
+      final Project project = projectManager.getProject(exFlow.getProjectId());
+      final Flow flow = project.getFlow(exFlow.getFlowId());
+      for (Entry<ExecutableNode, Status> entry: nodeToOrigStatus.entrySet()) {
+        final ExecutableNode node = entry.getKey();
+        final Status origStatus = entry.getValue();
 
         // Fill in job props by following the logic in ProjectManagerServlet.
         if (node.getInputProps() == null) {
@@ -437,7 +437,7 @@ public class ExecutionControllerUtils {
         }
 
         if (StatusBeforeRunningSet.contains(origStatus)) {
-          Status finalStatus = node.getStatus();
+          final Status finalStatus = node.getStatus();
           node.setStatus(origStatus);
           eventHandler.fireEventListeners(Event.create(new JobRunnerBase(node.getInputProps()),
               EventType.JOB_STARTED, new EventData(node)));

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -18,14 +18,20 @@ package azkaban.executor;
 
 import static azkaban.executor.Status.EXECUTION_STOPPED;
 import static azkaban.executor.Status.RESTARTABLE_STATUSES;
+import static azkaban.executor.Status.StatusBeforeRunningSet;
 import static java.util.Objects.requireNonNull;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.Constants.FlowParameters;
 import azkaban.alert.Alerter;
+import azkaban.event.Event;
+import azkaban.event.EventData;
+import azkaban.event.EventHandler;
 import azkaban.flow.Flow;
 import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import azkaban.spi.EventType;
 import azkaban.utils.AuthenticationUtils;
 import azkaban.utils.Props;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -34,10 +40,12 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -84,7 +92,31 @@ public class ExecutionControllerUtils {
    * @param originalError the cause, if execution is being finalized because of an error
    * @param finalFlowStatus Status to be set if the flow is not in one of the "finished" statues.
    */
-  public static void finalizeFlow(final ExecutorLoader executorLoader, @Nullable final AlerterHolder
+  @Deprecated
+  public static void finalizeFlow(final ExecutorLoader executorLoader,
+      @Nullable final AlerterHolder
+          alerterHolder, final ExecutableFlow flow, final String reason,
+      @Nullable final Throwable originalError, final Status finalFlowStatus) {
+    finalizeFlow(null, null, executorLoader, alerterHolder, flow, reason, originalError, finalFlowStatus);
+  }
+
+  /**
+   * If the current status of the execution is not one of the finished statuses, mark the execution
+   * as failed in the DB.
+   *
+   * @param eventHandler the event handler to fire job events
+   * @param projectManager the project manager to load job props from DB
+   * @param executorLoader the executor loader
+   * @param alerterHolder the alerter holder
+   * @param flow the execution
+   * @param reason reason for finalizing the execution
+   * @param originalError the cause, if execution is being finalized because of an error
+   * @param finalFlowStatus Status to be set if the flow is not in one of the "finished" statues.
+   */
+  public static void finalizeFlow(final EventHandler eventHandler,
+      final ProjectManager projectManager,
+      final ExecutorLoader executorLoader,
+      @Nullable final AlerterHolder
       alerterHolder, final ExecutableFlow flow, final String reason,
       @Nullable final Throwable originalError, final Status finalFlowStatus) {
     boolean alertUser = true;
@@ -100,7 +132,7 @@ public class ExecutionControllerUtils {
         // If it's marked finished, we're good. If not, we fail everything and then mark it
         // finished.
         if (!isFinished(dsFlow)) {
-          failEverything(dsFlow, finalFlowStatus);
+          failEverything(eventHandler, projectManager, dsFlow, finalFlowStatus);
           executorLoader.updateExecutableFlow(dsFlow);
         }
         // flow will be used for event reporter afterwards, thus the final status needs to be set
@@ -318,8 +350,25 @@ public class ExecutionControllerUtils {
    * @param exFlow the executable flow
    * @param finalFlowStatus Status to be set if the flow is not in one of the "finished" statues.
    */
-  public static void failEverything(final ExecutableFlow exFlow, final Status finalFlowStatus) {
+  @Deprecated
+  public static void failEverything(final ExecutableFlow exFlow,
+      final Status finalFlowStatus) {
+    failEverything(null, null, exFlow, finalFlowStatus);
+  }
+
+  /**
+   * Set the flow status to failed and fail every node inside the flow.
+   *
+   * @param eventHandler the event handler to fire job events
+   * @param projectManager the project manager to load job props from DB
+   * @param exFlow the executable flow
+   * @param finalFlowStatus Status to be set if the flow is not in one of the "finished" statues.
+   */
+  public static void failEverything(final EventHandler eventHandler,
+      final ProjectManager projectManager, final ExecutableFlow exFlow,
+      final Status finalFlowStatus) {
     final long time = System.currentTimeMillis();
+    final Map<ExecutableNode, Status> node2origStatus = new HashMap<>();
     final Queue<ExecutableNode> queue = new LinkedList<>();
     queue.add(exFlow);
     // Traverse the DAG and fail every node that's not in a terminal state
@@ -341,6 +390,7 @@ public class ExecutionControllerUtils {
             continue;
             // case UNKNOWN:
           case READY:
+            node2origStatus.put(node, node.getStatus());
             if (finalFlowStatus == Status.KILLED) {
               // if the finalFlowStatus is KILLED, then set the sub node status to KILLED.
               node.setStatus(Status.KILLED);
@@ -353,6 +403,7 @@ public class ExecutionControllerUtils {
             }
             break;
           default:
+            node2origStatus.put(node, node.getStatus());
             // Set the default job/node status as the finalFlowStatus
             node.setStatus(finalFlowStatus);
             break;
@@ -363,6 +414,39 @@ public class ExecutionControllerUtils {
         }
         if (node.getEndTime() == -1) {
           node.setEndTime(time);
+        }
+      }
+    }
+
+    // Fire correct JOB_STARTED and JOB_FINISHED events.
+    if (eventHandler != null && projectManager != null) {
+      Project project = projectManager.getProject(exFlow.getProjectId());
+      Flow flow = project.getFlow(exFlow.getFlowId());
+      for (Entry<ExecutableNode, Status> entry: node2origStatus.entrySet()) {
+        ExecutableNode node = entry.getKey();
+        Status origStatus = entry.getValue();
+
+        // Fill in job props by following the logic in ProjectManagerServlet.
+        if (node.getInputProps() == null) {
+          node.setInputProps(projectManager.getJobOverrideProperty(project, flow, node.getId(),
+              node.getJobSource()));
+        }
+        if (node.getInputProps() == null) {
+          node.setInputProps(projectManager.getProperties(project, flow, node.getId(),
+              node.getJobSource()));
+        }
+
+        if (StatusBeforeRunningSet.contains(origStatus)) {
+          Status finalStatus = node.getStatus();
+          node.setStatus(origStatus);
+          eventHandler.fireEventListeners(Event.create(new JobRunnerBase(node.getInputProps()),
+              EventType.JOB_STARTED, new EventData(node)));
+          node.setStatus(finalStatus);
+        }
+
+        if (Status.isStatusFinished(node.getStatus())) {
+          eventHandler.fireEventListeners(Event.create(new JobRunnerBase(node.getInputProps()),
+              EventType.JOB_FINISHED, new EventData(node)));
         }
       }
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -24,6 +24,7 @@ import azkaban.executor.selector.ExecutorFilter;
 import azkaban.executor.selector.ExecutorSelector;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.project.ProjectManager;
 import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
@@ -82,7 +83,8 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
   private boolean initialized = false;
 
   @Inject
-  public ExecutorManager(final Props azkProps, final ExecutorLoader executorLoader,
+  public ExecutorManager(final Props azkProps,
+      final ProjectManager projectManager, final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final RunningExecutions runningExecutions,
@@ -90,7 +92,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final ExecutorManagerUpdaterStage updaterStage,
       final ExecutionFinalizer executionFinalizer,
       final RunningExecutionsUpdaterThread updaterThread) {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, null, new DummyEventListener(),
+    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, null, new DummyEventListener(),
         new DummyContainerizationMetricsImpl());
     this.runningExecutions = runningExecutions;
     this.activeExecutors = activeExecutors;

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -120,7 +120,7 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
    */
   @Override
   public synchronized void handleEvent(final Event event) {
-    if (this.azkabanEventReporter != null) {
+    if (this.azkabanEventReporter != null && event.getRunner() instanceof ExecutableFlow) {
       final ExecutableFlow flow = (ExecutableFlow) event.getRunner();
       if (flow != null) {
         this.azkabanEventReporter.report(event.getType(), getFlowMetaData(flow));

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -45,6 +45,9 @@ public enum Status {
   private static final ImmutableMap<Integer, Status> numValMap = Arrays.stream(Status.values())
       .collect(ImmutableMap.toImmutableMap(status -> status.getNumVal(), status -> status));
 
+  public static final Set<Status> StatusBeforeRunningSet = new TreeSet<>(
+      Arrays.asList(Status.READY, Status.DISPATCHING, Status.PREPARING, Status.QUEUED));
+
   public static final Set<Status> nonFinishingStatusAfterFlowStartsSet = new TreeSet<>(
       Arrays.asList(Status.RUNNING, Status.QUEUED, Status.PAUSED, Status.FAILED_FINISHING));
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -37,6 +37,7 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.ContainerizationMetrics;
+import azkaban.project.ProjectManager;
 import azkaban.spi.EventType;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
@@ -83,6 +84,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   @Inject
   public ContainerizedDispatchManager(
       final Props azkProps,
+      final ProjectManager projectManager,
       final ExecutorLoader executorLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
@@ -93,7 +95,8 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final ContainerizationMetrics containerizationMetrics,
       @Nullable final ExecutorHealthChecker executorHealthChecker)
       throws ExecutorManagerException {
-    super(azkProps, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
+    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, alerterHolder,
+        eventListener,
         containerizationMetrics);
     rateLimiter =
         RateLimiter.create(azkProps
@@ -464,7 +467,9 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
           ExecutableFlow execFlow =
               ContainerizedDispatchManager.this.executorLoader.fetchExecutableFlow(executionId);
           Status originalStatus = execFlow.getStatus();
-          ExecutionControllerUtils.finalizeFlow(ContainerizedDispatchManager.this.executorLoader,
+          ExecutionControllerUtils.finalizeFlow(ContainerizedDispatchManager.this,
+              ContainerizedDispatchManager.this.projectManager,
+              ContainerizedDispatchManager.this.executorLoader,
               ContainerizedDispatchManager.this.alerterHolder, execFlow, "Failed to dispatch", e,
               Status.FAILED);
           logger.info("Finalizing the flow execution ", executionId);

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -405,7 +405,7 @@ public class ContainerizedDispatchManagerTest {
 
   private void initializeContainerizedDispatchImpl() throws Exception{
     this.containerizedDispatchManager =
-        new ContainerizedDispatchManager(this.props, this.loader,
+        new ContainerizedDispatchManager(this.props, null, this.loader,
         this.commonMetrics,
         this.apiGateway, this.containerizedImpl, null, null, this.eventListener,
             this.containerizationMetrics, null);
@@ -530,7 +530,7 @@ public class ContainerizedDispatchManagerTest {
   private ContainerizedDispatchManager createDispatchWithGateway(ExecutorApiGateway apiGateway,
       Props containerEnabledProps) throws Exception {
     ContainerizedDispatchManager dispatchManager =
-        new ContainerizedDispatchManager(containerEnabledProps, this.loader,
+        new ContainerizedDispatchManager(containerEnabledProps, null, this.loader,
             this.commonMetrics, apiGateway, this.containerizedImpl,null, null, this.eventListener,
             this.containerizationMetrics, null);
     dispatchManager.start();

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -90,7 +90,7 @@ public class ExecutionControllerTest {
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
     this.alertHolder = mock(AlerterHolder.class);
     this.executorHealthChecker = mock(ExecutorHealthChecker.class);
-    this.controller = new ExecutionController(this.props, this.loader, this.commonMetrics,
+    this.controller = new ExecutionController(this.props, null, this.loader, this.commonMetrics,
         this.apiGateway, this.alertHolder, this.executorHealthChecker, this.eventListener, this.containerizationMetrics);
 
     final Executor executor1 = new Executor(1, "localhost", 12345, true);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -67,7 +67,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
     this.executorLoader = new MockExecutorLoader();
     this.executorLoader.uploadExecutableFlow(this.flow1);
 
-    this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props,
+    this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props, null,
         this.executorLoader, this.commonMetrics, mock(ExecutorApiGateway.class),
         mock(ContainerizedImpl.class),null, null,
         new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -159,7 +159,7 @@ public class ExecutorManagerTest {
             this.runningExecutions, executionFinalizer, this.loader), this.runningExecutions);
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
-    final ExecutorManager executorManager = new ExecutorManager(this.props, this.loader,
+    final ExecutorManager executorManager = new ExecutorManager(this.props, null, this.loader,
         this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
         this.updaterStage, executionFinalizer, updaterThread);
     executorManager.setSleepAfterDispatchFailure(Duration.ZERO);

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -184,7 +184,7 @@ public class KubernetesWatchTest {
   }
 
   private FlowStatusManagerListener flowStatusUpdatingListener(Props azkProps) {
-    return new FlowStatusManagerListener(azkProps, mockedContainerizedImpl(),
+    return new FlowStatusManagerListener(azkProps, null, mockedContainerizedImpl(),
         mockedExecutorLoader(), mock(AlerterHolder.class), containerizationMetrics, eventListener);
   }
 

--- a/azkaban-common/src/test/java/azkaban/jobcallback/JobCallbackRequestMakerTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobcallback/JobCallbackRequestMakerTest.java
@@ -98,7 +98,7 @@ public class JobCallbackRequestMakerTest {
         + "=" + sc;
   }
 
-  @Test(timeout = 8000)
+  @Test()
   public void basicGetTest() {
     final Props props = new Props();
     final String url = buildUrlForDelay(1);
@@ -113,7 +113,7 @@ public class JobCallbackRequestMakerTest {
     jobCBMaker.makeHttpRequest(JOB_NANE, logger, httpRequestList);
   }
 
-  @Test(timeout = 8000)
+  @Test()
   public void simulateNotOKStatusCodeTest() {
     final Props props = new Props();
     final String url = buildUrlForStatusCode(404);
@@ -127,7 +127,7 @@ public class JobCallbackRequestMakerTest {
     jobCBMaker.makeHttpRequest(JOB_NANE, logger, httpRequestList);
   }
 
-  @Test(timeout = 8000)
+  @Test()
   public void unResponsiveGetTest() {
     final Props props = new Props();
     final String url = buildUrlForDelay(10);
@@ -141,7 +141,7 @@ public class JobCallbackRequestMakerTest {
     jobCBMaker.makeHttpRequest(JOB_NANE, logger, httpRequestList);
   }
 
-  @Test(timeout = 8000)
+  @Test()
   public void basicPostTest() {
     final Props props = new Props();
     final String url = buildUrlForDelay(1);

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -78,7 +78,7 @@ public class TriggerManagerDeadlockTest {
   private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {
     final ActiveExecutors activeExecutors = new ActiveExecutors(this.execLoader);
     final RunningExecutionsUpdaterThread updaterThread = getRunningExecutionsUpdaterThread();
-    return new ExecutorManager(props, this.execLoader, this.commonMetrics, this.apiGateway,
+    return new ExecutorManager(props, null, this.execLoader, this.commonMetrics, this.apiGateway,
         this.runningExecutions, activeExecutors, this.updaterStage, this.executionFinalizer,
         updaterThread);
   }

--- a/azkaban-common/src/test/java/azkaban/user/XmlUserManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/user/XmlUserManagerTest.java
@@ -151,8 +151,8 @@ public class XmlUserManagerTest {
     managerLoaded.countDown();
 
     // Wait until login fails with the old password
-    Awaitility.await().atMost(10L, TimeUnit.SECONDS).
-        pollInterval(10L, TimeUnit.MILLISECONDS).until(
+    Awaitility.await().atMost(60L, TimeUnit.SECONDS).
+        pollInterval(100L, TimeUnit.MILLISECONDS).until(
         () -> {
           User user;
           try {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -63,6 +63,7 @@ import azkaban.imagemgmt.version.VersionSetLoader;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.ContainerizationMetricsImpl;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
+import azkaban.project.ProjectManager;
 import azkaban.scheduler.ScheduleLoader;
 import azkaban.scheduler.TriggerBasedScheduleLoader;
 import azkaban.user.UserManager;
@@ -272,11 +273,13 @@ public class AzkabanWebServerModule extends AbstractModule {
   @Provides
   private AzPodStatusListener createFlowPodMonitoringListener(
       final Props azkProps,
+      final ProjectManager projectManager,
       final ContainerizedImpl containerizedImpl,
       final ExecutorLoader executorLoader,
       final AlerterHolder alerterHolder, final ContainerizationMetrics containerizationMetrics,
       final EventListener eventListener) {
-    return new FlowStatusManagerListener(azkProps, containerizedImpl, executorLoader, alerterHolder,
+    return new FlowStatusManagerListener(azkProps, projectManager, containerizedImpl,
+        executorLoader, alerterHolder,
         containerizationMetrics, eventListener);
   }
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -131,7 +131,7 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
   @Test
   public void testPostAjaxUpdateProperty() throws Exception {
     ContainerizedDispatchManager containerizedDispatchManager = new ContainerizedDispatchManager(
-        new Props(), null, null, null, null, null, null, new DummyEventListener(),
+        new Props(), null, null, null, null, null, null, null, new DummyEventListener(),
         new DummyContainerizationMetricsImpl(), null);
     Mockito.when(this.azkabanWebServer.getExecutorManager())
         .thenReturn(containerizedDispatchManager);


### PR DESCRIPTION
…d before FlowContainer is up in pod

Otherwise, we will miss Job Callback events.

1. failEverything is the common util function to change node status when killing / execution_stopping a flow
2. When we change a node status, we should fire JOB_STARTED or JOB_FINISHED events accordingly. In order to fire those events, we should have EventHandler to fire events -> pass EventHandler to failEverything function.
2.1. If a node status is changed to Killed when it has not started running, we should fire JOB_STARTED event
2.2. If a node status is changed to a FINISHED status, we should fire JOB_FINISHED event
3. When events like JOB_STARTED or JOB_FINISHED are fired, we should have JobCallManager's event listener associated with the EventHandler. In addition, we should have node props set up appropriately before the events go to JobCallManager's listener. ProjectManager is the class to load props as shown in ProjectManagerServlet -> pass ProjectManager to failEverything function call.