### PR TITLE
Fix bug when job callback is triggered in web server and job node is …

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -421,10 +421,12 @@ public class ExecutionControllerUtils {
     // Fire correct JOB_STARTED and JOB_FINISHED events.
     if (eventHandler != null && projectManager != null) {
       final Project project = projectManager.getProject(exFlow.getProjectId());
-      final Flow flow = project.getFlow(exFlow.getFlowId());
       for (Entry<ExecutableNode, Status> entry: nodeToOrigStatus.entrySet()) {
         final ExecutableNode node = entry.getKey();
         final Status origStatus = entry.getValue();
+        // We shouldn't use project.getFlow(exFlow.getFlowId()) b/c the node might be in embedded
+        // flows and exFlow might be the ancestor flow but not node's direct parent flow.
+        final Flow flow = project.getFlow(node.getParentFlow().getFlowId());
 
         // Fill in job props by following the logic in ProjectManagerServlet.
         if (node.getInputProps() == null) {


### PR DESCRIPTION
…running in flow2.0 & under embeded flows

When using projectManager.getJobOverrideProperty or projectManager.getProperties, the flow should be the direct parent flow of node instead of ancestor flow of the node in flow2.0.