### PR TITLE
Enable kafka log4j appender for both Azkaban flowLogs and jobLogs and…

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -291,9 +291,14 @@ public class Constants {
     public static final String HISTORY_SERVER_JOB_URL = "azkaban.server.external.history_server_job_url";
     public static final String SPARK_HISTORY_SERVER_JOB_URL = "azkaban.server.external.spark_history_server_job_url";
 
-    // Configures the Kafka appender for logging user jobs, specified for the exec server
-    public static final String AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST = "azkaban.server.logging.kafka.brokerList";
-    public static final String AZKABAN_SERVER_LOGGING_KAFKA_TOPIC = "azkaban.server.logging.kafka.topic";
+    // Configures the Kafka appender for logging user jobs and flows.
+    public static final String AZKABAN_LOGGING_KAFKA_ENABLED = "azkaban.logging.kafka.enabled";
+    public static final String AZKABAN_LOGGING_KAFKA_CLASS_PARAM = "azkaban.logging.kafka.class";
+    public static final String AZKABAN_LOGGING_KAFKA_BROKERS = "azkaban.logging.kafka.brokers";
+    public static final String AZKABAN_JOB_LOGGING_KAFKA_TOPIC = "azkaban.job.logging.kafka.topic";
+    public static final String AZKABAN_FLOW_LOGGING_KAFKA_TOPIC = "azkaban.flow.logging.kafka.topic";
+    public static final String AZKABAN_LOGGING_KAFKA_SCHEMA_REGISTRY_URL =
+        "azkaban.logging.kafka.schema.registry.url";
 
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
 
@@ -545,9 +550,6 @@ public class Constants {
   }
 
   public static class JobProperties {
-
-    // Job property that enables/disables using Kafka logging of user job logs
-    public static final String AZKABAN_JOB_LOGGING_KAFKA_ENABLE = "azkaban.job.logging.kafka.enable";
 
     /*
      * this parameter is used to replace EXTRA_HCAT_LOCATION that could fail when one of the uris is not available.

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile deps.mysqlConnector
     compile deps.snakeyaml
     compile deps.velocity
+    compile deps.kafkaLog4jAppender
 
     testRuntime deps.h2
 

--- a/azkaban-common/src/main/java/azkaban/utils/KafkaLog4jUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/KafkaLog4jUtils.java
@@ -24,7 +24,7 @@ public class KafkaLog4jUtils {
   }
 
   private static KafkaLog4jAppender getAzkabanKafkaLog4jAppender(final Props props,
-      final String execId, final String flowId, final String jobId, final String jobAttempt,
+      final String execId, final String name, final String jobAttempt,
       final String topicConfigKey) {
     final boolean loggingKafkaEnabled =
         props.getBoolean(AZKABAN_LOGGING_KAFKA_ENABLED, false);
@@ -44,7 +44,7 @@ public class KafkaLog4jUtils {
       KafkaLog4jAppender kafkaLog4jAppender =
           (KafkaLog4jAppender) kafkaLog4jAppenderClassConstructor.newInstance();
 
-      String[] origIds = new String[] {execId, flowId, jobId, jobAttempt};
+      String[] origIds = new String[] {execId, name, jobAttempt};
       String[] nonNullIds = Arrays.stream(origIds).filter(Objects::nonNull).toArray(String[]::new);
 
       kafkaLog4jAppender.setBrokerList(props
@@ -67,12 +67,12 @@ public class KafkaLog4jUtils {
    *
    * @param props Azkaban props
    * @param execId Azkaban exec id
-   * @param flowId Azkaban flow id
+   * @param name Azkaban flow id
    * @return KafkaLog4jAppender
    */
   public static KafkaLog4jAppender getAzkabanFlowKafkaLog4jAppender(final Props props,
-      final String execId, final String flowId) {
-    return getAzkabanKafkaLog4jAppender(props, execId, flowId, null, null,
+      final String execId, final String name) {
+    return getAzkabanKafkaLog4jAppender(props, execId, name, null,
         ConfigurationKeys.AZKABAN_FLOW_LOGGING_KAFKA_TOPIC);
   }
 
@@ -81,14 +81,13 @@ public class KafkaLog4jUtils {
    *
    * @param props Azkaban props
    * @param execId Azkaban exec id
-   * @param flowId Azkaban flow id
-   * @param jobId Azkaban job id
+   * @param name Azkaban job's nested id
    * @param jobAttempt Azkaban job attempt
    * @return KafkaLog4jAppender
    */
   public static KafkaLog4jAppender getAzkabanJobKafkaLog4jAppender(final Props props,
-      final String execId, final String flowId, final String jobId, final String jobAttempt) {
-    return getAzkabanKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt,
+      final String execId, final String name, final String jobAttempt) {
+    return getAzkabanKafkaLog4jAppender(props, execId, name, jobAttempt,
         ConfigurationKeys.AZKABAN_JOB_LOGGING_KAFKA_TOPIC);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/utils/KafkaLog4jUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/KafkaLog4jUtils.java
@@ -1,0 +1,94 @@
+package azkaban.utils;
+
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_CLASS_PARAM;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_ENABLED;
+
+import azkaban.Constants;
+import azkaban.Constants.ConfigurationKeys;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.kafka.log4jappender.KafkaLog4jAppender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for getting Azkaban Kafka Log4j Appender
+ */
+public class KafkaLog4jUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(KafkaLog4jUtils.class);
+
+  private static String getAzkabanKafkaLog4jName(final String[] ids) {
+    return String.join(".", ids);
+  }
+
+  private static KafkaLog4jAppender getAzkabanKafkaLog4jAppender(final Props props,
+      final String execId, final String flowId, final String jobId, final String jobAttempt,
+      final String topicConfigKey) {
+    final boolean loggingKafkaEnabled =
+        props.getBoolean(AZKABAN_LOGGING_KAFKA_ENABLED, false);
+
+    if (!loggingKafkaEnabled) {
+      logger.info("Server logging kafka is not enabled");
+      return null;
+    }
+
+    try {
+      final Class<?> kafkaLog4jAppenderClass =
+          props.getClass(AZKABAN_LOGGING_KAFKA_CLASS_PARAM, KafkaLog4jAppender.class);
+      logger.info("Loading kafka log4j appender class " + kafkaLog4jAppenderClass.getName());
+
+      final Constructor<?> kafkaLog4jAppenderClassConstructor =
+          kafkaLog4jAppenderClass.getConstructor();
+      KafkaLog4jAppender kafkaLog4jAppender =
+          (KafkaLog4jAppender) kafkaLog4jAppenderClassConstructor.newInstance();
+
+      String[] origIds = new String[] {execId, flowId, jobId, jobAttempt};
+      String[] nonNullIds = Arrays.stream(origIds).filter(Objects::nonNull).toArray(String[]::new);
+
+      kafkaLog4jAppender.setBrokerList(props
+          .getString(Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_BROKERS));
+      kafkaLog4jAppender.setTopic(props.getString(topicConfigKey));
+
+      // Concat necessary information for the custom appender to consume.
+      kafkaLog4jAppender.setName(getAzkabanKafkaLog4jName(nonNullIds));
+      kafkaLog4jAppender.activateOptions();
+
+      return kafkaLog4jAppender;
+    } catch (final Exception e) {
+      logger.error("Could not instantiate KafkaLog4jAppender", e);
+      return null;
+    }
+  }
+
+  /**
+   * Get Azkaban Kafka Log4j Appender for given Azkaban flow.
+   *
+   * @param props Azkaban props
+   * @param execId Azkaban exec id
+   * @param flowId Azkaban flow id
+   * @return KafkaLog4jAppender
+   */
+  public static KafkaLog4jAppender getAzkabanFlowKafkaLog4jAppender(final Props props,
+      final String execId, final String flowId) {
+    return getAzkabanKafkaLog4jAppender(props, execId, flowId, null, null,
+        ConfigurationKeys.AZKABAN_FLOW_LOGGING_KAFKA_TOPIC);
+  }
+
+  /**
+   * Get Azkaban Kafka Log4j Appender for given Azkaban job.
+   *
+   * @param props Azkaban props
+   * @param execId Azkaban exec id
+   * @param flowId Azkaban flow id
+   * @param jobId Azkaban job id
+   * @param jobAttempt Azkaban job attempt
+   * @return KafkaLog4jAppender
+   */
+  public static KafkaLog4jAppender getAzkabanJobKafkaLog4jAppender(final Props props,
+      final String execId, final String flowId, final String jobId, final String jobAttempt) {
+    return getAzkabanKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt,
+        ConfigurationKeys.AZKABAN_JOB_LOGGING_KAFKA_TOPIC);
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/utils/KafkaLog4jUtilTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/KafkaLog4jUtilTest.java
@@ -20,6 +20,7 @@ public class KafkaLog4jUtilTest {
   private final String execId = "12345";
   private final String flowId = "sample_flowid";
   private final String jobId = "sample_jobid";
+  private final String jobNestedId = flowId + ":" + jobId;
   private final String jobAttempt = "1";
 
   @Before
@@ -38,7 +39,7 @@ public class KafkaLog4jUtilTest {
     appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId,
         flowId);
     Assert.assertNull(appender);
-    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobAttempt);
     Assert.assertNull(appender);
   }
 
@@ -49,14 +50,14 @@ public class KafkaLog4jUtilTest {
     appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId,
         flowId);
     Assert.assertNull(appender);
-    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, jobNestedId, jobAttempt);
     Assert.assertNull(appender);
   }
 
   @Test
   public void validateFields() {
     final String expectedFlowAppenderName = execId + "." + flowId;
-    final String expectedJobAppenderName = execId + "." + flowId + "." + jobId + "." + jobAttempt;
+    final String expectedJobAppenderName = execId + "." + jobNestedId + "." + jobAttempt;
 
     KafkaLog4jAppender appender;
     appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId, flowId);
@@ -64,7 +65,7 @@ public class KafkaLog4jUtilTest {
     Assert.assertEquals(appender.getTopic(), expectedFlowLoggingKafkaTopic);
     Assert.assertEquals(appender.getName(), expectedFlowAppenderName);
 
-    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, jobNestedId, jobAttempt);
     Assert.assertEquals(appender.getBrokerList(), expectedKafkaBrokers);
     Assert.assertEquals(appender.getTopic(), expectedJobLoggingKafkaTopic);
     Assert.assertEquals(appender.getName(), expectedJobAppenderName);

--- a/azkaban-common/src/test/java/azkaban/utils/KafkaLog4jUtilTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/KafkaLog4jUtilTest.java
@@ -1,0 +1,77 @@
+package azkaban.utils;
+
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_FLOW_LOGGING_KAFKA_TOPIC;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_JOB_LOGGING_KAFKA_TOPIC;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_BROKERS;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_CLASS_PARAM;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_ENABLED;
+
+import org.apache.kafka.log4jappender.KafkaLog4jAppender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KafkaLog4jUtilTest {
+
+  private final Props props = new Props();
+  private final String expectedKafkaBrokers = "sample.kafka.azkaban.com:12345";
+  private final String expectedFlowLoggingKafkaTopic = "sample_flow_logging_kafka_topic";
+  private final String expectedJobLoggingKafkaTopic = "sample_flow_logging_kafka_topic";
+  private final String execId = "12345";
+  private final String flowId = "sample_flowid";
+  private final String jobId = "sample_jobid";
+  private final String jobAttempt = "1";
+
+  @Before
+  public void setUp() {
+    props.put(AZKABAN_LOGGING_KAFKA_ENABLED, "true");
+    props.put(AZKABAN_LOGGING_KAFKA_CLASS_PARAM, MockKafkaLog4jAppender.class.getName());
+    props.put(AZKABAN_LOGGING_KAFKA_BROKERS, expectedKafkaBrokers);
+    props.put(AZKABAN_FLOW_LOGGING_KAFKA_TOPIC, expectedFlowLoggingKafkaTopic);
+    props.put(AZKABAN_JOB_LOGGING_KAFKA_TOPIC, expectedJobLoggingKafkaTopic);
+  }
+
+  @Test
+  public void returnNullIfLoggingKafkaNotEnabled() {
+    KafkaLog4jAppender appender;
+    props.put(AZKABAN_LOGGING_KAFKA_ENABLED, "false");
+    appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId,
+        flowId);
+    Assert.assertNull(appender);
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    Assert.assertNull(appender);
+  }
+
+  @Test
+  public void returnNullIfKafkaClassIsNotFound() {
+    props.put(AZKABAN_LOGGING_KAFKA_CLASS_PARAM, "unknown_class");
+    KafkaLog4jAppender appender;
+    appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId,
+        flowId);
+    Assert.assertNull(appender);
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    Assert.assertNull(appender);
+  }
+
+  @Test
+  public void validateFields() {
+    final String expectedFlowAppenderName = execId + "." + flowId;
+    final String expectedJobAppenderName = execId + "." + flowId + "." + jobId + "." + jobAttempt;
+
+    KafkaLog4jAppender appender;
+    appender = KafkaLog4jUtils.getAzkabanFlowKafkaLog4jAppender(props, execId, flowId);
+    Assert.assertEquals(appender.getBrokerList(), expectedKafkaBrokers);
+    Assert.assertEquals(appender.getTopic(), expectedFlowLoggingKafkaTopic);
+    Assert.assertEquals(appender.getName(), expectedFlowAppenderName);
+
+    appender = KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(props, execId, flowId, jobId, jobAttempt);
+    Assert.assertEquals(appender.getBrokerList(), expectedKafkaBrokers);
+    Assert.assertEquals(appender.getTopic(), expectedJobLoggingKafkaTopic);
+    Assert.assertEquals(appender.getName(), expectedJobAppenderName);
+  }
+
+  public static class MockKafkaLog4jAppender extends KafkaLog4jAppender {
+    @Override
+    public void activateOptions() {}
+  }
+}

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     compile deps.hadoopCommon
     compile deps.guava
     compile deps.jsr305
