### PR TITLE
Split ExecutorLoader into ExecutorLoader and ExecutionLogsLoader, and pluginize ExecutionLogsLoader

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -299,6 +299,10 @@ public class Constants {
     public static final String AZKABAN_FLOW_LOGGING_KAFKA_TOPIC = "azkaban.flow.logging.kafka.topic";
     public static final String AZKABAN_LOGGING_KAFKA_SCHEMA_REGISTRY_URL =
         "azkaban.logging.kafka.schema.registry.url";
+    // This is designed for viewing logs emitted from above kafka appender
+    public static final String AZKABAN_OFFLINE_LOGS_LOADER_ENABLED = "azkaban.offline.logs.loader.enabled";
+    public static final String AZKABAN_OFFLINE_LOGS_LOADER_CLASS_PARAM =
+        "azkaban.offline.logs.loader.class";
 
     public static final String IS_METRICS_ENABLED = "azkaban.is.metrics.enabled";
 

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -747,6 +747,11 @@ public class Constants {
     public static final String ENV_MEMORY_REQUEST = "MEMORY_REQUEST";
   }
 
+  public static class LogConstants {
+    public static final String NEARLINE_LOGS = "nearlineLogs";
+    public static final String OFFLINE_LOGS = "offlineLogs";
+  }
+
   public static class ImageMgmtConstants {
 
     public static final String IMAGE_TYPE = "imageType";

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -21,6 +21,7 @@ import static azkaban.Constants.ConfigurationKeys.AZKABAN_EVENT_REPORTING_ENABLE
 import static azkaban.Constants.ImageMgmtConstants.IMAGE_RAMPUP_PLAN;
 import static azkaban.Constants.ImageMgmtConstants.IMAGE_TYPE;
 import static azkaban.Constants.ImageMgmtConstants.IMAGE_VERSION;
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
 
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.db.AzkabanDataSource;
@@ -44,6 +45,8 @@ import azkaban.imagemgmt.permission.PermissionManager;
 import azkaban.imagemgmt.permission.PermissionManagerImpl;
 import azkaban.imagemgmt.rampup.ImageRampupManager;
 import azkaban.imagemgmt.rampup.ImageRampupManagerImpl;
+import azkaban.logs.JdbcExecutionLogsLoader;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.project.InMemoryProjectCache;
 import azkaban.project.JdbcProjectImpl;
 import azkaban.project.ProjectCache;
@@ -94,6 +97,8 @@ public class AzkabanCommonModule extends AbstractModule {
     bind(TriggerLoader.class).to(JdbcTriggerImpl.class);
     bind(ProjectLoader.class).to(JdbcProjectImpl.class);
     bind(ExecutorLoader.class).to(JdbcExecutorLoader.class);
+    bind(ExecutionLogsLoader.class).annotatedWith(Names.named(NEARLINE_LOGS)).to(
+        JdbcExecutionLogsLoader.class);
     bind(ProjectCache.class).to(InMemoryProjectCache.class);
     bind(OsCpuUtil.class).toProvider(() -> {
       final int cpuLoadPeriodSec = this.props

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -15,7 +15,7 @@
  */
 package azkaban.executor;
 
-import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_OFFLINE_LOGS_LOADER_ENABLED;
 
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.inject.Named;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -62,9 +61,11 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
 
   private static final Logger logger = Logger.getLogger(AbstractExecutorManagerAdapter.class);
   protected final Props azkProps;
+  protected boolean offlineLogsLoaderEnabled;
   protected final ProjectManager projectManager;
   protected final ExecutorLoader executorLoader;
   protected final ExecutionLogsLoader nearlineExecutionLogsLoader;
+  protected final Optional<ExecutionLogsLoader> offlineExecutionLogsLoader;
   protected final CommonMetrics commonMetrics;
   protected final ExecutorApiGateway apiGateway;
   protected final AlerterHolder alerterHolder;
@@ -78,15 +79,19 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       final ProjectManager projectManager,
       final ExecutorLoader executorLoader,
       final ExecutionLogsLoader nearlineExecutionLogsLoader,
+      final ExecutionLogsLoader offlineExecutionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final AlerterHolder alerterHolder,
       final EventListener eventListener,
       final ContainerizationMetrics containerizationMetrics) {
     this.azkProps = azkProps;
+    this.offlineLogsLoaderEnabled = this.azkProps.getBoolean(AZKABAN_OFFLINE_LOGS_LOADER_ENABLED,
+        false);
     this.projectManager = projectManager;
     this.executorLoader = executorLoader;
     this.nearlineExecutionLogsLoader = nearlineExecutionLogsLoader;
+    this.offlineExecutionLogsLoader = Optional.ofNullable(offlineExecutionLogsLoader);
     this.commonMetrics = commonMetrics;
     this.apiGateway = apiGateway;
     this.alerterHolder = alerterHolder;
@@ -97,6 +102,16 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     this.addListener(eventListener);
     ServerUtils.configureJobCallback(logger, azkProps);
     this.addListener(JobCallbackManager.getInstance());
+  }
+
+  @Override
+  public void enableOfflineLogsLoader(boolean enabled) {
+    this.offlineLogsLoaderEnabled = enabled;
+  }
+
+  @Override
+  public boolean isOfflineLogsLoaderEnabled() {
+    return this.offlineLogsLoaderEnabled;
   }
 
   /**
@@ -445,8 +460,18 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
               typeParam, offsetParam, lengthParam);
       return LogData.createLogDataFromObject(result);
     } else {
-      return this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0, offset,
-          length);
+      LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0,
+          offset, length);
+
+      // Return offline logs if nearline logs are empty or the flow in kubernetes pod crashed
+      if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
+          (logData.getLength() == 0 ||
+              (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
+                  (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
+        return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), "", 0,
+            offset, length);
+      }
+      return logData;
     }
   }
 
@@ -470,8 +495,22 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
               typeParam, jobIdParam, offsetParam, lengthParam, attemptParam);
       return LogData.createLogDataFromObject(result);
     } else {
-      return this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId, attempt,
-          offset, length);
+      LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId,
+          attempt, offset, length);
+
+      // Return offline logs if nearline logs are empty or the flow and job in kubernetes pod
+      // crashed
+      if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
+          (logData.getLength() == 0 ||
+              (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
+                  (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
+        final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
+        if (node.getStatus() == Status.KILLED || node.getStatus() == Status.EXECUTION_STOPPED) {
+          return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), jobId,
+              attempt, offset, length);
+        }
+      }
+      return logData;
     }
   }
 
@@ -591,7 +630,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       // Killed flow events can only be sent out if callWithReferenceByUser completed successfully
       // so we need to manually send one here.
       this.fireEventListeners(Event.create(executableFlow,
-      EventType.FLOW_FINISHED, new EventData(executableFlow)));
+          EventType.FLOW_FINISHED, new EventData(executableFlow)));
       // Throwing exception to make the reason appear on the UI.
       throw new ExecutorManagerException(finalizingReason
           + " Finalizing the flow.");

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -15,6 +15,8 @@
  */
 package azkaban.executor;
 
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
@@ -24,6 +26,7 @@ import azkaban.event.EventHandler;
 import azkaban.event.EventListener;
 import azkaban.flow.FlowUtils;
 import azkaban.jobcallback.JobCallbackManager;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.project.Project;
@@ -46,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Named;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -60,6 +64,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   protected final Props azkProps;
   protected final ProjectManager projectManager;
   protected final ExecutorLoader executorLoader;
+  protected final ExecutionLogsLoader nearlineExecutionLogsLoader;
   protected final CommonMetrics commonMetrics;
   protected final ExecutorApiGateway apiGateway;
   protected final AlerterHolder alerterHolder;
@@ -72,6 +77,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   protected AbstractExecutorManagerAdapter(final Props azkProps,
       final ProjectManager projectManager,
       final ExecutorLoader executorLoader,
+      final ExecutionLogsLoader nearlineExecutionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final AlerterHolder alerterHolder,
@@ -80,6 +86,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     this.azkProps = azkProps;
     this.projectManager = projectManager;
     this.executorLoader = executorLoader;
+    this.nearlineExecutionLogsLoader = nearlineExecutionLogsLoader;
     this.commonMetrics = commonMetrics;
     this.apiGateway = apiGateway;
     this.alerterHolder = alerterHolder;
@@ -438,7 +445,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
               typeParam, offsetParam, lengthParam);
       return LogData.createLogDataFromObject(result);
     } else {
-      return this.executorLoader.fetchLogs(exFlow.getExecutionId(), "", 0, offset,
+      return this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0, offset,
           length);
     }
   }
@@ -463,7 +470,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
               typeParam, jobIdParam, offsetParam, lengthParam, attemptParam);
       return LogData.createLogDataFromObject(result);
     } else {
-      return this.executorLoader.fetchLogs(exFlow.getExecutionId(), jobId, attempt,
+      return this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId, attempt,
           offset, length);
     }
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -15,8 +15,11 @@
  */
 package azkaban.executor;
 
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+
 import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.project.ProjectManager;
