### PR TITLE
Use Azkaban external (user facing) web server url if configured

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -977,10 +977,13 @@ public class JobRunner extends JobRunnerBase implements Runnable {
   }
 
   /**
-   * Build Azkaban frontend base url. Use external configs
-   * ({@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME},
-   * {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_EXTERNAL_SSL_PORT}) if set
-   * else {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_URL}
+   * Build Azkaban frontend base url. Use external or user facing configs (for the cases where the
+   * Web server is behind a proxy for example) if set else use property
+   * {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_URL}.
+   * User facing access is configured with properties:
+   * {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME},
+   * {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_EXTERNAL_SSL_PORT} and
+   * {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_EXTERNAL_PORT}
    */
   private String getAzkabanWebServerURL() {
     String azkabanWebServerURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/JobRunner.java
@@ -983,7 +983,7 @@ public class JobRunner extends JobRunnerBase implements Runnable {
    * else {@link azkaban.Constants.ConfigurationKeys#AZKABAN_WEBSERVER_URL}
    */
   private String getAzkabanWebServerURL() {
-    String azkabanWebServerURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);;
+    String azkabanWebServerURL = this.azkabanProps.get(AZKABAN_WEBSERVER_URL);
 
     // Use Azkaban external web server url if configured.
     final String webServerExternalHostname =


### PR DESCRIPTION
when generating execution related urls in runtime properties.