### PR TITLE
Do not use offline logs when getting application ids

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -475,8 +475,8 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
   }
 
   protected LogData getJobLogData(final ExecutableFlow exFlow, final String jobId, final int offset,
-      final int length,
-      final int attempt, final Pair<ExecutionReference, ExecutableFlow> pair)
+      final int length, final int attempt, final Pair<ExecutionReference, ExecutableFlow> pair,
+      final boolean nearlineOnly)
       throws ExecutorManagerException {
     if (pair != null) {
       final Pair<String, String> typeParam = new Pair<>("type", "job");
@@ -497,8 +497,8 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId,
           attempt, offset, length);
       // Return offline logs if nearline logs are empty or the flow and job in kubernetes pod
-      // crashed
-      if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
+      // crashed and nearlineOnly is turned off
+      if (!nearlineOnly && offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
           (logData == null ||
               (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
                   (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
@@ -547,7 +547,15 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       final int offset, final int length, final int attempt) throws ExecutorManagerException {
     final Pair<ExecutionReference, ExecutableFlow> pair = this.executorLoader
         .fetchActiveFlowByExecId(exFlow.getExecutionId());
-    return getJobLogData(exFlow, jobId, offset, length, attempt, pair);
+    return getJobLogData(exFlow, jobId, offset, length, attempt, pair, false);
+  }
+
+  @Override
+  public LogData getExecutionJobLogNearlineOnly(final ExecutableFlow exFlow, final String jobId,
+      final int offset, final int length, final int attempt) throws ExecutorManagerException {
+    final Pair<ExecutionReference, ExecutableFlow> pair = this.executorLoader
+        .fetchActiveFlowByExecId(exFlow.getExecutionId());
+    return getJobLogData(exFlow, jobId, offset, length, attempt, pair, true);
   }
 
   @Override
@@ -767,7 +775,10 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     final Set<String> applicationIds = new LinkedHashSet<>();
     int offset = 0;
     try {
-      LogData data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
+      // Loading all offline logs batch by batch is time-consuming.
+      // Instead, we are targeting on improving getApplicationIds mechanism this year so it will
+      // not rely on full job logs to resolve the application ids.
+      LogData data = getExecutionJobLogNearlineOnly(exFlow, jobId, offset, 50000, attempt);
       while (data != null && data.getLength() > 0) {
         logger.info("Get application ID for execution " + exFlow.getExecutionId() + ", job"
             + " " + jobId + ", attempt " + attempt + ", data offset " + offset);
@@ -783,7 +794,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
         }
         applicationIds.addAll(ExecutionControllerUtils.findApplicationIdsFromLog(logData));
         offset = data.getOffset() + logData.length();
-        data = getExecutionJobLog(exFlow, jobId, offset, 50000, attempt);
+        data = getExecutionJobLogNearlineOnly(exFlow, jobId, offset, 50000, attempt);
       }
     } catch (final ExecutorManagerException e) {
       logger.error("Failed to get application ID for execution " + exFlow.getExecutionId() +

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -532,7 +532,15 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
       final int offset, final int length, final int attempt) throws ExecutorManagerException {
     final Pair<ExecutionReference, ExecutableFlow> pair =
         this.runningExecutions.get().get(exFlow.getExecutionId());
-    return getJobLogData(exFlow, jobId, offset, length, attempt, pair);
+    return getJobLogData(exFlow, jobId, offset, length, attempt, pair, false);
+  }
+
+  @Override
+  public LogData getExecutionJobLogNearlineOnly(final ExecutableFlow exFlow, final String jobId,
+      final int offset, final int length, final int attempt) throws ExecutorManagerException {
+    final Pair<ExecutionReference, ExecutableFlow> pair =
+        this.runningExecutions.get().get(exFlow.getExecutionId());
+    return getJobLogData(exFlow, jobId, offset, length, attempt, pair, true);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -94,6 +94,10 @@ public interface ExecutorManagerAdapter {
   public LogData getExecutionJobLog(ExecutableFlow exFlow, String jobId,
       int offset, int length, int attempt) throws ExecutorManagerException;
 
+  @Deprecated
+  public LogData getExecutionJobLogNearlineOnly(ExecutableFlow exFlow, String jobId,
+      int offset, int length, int attempt) throws ExecutorManagerException;
+
   public List<Object> getExecutionJobStats(ExecutableFlow exflow, String jobId,
       int attempt) throws ExecutorManagerException;
 


### PR DESCRIPTION
There are reported slowness issues when clicking job logs button in UI when offline logs is enabled. 
The RC is: getApplicationIds function synchronously loads all logs from offline logs batch by batch (default batch size: 50000 Bytes), it can be very slow when log size is huge. Note: Most offline log fetching throughput is great but latency is worse than fetching from Nearline log MySQL.

As short-term mitigation, we will not use offline logs when getApplicationIds.
For long-term, we will improve getApplicationIds soon in these months to remove its dependency over reading job logs so this PR can be reverted after that.