@@ -31,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,12 +54,13 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
   @Inject
   public ExecutionController(final Props azkProps,
       final ProjectManager projectManager, final ExecutorLoader executorLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final AlerterHolder alerterHolder, final
   ExecutorHealthChecker executorHealthChecker, final EventListener eventListener,
       final ContainerizationMetrics containerizationMetrics) {
-    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
-        containerizationMetrics);
+    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
+        alerterHolder, eventListener, containerizationMetrics);
     this.executorHealthChecker = executorHealthChecker;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -16,6 +16,7 @@
 package azkaban.executor;
 
 import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+import static azkaban.Constants.LogConstants.OFFLINE_LOGS;
 
 import azkaban.DispatchMethod;
 import azkaban.event.EventListener;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -54,12 +56,14 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
   @Inject
   public ExecutionController(final Props azkProps,
       final ProjectManager projectManager, final ExecutorLoader executorLoader,
-      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader nearlineExecutionLogsLoader,
+      @Named(OFFLINE_LOGS) @Nullable final ExecutionLogsLoader offlineExecutionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway, final AlerterHolder alerterHolder, final
   ExecutorHealthChecker executorHealthChecker, final EventListener eventListener,
       final ContainerizationMetrics containerizationMetrics) {
-    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
+    super(azkProps, projectManager, executorLoader, nearlineExecutionLogsLoader,
+        offlineExecutionLogsLoader,  commonMetrics, apiGateway,
         alerterHolder, eventListener, containerizationMetrics);
     this.executorHealthChecker = executorHealthChecker;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
@@ -54,7 +54,7 @@ public class ExecutionLogsDao {
   }
 
   // TODO kunkun-tang: the interface's parameter is called endByte, but actually is length.
-  LogData fetchLogs(final int execId, final String name, final int attempt,
+  public LogData fetchLogs(final int execId, final String name, final int attempt,
       final int startByte,
       final int length) throws ExecutorManagerException {
     final FetchLogsHandler handler = new FetchLogsHandler(startByte, length + startByte);
@@ -135,7 +135,7 @@ public class ExecutionLogsDao {
     }
   }
 
-  int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
+  public int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
       throws ExecutorManagerException {
     int totalRecordsRemoved = 0;
     int removedRecords;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -161,6 +161,7 @@ public interface ExecutorLoader {
    *
    * @return isSuccess
    */
+  @Deprecated
   void postExecutorEvent(Executor executor, EventType type, String user,
       String message) throws ExecutorManagerException;
 
@@ -175,6 +176,7 @@ public interface ExecutorLoader {
    *
    * @return List<ExecutorLogEvent>
    */
+  @Deprecated
   List<ExecutorLogEvent> getExecutorEvents(Executor executor, int num,
       int offset) throws ExecutorManagerException;
 
@@ -259,13 +261,7 @@ public interface ExecutorLoader {
   boolean updateExecutableReference(int execId, long updateTime)
       throws ExecutorManagerException;
 
-  LogData fetchLogs(int execId, String name, int attempt, int startByte,
-      int endByte) throws ExecutorManagerException;
-
   List<Object> fetchAttachments(int execId, String name, int attempt)
-      throws ExecutorManagerException;
-
-  void uploadLogFile(int execId, String name, int attempt, File... files)
       throws ExecutorManagerException;
 
   void uploadAttachmentFile(ExecutableNode node, File file)
@@ -304,9 +300,6 @@ public interface ExecutorLoader {
       throws ExecutorManagerException;
 
   Pair<Props, Props> fetchExecutionJobProps(int execId, String jobId)
-      throws ExecutorManagerException;
-
-  int removeExecutionLogsByTime(long millis, int recordCleanupLimit)
       throws ExecutorManagerException;
 
   void unsetExecutorIdForExecution(final int executionId) throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -16,12 +16,16 @@
 
 package azkaban.executor;
 
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+import static azkaban.Constants.LogConstants.OFFLINE_LOGS;
+
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.executor.selector.ExecutorComparator;
 import azkaban.executor.selector.ExecutorFilter;
 import azkaban.executor.selector.ExecutorSelector;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.project.ProjectManager;
@@ -50,6 +54,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -85,6 +90,7 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
   @Inject
   public ExecutorManager(final Props azkProps,
       final ProjectManager projectManager, final ExecutorLoader executorLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final RunningExecutions runningExecutions,
@@ -92,8 +98,8 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final ExecutorManagerUpdaterStage updaterStage,
       final ExecutionFinalizer executionFinalizer,
       final RunningExecutionsUpdaterThread updaterThread) {
-    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, null, new DummyEventListener(),
-        new DummyContainerizationMetricsImpl());
+    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
+        null, new DummyEventListener(), new DummyContainerizationMetricsImpl());
     this.runningExecutions = runningExecutions;
     this.activeExecutors = activeExecutors;
     this.updaterStage = updaterStage;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -90,7 +91,8 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
   @Inject
   public ExecutorManager(final Props azkProps,
       final ProjectManager projectManager, final ExecutorLoader executorLoader,
-      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader nearlineExecutionLogsLoader,
+      @Named(OFFLINE_LOGS) @Nullable final ExecutionLogsLoader offlineExecutionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final RunningExecutions runningExecutions,
@@ -98,8 +100,9 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final ExecutorManagerUpdaterStage updaterStage,
       final ExecutionFinalizer executionFinalizer,
       final RunningExecutionsUpdaterThread updaterThread) {
-    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
-        null, new DummyEventListener(), new DummyContainerizationMetricsImpl());
+    super(azkProps, projectManager, executorLoader, nearlineExecutionLogsLoader,
+        offlineExecutionLogsLoader, commonMetrics, apiGateway, null, new DummyEventListener(),
+        new DummyContainerizationMetricsImpl());
     this.runningExecutions = runningExecutions;
     this.activeExecutors = activeExecutors;
     this.updaterStage = updaterStage;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -30,6 +30,10 @@ import java.util.Set;
 
 public interface ExecutorManagerAdapter {
 
+  public void enableOfflineLogsLoader(boolean enabled);
+
+  public boolean isOfflineLogsLoaderEnabled();
+
   public boolean isFlowRunning(int projectId, String flowId);
 
   public ExecutableFlow getExecutableFlow(int execId)

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -18,7 +18,6 @@ package azkaban.executor;
 import azkaban.DispatchMethod;
 import azkaban.executor.ExecutorLogEvent.EventType;
 import azkaban.project.ProjectLoader;
-import azkaban.utils.FileIOUtils.LogData;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableMap;
@@ -36,7 +35,6 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   private final ExecutionFlowDao executionFlowDao;
   private final ExecutorDao executorDao;
   private final ExecutionJobDao executionJobDao;
-  private final ExecutionLogsDao executionLogsDao;
   private final ExecutorEventsDao executorEventsDao;
   private final ActiveExecutingFlowsDao activeExecutingFlowsDao;
   private final FetchActiveFlowDao fetchActiveFlowDao;
@@ -49,7 +47,6 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   public JdbcExecutorLoader(final ExecutionFlowDao executionFlowDao,
       final ExecutorDao executorDao,
       final ExecutionJobDao executionJobDao,
-      final ExecutionLogsDao executionLogsDao,
       final ExecutorEventsDao executorEventsDao,
       final ActiveExecutingFlowsDao activeExecutingFlowsDao,
       final FetchActiveFlowDao fetchActiveFlowDao,
@@ -60,7 +57,6 @@ public class JdbcExecutorLoader implements ExecutorLoader {
     this.executionFlowDao = executionFlowDao;
     this.executorDao = executorDao;
     this.executionJobDao = executionJobDao;
-    this.executionLogsDao = executionLogsDao;
     this.executorEventsDao = executorEventsDao;
     this.activeExecutingFlowsDao = activeExecutingFlowsDao;
     this.fetchActiveFlowDao = fetchActiveFlowDao;
@@ -278,25 +274,10 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte,
-      final int length) throws ExecutorManagerException {
-
-    return this.executionLogsDao.fetchLogs(execId, name, attempt, startByte, length);
-  }
-
-  @Override
   public List<Object> fetchAttachments(final int execId, final String jobId, final int attempt)
       throws ExecutorManagerException {
 
     return this.executionJobDao.fetchAttachments(execId, jobId, attempt);
-  }
-
-  @Override
-  public void uploadLogFile(final int execId, final String name, final int attempt,
-      final File... files)
-      throws ExecutorManagerException {
-    this.executionLogsDao.uploadLogFile(execId, name, attempt, files);
   }
 
   @Override
@@ -365,12 +346,6 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   public Executor fetchExecutorByExecutionId(final int executionId)
       throws ExecutorManagerException {
     return this.executorDao.fetchExecutorByExecutionId(executionId);
-  }
-
-  @Override
-  public int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
-      throws ExecutorManagerException {
-    return this.executionLogsDao.removeExecutionLogsByTime(millis, recordCleanupLimit);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -15,6 +15,8 @@
  */
 package azkaban.executor.container;
 
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+
 import azkaban.Constants;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.Constants.FlowParameters;
@@ -35,6 +37,7 @@ import azkaban.executor.ExecutorHealthChecker;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.ContainerizationMetrics;
 import azkaban.project.ProjectManager;
@@ -55,6 +58,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +90,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final Props azkProps,
       final ProjectManager projectManager,
       final ExecutorLoader executorLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final ContainerizedImpl containerizedImpl,
@@ -95,9 +100,8 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final ContainerizationMetrics containerizationMetrics,
       @Nullable final ExecutorHealthChecker executorHealthChecker)
       throws ExecutorManagerException {
-    super(azkProps, projectManager, executorLoader, commonMetrics, apiGateway, alerterHolder,
-        eventListener,
-        containerizationMetrics);
+    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
+        alerterHolder, eventListener, containerizationMetrics);
     rateLimiter =
         RateLimiter.create(azkProps
             .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -16,6 +16,7 @@
 package azkaban.executor.container;
 
 import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+import static azkaban.Constants.LogConstants.OFFLINE_LOGS;
 
 import azkaban.Constants;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
@@ -90,7 +91,8 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final Props azkProps,
       final ProjectManager projectManager,
       final ExecutorLoader executorLoader,
-      @Named(NEARLINE_LOGS) final ExecutionLogsLoader executionLogsLoader,
+      @Named(NEARLINE_LOGS) final ExecutionLogsLoader nearlineExecutionLogsLoader,
+      @Named(OFFLINE_LOGS) @Nullable final ExecutionLogsLoader offlineExecutionLogsLoader,
       final CommonMetrics commonMetrics,
       final ExecutorApiGateway apiGateway,
       final ContainerizedImpl containerizedImpl,
@@ -100,8 +102,9 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
       final ContainerizationMetrics containerizationMetrics,
       @Nullable final ExecutorHealthChecker executorHealthChecker)
       throws ExecutorManagerException {
-    super(azkProps, projectManager, executorLoader, executionLogsLoader, commonMetrics, apiGateway,
-        alerterHolder, eventListener, containerizationMetrics);
+    super(azkProps, projectManager, executorLoader, nearlineExecutionLogsLoader,
+        offlineExecutionLogsLoader, commonMetrics, apiGateway, alerterHolder, eventListener,
+        containerizationMetrics);
     rateLimiter =
         RateLimiter.create(azkProps
             .getInt(ContainerizedDispatchManagerProperties.CONTAINERIZED_CREATION_RATE_LIMIT, 20));

--- a/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
@@ -1,0 +1,17 @@
+package azkaban.logs;
+
+import azkaban.executor.ExecutorManagerException;
+import azkaban.utils.FileIOUtils.LogData;
+import java.io.File;
+
+public interface ExecutionLogsLoader {
+
+  void uploadLogFile(int execId, String name, int attempt, File... files)
+      throws ExecutorManagerException;
+
+  LogData fetchLogs(int execId, String name, int attempt, int startByte,
+      int endByte) throws ExecutorManagerException;
+
+  int removeExecutionLogsByTime(long millis, int recordCleanupLimit)
+      throws ExecutorManagerException;
+}

--- a/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
@@ -1,0 +1,38 @@
+package azkaban.logs;
+
+import azkaban.executor.ExecutionLogsDao;
+import azkaban.executor.ExecutorManagerException;
+import azkaban.utils.FileIOUtils.LogData;
+import java.io.File;
+import javax.inject.Inject;
+
+public class JdbcExecutionLogsLoader implements ExecutionLogsLoader {
+
+  private final ExecutionLogsDao executionLogsDao;
+
+  @Inject
+  public JdbcExecutionLogsLoader(final ExecutionLogsDao executionLogsDao) {
+    this.executionLogsDao = executionLogsDao;
+  }
+
+  @Override
+  public LogData fetchLogs(final int execId, final String name, final int attempt,
+      final int startByte,
+      final int length) throws ExecutorManagerException {
+
+    return this.executionLogsDao.fetchLogs(execId, name, attempt, startByte, length);
+  }
+
+  @Override
+  public void uploadLogFile(final int execId, final String name, final int attempt,
+      final File... files)
+      throws ExecutorManagerException {
+    this.executionLogsDao.uploadLogFile(execId, name, attempt, files);
+  }
+
+  @Override
+  public int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
+      throws ExecutorManagerException {
+    return this.executionLogsDao.removeExecutionLogsByTime(millis, recordCleanupLimit);
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -75,7 +75,8 @@ public class ContainerizedDispatchManagerTest {
   private Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows = new HashMap<>();
   private List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows = new ArrayList<>();
   private ExecutorLoader executorLoader;
-  private ExecutionLogsLoader executionLogsLoader;
+  private ExecutionLogsLoader nearlineExecutionLogsLoader;
+  private ExecutionLogsLoader offlineExecutionLogsLoader;
   private ExecutorApiGateway apiGateway;
   private ContainerizedImpl containerizedImpl;
   private ContainerizedDispatchManager containerizedDispatchManager;
@@ -100,7 +101,8 @@ public class ContainerizedDispatchManagerTest {
     this.props = new Props();
     this.user = TestUtils.getTestUser();
     this.executorLoader = mock(ExecutorLoader.class);
-    this.executionLogsLoader = mock(ExecutionLogsLoader.class);
+    this.nearlineExecutionLogsLoader = mock(ExecutionLogsLoader.class);
+    this.offlineExecutionLogsLoader = mock(ExecutionLogsLoader.class);
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.containerizedImpl = mock(ContainerizedImpl.class);
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
@@ -409,8 +411,9 @@ public class ContainerizedDispatchManagerTest {
   private void initializeContainerizedDispatchImpl() throws Exception{
     this.containerizedDispatchManager =
         new ContainerizedDispatchManager(this.props, null, this.executorLoader,
-            this.executionLogsLoader, this.commonMetrics, this.apiGateway, this.containerizedImpl,
-            null, null, this.eventListener, this.containerizationMetrics, null);
+            this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader, this.commonMetrics,
+            this.apiGateway, this.containerizedImpl, null, null, this.eventListener,
+            this.containerizationMetrics, null);
   }
 
   @Test
@@ -533,8 +536,9 @@ public class ContainerizedDispatchManagerTest {
       Props containerEnabledProps) throws Exception {
     ContainerizedDispatchManager dispatchManager =
         new ContainerizedDispatchManager(containerEnabledProps, null, this.executorLoader,
-            this.executionLogsLoader, this.commonMetrics, apiGateway, this.containerizedImpl,null,
-            null, this.eventListener, this.containerizationMetrics, null);
+            this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader, this.commonMetrics,
+            apiGateway, this.containerizedImpl, null, null, this.eventListener,
+            this.containerizationMetrics, null);
     dispatchManager.start();
     return dispatchManager;
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -67,7 +67,8 @@ public class ExecutionControllerTest {
   private List<Executor> allExecutors = new ArrayList<>();
   private ExecutionController controller;
   private ExecutorLoader executorLoader;
-  private ExecutionLogsLoader executionLogsLoader;
+  private ExecutionLogsLoader nearlineExecutionLogsLoader;
+  private ExecutionLogsLoader offlineExecutionLogsLoader;
   private ExecutorApiGateway apiGateway;
   private AlerterHolder alertHolder;
   private ExecutorHealthChecker executorHealthChecker;
@@ -88,14 +89,16 @@ public class ExecutionControllerTest {
     this.props = new Props();
     this.user = TestUtils.getTestUser();
     this.executorLoader = mock(ExecutorLoader.class);
-    this.executionLogsLoader = mock(ExecutionLogsLoader.class);
+    this.nearlineExecutionLogsLoader = mock(ExecutionLogsLoader.class);
+    this.offlineExecutionLogsLoader = mock(ExecutionLogsLoader.class);
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
     this.alertHolder = mock(AlerterHolder.class);
     this.executorHealthChecker = mock(ExecutorHealthChecker.class);
     this.controller = new ExecutionController(this.props, null, this.executorLoader,
-        this.executionLogsLoader, this.commonMetrics, this.apiGateway, this.alertHolder,
-        this.executorHealthChecker, this.eventListener, this.containerizationMetrics);
+        this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader, this.commonMetrics,
+        this.apiGateway, this.alertHolder, this.executorHealthChecker, this.eventListener,
+        this.containerizationMetrics);
 
     final Executor executor1 = new Executor(1, "localhost", 12345, true);
     final Executor executor2 = new Executor(2, "localhost", 12346, true);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -36,7 +36,8 @@ public class ExecutionControllerUtilsRestartFlowTest {
   private Flow flow;
   private ExecutableFlow flow1;
   private ExecutorLoader executorLoader;
-  private ExecutionLogsLoader executionLogsLoader;
+  private ExecutionLogsLoader nearlineExecutionLogsLoader;
+  private ExecutionLogsLoader offlineExecutionLogsLoader;
   private User user;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private final CommonMetrics commonMetrics = new CommonMetrics(
@@ -69,12 +70,12 @@ public class ExecutionControllerUtilsRestartFlowTest {
 
     this.executorLoader = new MockExecutorLoader();
     this.executorLoader.uploadExecutableFlow(this.flow1);
-    this.executionLogsLoader = new MockExecutionLogsLoader();
+    this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
 
     this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props, null,
-        this.executorLoader, this.executionLogsLoader, this.commonMetrics,
-        mock(ExecutorApiGateway.class), mock(ContainerizedImpl.class),null, null,
-        new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
+        this.executorLoader, this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader,
+        this.commonMetrics, mock(ExecutorApiGateway.class), mock(ContainerizedImpl.class),null,
+        null, new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
     this.projectManager = mock(ProjectManager.class);
     when(this.projectManager.getProject(projectId)).thenReturn(this.project);
 

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -9,6 +9,8 @@ import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.executor.container.ContainerizedImpl;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowUtils;
+import azkaban.logs.ExecutionLogsLoader;
+import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.metrics.MetricsManager;
@@ -33,7 +35,8 @@ public class ExecutionControllerUtilsRestartFlowTest {
   private Props props;
   private Flow flow;
   private ExecutableFlow flow1;
-  private MockExecutorLoader executorLoader;
+  private ExecutorLoader executorLoader;
+  private ExecutionLogsLoader executionLogsLoader;
   private User user;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private final CommonMetrics commonMetrics = new CommonMetrics(
@@ -66,10 +69,11 @@ public class ExecutionControllerUtilsRestartFlowTest {
 
     this.executorLoader = new MockExecutorLoader();
     this.executorLoader.uploadExecutableFlow(this.flow1);
+    this.executionLogsLoader = new MockExecutionLogsLoader();
 
     this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props, null,
-        this.executorLoader, this.commonMetrics, mock(ExecutorApiGateway.class),
-        mock(ContainerizedImpl.class),null, null,
+        this.executorLoader, this.executionLogsLoader, this.commonMetrics,
+        mock(ExecutorApiGateway.class), mock(ContainerizedImpl.class),null, null,
         new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
     this.projectManager = mock(ProjectManager.class);
     when(this.projectManager.getProject(projectId)).thenReturn(this.project);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -30,6 +30,8 @@ import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
+import azkaban.logs.ExecutionLogsLoader;
+import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.user.User;
@@ -67,7 +69,8 @@ public class ExecutorManagerTest {
   private final CommonMetrics commonMetrics = new CommonMetrics(
       new MetricsManager(new MetricRegistry()));
   private ExecutorManager manager;
-  private ExecutorLoader loader;
+  private ExecutorLoader executorLoader;
+  private ExecutionLogsLoader executionLogsLoader;
   private Props props;
   private User user;
   private ExecutableFlow flow1;
@@ -86,7 +89,8 @@ public class ExecutorManagerTest {
     this.mailAlerter = mock(Alerter.class);
     this.alertHolder = mock(AlerterHolder.class);
     when(this.alertHolder.get("email")).thenReturn(this.mailAlerter);
-    this.loader = new MockExecutorLoader();
+    this.executorLoader = new MockExecutorLoader();
+    this.executionLogsLoader = new MockExecutionLogsLoader();
     this.runningExecutions = new RunningExecutions();
     this.updaterStage = new ExecutorManagerUpdaterStage();
   }
@@ -104,8 +108,8 @@ public class ExecutorManagerTest {
   private ExecutorManager createMultiExecutorManagerInstance() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
     this.props.put(Constants.ConfigurationKeys.QUEUEPROCESSING_ENABLED, "false");
-    this.loader.addExecutor("localhost", 12345);
-    this.loader.addExecutor("localhost", 12346);
+    this.executorLoader.addExecutor("localhost", 12345);
+    this.executorLoader.addExecutor("localhost", 12346);
     return createExecutorManager();
   }
 
@@ -137,8 +141,8 @@ public class ExecutorManagerTest {
   @Test
   public void testMultipleExecutorScenario() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
+    final Executor executor1 = this.executorLoader.addExecutor("localhost", 12345);
+    final Executor executor2 = this.executorLoader.addExecutor("localhost", 12346);
 
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
@@ -150,18 +154,20 @@ public class ExecutorManagerTest {
   private ExecutorManager createExecutorManager()
       throws ExecutorManagerException {
     // TODO rename this test to ExecutorManagerIntegrationTest & create separate unit tests as well?
-    final ActiveExecutors activeExecutors = new ActiveExecutors(this.loader);
-    final ExecutionFinalizer executionFinalizer = new ExecutionFinalizer(this.loader,
+    final ActiveExecutors activeExecutors = new ActiveExecutors(this.executorLoader);
+    final ExecutionFinalizer executionFinalizer = new ExecutionFinalizer(this.executorLoader,
         this.updaterStage, this.alertHolder, this.runningExecutions);
     final RunningExecutionsUpdaterThread updaterThread = new RunningExecutionsUpdaterThread(
         new RunningExecutionsUpdater(
             this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-            this.runningExecutions, executionFinalizer, this.loader), this.runningExecutions);
+            this.runningExecutions, executionFinalizer, this.executorLoader),
+        this.runningExecutions);
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
-    final ExecutorManager executorManager = new ExecutorManager(this.props, null, this.loader,
-        this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
-        this.updaterStage, executionFinalizer, updaterThread);
+    final ExecutorManager executorManager = new ExecutorManager(this.props, null,
+        this.executorLoader, this.executionLogsLoader, this.commonMetrics, this.apiGateway,
+        this.runningExecutions, activeExecutors, this.updaterStage, executionFinalizer,
+        updaterThread);
     executorManager.setSleepAfterDispatchFailure(Duration.ZERO);
     executorManager.initialize();
     return executorManager;
@@ -173,16 +179,16 @@ public class ExecutorManagerTest {
   @Test
   public void testSetupExecutorsSucess() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.executorLoader.addExecutor("localhost", 12345);
     final ExecutorManager manager = createExecutorManager();
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
         new Executor[]{executor1});
 
     // mark older executor as inactive
     executor1.setActive(false);
-    this.loader.updateExecutor(executor1);
-    final Executor executor2 = this.loader.addExecutor("localhost", 12346);
-    final Executor executor3 = this.loader.addExecutor("localhost", 12347);
+    this.executorLoader.updateExecutor(executor1);
+    final Executor executor2 = this.executorLoader.addExecutor("localhost", 12346);
+    final Executor executor3 = this.executorLoader.addExecutor("localhost", 12347);
     manager.setupExecutors();
 
     Assert.assertArrayEquals(manager.getAllActiveExecutors().toArray(),
@@ -196,7 +202,7 @@ public class ExecutorManagerTest {
   @Test(expected = ExecutorManagerException.class)
   public void testSetupExecutorsException() throws Exception {
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
-    final Executor executor1 = this.loader.addExecutor("localhost", 12345);
+    final Executor executor1 = this.executorLoader.addExecutor("localhost", 12345);
     final ExecutorManager manager = createExecutorManager();
     final Set<Executor> activeExecutors =
         new HashSet(manager.getAllActiveExecutors());
@@ -205,7 +211,7 @@ public class ExecutorManagerTest {
 
     // mark older executor as inactive
     executor1.setActive(false);
-    this.loader.updateExecutor(executor1);
+    this.executorLoader.updateExecutor(executor1);
     manager.setupExecutors();
   }
 
@@ -244,7 +250,7 @@ public class ExecutorManagerTest {
     final List<Integer> testFlows = Arrays.asList(flow1.getExecutionId(), flow2.getExecutionId());
 
     final List<Pair<ExecutionReference, ExecutableFlow>> queuedFlowsDB =
-        this.loader.fetchQueuedFlows();
+        this.executorLoader.fetchQueuedFlows();
     Assert.assertEquals(queuedFlowsDB.size(), testFlows.size());
     // Verify things are correctly setup in db
     for (final Pair<ExecutionReference, ExecutableFlow> pair : queuedFlowsDB) {
@@ -288,7 +294,7 @@ public class ExecutorManagerTest {
 
     manager.cancelFlow(flow1, testUser.getUserId());
     final ExecutableFlow fetchedFlow =
-        this.loader.fetchExecutableFlow(flow1.getExecutionId());
+        this.executorLoader.fetchExecutableFlow(flow1.getExecutionId());
     Assert.assertEquals(fetchedFlow.getStatus(), Status.FAILED);
 
     Assert.assertFalse(manager.getRunningFlows().contains(flow1));
@@ -300,7 +306,7 @@ public class ExecutorManagerTest {
     testSetUpForRunningFlows();
     this.manager.start();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
-    when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
+    when(this.executorLoader.fetchExecutableFlow(-1)).thenReturn(flow1);
     mockFlowDoesNotExist();
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
     final ExecutableFlow fetchedFlow = waitFlowFinished(flow1);
@@ -316,7 +322,7 @@ public class ExecutorManagerTest {
     testSetUpForRunningFlows();
     this.manager.start();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
-    doReturn(flow1).when(this.loader).fetchExecutableFlow(-1);
+    doReturn(flow1).when(this.executorLoader).fetchExecutableFlow(-1);
     mockFlowDoesNotExist();
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
         .thenThrow(new ExecutorManagerException("Mocked dispatch exception"))
@@ -327,7 +333,7 @@ public class ExecutorManagerTest {
         .callWithExecutable(flow1, this.manager.fetchExecutor(1), ConnectorParams.EXECUTE_ACTION);
     verify(this.apiGateway)
         .callWithExecutable(flow1, this.manager.fetchExecutor(2), ConnectorParams.EXECUTE_ACTION);
-    verify(this.loader, Mockito.times(1)).unassignExecutor(-1);
+    verify(this.executorLoader, Mockito.times(1)).unassignExecutor(-1);
   }
 
   /**
@@ -341,7 +347,7 @@ public class ExecutorManagerTest {
     this.manager.start();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.getExecutionOptions().setFailureEmails(Arrays.asList("test@example.com"));
-    when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
+    when(this.executorLoader.fetchExecutableFlow(-1)).thenReturn(flow1);
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
         .thenThrow(new ExecutorManagerException("Mocked dispatch exception"));
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
@@ -350,7 +356,7 @@ public class ExecutorManagerTest {
         .callWithExecutable(flow1, this.manager.fetchExecutor(1), ConnectorParams.EXECUTE_ACTION);
     verify(this.apiGateway)
         .callWithExecutable(flow1, this.manager.fetchExecutor(2), ConnectorParams.EXECUTE_ACTION);
-    verify(this.loader, Mockito.times(2)).unassignExecutor(-1);
+    verify(this.executorLoader, Mockito.times(2)).unassignExecutor(-1);
     verify(this.mailAlerter).alertOnError(eq(flow1),
         eq("Failed to dispatch queued execution derived-member-data because reached "
             + "azkaban.maxDispatchingErrors (tried 2 executors)"),
@@ -381,8 +387,8 @@ public class ExecutorManagerTest {
     testSetUpForRunningFlows();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow1);
-    verify(this.loader).addActiveExecutableReference(any());
+    verify(this.executorLoader).uploadExecutableFlow(flow1);
+    verify(this.executorLoader).addActiveExecutableReference(any());
   }
 
   // Too many concurrent flows will fail job submission
@@ -402,9 +408,9 @@ public class ExecutorManagerTest {
         .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
     flow4.setExecutionId(104);
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow1);
+    verify(this.executorLoader).uploadExecutableFlow(flow1);
     this.manager.submitExecutableFlow(flow2, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow2);
+    verify(this.executorLoader).uploadExecutableFlow(flow2);
     this.manager.submitExecutableFlow(flow3, this.user.getUserId());
     this.manager.submitExecutableFlow(flow4, this.user.getUserId());
   }
@@ -428,13 +434,13 @@ public class ExecutorManagerTest {
         .createTestExecutableFlowFromYaml("basicyamlshelltest", "bashSleep");
     flow4.setExecutionId(104);
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow1);
+    verify(this.executorLoader).uploadExecutableFlow(flow1);
     this.manager.submitExecutableFlow(flow2, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow2);
+    verify(this.executorLoader).uploadExecutableFlow(flow2);
     this.manager.submitExecutableFlow(flow3, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow3);
+    verify(this.executorLoader).uploadExecutableFlow(flow3);
     this.manager.submitExecutableFlow(flow4, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow4);
+    verify(this.executorLoader).uploadExecutableFlow(flow4);
   }
 
   @Ignore
@@ -492,7 +498,7 @@ public class ExecutorManagerTest {
     this.manager.start();
     final ExecutableFlow flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
     flow1.getExecutionOptions().setFailureEmails(Arrays.asList("test@example.com"));
-    when(this.loader.fetchExecutableFlow(-1)).thenReturn(flow1);
+    when(this.executorLoader.fetchExecutableFlow(-1)).thenReturn(flow1);
 
     // fail 2 first dispatch attempts, then succeed
     when(this.apiGateway.callWithExecutable(any(), any(), eq(ConnectorParams.EXECUTE_ACTION)))
@@ -516,7 +522,7 @@ public class ExecutorManagerTest {
     verify(this.apiGateway, Mockito.times(3))
         .callWithExecutable(eq(flow1), any(), eq(ConnectorParams.EXECUTE_ACTION));
 
-    verify(this.loader, Mockito.times(2)).unassignExecutor(-1);
+    verify(this.executorLoader, Mockito.times(2)).unassignExecutor(-1);
   }
 
   @Test
@@ -530,8 +536,8 @@ public class ExecutorManagerTest {
     // unlock the flow
     flow1.setLocked(false);
     this.manager.submitExecutableFlow(flow1, this.user.getUserId());
-    verify(this.loader).uploadExecutableFlow(flow1);
-    verify(this.loader).addActiveExecutableReference(any());
+    verify(this.executorLoader).uploadExecutableFlow(flow1);
+    verify(this.executorLoader).addActiveExecutableReference(any());
   }
 
   /**
@@ -597,7 +603,7 @@ public class ExecutorManagerTest {
    * TODO: will move below method to setUp() and run before every test for both runningFlows and queuedFlows
    */
   private void testSetUpForRunningFlows() throws Exception {
-    this.loader = mock(ExecutorLoader.class);
+    this.executorLoader = mock(ExecutorLoader.class);
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.user = TestUtils.getTestUser();
     this.props.put(Constants.ConfigurationKeys.USE_MULTIPLE_EXECUTORS, "true");
@@ -614,7 +620,7 @@ public class ExecutorManagerTest {
     executors.add(executor1);
     executors.add(executor2);
 
-    when(this.loader.fetchActiveExecutors()).thenReturn(executors);
+    when(this.executorLoader.fetchActiveExecutors()).thenReturn(executors);
     this.manager = createExecutorManager();
 
     this.flow1 = TestUtils.createTestExecutableFlow("exectest1", "exec1", DispatchMethod.PUSH);
@@ -625,7 +631,7 @@ public class ExecutorManagerTest {
     this.ref2 = new ExecutionReference(this.flow2.getExecutionId(), executor2, DispatchMethod.PUSH);
     this.activeFlows.put(this.flow1.getExecutionId(), new Pair<>(this.ref1, this.flow1));
     this.activeFlows.put(this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2));
-    when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
+    when(this.executorLoader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
   }
 
   private ExecutableFlow waitFlowFinished(final ExecutableFlow flow) throws Exception {
@@ -639,7 +645,7 @@ public class ExecutorManagerTest {
   }
 
   private ExecutableFlow fetchFlow(final ExecutableFlow flow) throws ExecutorManagerException {
-    return this.loader.fetchExecutableFlow(flow.getExecutionId());
+    return this.executorLoader.fetchExecutableFlow(flow.getExecutionId());
   }
 
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -70,7 +70,8 @@ public class ExecutorManagerTest {
       new MetricsManager(new MetricRegistry()));
   private ExecutorManager manager;
   private ExecutorLoader executorLoader;
-  private ExecutionLogsLoader executionLogsLoader;
+  private ExecutionLogsLoader nearlineExecutionLogsLoader;
+  private ExecutionLogsLoader offlineExecutionLogsLoader;
   private Props props;
   private User user;
   private ExecutableFlow flow1;
@@ -90,7 +91,8 @@ public class ExecutorManagerTest {
     this.alertHolder = mock(AlerterHolder.class);
     when(this.alertHolder.get("email")).thenReturn(this.mailAlerter);
     this.executorLoader = new MockExecutorLoader();
-    this.executionLogsLoader = new MockExecutionLogsLoader();
+    this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
+    this.offlineExecutionLogsLoader = new MockExecutionLogsLoader();
     this.runningExecutions = new RunningExecutions();
     this.updaterStage = new ExecutorManagerUpdaterStage();
   }
@@ -165,8 +167,9 @@ public class ExecutorManagerTest {
     updaterThread.waitTimeIdleMs = 0;
     updaterThread.waitTimeMs = 0;
     final ExecutorManager executorManager = new ExecutorManager(this.props, null,
-        this.executorLoader, this.executionLogsLoader, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, activeExecutors, this.updaterStage, executionFinalizer,
+        this.executorLoader, this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader,
+        this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
+        this.updaterStage, executionFinalizer,
         updaterThread);
     executorManager.setSleepAfterDispatchFailure(Duration.ZERO);
     executorManager.initialize();

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -139,20 +139,6 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public void uploadLogFile(final int execId, final String name, final int attempt,
-      final File... files)
-      throws ExecutorManagerException {
-    for (final File file : files) {
-      try {
-        final String logs = FileUtils.readFileToString(file, "UTF-8");
-        LOGGER.info("Uploaded log for [" + name + "]:[" + execId + "]:\n" + logs);
-      } catch (final IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
-  @Override
   public void updateExecutableFlow(final ExecutableFlow flow)
       throws ExecutorManagerException {
     final ExecutableFlow toUpdate = this.flows.get(flow.getExecutionId());
@@ -225,14 +211,6 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte,
-      final int endByte) throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
   public List<ExecutableFlow> fetchFlowHistory(final int skip, final int num)
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
@@ -294,13 +272,6 @@ public class MockExecutorLoader implements ExecutorLoader {
       throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
-  }
-
-  @Override
-  public int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
-      throws ExecutorManagerException {
-    // TODO Auto-generated method stub
-    return 0;
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/logs/MockExecutionLogsLoader.java
+++ b/azkaban-common/src/test/java/azkaban/logs/MockExecutionLogsLoader.java
@@ -1,0 +1,49 @@
+package azkaban.logs;
+
+import azkaban.executor.ExecutorLoader;
+import azkaban.executor.ExecutorManagerException;
+import azkaban.executor.MockExecutorLoader;
+import azkaban.utils.FileIOUtils.LogData;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Used in unit tests to mock the "DB layer" (the real implementation is JdbcExecutionsLogLoader).
+ * Captures status updates of jobs and flows (in memory) so that they can be checked in tests.
+ */
+public class MockExecutionLogsLoader implements ExecutionLogsLoader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MockExecutionLogsLoader.class);
+
+  @Override
+  public void uploadLogFile(final int execId, final String name, final int attempt,
+      final File... files)
+      throws ExecutorManagerException {
+    for (final File file : files) {
+      try {
+        final String logs = FileUtils.readFileToString(file, "UTF-8");
+        LOGGER.info("Uploaded log for [" + name + "]:[" + execId + "]:\n" + logs);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public LogData fetchLogs(final int execId, final String name, final int attempt,
+      final int startByte,
+      final int endByte) throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int removeExecutionLogsByTime(final long millis, final int recordCleanupLimit)
+      throws ExecutorManagerException {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -31,6 +31,8 @@ import azkaban.executor.MockExecutorLoader;
 import azkaban.executor.RunningExecutions;
 import azkaban.executor.RunningExecutionsUpdater;
 import azkaban.executor.RunningExecutionsUpdaterThread;
+import azkaban.logs.ExecutionLogsLoader;
+import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.trigger.builtin.CreateTriggerAction;
@@ -49,7 +51,8 @@ public class TriggerManagerDeadlockTest {
 
   TriggerLoader loader;
   TriggerManager triggerManager;
-  ExecutorLoader execLoader;
+  ExecutorLoader executorLoader;
+  ExecutionLogsLoader executionLogsLoader;
   ExecutorApiGateway apiGateway;
   RunningExecutions runningExecutions;
   private ExecutorManagerUpdaterStage updaterStage;
@@ -63,12 +66,13 @@ public class TriggerManagerDeadlockTest {
     final Props props = new Props();
     props.put("trigger.scan.interval", 1000);
     props.put(ConfigurationKeys.EXECUTOR_PORT, 12321);
-    this.execLoader = new MockExecutorLoader();
+    this.executorLoader = new MockExecutorLoader();
+    this.executionLogsLoader = new MockExecutionLogsLoader();
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.runningExecutions = new RunningExecutions();
     this.updaterStage = new ExecutorManagerUpdaterStage();
     this.alertHolder = mock(AlerterHolder.class);
-    this.executionFinalizer = new ExecutionFinalizer(this.execLoader,
+    this.executionFinalizer = new ExecutionFinalizer(this.executorLoader,
         this.updaterStage, this.alertHolder, this.runningExecutions);
     this.commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
     final ExecutorManager executorManager = getExecutorManager(props);
@@ -76,17 +80,18 @@ public class TriggerManagerDeadlockTest {
   }
 
   private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {
-    final ActiveExecutors activeExecutors = new ActiveExecutors(this.execLoader);
+    final ActiveExecutors activeExecutors = new ActiveExecutors(this.executorLoader);
     final RunningExecutionsUpdaterThread updaterThread = getRunningExecutionsUpdaterThread();
-    return new ExecutorManager(props, null, this.execLoader, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, activeExecutors, this.updaterStage, this.executionFinalizer,
-        updaterThread);
+    return new ExecutorManager(props, null, this.executorLoader, this.executionLogsLoader,
+        this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
+        this.updaterStage, this.executionFinalizer, updaterThread);
   }
 
   private RunningExecutionsUpdaterThread getRunningExecutionsUpdaterThread() {
     return new RunningExecutionsUpdaterThread(new RunningExecutionsUpdater(
         this.updaterStage, this.alertHolder, this.commonMetrics, this.apiGateway,
-        this.runningExecutions, this.executionFinalizer, this.execLoader), this.runningExecutions);
+        this.runningExecutions, this.executionFinalizer, this.executorLoader),
+        this.runningExecutions);
   }
 
   @After

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -52,7 +52,8 @@ public class TriggerManagerDeadlockTest {
   TriggerLoader loader;
   TriggerManager triggerManager;
   ExecutorLoader executorLoader;
-  ExecutionLogsLoader executionLogsLoader;
+  ExecutionLogsLoader nearlineExecutionLogsLoader;
+  ExecutionLogsLoader offlineExecutionLogsLoader;
   ExecutorApiGateway apiGateway;
   RunningExecutions runningExecutions;
   private ExecutorManagerUpdaterStage updaterStage;
@@ -67,7 +68,8 @@ public class TriggerManagerDeadlockTest {
     props.put("trigger.scan.interval", 1000);
     props.put(ConfigurationKeys.EXECUTOR_PORT, 12321);
     this.executorLoader = new MockExecutorLoader();
-    this.executionLogsLoader = new MockExecutionLogsLoader();
+    this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
+    this.offlineExecutionLogsLoader = new MockExecutionLogsLoader();
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.runningExecutions = new RunningExecutions();
     this.updaterStage = new ExecutorManagerUpdaterStage();
@@ -82,9 +84,10 @@ public class TriggerManagerDeadlockTest {
   private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {
     final ActiveExecutors activeExecutors = new ActiveExecutors(this.executorLoader);
     final RunningExecutionsUpdaterThread updaterThread = getRunningExecutionsUpdaterThread();
-    return new ExecutorManager(props, null, this.executorLoader, this.executionLogsLoader,
-        this.commonMetrics, this.apiGateway, this.runningExecutions, activeExecutors,
-        this.updaterStage, this.executionFinalizer, updaterThread);
+    return new ExecutorManager(props, null, this.executorLoader, this.nearlineExecutionLogsLoader,
+        this.offlineExecutionLogsLoader, this.commonMetrics, this.apiGateway,
+        this.runningExecutions, activeExecutors, this.updaterStage, this.executionFinalizer,
+        updaterThread);
   }
 
   private RunningExecutionsUpdaterThread getRunningExecutionsUpdaterThread() {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecServerModule.java
@@ -19,8 +19,6 @@ package azkaban.execapp;
 
 import azkaban.cluster.ClusterModule;
 import azkaban.common.ExecJettyServerModule;
-import azkaban.executor.ExecutorLoader;
-import azkaban.executor.JdbcExecutorLoader;
 import com.google.inject.AbstractModule;
 
 
@@ -35,7 +33,6 @@ public class AzkabanExecServerModule extends AbstractModule {
   protected void configure() {
     install(new ExecJettyServerModule());
     install(new ClusterModule());
-    bind(ExecutorLoader.class).to(JdbcExecutorLoader.class);
   }
 
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -38,6 +38,8 @@ import azkaban.flow.FlowUtils;
 import azkaban.imagemgmt.version.VersionSet;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
+import azkaban.logs.ExecutionLogsLoader;
+import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.project.FlowLoader;
@@ -72,6 +74,7 @@ public class FlowRunnerTestUtil {
   private final File projectDir;
   private final ProjectLoader projectLoader;
   private ExecutorLoader executorLoader;
+  private final ExecutionLogsLoader executionLogsLoader;
   private final ProjectFileHandler handler;
 
   public FlowRunnerTestUtil(final String flowName, final TemporaryFolder temporaryFolder)
@@ -86,6 +89,7 @@ public class FlowRunnerTestUtil {
 
     this.executorLoader = mock(ExecutorLoader.class);
     when(this.executorLoader.updateExecutableReference(anyInt(), anyLong())).thenReturn(true);
+    this.executionLogsLoader = mock(ExecutionLogsLoader.class);
 
     this.projectLoader = mock(ProjectLoader.class);
     this.handler = new ProjectFileHandler(1, 1, 1, "testUser", "zip", "test.zip",
@@ -281,7 +285,7 @@ public class FlowRunnerTestUtil {
     final CommonMetrics commonMetrics = new CommonMetrics(metricsManager);
     final ExecMetrics execMetrics = new ExecMetrics(metricsManager);
     final FlowRunner runner =
-        new FlowRunner(exFlow, this.executorLoader, this.projectLoader,
+        new FlowRunner(exFlow, this.executorLoader, this.executionLogsLoader, this.projectLoader,
             this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), commonMetrics,
             execMetrics);
     if (eventCollector != null) {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/JobRunnerTest.java
@@ -34,6 +34,8 @@ import azkaban.imagemgmt.version.VersionSet;
 import azkaban.jobExecutor.JobClassLoader;
 import azkaban.jobtype.JobTypeManager;
 import azkaban.jobtype.JobTypePluginSet;
+import azkaban.logs.ExecutionLogsLoader;
+import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.spi.EventType;
 import azkaban.test.TestUtils;
 import azkaban.utils.Props;
@@ -94,10 +96,12 @@ public class JobRunnerTest {
 
   @Test
   public void testEffectiveUser() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     runner.run();
     String effectiveUser = runner.getEffectiveUser();
     Assert.assertEquals(SUBMIT_USER, effectiveUser);
@@ -107,8 +111,8 @@ public class JobRunnerTest {
         .addDefaultProxyUsersJobTypeClasses(InteractiveTestJob.class.getName());
     this.jobtypeManager.getJobTypePluginSet().addDefaultProxyUser("test", "defaultTestUser");
 
-    runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+    runner = createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+        eventCollector);
     runner.run();
     effectiveUser = runner.getEffectiveUser();
     Mockito.verify(runner.getFlowRunnerProxy(), Mockito.times(1)).setEffectiveUser(runner.getJobId(),
@@ -119,10 +123,12 @@ public class JobRunnerTest {
 
   @Test
   public void testBasicRun() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     final ExecutableNode node = runner.getNode();
     // Job starts to queue
     runner.setTimeInQueue(System.currentTimeMillis());
@@ -164,7 +170,7 @@ public class JobRunnerTest {
     // Verify that user.to.proxy is default to submit user.
     Assert.assertEquals(SUBMIT_USER, runner.getProps().get(JobProperties.USER_TO_PROXY));
 
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == 3);
 
     Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector
@@ -198,10 +204,12 @@ public class JobRunnerTest {
 
   @Test
   public void testFailedRun() {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, true, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, true, executorLoader, executionLogsLoader,
+            eventCollector);
     final ExecutableNode node = runner.getNode();
 
     Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED
@@ -218,7 +226,7 @@ public class JobRunnerTest {
     Assert.assertTrue(logFile.exists());
     Assert.assertTrue(eventCollector.checkOrdering());
     Assert.assertTrue(!runner.isKilled());
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == 3);
     // Check failureMessage and modifiedBy
     Assert.assertEquals("unknown", runner.getNode().getModifiedBy());
     Assert.assertEquals("java.lang.RuntimeException: Forced"
@@ -234,10 +242,12 @@ public class JobRunnerTest {
 
   @Test
   public void testDisabledRun() {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     final ExecutableNode node = runner.getNode();
 
     node.setStatus(Status.DISABLED);
@@ -258,7 +268,7 @@ public class JobRunnerTest {
     Assert.assertTrue(runner.getLogFilePath() == null);
     Assert.assertTrue(eventCollector.checkOrdering());
 
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == null);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == null);
 
     Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.JOB_STARTED, EventType.JOB_FINISHED);
@@ -269,10 +279,12 @@ public class JobRunnerTest {
 
   @Test
   public void testPreKilledRun() {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     final ExecutableNode node = runner.getNode();
 
     node.setStatus(Status.KILLED);
@@ -288,7 +300,7 @@ public class JobRunnerTest {
     // Give it 2000 ms to fail.
     Assert.assertTrue(node.getEndTime() - node.getStartTime() < 2000);
 
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == null);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == null);
 
     // Log file and output files should not exist.
     final Props outputProps = runner.getNode().getOutputProps();
@@ -304,10 +316,12 @@ public class JobRunnerTest {
 
   @Test
   public void testCancelRun() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(13, "testJob", 10, false, loader, eventCollector);
+        createJobRunner(13, "testJob", 10, false, executorLoader, executionLogsLoader,
+            eventCollector);
     final ExecutableNode node = runner.getNode();
 
     Assert.assertTrue(runner.getStatus() != Status.SUCCEEDED
@@ -329,7 +343,7 @@ public class JobRunnerTest {
     Assert.assertTrue(node.getStartTime() > 0 && node.getEndTime() > 0);
     // Give it some time to fail.
     Assert.assertTrue(node.getEndTime() - node.getStartTime() < 3000);
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == 3);
     // Check job kill time, user killed the job, and failure message
     Assert.assertEquals("dementor1", runner.getNode().getModifiedBy());
     Assert.assertTrue(runner.getJobKillTime() != -1);
@@ -349,10 +363,12 @@ public class JobRunnerTest {
 
   @Test
   public void testDelayedExecutionJob() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     runner.setDelayStart(10_000);
     final long startTime = System.currentTimeMillis();
     final ExecutableNode node = runner.getNode();
@@ -385,7 +401,7 @@ public class JobRunnerTest {
     Assert.assertTrue(outputProps != null);
     Assert.assertTrue(logFile.exists());
     Assert.assertFalse(runner.isKilled());
-    Assert.assertTrue(loader.getNodeUpdateCount(node.getId()) == 3);
+    Assert.assertTrue(executorLoader.getNodeUpdateCount(node.getId()) == 3);
 
     Assert.assertTrue(eventCollector.checkOrdering());
     Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
@@ -395,10 +411,12 @@ public class JobRunnerTest {
 
   @Test
   public void testDelayedExecutionCancelledJob() throws Exception {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector);
     runner.setDelayStart(10_000);
     final long startTime = System.currentTimeMillis();
     final ExecutableNode node = runner.getNode();
@@ -435,19 +453,21 @@ public class JobRunnerTest {
 
     // wait so that there's time to make the "DB update" for KILLED status
     TestUtils.await().untilAsserted(
-        () -> assertThat(loader.getNodeUpdateCount("testJob")).isEqualTo(2));
+        () -> assertThat(executorLoader.getNodeUpdateCount("testJob")).isEqualTo(2));
     Assert.assertFalse(runner.getLogger().getAllAppenders().hasMoreElements());
     eventCollector.assertEvents(EventType.JOB_FINISHED);
   }
 
   @Test
   public void testCustomLogLayout() throws IOException {
-    final MockExecutorLoader loader = new MockExecutorLoader();
+    final MockExecutorLoader executorLoader = new MockExecutorLoader();
+    final MockExecutionLogsLoader executionLogsLoader = new MockExecutionLogsLoader();
     final EventCollectorListener eventCollector = new EventCollectorListener();
     final Props azkabanProps = new Props();
     azkabanProps.put(JobProperties.JOB_LOG_LAYOUT, "TEST %c{1} %p - %m\n");
     final JobRunner runner =
-        createJobRunner(1, "testJob", 0, false, loader, eventCollector, azkabanProps);
+        createJobRunner(1, "testJob", 0, false, executorLoader, executionLogsLoader,
+            eventCollector, azkabanProps);
     runner.run();
     try (final BufferedReader br = getLogReader(runner.getLogFile())) {
       final String firstLine = br.readLine();
@@ -466,12 +486,16 @@ public class JobRunnerTest {
   }
 
   private JobRunner createJobRunner(final int execId, final String name, final int time,
-      final boolean fail, final ExecutorLoader loader, final EventCollectorListener listener) {
-    return createJobRunner(execId, name, time, fail, loader, listener, new Props());
+      final boolean fail, final ExecutorLoader executorLoader,
+      final ExecutionLogsLoader executionLogsLoader, final EventCollectorListener listener) {
+    return createJobRunner(execId, name, time, fail, executorLoader, executionLogsLoader, listener,
+        new Props());
   }
 
   private JobRunner createJobRunner(final int execId, final String name, final int time,
-      final boolean fail, final ExecutorLoader loader, final EventCollectorListener listener, Props jobProps) {
+      final boolean fail, final ExecutorLoader executorLoader,
+      final ExecutionLogsLoader executionLogsLoader, final EventCollectorListener listener,
+      Props jobProps) {
     final Props azkabanProps = new Props();
     final ExecutableFlow flow = new ExecutableFlow();
     flow.setExecutionId(execId);
@@ -489,8 +513,8 @@ public class JobRunnerTest {
     final HashSet<String> proxyUsers = new HashSet<>();
     proxyUsers.add(flow.getSubmitUser());
     FlowRunnerProxy flowRunnerProxy = Mockito.mock(FlowRunnerProxy.class);
-    final JobRunner runner = new JobRunner(node, this.workingDir, loader, this.jobtypeManager,
-        azkabanProps, flowRunnerProxy);
+    final JobRunner runner = new JobRunner(node, this.workingDir, executorLoader,
+        executionLogsLoader, this.jobtypeManager, azkabanProps, flowRunnerProxy);
     runner.setLogSettings(this.logger, "5MB", 4);
 
     runner.addListener(listener);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/event/RemoteFlowWatcherTest.java
@@ -21,6 +21,7 @@ import azkaban.execapp.FlowRunnerTestUtil;
 import azkaban.executor.InteractiveTestJob;
 import azkaban.executor.MockExecutorLoader;
 import azkaban.executor.Status;
+import azkaban.logs.MockExecutionLogsLoader;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -16,7 +16,6 @@
 package azkaban.webapp;
 
 import static azkaban.Constants.AZKABAN_SERVLET_CONTEXT_KEY;
-import static azkaban.Constants.ConfigurationKeys.DEFAULT_TIMEZONE_ID;
 import static azkaban.Constants.ConfigurationKeys.ENABLE_QUARTZ;
 import static azkaban.Constants.MAX_FORM_CONTENT_SIZE;
 import static azkaban.ServiceProvider.SERVICE_PROVIDER;
@@ -111,7 +110,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.TimeZone;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -121,7 +119,6 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.jmx.HierarchyDynamicMBean;
 import org.apache.velocity.app.VelocityEngine;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.joda.time.DateTimeZone;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
@@ -1,13 +1,16 @@
 package azkaban.webapp;
 
+import static azkaban.Constants.LogConstants.NEARLINE_LOGS;
+
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.executor.ExecutorLoader;
+import azkaban.logs.ExecutionLogsLoader;
 import azkaban.utils.Props;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -19,7 +22,7 @@ public class ExecutionLogsCleaner {
 
    private static final Logger logger = LoggerFactory.getLogger(ExecutionLogsCleaner.class);
    private final ScheduledExecutorService scheduler;
-   private final ExecutorLoader executorLoader;
+   private final ExecutionLogsLoader executionLogsLoader;
    private final Props azkProps;
    private long executionLogsRetentionMs;
    // 12 weeks
@@ -33,10 +36,13 @@ public class ExecutionLogsCleaner {
    private static final int DEFAULT_LOG_CLEANUP_RECORD_LIMIT = 1000;
    private int executionLogCleanupRecordLimit;
 
+   // Only applicable to nearline/jdbc logs.
+   // We expect offline logs to be managed by another platform where retention is handled well.
    @Inject
-   public ExecutionLogsCleaner(final Props azkProps, final ExecutorLoader executorLoader) {
+   public ExecutionLogsCleaner(final Props azkProps,
+       final @Named(NEARLINE_LOGS) ExecutionLogsLoader executionLogsLoader) {
       this.azkProps = azkProps;
-      this.executorLoader = executorLoader;
+      this.executionLogsLoader = executionLogsLoader;
       this.scheduler =
           Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat(
               "azk-execlog-cleaner").build());
@@ -69,7 +75,8 @@ public class ExecutionLogsCleaner {
    private void cleanOldExecutionLogs(final long millis) {
       final long beforeDeleteLogsTimestamp = System.currentTimeMillis();
       try {
-         final int count = this.executorLoader.removeExecutionLogsByTime(millis, this.executionLogCleanupRecordLimit);
+         final int count = this.executionLogsLoader.removeExecutionLogsByTime(millis,
+             this.executionLogCleanupRecordLimit);
          logger.info("Cleaned up " + count + " log entries.");
       } catch (final Exception e) {
          logger.error("log clean up failed. ", e);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/ExecutionLogsCleaner.java
@@ -25,9 +25,8 @@ public class ExecutionLogsCleaner {
    private final ExecutionLogsLoader executionLogsLoader;
    private final Props azkProps;
    private long executionLogsRetentionMs;
-   // 12 weeks
-   private static final long DEFAULT_EXECUTION_LOGS_RETENTION_MS = 3 * 4 * 7
-       * 24 * 60 * 60 * 1000L;
+   // 30 days
+   private static final long DEFAULT_EXECUTION_LOGS_RETENTION_MS = 30 * 24 * 60 * 60 * 1000L;
 
    // 1 hour
    private static final long DEFAULT_LOG_CLEANUP_INTERVAL_SECONDS = 60 * 60;

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1068,6 +1068,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
               "ExecutorManagerAdapter is not of type: " + ContainerizedDispatchManager.class
                   .getName());
         }
+      } else if (propType.equals("general")) {
+        updateGeneralProps(req, ret);
       } else {
         ret.put("error", "Unsupported propType: " + propType);
       }
@@ -1107,6 +1109,21 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       case REMOVE_FROM_DENY_LIST:
         containerizedDispatchManager.getContainerProxyUserCriteria()
             .removeFromDenyList(ServletUtils.getSetFromString(val));
+        break;
+      default:
+        break;
+    }
+  }
+
+  private void updateGeneralProps(final HttpServletRequest req,
+      final HashMap<String, Object> ret)
+      throws ServletException {
+    String subType = getParam(req, "subType");
+    GeneralPropUpdate generalPropUpdate = GeneralPropUpdate.fromParam(subType);
+    String val = getParam(req, "val");
+    switch (generalPropUpdate) {
+      case ENABLE_OFFLINE_LOGS_LOADER:
+        this.executorManagerAdapter.enableOfflineLogsLoader(Boolean.parseBoolean(val));
         break;
       default:
         break;
@@ -1165,6 +1182,30 @@ enum ContainerPropUpdate {
       }
     }
     throw new IllegalArgumentException(
-        "No ContainerPropUpdates corresponding to param value " + param);
+        "No ContainerPropUpdate corresponding to param value " + param);
+  }
+}
+
+enum GeneralPropUpdate {
+  ENABLE_OFFLINE_LOGS_LOADER("enableOfflineLogsLoader");
+
+  private final String param;
+
+  GeneralPropUpdate(String param) {
+    this.param = param;
+  }
+
+  public String getParam() {
+    return param;
+  }
+
+  public static GeneralPropUpdate fromParam(String param) {
+    for (GeneralPropUpdate value : GeneralPropUpdate.values()) {
+      if (value.getParam().equals(param)) {
+        return value;
+      }
+    }
+    throw new IllegalArgumentException(
+        "No GeneralPropUpdate corresponding to param value " + param);
   }
 }

--- a/azkaban-web-server/src/test/java/azkaban/webapp/ExecutionLogsCleanerTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/ExecutionLogsCleanerTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 
 import azkaban.Constants.ConfigurationKeys;
-import azkaban.executor.ExecutorLoader;
+import azkaban.logs.JdbcExecutionLogsLoader;
 import azkaban.utils.Props;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -15,7 +15,7 @@ import org.mockito.Mockito;
 
 public class ExecutionLogsCleanerTest {
   private Props props;
-  private ExecutorLoader loader;
+  private JdbcExecutionLogsLoader loader;
   private ExecutionLogsCleaner executionLogsCleaner;
 
   @Before
@@ -23,7 +23,7 @@ public class ExecutionLogsCleanerTest {
     this.props = new Props();
     /* This config will set the thread to run every 2 seconds */
     this.props.put(ConfigurationKeys.EXECUTION_LOGS_CLEANUP_INTERVAL_SECONDS, 2);
-    this.loader = mock(ExecutorLoader.class);
+    this.loader = mock(JdbcExecutionLogsLoader.class);
     this.executionLogsCleaner = new ExecutionLogsCleaner(this.props, this.loader);
   }
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -131,7 +131,8 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
   @Test
   public void testPostAjaxUpdateProperty() throws Exception {
     ContainerizedDispatchManager containerizedDispatchManager = new ContainerizedDispatchManager(
-        new Props(), null, null, null, null, null, null, null, new DummyEventListener(),
+        new Props(), null, null, null, null,
+        null, null, null, null, new DummyEventListener(),
         new DummyContainerizationMetricsImpl(), null);
     Mockito.when(this.azkabanWebServer.getExecutorManager())
         .thenReturn(containerizedDispatchManager);

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -16,8 +16,13 @@
 package azkaban.webapp.servlet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
 
+import azkaban.executor.AbstractExecutorManagerAdapter;
 import azkaban.executor.container.ContainerizedDispatchManager;
 import azkaban.executor.DummyEventListener;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
@@ -36,6 +41,7 @@ import org.codehaus.jackson.JsonNode;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
@@ -129,9 +135,9 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
   }
 
   @Test
-  public void testPostAjaxUpdateProperty() throws Exception {
+  public void testPostAjaxUpdateContainerProperty() throws Exception {
     ContainerizedDispatchManager containerizedDispatchManager = new ContainerizedDispatchManager(
-        new Props(), null, null, null, null,
+        new Props(), null, null, null, null, null,
         null, null, null, null, new DummyEventListener(),
         new DummyContainerizationMetricsImpl(), null);
     Mockito.when(this.azkabanWebServer.getExecutorManager())
@@ -186,5 +192,33 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
     this.executorServlet.handlePost(this.req, this.res, this.session);
     output = containerizedDispatchManager.getContainerProxyUserCriteria().getDenyList();
     assertEquals(ImmutableSet.of("azdev"), output);
+  }
+
+  @Test
+  public void testPostAjaxUpdateGeneralProperty() throws Exception {
+    AbstractExecutorManagerAdapter abstractExecutorManagerAdapter =
+        mock(AbstractExecutorManagerAdapter.class);
+    Mockito.doCallRealMethod().when(abstractExecutorManagerAdapter).enableOfflineLogsLoader(anyBoolean());
+    Mockito.doCallRealMethod().when(abstractExecutorManagerAdapter).isOfflineLogsLoaderEnabled();
+    Mockito.when(this.azkabanWebServer.getExecutorManager())
+        .thenReturn(abstractExecutorManagerAdapter);
+    this.executorServlet.init(this.servletConfig);
+
+    this.req.addParameter("ajax", "updateProp");
+    this.req.addParameter("propType", "general");
+
+    this.req.removeParameter("subType");
+    this.req.removeParameter("val");
+    this.req.addParameter("subType", "enableOfflineLogsLoader");
+    this.req.addParameter("val","true");
+    this.executorServlet.handlePost(this.req, this.res, this.session);
+    assertTrue(abstractExecutorManagerAdapter.isOfflineLogsLoaderEnabled());
+
+    this.req.removeParameter("subType");
+    this.req.removeParameter("val");
+    this.req.addParameter("subType", "enableOfflineLogsLoader");
+    this.req.addParameter("val","false");
+    this.executorServlet.handlePost(this.req, this.res, this.session);
+    assertFalse(abstractExecutorManagerAdapter.isOfflineLogsLoaderEnabled());
   }
 }

--- a/docs/howTo.rst
+++ b/docs/howTo.rst
@@ -82,3 +82,10 @@ property to your appender:
 .. code-block:: guess
 
    azkaban.logging.kafka.class=a.b.c.yourKafkaLog4jAppender
+
+You can use following properties to view the logs emitted by kafka log4j appender:
+
+.. code-block:: guess
+
+   azkaban.offline.logging.enabled=true
+   azkaban.offline.logging.class=a.b.c.yourKafkaLogViewer


### PR DESCRIPTION
New log read logic in AbstractExecutorManagerAdapter.java:
1. Read from local file if execution is running
2. Read from MySQL/NearlineExecutionLogsLoader for nearline
3. Read from external logs loader / OfflineExecutionLogsLoader emitted by Kafka log4j appender if pod/execution is crashed OR no logs available in NearlineExecutionLogsLoader/MySQL
3.1. Inject dependencies NearlineExecutionLogsLoader and OfflineExecutionLogsLoader in AzkabanCommonModule
4. Introduce new API endpoint to turn on/off OfflineExecutionLogsLoader in web server at runtime: /executor?ajax=updateProp&propType=general&subType= enableOfflineLogsLoader&val=true

Since we have OfflineExecutionLogsLoader ready, we will reduce the default MySQL retention period from 12 weeks to 30 days.