### PR TITLE
Set queued flows as executions in PREPARING state via containerized dispatch method

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -149,7 +149,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   public List<Integer> getQueuedFlowIds() {
     final List<Integer> allIds = new ArrayList<>();
     try {
-      getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.READY));
+      getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.PREPARING));
     } catch (final ExecutorManagerException e) {
       logger.error("Failed to get queued flow ids.", e);
     }
@@ -157,7 +157,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   /**
-   * Get size of queued flows. The status for queued flows is READY for containerization.
+   * Get size of queued flows. The status for queued flows is PREPARING for containerization.
    *
    * @return
    */

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -142,13 +142,15 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   /**
-   * Get queued flow ids from database. The status for queued flows is READY for containerization.
+   * Get queued flow ids from database. The status for queued flows is PREPARING or DISPATCHING for
+   * containerization.
    *
    * @return
    */
   public List<Integer> getQueuedFlowIds() {
     final List<Integer> allIds = new ArrayList<>();
     try {
+      getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.DISPATCHING));
       getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.PREPARING));
     } catch (final ExecutorManagerException e) {
       logger.error("Failed to get queued flow ids.", e);
@@ -157,7 +159,7 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   }
 
   /**
-   * Get size of queued flows. The status for queued flows is PREPARING for containerization.
+   * Get size of queued flows. The status for queued flows is PREPARING or DISPATCHING for containerization.
    *
    * @return
    */

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -186,8 +186,8 @@ public class HttpRequestUtils {
     if (!hasPermission(userManager, user, Type.ADMIN)) {
       params.remove(ExecutionOptions.FLOW_PRIORITY);
       params.remove(ExecutionOptions.USE_EXECUTOR);
-      params.remove(FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
-      params.remove(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
+//      params.remove(FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
+//      params.remove(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
       params.remove(FlowParameters.FLOW_PARAM_DISABLE_POD_CLEANUP);
       // Passing test version will be allowed for Azkaban ADMIN role only
       params.remove(FlowParameters.FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION);

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -186,8 +186,8 @@ public class HttpRequestUtils {
     if (!hasPermission(userManager, user, Type.ADMIN)) {
       params.remove(ExecutionOptions.FLOW_PRIORITY);
       params.remove(ExecutionOptions.USE_EXECUTOR);
-//      params.remove(FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
-//      params.remove(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
+      params.remove(FlowParameters.FLOW_PARAM_JAVA_ENABLE_DEBUG);
+      params.remove(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD);
       params.remove(FlowParameters.FLOW_PARAM_DISABLE_POD_CLEANUP);
       // Passing test version will be allowed for Azkaban ADMIN role only
       params.remove(FlowParameters.FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION);

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -149,7 +149,7 @@ public class ContainerizedDispatchManagerTest {
     when(this.executorLoader.fetchActiveFlowByExecId(flow1.getExecutionId())).thenReturn(
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), DispatchMethod.CONTAINERIZED), flow1));
     this.queuedFlows = ImmutableList.of(new Pair<>(this.ref1, this.flow1));
-    when(this.executorLoader.fetchQueuedFlows(Status.READY)).thenReturn(this.queuedFlows);
+    when(this.executorLoader.fetchQueuedFlows(Status.PREPARING)).thenReturn(this.queuedFlows);
 
     Pair<ExecutionReference, ExecutableFlow> executionReferencePair =
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -30,6 +30,8 @@ import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.OnContainerizedExecutionEventListener;
 import azkaban.executor.Status;
+import azkaban.metrics.ContainerizationMetrics;
+import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
@@ -50,6 +52,7 @@ public class ContainerCleanupManagerTest {
   private ContainerizedImpl containerImpl;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private ContainerCleanupManager cleaner;
+  private DummyContainerizationMetricsImpl metrics;
 
   @Before
   public void setup() throws Exception {
@@ -58,7 +61,7 @@ public class ContainerCleanupManagerTest {
     this.containerImpl = mock(ContainerizedImpl.class);
     this.containerizedDispatchManager = mock(ContainerizedDispatchManager.class);
     this.cleaner = new ContainerCleanupManager(this.props, this.executorLoader,
-        this.containerImpl, this.containerizedDispatchManager);
+        this.containerImpl, this.containerizedDispatchManager, this.metrics);
   }
 
   @Test


### PR DESCRIPTION
so that metric of NumQueuedFlows can represent actual number of queued flows; Increase ContainerDispatchFail meter when pod is cleaned up by CleanupManager when stuck in PREPARING and DISPATCHING