### PR TITLE
Revert "Revert "Use Apache's Parquet-Avro which uses Avro 1.9.2 (#2810)"" and fix Avro HDFS file viewer bugs

### DIFF
--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/AvroFileViewer.java
@@ -34,10 +34,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AccessControlException;
 import org.apache.log4j.Logger;
 
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-
 /**
  * This class implements a viewer of avro files
  *
@@ -156,17 +152,13 @@ public class AvroFileViewer extends HdfsFileViewer {
     }
 
     DataFileStream<Object> avroDatastream = null;
-    JsonGenerator g = null;
 
     try {
       avroDatastream = getAvroDataStream(fs, path);
       Schema schema = avroDatastream.getSchema();
       DatumWriter<Object> avroWriter = new GenericDatumWriter<Object>(schema);
 
-      g = new JsonFactory().createJsonGenerator(
-          outputStream, JsonEncoding.UTF8);
-      g.useDefaultPrettyPrinter();
-      Encoder encoder = EncoderFactory.get().jsonEncoder(schema, g);
+      Encoder encoder = EncoderFactory.get().jsonEncoder(schema, outputStream, true);
 
       long endTime = System.currentTimeMillis() + STOP_TIME;
       int lineno = 1; // line number starts from 1
@@ -186,10 +178,9 @@ public class AvroFileViewer extends HdfsFileViewer {
           .getLocalizedMessage()).getBytes("UTF-8"));
       throw e;
     } finally {
-      if (g != null) {
-        g.close();
+      if (avroDatastream != null) {
+        avroDatastream.close();
       }
-      avroDatastream.close();
     }
   }
 

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ParquetFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ParquetFileViewer.java
@@ -30,8 +30,8 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
-import org.apache.parquet.avro.AvroParquetReader;
-import org.apache.parquet.avro.AvroSchemaConverter;
+import parquet.avro.AvroParquetReader;
+import parquet.avro.AvroSchemaConverter;
 
 /**
  * This class implements a viewer for Parquet files.

--- a/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ParquetFileViewer.java
+++ b/az-hdfs-viewer/src/main/java/azkaban/viewer/hdfs/ParquetFileViewer.java
@@ -29,15 +29,9 @@ import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.AccessControlException;
 import org.apache.log4j.Logger;
-
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-
-import parquet.avro.AvroParquetReader;
-import parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroSchemaConverter;
 
 /**
  * This class implements a viewer for Parquet files.
@@ -45,10 +39,10 @@ import parquet.avro.AvroSchemaConverter;
  * @author David Z. Chen (dchen@linkedin.com)
  */
 public class ParquetFileViewer extends HdfsFileViewer {
-  private static Logger logger = Logger.getLogger(ParquetFileViewer.class);
+  private static final Logger logger = Logger.getLogger(ParquetFileViewer.class);
 
   // Will spend 5 seconds trying to pull data and then stop.
-  private final static long STOP_TIME = 2000l;
+  private final static long STOP_TIME = 2000L;
 
   private static final String VIEWER_NAME = "Parquet";
 
@@ -58,15 +52,14 @@ public class ParquetFileViewer extends HdfsFileViewer {
   }
 
   @Override
-  public Set<Capability> getCapabilities(FileSystem fs, Path path)
-      throws AccessControlException {
+  public Set<Capability> getCapabilities(FileSystem fs, Path path) {
     if (logger.isDebugEnabled()) {
       logger.debug("Parquet file path: " + path.toUri().getPath());
     }
 
     AvroParquetReader<GenericRecord> parquetReader = null;
     try {
-      parquetReader = new AvroParquetReader<GenericRecord>(path);
+      parquetReader = new AvroParquetReader<>(path);
     } catch (IOException e) {
       if (logger.isDebugEnabled()) {
         logger.debug(path.toUri().getPath() + " is not a Parquet file.");
@@ -93,16 +86,9 @@ public class ParquetFileViewer extends HdfsFileViewer {
       logger.debug("Display Parquet file: " + path.toUri().getPath());
     }
 
-    JsonGenerator json = null;
     AvroParquetReader<GenericRecord> parquetReader = null;
     try {
-      parquetReader = new AvroParquetReader<GenericRecord>(path);
-
-      // Initialize JsonGenerator.
-      json =
-          new JsonFactory()
-              .createJsonGenerator(outputStream, JsonEncoding.UTF8);
-      json.useDefaultPrettyPrinter();
+      parquetReader = new AvroParquetReader<>(path);
 
       // Declare the avroWriter encoder that will be used to output the records
       // as JSON but don't construct them yet because we need the first record
@@ -121,7 +107,7 @@ public class ParquetFileViewer extends HdfsFileViewer {
         if (avroWriter == null) {
           Schema schema = record.getSchema();
           avroWriter = new GenericDatumWriter<GenericRecord>(schema);
-          encoder = EncoderFactory.get().jsonEncoder(schema, json);
+          encoder = EncoderFactory.get().jsonEncoder(schema, outputStream, true);
         }
 
         if (line >= startLine) {
@@ -138,12 +124,10 @@ public class ParquetFileViewer extends HdfsFileViewer {
       throw e;
     } catch (Throwable t) {
       logger.error(t.getMessage());
-      return;
     } finally {
-      if (json != null) {
-        json.close();
+      if (parquetReader != null) {
+        parquetReader.close();
       }
-      parquetReader.close();
     }
   }
 
@@ -152,7 +136,7 @@ public class ParquetFileViewer extends HdfsFileViewer {
     String schema = null;
     try {
       AvroParquetReader<GenericRecord> parquetReader =
-          new AvroParquetReader<GenericRecord>(path);
+          new AvroParquetReader<>(path);
       GenericRecord record = parquetReader.read();
       if (record == null) {
         return null;

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ ext.deps = [
     mongoDriver          : 'org.mongodb:mongo-java-driver:2.14.0',
     mysqlConnector       : 'mysql:mysql-connector-java:8.0.20',
     pig                  : 'org.apache.pig:pig:' + versions.pig,
-    parquetAvro          : 'org.apache.parquet:parquet-avro:1.11.1',
+    parquetAvro          : 'com.twitter:parquet-avro:1.6.0',
     parquetBundle        : 'com.twitter:parquet-hadoop-bundle:1.3.2',
     powermock            : 'org.powermock:powermock-api-mockito2:2.0.2',
     powermockmodulejunit4: 'org.powermock:powermock-module-junit4:2.0.2',

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ ext.deps = [
     mongoDriver          : 'org.mongodb:mongo-java-driver:2.14.0',
     mysqlConnector       : 'mysql:mysql-connector-java:8.0.20',
     pig                  : 'org.apache.pig:pig:' + versions.pig,
-    parquetAvro          : 'com.twitter:parquet-avro:1.6.0',
+    parquetAvro          : 'org.apache.parquet:parquet-avro:1.11.1',
     parquetBundle        : 'com.twitter:parquet-hadoop-bundle:1.3.2',
     powermock            : 'org.powermock:powermock-api-mockito2:2.0.2',
     powermockmodulejunit4: 'org.powermock:powermock-module-junit4:2.0.2',


### PR DESCRIPTION
1. The changes are needed for potential avro upgrades to 1.9.2 because _EncoderFactory.get().jsonEncoder(schema, g);_ interface will be no longer available there.
2. The issue mentioned in https://github.com/azkaban/azkaban/pull/2861 is fixed by reverting the parquetAvro package changes. Reproduced successfully and verified it can work after my fix.