### PR TITLE
Fail azkaban flow when conditional variable cannot be resolved

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -392,5 +393,9 @@ public class ExecutableFlowBase extends ExecutableNode {
     } else {
       return this.getId() + ":" + this.getFlowId();
     }
+  }
+
+  public Set<String> getExecutableNodeIds() {
+    return executableNodes.keySet();
   }
 }


### PR DESCRIPTION
Currently the conditional azkaban workflow will return null when
attempting to resolve a variable in the job properties. However,
this leads to strange exceptions such as ones seen here:

https://github.com/azkaban/azkaban/issues/1897

"javax.script.ScriptException: <eval>:1:1 Expected ; but found {"

This is not very helpful and indicitive of what the problem is.
This changeset fails hard if required variables cannot be found,
the job name cannot be found, or the properties don't exist.
It also provides helpful other information like the available properties
that have variables to choose from.