### PR TITLE
Return offline logs if nearline logs are empty

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -462,11 +462,8 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0,
           offset, length, exFlow.getEndTime());
-      // Return offline logs if nearline logs are empty or the flow in kubernetes pod crashed
-      if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
-          (logData == null ||
-              (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
-                  (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
+      // Return offline logs if nearline logs are empty
+      if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() && logData == null) {
         return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), "", 0,
             offset, length, exFlow.getEndTime());
       }
@@ -496,17 +493,10 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId,
           attempt, offset, length, exFlow.getEndTime());
-      // Return offline logs if nearline logs are empty or the flow and job in kubernetes pod
-      // crashed and nearlineOnly is turned off
-      if (!nearlineOnly && offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() &&
-          (logData == null ||
-              (exFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED &&
-                  (exFlow.getStatus() == Status.KILLED || exFlow.getStatus() == Status.EXECUTION_STOPPED)))) {
-        final ExecutableNode node = exFlow.getExecutableNodePath(jobId);
-        if (node.getStatus() == Status.KILLED || node.getStatus() == Status.EXECUTION_STOPPED) {
-          return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), jobId,
-              attempt, offset, length, exFlow.getEndTime());
-        }
+      // Return offline logs if nearline logs are empty
+      if (!nearlineOnly && offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() && logData == null) {
+        return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), jobId,
+            attempt, offset, length, exFlow.getEndTime());
       }
       return logData;
     }


### PR DESCRIPTION
The original logic assumes nearline logs will not be empty if flow/job is crashed (what logPodDetails PR will do). There is no need to guarantee that assumption now as logPodDetails PR is abandoned. Instead, if mysql logs is empty, we can fetch offline logs directly without any additional checking.