### PR TITLE
Fail azkaban flow when conditional variable cannot be resolved

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlowBase.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -392,5 +393,9 @@ public class ExecutableFlowBase extends ExecutableNode {
     } else {
       return this.getId() + ":" + this.getFlowId();
     }
+  }
+
+  public Set<String> getExecutableNodeIds() {
+    return executableNodes.keySet();
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -88,12 +88,30 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     final Props generatedProperties = new Props();
     generatedProperties.put("key1", "value1");
     generatedProperties.put("key2", "value2");
+    generatedProperties.put("key3", "value4");
     InteractiveTestJob.getTestJob("jobA").succeedJob(generatedProperties);
     assertStatus(flow, "jobA", Status.SUCCEEDED);
     assertStatus(flow, "jobB", Status.SUCCEEDED);
     assertStatus(flow, "jobC", Status.CANCELLED);
     assertStatus(flow, "jobD", Status.CANCELLED);
     assertFlowStatus(flow, Status.KILLED);
+  }
+
+  @Test
+  public void flowShouldFailWhenConditionalParameterDoesntExist() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_2, flowProps);
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    assertStatus(flow, "jobA", Status.RUNNING);
+    final Props generatedProperties = new Props();
+    generatedProperties.put("key1", "value1");
+    generatedProperties.put("key2", "value2");
+    InteractiveTestJob.getTestJob("jobA").succeedJob(generatedProperties);
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.SUCCEEDED);
+    assertStatus(flow, "jobC", Status.READY);
+    assertStatus(flow, "jobD", Status.READY);
+    assertFlowStatus(flow, Status.FAILED);
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
@@ -73,6 +73,7 @@ public class FlowRunnerConditionalJobsTest extends FlowRunnerTestBase {
     final Props generatedProperties = new Props();
     generatedProperties.put("key1", "value1");
     generatedProperties.put("key2", "value2");
+    generatedProperties.put("key3", "value4");
     InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_2 + ":") + "jobA").succeedJob(generatedProperties);
     assertStatus(flow, "jobA", Status.SUCCEEDED);
     assertStatus(flow, "jobB", Status.SUCCEEDED);
@@ -144,7 +145,7 @@ public class FlowRunnerConditionalJobsTest extends FlowRunnerTestBase {
    * JobB has defined "condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var
    * f = new File('new'); f.createNewFile(); }"
    * Null ProtectionDomain will restrict this arbitrary code from creating a new file.
-   * However it will not kick in when the change for condition whitelisting is implemented.
+   * However it will not kick in when the change for condition allow-listing is implemented.
    * As a result, this test case will be ignored.
    *
    * @throws Exception the exception


### PR DESCRIPTION
Currently the conditional azkaban workflow will return null when
attempting to resolve a variable in the job properties. However,
this leads to strange exceptions such as ones seen here:

https://github.com/azkaban/azkaban/issues/1897

"javax.script.ScriptException: <eval>:1:1 Expected ; but found {"

This is not very helpful and indicitive of what the problem is.
This changeset fails hard if required variables cannot be found,
the job name cannot be found, or the properties don't exist.
It also provides helpful other information like the available properties
that have variables to choose from.