-    compile deps.kafkaLog4jAppender
     compile deps.failsafe
 
     testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -364,10 +364,11 @@ public class JobRunner extends JobRunnerBase implements Runnable {
       }
 
       if (this.azkabanProps.getBoolean(Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_ENABLED, false)) {
+        // Keep the names consistent as what we did in uploadLogFile()
         this.kafkaLog4jAppender =
             KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(this.azkabanProps,
-                String.valueOf(this.executionId),  this.node.getParentFlow().getFlowId(),
-                getJobId(), String.valueOf(this.node.getAttempt()));
+                String.valueOf(this.executionId), this.node.getNestedId(),
+                String.valueOf(this.node.getAttempt()));
 
         if (this.kafkaLog4jAppender != null) {
           this.logger.addAppender(this.kafkaLog4jAppender);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -43,11 +43,9 @@ import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypeManagerException;
 import azkaban.spi.EventType;
 import azkaban.utils.ExecuteAsUser;
-import azkaban.utils.ExternalLinkUtils;
-import azkaban.utils.PatternLayoutEscaped;
+import azkaban.utils.KafkaLog4jUtils;
 import azkaban.utils.Props;
 import azkaban.utils.StringUtils;
-import azkaban.utils.UndefinedPropertyException;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -87,7 +85,7 @@ public class JobRunner extends JobRunnerBase implements Runnable {
   private final FlowRunnerProxy flowRunnerProxy;
   private Logger flowLogger = null;
   private Appender jobAppender = null;
-  private Optional<Appender> kafkaAppender = Optional.empty();
+  private KafkaLog4jAppender kafkaLog4jAppender;
   private File logFile;
   private String attachmentFileName;
   private Job job;
@@ -365,32 +363,18 @@ public class JobRunner extends JobRunnerBase implements Runnable {
             + " for job " + this.jobId, e);
       }
 
-      if (this.props.getBoolean(Constants.JobProperties.AZKABAN_JOB_LOGGING_KAFKA_ENABLE, false)) {
-        // Only attempt appender construction if required properties are present
-        if (this.azkabanProps
-            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST)
-            && this.azkabanProps
-            .containsKey(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC)) {
-          try {
-            attachKafkaAppender(createKafkaAppender());
-          } catch (final Exception e) {
-            removeAppender(this.kafkaAppender);
-            this.flowLogger.error("Failed to create Kafka appender for job " + this.jobId, e);
-          }
-        } else {
-          this.flowLogger.info(
-              "Kafka appender not created as brokerlist or topic not provided by executor server");
+      if (this.azkabanProps.getBoolean(Constants.ConfigurationKeys.AZKABAN_LOGGING_KAFKA_ENABLED, false)) {
+        this.kafkaLog4jAppender =
+            KafkaLog4jUtils.getAzkabanJobKafkaLog4jAppender(this.azkabanProps,
+                String.valueOf(this.executionId),  this.node.getParentFlow().getFlowId(),
+                getJobId(), String.valueOf(this.node.getAttempt()));
+
+        if (this.kafkaLog4jAppender != null) {
+          this.logger.addAppender(this.kafkaLog4jAppender);
+          this.logger.setAdditivity(false);
+          this.flowLogger.info("Attached new Kafka appender for job " + this.jobId);
         }
       }
-    }
-
-    final String externalViewer = ExternalLinkUtils
-        .getExternalLogViewer(this.azkabanProps, this.jobId,
-            this.props);
-    if (!externalViewer.isEmpty()) {
-      this.logger.info("If you want to leverage AZ ELK logging support, you need to follow the "
-          + "instructions: http://azkaban.github.io/azkaban/docs/latest/#how-to");
-      this.logger.info("If you did the above step, see logs at: " + externalViewer);
     }
   }
 
