### PR TITLE
Only allow fetching one batch of flow log at a time

### DIFF
--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -35,7 +35,7 @@
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1646723409"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/exflow.js?v=1659475516"></script>
   <script type="text/javascript">
     var contextURL = "${context}";
     var currentTime = ${currentTime};


### PR DESCRIPTION
There is a bug to load flow logs in UI: if the user click on "Refresh" button multiple times without waiting for the previous log batch to be loaded. Same log batch will be loaded together via Azkaban API and rendered in the UI.

Instead, we should do **wait** for the previous log batch to be loaded and then fetch the next batch.