### PR TITLE
Add flowEndTime to fetchLogs interface

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -461,14 +461,14 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       return LogData.createLogDataFromObject(result);
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0,
-          offset, length);
+          offset, length, exFlow.getEndTime());
       // Return offline logs if nearline logs are empty or the flow in kubernetes pod crashed
       if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
           (logData == null ||
               (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
                   (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
         return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), "", 0,
-            offset, length);
+            offset, length, exFlow.getEndTime());
       }
       return logData;
     }
@@ -495,7 +495,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       return LogData.createLogDataFromObject(result);
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId,
-          attempt, offset, length);
+          attempt, offset, length, exFlow.getEndTime());
       // Return offline logs if nearline logs are empty or the flow and job in kubernetes pod
       // crashed
       if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
@@ -505,7 +505,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
         final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
         if (node.getStatus() == Status.KILLED || node.getStatus() == Status.EXECUTION_STOPPED) {
           return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), jobId,
-              attempt, offset, length);
+              attempt, offset, length, exFlow.getEndTime());
         }
       }
       return logData;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionLogsDao.java
@@ -53,10 +53,8 @@ public class ExecutionLogsDao {
     this.dbOperator = dbOperator;
   }
 
-  // TODO kunkun-tang: the interface's parameter is called endByte, but actually is length.
   public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte,
-      final int length) throws ExecutorManagerException {
+      final int startByte, final int length) throws ExecutorManagerException {
     final FetchLogsHandler handler = new FetchLogsHandler(startByte, length + startByte);
     try {
       return this.dbOperator.query(FetchLogsHandler.FETCH_LOGS, handler,

--- a/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
@@ -9,8 +9,11 @@ public interface ExecutionLogsLoader {
   void uploadLogFile(int execId, String name, int attempt, File... files)
       throws ExecutorManagerException;
 
+  // FlowEndTime is needed for offline logs to tell if the logs are complete or not considering
+  // every offline logging platform has decent amount of delay from when log-is-sent to when
+  // log-is-available.
   LogData fetchLogs(int execId, String name, int attempt, int startByte,
-      int length) throws ExecutorManagerException;
+      int length, long flowEndTime) throws ExecutorManagerException;
 
   int removeExecutionLogsByTime(long millis, int recordCleanupLimit)
       throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
@@ -17,8 +17,7 @@ public class JdbcExecutionLogsLoader implements ExecutionLogsLoader {
 
   @Override
   public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte,
-      final int length) throws ExecutorManagerException {
+      final int startByte, final int length, final long flowEndTime) throws ExecutorManagerException {
 
     return this.executionLogsDao.fetchLogs(execId, name, attempt, startByte, length);
   }

--- a/azkaban-common/src/test/java/azkaban/logs/MockExecutionLogsLoader.java
+++ b/azkaban-common/src/test/java/azkaban/logs/MockExecutionLogsLoader.java
@@ -34,8 +34,7 @@ public class MockExecutionLogsLoader implements ExecutionLogsLoader {
 
   @Override
   public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte,
-      final int endByte) throws ExecutorManagerException {
+      final int startByte, final int endByte, final long flowEndTime) throws ExecutorManagerException {
     // TODO Auto-generated method stub
     return null;
   }


### PR DESCRIPTION
Since we introduced offline logging fetching recently into Azkaban and every offline logging fetching platform has decent amount of delay from log-is-sent to log-is-available, we need flowEndTime here in order to tell if the offline logs is complete or not, something like:
If flowEndTime + offlineLogAvailableSLA >= currentTime: offline logs are incomplete
If flowEndTime + offlineLogAvailableSLA < currentTime: offline logs are complete