@@ -427,40 +411,6 @@ public class JobRunner extends JobRunnerBase implements Runnable {
     this.attachmentFileName = file.getAbsolutePath();
   }
 
-  private void attachKafkaAppender(final KafkaLog4jAppender appender) {
-    // This should only be called once
-    assert (!this.kafkaAppender.isPresent());
-
-    this.kafkaAppender = Optional.of(appender);
-    this.logger.addAppender(this.kafkaAppender.get());
-    this.logger.setAdditivity(false);
-    this.flowLogger.info("Attached new Kafka appender for job " + this.jobId);
-  }
-
-  private KafkaLog4jAppender createKafkaAppender() throws UndefinedPropertyException {
-    final KafkaLog4jAppender kafkaProducer = new KafkaLog4jAppender();
-    kafkaProducer.setSyncSend(false);
-    kafkaProducer.setBrokerList(this.azkabanProps
-        .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_BROKERLIST));
-    kafkaProducer.setTopic(
-        this.azkabanProps
-            .getString(Constants.ConfigurationKeys.AZKABAN_SERVER_LOGGING_KAFKA_TOPIC));
-
-    final String layoutString = LogUtil.createLogPatternLayoutJsonString(this.props, this.jobId);
-
-    kafkaProducer.setLayout(new PatternLayoutEscaped(layoutString));
-    kafkaProducer.activateOptions();
-
-    this.flowLogger.info("Created kafka appender for " + this.jobId);
-    return kafkaProducer;
-  }
-
-  private void removeAppender(final Optional<Appender> appender) {
-    if (appender.isPresent()) {
-      removeAppender(appender.get());
-    }
-  }
-
   private void removeAppender(final Appender appender) {
     if (appender != null) {
       this.logger.removeAppender(appender);
@@ -469,12 +419,8 @@ public class JobRunner extends JobRunnerBase implements Runnable {
   }
 
   private void closeLogger() {
-    if (this.jobAppender != null) {
-      removeAppender(this.jobAppender);
-    }
-    if (this.kafkaAppender.isPresent()) {
-      removeAppender(this.kafkaAppender);
-    }
+    removeAppender(this.jobAppender);
+    removeAppender(this.kafkaLog4jAppender);
   }
 
   private void writeStatus() {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -29,6 +29,8 @@ import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_UPLOAD_USER;
 import static azkaban.Constants.EventReporterConstants.PROJECT_NAME;
 import static azkaban.Constants.EventReporterConstants.SLA_OPTIONS;
 import static azkaban.Constants.EventReporterConstants.VERSION_SET;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 import azkaban.Constants;
 import azkaban.utils.ServerUtils;
@@ -86,6 +88,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SUCCEEDED);
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_FINISHED);
   }
 
@@ -125,6 +128,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job8", Status.SUCCEEDED);
     assertStatus("job10", Status.SKIPPED);
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_FINISHED);
   }
 
@@ -156,6 +160,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_STATUS_CHANGED,  EventType.FLOW_FINISHED);
   }
 
@@ -190,6 +195,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job9", Status.CANCELLED);
     assertStatus("job10", Status.CANCELLED);
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     // Two FLOW_STATUS_CHANGED events fired, one for FAILED and one for KILLED
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_STATUS_CHANGED,
         EventType.FLOW_STATUS_CHANGED, EventType.FLOW_FINISHED);
@@ -221,6 +227,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertStatus("job10", Status.CANCELLED);
     assertThreadShutDown();
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_STATUS_CHANGED, EventType.FLOW_FINISHED);
   }
 
@@ -260,6 +267,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     Assert.assertFalse(this.runner.getFlowKillTime() == -1);
     Assert.assertEquals("me", this.runner.getExecutableFlow().getModifiedBy());
 
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_STATUS_CHANGED, EventType.FLOW_FINISHED);
   }
 
@@ -284,7 +292,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     // Cannot pause a flow that is being killed or that has already been killed. This should throw
     // IllegalStateException.
     this.runner.pause("me");
-
   }
 
   @Test
@@ -305,6 +312,7 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     assertAttempts("job-retry-fail", 2);
 
     waitForAndAssertFlowStatus(Status.FAILED);
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest2.java
@@ -32,6 +32,7 @@ import azkaban.spi.EventType;
 import azkaban.utils.Props;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -265,6 +266,8 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     InteractiveTestJob.getTestJob("jobf").succeedJob();
     assertStatus("jobf", Status.SUCCEEDED);
     waitForAndAssertFlowStatus(Status.SUCCEEDED);
+    assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -320,6 +323,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -358,6 +362,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -408,6 +413,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   @Test
@@ -459,6 +465,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -518,6 +525,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.CANCELLED);
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -566,8 +574,9 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobe", Status.CANCELLED);
     assertStatus("jobf", Status.CANCELLED);
 
-    assertThreadShutDown();
     waitForAndAssertFlowStatus(Status.KILLED);
+    assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -654,6 +663,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.SUCCEEDED);
     waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -703,6 +713,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -755,6 +766,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -837,6 +849,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("jobf", Status.SUCCEEDED);
     waitForAndAssertFlowStatus(Status.SUCCEEDED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -885,6 +898,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -945,6 +959,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -1002,6 +1017,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.FAILED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -1025,6 +1041,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -1069,6 +1086,7 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
 
     waitForAndAssertFlowStatus(Status.KILLED);
     assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
   /**
@@ -1098,7 +1116,8 @@ public class FlowRunnerTest2 extends FlowRunnerTestBase {
     assertStatus("joba", Status.READY);
     assertStatus("joba1", Status.READY);
     waitForAndAssertFlowStatus(Status.KILLED);
-    this.runner = null;
+    assertThreadShutDown();
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
   }
 
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -166,6 +166,7 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector
         .assertEvents(EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED, EventType.JOB_FINISHED);
   }
@@ -223,6 +224,7 @@ public class JobRunnerTest {
     Assert.assertEquals("java.lang.RuntimeException: Forced"
             + " failure of testJob", runner.getNode().getFailureMessage());
 
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector
         .assertEvents(EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED, EventType.JOB_FINISHED);
 
@@ -258,6 +260,7 @@ public class JobRunnerTest {
 
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == null);
 
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.JOB_STARTED, EventType.JOB_FINISHED);
 
     Assert.assertFalse("Thread ContextClassLoader not reset properly",
@@ -292,6 +295,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps == null);
     Assert.assertTrue(runner.getLogFilePath() == null);
     Assert.assertTrue(!runner.isKilled());
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.JOB_STARTED, EventType.JOB_FINISHED);
 
     Assert.assertFalse("Thread ContextClassLoader not reset properly",
@@ -338,6 +342,7 @@ public class JobRunnerTest {
     Assert.assertTrue(logFile.exists());
     Assert.assertTrue(eventCollector.checkOrdering());
     Assert.assertTrue(runner.isKilled());
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector
         .assertEvents(EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED, EventType.JOB_FINISHED);
   }
@@ -383,6 +388,7 @@ public class JobRunnerTest {
     Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
 
     Assert.assertTrue(eventCollector.checkOrdering());
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector
         .assertEvents(EventType.JOB_STARTED, EventType.JOB_STATUS_CHANGED, EventType.JOB_FINISHED);
   }
@@ -430,6 +436,7 @@ public class JobRunnerTest {
     // wait so that there's time to make the "DB update" for KILLED status
     TestUtils.await().untilAsserted(
         () -> assertThat(loader.getNodeUpdateCount("testJob")).isEqualTo(2));
+    Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.JOB_FINISHED);
   }
 

--- a/docs/howTo.rst
+++ b/docs/howTo.rst
@@ -31,33 +31,35 @@ Only users with admin privileges can use this action. This action need
 at least one active executor to be successful. Use curl or simply visit
 following URL:- ``WEBSERVER_URL/executor?ajax=reloadExecutors``
 
-Logging job logs to a Kafka cluster
+Logging logs to a Kafka cluster
 -----------------------------------
 
-Azkaban supports sending job logs to a log ingestion (such as ELK)
+Azkaban supports sending job and flow logs to a log ingestion (such as ELK)
 cluster via a Kafka appender. In order to enable this in Azkaban, you
-will need to set two exec server properties (shown here with sample
+will need to set three logging kafka properties (shown here with sample
 values):
 
 .. code-block:: guess
 
-   azkaban.server.logging.kafka.brokerList=localhost:9092
-   azkaban.server.logging.kafka.topic=azkaban-logging
+   azkaban.logging.kafka.brokers=localhost:9092
+   azkaban.job.logging.kafka.topic=azkaban-job-logging
+   azkaban.flow.logging.kafka.topic=azkaban-flow-logging
 
 These configure where Azkaban can find your Kafka cluster, and also
 which topic to put the logs under. Failure to provide these parameters
 will result in Azkaban refusing to create a Kafka appender upon
 requesting one.
 
-In order to configure a job to send its logs to Kafka, the following job
+In order to configure jobs and flows to send its logs to Kafka, the following
 property needs to be set to true:
 
 .. code-block:: guess
 
-   azkaban.job.logging.kafka.enable=true
+   azkaban.logging.kafka.enabled=true
 
-Jobs with this setting enabled will broadcast its log messages in JSON
-form to the Kafka cluster. It has the following structure:
+By default, the logging kafka log4j appender is org.apache.kafka.log4jappender.KafkaLog4jAppender
+ and logs will broadcast in JSON form to the Kafka cluster. It has the following
+structure:
 
 .. code-block:: guess
 
@@ -72,3 +74,11 @@ form to the Kafka cluster. It has the following structure:
      "flowid": "ID of flow",
      "execid": "ID of execution"
    }
+
+Instead of using the default kafka log4j appender, you can plug in your own logging kafka log4j
+appender by extending org.apache.kafka.log4jappender.KafkaLog4jAppender and set the following
+property to your appender:
+
+.. code-block:: guess
+
+   azkaban.logging.kafka.class=a.b.c.yourKafkaLog4jAppender


### PR DESCRIPTION
… modernize the old kafka appender design.

Refer to docs/howTo.rst file for more detailed explanations.