### PR TITLE
Implement CreateRule for RampManager

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -765,6 +765,7 @@ public class Constants {
     public static final String VERSION_STATE = "versionState";
     public static final String ID_KEY = "id";
     public static final String IMAGE_RAMPUP_PLAN = "imageRampupPlan";
+    public static final String IMAGE_RAMP_RULE = "imageRampRule";
     public static final String IMAGE_UPDATE_ADD_USER = "addImageOwners";
     public static final String IMAGE_UPDATE_REMOVE_USER = "removeImageOwners";
   }

--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -44,6 +44,8 @@ import azkaban.imagemgmt.daos.ImageTypeDao;
 import azkaban.imagemgmt.daos.ImageTypeDaoImpl;
 import azkaban.imagemgmt.daos.ImageVersionDao;
 import azkaban.imagemgmt.daos.ImageVersionDaoImpl;
+import azkaban.imagemgmt.daos.RampRuleDao;
+import azkaban.imagemgmt.daos.RampRuleDaoImpl;
 import azkaban.imagemgmt.permission.PermissionManager;
 import azkaban.imagemgmt.permission.PermissionManagerImpl;
 import azkaban.imagemgmt.rampup.ImageRampupManager;
@@ -224,6 +226,7 @@ public class AzkabanCommonModule extends AbstractModule {
       bind(ImageVersionDao.class).to(ImageVersionDaoImpl.class).in(Scopes.SINGLETON);
       bind(ImageRampupDao.class).to(ImageRampupDaoImpl.class).in(Scopes.SINGLETON);
       bind(ImageRampupManager.class).to(ImageRampupManagerImpl.class).in(Scopes.SINGLETON);
+      bind(RampRuleDao.class).to(RampRuleDaoImpl.class).in(Scopes.SINGLETON);
       bind(ImageMgmtCommonDao.class).to(ImageMgmtCommonDaoImpl.class).in(Scopes.SINGLETON);
       bind(PermissionManager.class).to(PermissionManagerImpl.class).in(Scopes.SINGLETON);
       bind(Converter.class).annotatedWith(Names.named(IMAGE_TYPE))

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.daos;
 
 import azkaban.imagemgmt.models.ImageRampRule;
@@ -5,19 +20,42 @@ import azkaban.imagemgmt.models.ImageRampRule;
 
 /**
 * Data access object (DAO) for accessing image ramp rule that deny an image ramping version for flows.
-* This interface defines add/remove/modify an image ramp rule.
+* This interface defines add/remove/modify/get an image ramp rule.
 * */
 public interface RampRuleDao {
 
-  boolean isHPRule(String ruleId);
+  /**
+   * Query table ramp_rules to check whether a HPFlowRule .
+   *
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @return true - if ramp rule is setup for HP Flows, denying any ramp up plan;
+   *         false - if ramp rule is normal rule, regulate only on certain image version.
+   */
+  boolean isHPFlowRule(final String ruleName);
 
-  /*
-  * Insert a new row into DB for ramp rule
-  * */
-  int addRampRule(ImageRampRule rule);
+  /**
+   * Insert Image Ramp Rule metadata into DB.
+   *
+   * @param rule - RampRule model created in {@see ImageRampRuleServiceImpl}
+   * @return int - id of the DB entry
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  int addRampRule(final ImageRampRule rule);
 
-  String getOwners(String ruleId);
+  /**
+   * Query table ramp_rules to get owners of Ramp rule.
+   *
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @return owners of the ramp rule.
+   */
+  String getOwners(final String ruleName);
 
-  void deleteRampRule(String ruleId);
+  /**
+   * delete the ramp_rules to get owners of Ramp rule.
+   *
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  void deleteRampRule(final String ruleName);
 
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -1,0 +1,23 @@
+package azkaban.imagemgmt.daos;
+
+import azkaban.imagemgmt.models.ImageRampRule;
+
+
+/**
+* Data access object (DAO) for accessing image ramp rule that deny an image ramping version for flows.
+* This interface defines add/remove/modify an image ramp rule.
+* */
+public interface RampRuleDao {
+
+  boolean isHPRule(String ruleId);
+
+  /*
+  * Insert a new row into DB for ramp rule
+  * */
+  int addRampRule(ImageRampRule rule);
+
+  String getOwners(String ruleId);
+
+  void deleteRampRule(String ruleId);
+
+}

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
@@ -1,12 +1,24 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.daos;
 
 import azkaban.db.DatabaseOperator;
 import azkaban.imagemgmt.exception.ErrorCode;
 import azkaban.imagemgmt.exception.ImageMgmtDaoException;
-import azkaban.imagemgmt.exception.ImageMgmtException;
-import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
 import azkaban.imagemgmt.models.ImageRampRule;
-import azkaban.imagemgmt.models.ImageType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -23,14 +35,18 @@ import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.log4j.Logger;
 import org.bouncycastle.util.Strings;
 
-
+/**
+ * Dao Implementation for access DB of table ramp_rules.
+ * Create/update/delete/get RampRule or partial RampRule metadata. {@link ImageRampRule}
+ * */
 @Singleton
 public class RampRuleDaoImpl implements RampRuleDao {
   private static final Logger LOG = Logger.getLogger(RampRuleDaoImpl.class);
   private final DatabaseOperator databaseOperator;
 
   private static String INSERT_RAMP_RULE = "INSERT into ramp_rules "
-      + "(rule_id, image_name, image_version, owners, is_HP, created_by, created_on) values (?, ?, ?, ?, ?, ?, ?)";
+      + "(rule_name, image_name, image_version, owners, is_HP, created_by, created_on, modified_by, modified_on)"
+      + " values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   @Inject
   public RampRuleDaoImpl(DatabaseOperator databaseOperator) {
@@ -38,50 +54,60 @@ public class RampRuleDaoImpl implements RampRuleDao {
   }
 
   @Override
-  public boolean isHPRule(String ruleId) {
+  public boolean isHPFlowRule(final String ruleName) {
     return false;
   }
 
+  /**
+   * Insert new ramp rule into DB, check if duplicate ruleName exists first
+   *
+   * @param rampRule
+   * @throws ImageMgmtDaoException
+   * */
   @Override
-  public int addRampRule(ImageRampRule rampRule) {
+  public int addRampRule(final ImageRampRule rampRule) {
     try {
+      // duplicated rule should be forbidden as client side error, which needs a separate check to
+      // avoid it falls into normal SQL Exception as server error.
       List<ImageRampRule> rampRules = databaseOperator.query(
-          FetchRampRuleHandler.FETCH_RAMP_RULE_BY_ID, new FetchRampRuleHandler(), rampRule.getRuleId());
+          FetchRampRuleHandler.FETCH_RAMP_RULE_BY_ID, new FetchRampRuleHandler(), rampRule.getRuleName());
       if (!rampRules.isEmpty()) {
-        LOG.error("Error in create ramp rule on duplicate ruleId: " + rampRule.getRuleId());
-        throw new ImageMgmtException(ErrorCode.BAD_REQUEST,
-            "Error in create ramp rule on duplicate ruleId: " + rampRule.getRuleId());
+        LOG.error("Error in create ramp rule on duplicate ruleName: " + rampRule.getRuleName());
+        throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST,
+            "Error in create ramp rule on duplicate ruleName: " + rampRule.getRuleName());
       }
       return this.databaseOperator.update(INSERT_RAMP_RULE,
-          rampRule.getRuleId(),
+          rampRule.getRuleName(),
           rampRule.getImageName(),
           rampRule.getImageVersion(),
           rampRule.getOwners(),
           rampRule.isHPRule(),
           rampRule.getCreatedBy(),
+          Timestamp.valueOf(LocalDateTime.now()),
+          rampRule.getCreatedBy(),
           Timestamp.valueOf(LocalDateTime.now()));
     } catch (SQLException e) {
       LOG.error("Error in create ramp rule on DB" + rampRule);
       throw new ImageMgmtDaoException(ErrorCode.INTERNAL_SERVER_ERROR,
-          "Error creating ramp rule " + rampRule.getRuleId() + "with " + e.getMessage());
+          "Error creating ramp rule " + rampRule.getRuleName() + "with " + e.getMessage());
     }
   }
 
   @Override
-  public String getOwners(String ruleId) {
+  public String getOwners(final String ruleName) {
     return null;
   }
 
   @Override
-  public void deleteRampRule(String ruleId) {
+  public void deleteRampRule(final String ruleName) {
 
   }
 
   public static class FetchRampRuleHandler implements ResultSetHandler<List<ImageRampRule>> {
 
     private static final String FETCH_RAMP_RULE_BY_ID =
-        "SELECT rule_id, image_name, image_version, owners, is_HP"
-            + " FROM ramp_rules WHERE rule_id = ?";
+        "SELECT rule_name, image_name, image_version, owners, is_HP"
+            + " FROM ramp_rules WHERE rule_name = ?";
 
     @Override
     public List<ImageRampRule> handle(final ResultSet rs) throws SQLException {
@@ -90,13 +116,19 @@ public class RampRuleDaoImpl implements RampRuleDao {
       }
       final List<ImageRampRule> imageRampRules = new ArrayList<>();
       do {
-        final String ruleId = rs.getString("rule_id");
+        final String ruleName = rs.getString("rule_name");
         final String imageName = rs.getString("image_name");
         final String imageVersion = rs.getString("image_version");
         final String owners = rs.getString("owners");
         final boolean isHP = rs.getBoolean("is_HP");
         Set<String> ownerLists = new HashSet<>(Arrays.asList(Strings.split(owners, ',')));
-        final ImageRampRule imageRampRule = new ImageRampRule(ruleId, imageName, imageVersion, ownerLists, isHP);
+        final ImageRampRule imageRampRule = new ImageRampRule.Builder()
+            .setRuleName(ruleName)
+            .setImageName(imageName)
+            .setImageVersion(imageVersion)
+            .setOwners(ownerLists)
+            .setHPRule(isHP)
+            .build();
         imageRampRules.add(imageRampRule);
       } while (rs.next());
       return imageRampRules;

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
@@ -49,7 +49,7 @@ public class RampRuleDaoImpl implements RampRuleDao {
       + " values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   @Inject
-  public RampRuleDaoImpl(DatabaseOperator databaseOperator) {
+  public RampRuleDaoImpl(final DatabaseOperator databaseOperator) {
     this.databaseOperator = databaseOperator;
   }
 

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
@@ -1,0 +1,105 @@
+package azkaban.imagemgmt.daos;
+
+import azkaban.db.DatabaseOperator;
+import azkaban.imagemgmt.exception.ErrorCode;
+import azkaban.imagemgmt.exception.ImageMgmtDaoException;
+import azkaban.imagemgmt.exception.ImageMgmtException;
+import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
+import azkaban.imagemgmt.models.ImageRampRule;
+import azkaban.imagemgmt.models.ImageType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.commons.dbutils.ResultSetHandler;
+import org.apache.log4j.Logger;
+import org.bouncycastle.util.Strings;
+
+
+@Singleton
+public class RampRuleDaoImpl implements RampRuleDao {
+  private static final Logger LOG = Logger.getLogger(RampRuleDaoImpl.class);
+  private final DatabaseOperator databaseOperator;
+
+  private static String INSERT_RAMP_RULE = "INSERT into ramp_rules "
+      + "(rule_id, image_name, image_version, owners, is_HP, created_by, created_on) values (?, ?, ?, ?, ?, ?, ?)";
+
+  @Inject
+  public RampRuleDaoImpl(DatabaseOperator databaseOperator) {
+    this.databaseOperator = databaseOperator;
+  }
+
+  @Override
+  public boolean isHPRule(String ruleId) {
+    return false;
+  }
+
+  @Override
+  public int addRampRule(ImageRampRule rampRule) {
+    try {
+      List<ImageRampRule> rampRules = databaseOperator.query(
+          FetchRampRuleHandler.FETCH_RAMP_RULE_BY_ID, new FetchRampRuleHandler(), rampRule.getRuleId());
+      if (!rampRules.isEmpty()) {
+        LOG.error("Error in create ramp rule on duplicate ruleId: " + rampRule.getRuleId());
+        throw new ImageMgmtException(ErrorCode.BAD_REQUEST,
+            "Error in create ramp rule on duplicate ruleId: " + rampRule.getRuleId());
+      }
+      return this.databaseOperator.update(INSERT_RAMP_RULE,
+          rampRule.getRuleId(),
+          rampRule.getImageName(),
+          rampRule.getImageVersion(),
+          rampRule.getOwners(),
+          rampRule.isHPRule(),
+          rampRule.getCreatedBy(),
+          Timestamp.valueOf(LocalDateTime.now()));
+    } catch (SQLException e) {
+      LOG.error("Error in create ramp rule on DB" + rampRule);
+      throw new ImageMgmtDaoException(ErrorCode.INTERNAL_SERVER_ERROR,
+          "Error creating ramp rule " + rampRule.getRuleId() + "with " + e.getMessage());
+    }
+  }
+
+  @Override
+  public String getOwners(String ruleId) {
+    return null;
+  }
+
+  @Override
+  public void deleteRampRule(String ruleId) {
+
+  }
+
+  public static class FetchRampRuleHandler implements ResultSetHandler<List<ImageRampRule>> {
+
+    private static final String FETCH_RAMP_RULE_BY_ID =
+        "SELECT rule_id, image_name, image_version, owners, is_HP"
+            + " FROM ramp_rules WHERE rule_id = ?";
+
+    @Override
+    public List<ImageRampRule> handle(final ResultSet rs) throws SQLException {
+      if (!rs.next()) {
+        return Collections.emptyList();
+      }
+      final List<ImageRampRule> imageRampRules = new ArrayList<>();
+      do {
+        final String ruleId = rs.getString("rule_id");
+        final String imageName = rs.getString("image_name");
+        final String imageVersion = rs.getString("image_version");
+        final String owners = rs.getString("owners");
+        final boolean isHP = rs.getBoolean("is_HP");
+        Set<String> ownerLists = new HashSet<>(Arrays.asList(Strings.split(owners, ',')));
+        final ImageRampRule imageRampRule = new ImageRampRule(ruleId, imageName, imageVersion, ownerLists, isHP);
+        imageRampRules.add(imageRampRule);
+      } while (rs.next());
+      return imageRampRules;
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageRampRuleRequestDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageRampRuleRequestDTO.java
@@ -1,16 +1,33 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.dto;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-
+/**
+ * This class represents ImageRampRule Request when receiving request body from user.
+ * */
 public class ImageRampRuleRequestDTO extends BaseDTO {
   // Represents the name of the Ramp rule
-  @JsonProperty("ruleId")
-  @NotBlank(message = "ruleId cannot be blank.", groups = ValidationOnCreate.class)
-  @NotNull(message = "ruleId cannot be null.")
-  private String ruleId;
+  @JsonProperty("ruleName")
+  @NotBlank(message = "ruleName cannot be blank.", groups = ValidationOnCreate.class)
+  @NotNull(message = "ruleName cannot be null.")
+  private String ruleName;
   // Represents the name of the image type for the rule
   @JsonProperty("imageName")
   @NotBlank(message = "imageName cannot be blank.", groups = {ValidationOnCreate.class})
@@ -22,8 +39,8 @@ public class ImageRampRuleRequestDTO extends BaseDTO {
   @NotNull(message = "imageVersion cannot be null.")
   private String imageVersion;
 
-  public void setRuleId(String ruleId) {
-    this.ruleId = ruleId;
+  public void setRuleName(String ruleName) {
+    this.ruleName = ruleName;
   }
 
   public void setImageName(String imageName) {
@@ -34,8 +51,8 @@ public class ImageRampRuleRequestDTO extends BaseDTO {
     this.imageVersion = imageVersion;
   }
 
-  public String getRuleId() {
-    return ruleId;
+  public String getRuleName() {
+    return ruleName;
   }
 
   public String getImageName() {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageRampRuleRequestDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/ImageRampRuleRequestDTO.java
@@ -1,0 +1,49 @@
+package azkaban.imagemgmt.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+
+public class ImageRampRuleRequestDTO extends BaseDTO {
+  // Represents the name of the Ramp rule
+  @JsonProperty("ruleId")
+  @NotBlank(message = "ruleId cannot be blank.", groups = ValidationOnCreate.class)
+  @NotNull(message = "ruleId cannot be null.")
+  private String ruleId;
+  // Represents the name of the image type for the rule
+  @JsonProperty("imageName")
+  @NotBlank(message = "imageName cannot be blank.", groups = {ValidationOnCreate.class})
+  @NotNull(message = "imageName cannot be null.")
+  private String imageName;
+  // Represents the name of the image version for the rule
+  @JsonProperty("imageVersion")
+  @NotBlank(message = "imageVersion cannot be blank.", groups = {ValidationOnCreate.class})
+  @NotNull(message = "imageVersion cannot be null.")
+  private String imageVersion;
+
+  public void setRuleId(String ruleId) {
+    this.ruleId = ruleId;
+  }
+
+  public void setImageName(String imageName) {
+    this.imageName = imageName;
+  }
+
+  public void setImageVersion(String imageVersion) {
+    this.imageVersion = imageVersion;
+  }
+
+  public String getRuleId() {
+    return ruleId;
+  }
+
+  public String getImageName() {
+    return imageName;
+  }
+
+  public String getImageVersion() {
+    return imageVersion;
+  }
+
+}

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
@@ -16,7 +16,6 @@
 package azkaban.imagemgmt.models;
 
 import java.util.Set;
-import javax.annotation.Nullable;
 
 
 /**
@@ -24,26 +23,26 @@ import javax.annotation.Nullable;
  */
 public class ImageRampRule extends BaseModel {
   // ramp rule name
-  String ruleName;
+  final String ruleName;
   // image name of ramp rule for
-  String imageName;
+  final String imageName;
   // image version of ramp rule for
   String imageVersion;
   // rule owners
-  Set<String> owners;
+  final Set<String> owners;
   // Ramp Rule for HP flows
   // ture if rule is for HP flow; false otherwise
-  boolean isHPRule;
+  final boolean isHPRule;
 
-  public ImageRampRule(String ruleName,
-                String imageName,
-                String imageVersion,
-                Set<String> owners,
-                boolean isHP,
-                String createdBy,
-                @Nullable String createdOn ,
-                @Nullable String modifiedBy,
-                @Nullable String modifiedOn) {
+  public ImageRampRule(final String ruleName,
+                       final String imageName,
+                       final String imageVersion,
+                       final Set<String> owners,
+                       final boolean isHP,
+                       final String createdBy,
+                       final String createdOn ,
+                       final String modifiedBy,
+                       final String modifiedOn) {
     this.ruleName = ruleName;
     this.imageName = imageName;
     this.imageVersion = imageVersion;

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
@@ -1,0 +1,50 @@
+package azkaban.imagemgmt.models;
+
+import java.util.List;
+import java.util.Set;
+
+
+public class ImageRampRule extends BaseModel {
+  // ramp rule name
+  String ruleId;
+  // image name of ramp rule for
+  String imageName;
+  // image version of ramp rule for
+  String imageVersion;
+  // rule owners
+  Set<String> owners;
+  // Ramp Rule for HP flows or not
+  boolean isHPRule;
+
+  public ImageRampRule(String ruleId,
+                String imageName,
+                String imageVersion,
+                Set<String> owners,
+                boolean isHP) {
+    this.ruleId = ruleId;
+    this.imageName = imageName;
+    this.imageVersion = imageVersion;
+    this.owners = owners;
+    this.isHPRule = isHP;
+  }
+
+  public String getRuleId() {
+    return ruleId;
+  }
+
+  public String getImageName() {
+    return imageName;
+  }
+
+  public String getImageVersion() {
+    return imageVersion;
+  }
+
+  public String getOwners() {
+    return String.join(",", owners);
+  }
+
+  public boolean isHPRule() {
+    return isHPRule;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageRampRule.java
@@ -1,35 +1,62 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.models;
 
-import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 
+/**
+ * This class represents Image Ramp Rule metadata.
+ */
 public class ImageRampRule extends BaseModel {
   // ramp rule name
-  String ruleId;
+  String ruleName;
   // image name of ramp rule for
   String imageName;
   // image version of ramp rule for
   String imageVersion;
   // rule owners
   Set<String> owners;
-  // Ramp Rule for HP flows or not
+  // Ramp Rule for HP flows
+  // ture if rule is for HP flow; false otherwise
   boolean isHPRule;
 
-  public ImageRampRule(String ruleId,
+  public ImageRampRule(String ruleName,
                 String imageName,
                 String imageVersion,
                 Set<String> owners,
-                boolean isHP) {
-    this.ruleId = ruleId;
+                boolean isHP,
+                String createdBy,
+                @Nullable String createdOn ,
+                @Nullable String modifiedBy,
+                @Nullable String modifiedOn) {
+    this.ruleName = ruleName;
     this.imageName = imageName;
     this.imageVersion = imageVersion;
     this.owners = owners;
     this.isHPRule = isHP;
+    super.createdBy = createdBy;
+    super.createdOn = createdOn;
+    super.modifiedBy = modifiedBy;
+    super.modifiedOn = modifiedOn;
   }
 
-  public String getRuleId() {
-    return ruleId;
+  public String getRuleName() {
+    return ruleName;
   }
 
   public String getImageName() {
@@ -46,5 +73,77 @@ public class ImageRampRule extends BaseModel {
 
   public boolean isHPRule() {
     return isHPRule;
+  }
+
+  public static class Builder {
+    // ramp rule name
+    String ruleName;
+    // image name of ramp rule for
+    String imageName;
+    // image version of ramp rule for
+    String imageVersion;
+    // rule owners
+    Set<String> owners;
+    // Ramp Rule for HP flows or not
+    boolean isHPRule;
+    // Created by user
+    String createdBy;
+    // Created Time
+    String createdOn;
+    // Modified by user
+    String modifiedBy;
+    // Modified Time
+    String modifiedOn;
+
+    public Builder setRuleName(String ruleName) {
+      this.ruleName = ruleName;
+      return this;
+    }
+
+    public Builder setImageName(String imageName) {
+      this.imageName = imageName;
+      return this;
+    }
+
+    public Builder setImageVersion(String imageVersion) {
+      this.imageVersion = imageVersion;
+      return this;
+    }
+
+    public Builder setOwners(Set<String> owners) {
+      this.owners = owners;
+      return this;
+    }
+
+    public Builder setHPRule(boolean HPRule) {
+      isHPRule = HPRule;
+      return this;
+    }
+
+    public Builder setCreatedBy(String createdBy) {
+      this.createdBy = createdBy;
+      return this;
+    }
+
+    public Builder setCreatedOn(String createdOn) {
+      this.createdOn = createdOn;
+      return this;
+    }
+
+    public Builder setModifiedBy(String modifiedBy) {
+      this.modifiedBy = modifiedBy;
+      return this;
+    }
+
+    public Builder setModifiedOn(String modifiedOn) {
+      this.modifiedOn = modifiedOn;
+      return this;
+    }
+
+    public ImageRampRule build() {
+      return new ImageRampRule(ruleName, imageName, imageVersion, owners, isHPRule,
+         createdBy, createdOn, modifiedBy, modifiedOn);
+    }
+
   }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
@@ -50,4 +50,12 @@ public interface PermissionManager {
   public Set<String> validatePermissionAndGetOwnerships(final String imageTypeName, final User user)
       throws ImageMgmtException;
 
+  /**
+   * Method to check if user is Azkaban Admin.
+   *
+   * @param user
+   * @return true, if azkaban dev
+   *         false otherwise
+   */
+  public boolean isAzkabanAdmin(final User user);
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
@@ -18,7 +18,10 @@ package azkaban.imagemgmt.permission;
 
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.user.Permission.Type;
+import azkaban.user.User;
 import azkaban.user.UserManager;
+import java.util.Set;
+
 
 /**
  * Interface defines method to check the permission for accessing image management APIs.
@@ -28,14 +31,23 @@ public interface PermissionManager {
   /**
    * Checks the permission based on user manager, image type name, user id and Permission type.
    *
-   * @param userManager
    * @param imageTypeName
    * @param userId
    * @param type
    * @return boolean
    */
-  public boolean hasPermission(final UserManager userManager, final String imageTypeName,
-      final String userId, final Type type)
+  public boolean hasPermission(final String imageTypeName, final String userId, final Type type)
+      throws ImageMgmtException;
+
+  /**
+   * Checks the permission based on user manager, image type name, user id and Permission type;
+   * @return Set of Ldap Groups
+   *
+   * @param imageTypeName
+   * @param user
+   * @return the ownership set of desired image type
+   */
+  public Set<String> validatePermissionAndGetOwnerships(final String imageTypeName, final User user)
       throws ImageMgmtException;
 
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManagerImpl.java
@@ -22,6 +22,7 @@ import azkaban.imagemgmt.exception.ImageMgmtValidationException;
 import azkaban.imagemgmt.models.ImageOwnership;
 import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
+import azkaban.user.Role;
 import azkaban.user.User;
 import azkaban.user.UserManager;
 import java.util.HashSet;
@@ -89,13 +90,12 @@ public class PermissionManagerImpl implements PermissionManager {
    * @return boolean
    */
   @Override
-  public Set<String> validatePermissionAndGetOwnerships(String imageTypeName, User user)
+  public Set<String> validatePermissionAndGetOwnerships(final String imageTypeName, final User user)
       throws ImageMgmtException {
     String userId = user.getUserId();
     // validate azkaban admin
-    boolean isAzkabanAdmin = user.getRoles().stream()
-        .anyMatch(role -> userManager.getRole(role).getPermission().isPermissionSet(Type.ADMIN));
-    // fetch owners from image_ownerships with matching permission set (i.g. ADMIN)
+    boolean isAzkabanAdmin = isAzkabanAdmin(user);
+    // fetch owners from image_ownerships with matching permission set (e.g. ADMIN)
     Set<String> imageOwnerships = imageTypeDao.getImageTypeOwnership(imageTypeName).stream()
         .map(ImageOwnership::getOwner)
         .collect(Collectors.toSet());
@@ -107,5 +107,18 @@ public class PermissionManagerImpl implements PermissionManager {
       throw new ImageMgmtValidationException(ErrorCode.UNAUTHORIZED, errorMsg);
     }
     return imageOwnerships;
+  }
+
+  /**
+   * Method to check if user is Azkaban Admin.
+   *
+   * @param user
+   * @return true, if azkaban dev
+   *         false otherwise
+   */
+  @Override
+  public boolean isAzkabanAdmin(final User user) {
+    return user.getRoles().stream()
+        .anyMatch(role -> userManager.getRole(role).getPermission().isPermissionSet(Type.ADMIN));
   }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/utils/ConverterUtils.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/utils/ConverterUtils.java
@@ -16,6 +16,7 @@
 package azkaban.imagemgmt.utils;
 
 import azkaban.imagemgmt.dto.BaseDTO;
+import azkaban.imagemgmt.exception.ErrorCode;
 import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,15 +61,15 @@ public class ConverterUtils {
       return this.objectMapper.readValue(jsonPayloadString, dtoClass);
     } catch (final JsonParseException e) {
       log.error("Exception while parsing input json ", e);
-      throw new ImageMgmtInvalidInputException(
+      throw new ImageMgmtInvalidInputException(ErrorCode.BAD_REQUEST,
           "Exception while reading input payload. Invalid input.");
     } catch (final JsonMappingException e) {
       log.error("Exception while converting input json ", e);
-      throw new ImageMgmtInvalidInputException(
+      throw new ImageMgmtInvalidInputException(ErrorCode.BAD_REQUEST,
           "Exception while reading input payload. Invalid input.");
     } catch (final IOException e) {
       log.error("IOException occurred while converting input json ", e);
-      throw new ImageMgmtInvalidInputException(
+      throw new ImageMgmtInvalidInputException(ErrorCode.BAD_REQUEST,
           "Exception while reading input payload. Invalid input.");
     }
   }

--- a/azkaban-db/src/main/sql/create.ramp_rules.sql
+++ b/azkaban-db/src/main/sql/create.ramp_rules.sql
@@ -1,0 +1,15 @@
+CREATE TABLE ramp_rules (
+    rule_id VARCHAR(100) NOT NULL,
+    image_name VARCHAR(200) NOT NULL,
+    image_version VARCHAR (100) NOT NULL,
+    owners VARCHAR (1000) NOT NULL,
+    is_HP BIT NOT NULL,
+    created_by VARCHAR(20) NOT NULL,
+    created_on DATE NOT NULL,
+    modified_by VARCHAR(20),
+    modified_on DATE,
+    PRIMARY KEY (rule_id)
+);
+
+CREATE INDEX idx_rule_id
+    ON ramp_rules (rule_id);

--- a/azkaban-db/src/main/sql/create.ramp_rules.sql
+++ b/azkaban-db/src/main/sql/create.ramp_rules.sql
@@ -1,5 +1,5 @@
 CREATE TABLE ramp_rules (
-    rule_id VARCHAR(100) NOT NULL,
+    rule_name VARCHAR(100) NOT NULL,
     image_name VARCHAR(200) NOT NULL,
     image_version VARCHAR (100) NOT NULL,
     owners VARCHAR (1000) NOT NULL,
@@ -8,8 +8,8 @@ CREATE TABLE ramp_rules (
     created_on DATE NOT NULL,
     modified_by VARCHAR(20),
     modified_on DATE,
-    PRIMARY KEY (rule_id)
+    PRIMARY KEY (rule_name)
 );
 
-CREATE INDEX idx_rule_id
-    ON ramp_rules (rule_id);
+CREATE INDEX idx_rule_name
+    ON ramp_rules (rule_name);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -1,0 +1,27 @@
+package azkaban.imagemgmt.services;
+
+import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.models.ImageRampRule;
+import java.util.List;
+
+/**
+ * Interface for ImageRampRule Service,
+ * support the basic operation to add/modify/delete ramp rule
+ * */
+public interface ImageRampRuleService {
+
+  /**
+   * Create a normal exclusive Rule for a certain version of an image type,
+   * validation performed before insert into DB.
+   * throws @ImageMgmtException
+   * */
+  void createRule(ImageRampRuleRequestDTO rule, String ldapUser, boolean isAzkabanAdmin);
+
+  void createHpFlowRule(ImageRampRule rule);
+
+  void deleteRule(String ruleId);
+
+  void addFlowsToRule(List<String> flowIds, String ruleId);
+
+  void updateVersionOnRule(String newVersion, String ruleId);
+}

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -35,13 +35,13 @@ public interface ImageRampRuleService {
    * @param ldapUser
    * @throws ImageMgmtException
    * */
-  void createRule(ImageRampRuleRequestDTO rampRuleRequestDTO, final User ldapUser);
+  void createRule(final ImageRampRuleRequestDTO rampRuleRequestDTO, final User ldapUser);
 
-  void createHpFlowRule(ImageRampRule rule);
+  void createHpFlowRule(final ImageRampRule rule);
 
-  void deleteRule(String ruleName);
+  void deleteRule(final String ruleName);
 
-  void addFlowsToRule(List<String> flowIds, String ruleName);
+  void addFlowsToRule(final List<String> flowIds, final String ruleName);
 
-  void updateVersionOnRule(String newVersion, String ruleName);
+  void updateVersionOnRule(final String newVersion, final String ruleName);
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.services;
 
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageRampRule;
+import azkaban.user.User;
 import java.util.List;
 
 /**
@@ -13,15 +30,18 @@ public interface ImageRampRuleService {
   /**
    * Create a normal exclusive Rule for a certain version of an image type,
    * validation performed before insert into DB.
-   * throws @ImageMgmtException
+   *
+   * @param rampRuleRequestDTO
+   * @param ldapUser
+   * @throws ImageMgmtException
    * */
-  void createRule(ImageRampRuleRequestDTO rule, String ldapUser, boolean isAzkabanAdmin);
+  void createRule(ImageRampRuleRequestDTO rampRuleRequestDTO, final User ldapUser);
 
   void createHpFlowRule(ImageRampRule rule);
 
-  void deleteRule(String ruleId);
+  void deleteRule(String ruleName);
 
-  void addFlowsToRule(List<String> flowIds, String ruleId);
+  void addFlowsToRule(List<String> flowIds, String ruleName);
 
-  void updateVersionOnRule(String newVersion, String ruleId);
+  void updateVersionOnRule(String newVersion, String ruleName);
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
@@ -1,0 +1,93 @@
+package azkaban.imagemgmt.services;
+
+import azkaban.imagemgmt.daos.ImageTypeDao;
+import azkaban.imagemgmt.daos.ImageVersionDao;
+import azkaban.imagemgmt.daos.RampRuleDao;
+import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.exception.ErrorCode;
+import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
+import azkaban.imagemgmt.exception.ImageMgmtInvalidPermissionException;
+import azkaban.imagemgmt.models.ImageOwnership;
+import azkaban.imagemgmt.models.ImageRampRule;
+import azkaban.imagemgmt.models.ImageType;
+import azkaban.user.UserManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.log4j.Logger;
+
+@Singleton
+public class ImageRampRuleServiceImpl implements ImageRampRuleService {
+
+  public static final Logger log = Logger.getLogger(ImageRampRuleServiceImpl.class);
+
+  private final RampRuleDao rampRuleDao;
+  private final ImageTypeDao imageTypeDao;
+  private final ImageVersionDao imageVersionDao;
+  private final UserManager userManager;
+
+  @Inject
+  public ImageRampRuleServiceImpl(RampRuleDao rampRuleDao,
+                                  ImageTypeDao imageTypeDao,
+                                  ImageVersionDao imageVersionDao,
+                                  UserManager userManager) {
+    this.rampRuleDao = rampRuleDao;
+    this.imageTypeDao = imageTypeDao;
+    this.imageVersionDao = imageVersionDao;
+    this.userManager = userManager;
+  }
+
+  @Override
+  public void createRule(ImageRampRuleRequestDTO rampRuleRequest, String ldapUser, boolean isAzkabanAdmin){
+    // validate image_name and image_version
+    final ImageType imageType = imageTypeDao
+      .getImageTypeByName(rampRuleRequest.getImageName())
+        .orElseThrow(() -> new ImageMgmtInvalidInputException(ErrorCode.NOT_FOUND, String.format("Unable to"
+            + " fetch image type metadata. Invalid image type: %s.", rampRuleRequest.getImageName())));
+    if (!this.imageVersionDao.isInvalidVersion(rampRuleRequest.getImageName(), rampRuleRequest.getImageVersion())) {
+      throw new ImageMgmtInvalidInputException(ErrorCode.NOT_FOUND, String.format(
+          "Unable to fetch image version metadata. Invalid image version: %s.", rampRuleRequest.getImageVersion()));
+    }
+    boolean isAuthorized = isAzkabanAdmin;
+    //fetch owners from image_ownerships
+    Set<String> imageOwnerships = imageTypeDao.getImageTypeOwnership(rampRuleRequest.getImageName()).stream()
+        .map(ImageOwnership::getOwner).collect(Collectors.toSet());
+    // validate if user has permission to create rule, if not azkaban admin user
+    if (!imageOwnerships.isEmpty() &&
+        (imageOwnerships.contains(ldapUser) || userManager.validateUserGroupMembership(ldapUser, imageOwnerships))) {
+      isAuthorized = true;
+    }
+    if (!isAuthorized) {
+      throw new ImageMgmtInvalidPermissionException(ErrorCode.UNAUTHORIZED,
+          "Only image type owners would be authorized to create ramp rules, "
+              + "unauthorized user " + ldapUser + " is not in " + imageOwnerships);
+    }
+    // convert ImageRampRule and insert new ramp rule into DB
+    ImageRampRule rampRule = new ImageRampRule(rampRuleRequest.getRuleId(), rampRuleRequest.getImageName(),
+        rampRuleRequest.getImageVersion(), imageOwnerships, false);
+    rampRule.setCreatedBy(ldapUser);
+    rampRuleDao.addRampRule(rampRule);
+  }
+
+  @Override
+  public void createHpFlowRule(ImageRampRule rule) {
+
+  }
+
+  @Override
+  public void deleteRule(String ruleId) {
+
+  }
+
+  @Override
+  public void addFlowsToRule(List<String> flowIds, String ruleId) {
+
+  }
+
+  @Override
+  public void updateVersionOnRule(String newVersion, String ruleId) {
+
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
@@ -26,7 +26,6 @@ import azkaban.imagemgmt.exception.ImageMgmtInvalidPermissionException;
 import azkaban.imagemgmt.models.ImageRampRule;
 import azkaban.imagemgmt.models.ImageType;
 import azkaban.imagemgmt.permission.PermissionManager;
-import azkaban.user.Permission;
 import azkaban.user.User;
 import java.util.List;
 import java.util.Set;
@@ -48,8 +47,10 @@ public class ImageRampRuleServiceImpl implements ImageRampRuleService {
   private final PermissionManager permissionManager;
 
   @Inject
-  public ImageRampRuleServiceImpl(RampRuleDao rampRuleDao, ImageTypeDao imageTypeDao, ImageVersionDao imageVersionDao,
-      PermissionManager permissionManager) {
+  public ImageRampRuleServiceImpl(final RampRuleDao rampRuleDao,
+                                  final ImageTypeDao imageTypeDao,
+                                  final ImageVersionDao imageVersionDao,
+                                  final PermissionManager permissionManager) {
     this.rampRuleDao = rampRuleDao;
     this.imageTypeDao = imageTypeDao;
     this.imageVersionDao = imageVersionDao;
@@ -67,7 +68,7 @@ public class ImageRampRuleServiceImpl implements ImageRampRuleService {
    * @throws ImageMgmtInvalidPermissionException when user does not have permission
    * */
   @Override
-  public void createRule(ImageRampRuleRequestDTO rampRuleRequest, User ldapUser){
+  public void createRule(final ImageRampRuleRequestDTO rampRuleRequest, final User ldapUser){
     // validate image_name and image_version
     final ImageType imageType = imageTypeDao
       .getImageTypeByName(rampRuleRequest.getImageName())
@@ -94,22 +95,22 @@ public class ImageRampRuleServiceImpl implements ImageRampRuleService {
   }
 
   @Override
-  public void createHpFlowRule(ImageRampRule rule) {
+  public void createHpFlowRule(final ImageRampRule rule) {
 
   }
 
   @Override
-  public void deleteRule(String ruleName) {
+  public void deleteRule(final String ruleName) {
 
   }
 
   @Override
-  public void addFlowsToRule(List<String> flowIds, String ruleName) {
+  public void addFlowsToRule(final List<String> flowIds, final String ruleName) {
 
   }
 
   @Override
-  public void updateVersionOnRule(String newVersion, String ruleName) {
+  public void updateVersionOnRule(final String newVersion, final String ruleName) {
 
   }
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
@@ -86,9 +86,9 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
    *
    * @throws ImageMgmtException with different ErrorCode, and the detailed error message.
    **/
-  private void handleCreateRampRule(HttpServletRequest req,
-                                    HttpServletResponse resp,
-                                    User user)
+  private void handleCreateRampRule(final HttpServletRequest req,
+                                    final HttpServletResponse resp,
+                                    final User user)
                                     throws ServletException {
     String requestBody = HttpRequestUtils.getBody(req);
     ImageRampRuleRequestDTO rampRuleRequestDTO;

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
@@ -1,0 +1,85 @@
+package azkaban.imagemgmt.servlets;
+
+import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.exception.ErrorCode;
+import azkaban.imagemgmt.exception.ImageMgmtException;
+import azkaban.imagemgmt.services.ImageRampRuleService;
+import azkaban.imagemgmt.utils.ConverterUtils;
+import azkaban.server.HttpRequestUtils;
+import azkaban.server.session.Session;
+import azkaban.webapp.AzkabanWebServer;
+import azkaban.webapp.servlet.LoginAbstractAzkabanServlet;
+import java.io.IOException;
+import java.util.ArrayList;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
+  private static final Logger LOG = LoggerFactory.getLogger(ImageRampRuleServlet.class);
+
+  private ImageRampRuleService imageRampRuleService;
+  private ConverterUtils utils;
+
+  private final static String CREATE_RULE_URI = "/imageRampRule/createRule";
+
+  public ImageRampRuleServlet() {
+    super(new ArrayList<>());
+  }
+
+  @Override
+  public void init(final ServletConfig config) throws ServletException {
+    super.init(config);
+    final AzkabanWebServer server = (AzkabanWebServer) getApplication();
+    this.imageRampRuleService = server.getImageRampRuleService();
+    this.utils = server.getConverterUtils();
+  }
+
+  @Override
+  protected void handleGet(HttpServletRequest req, HttpServletResponse resp, Session session)
+      throws ServletException, IOException {
+
+  }
+
+  @Override
+  protected void handlePost(HttpServletRequest req, HttpServletResponse resp, Session session)
+      throws ServletException, IOException {
+      String requestURI = req.getRequestURI();
+      String userId = session.getUser().getUserId();
+      boolean isAzkabanAdmin = isAzkabanAdmin(session.getUser());
+      if (CREATE_RULE_URI.equals(requestURI)) {
+        LOG.info("handle request from post uri: " + requestURI);
+        handleCreateRampRule(req, resp, userId, isAzkabanAdmin);
+      }
+  }
+
+  // create an exclusive rule for a certain version of the image,
+  // any failure would be wrapped into ImageMgmtException with different ErrorCode,
+  // as long with the detailed error message back to the client.
+  // Successful call would return CREATED(201)
+  private void handleCreateRampRule(HttpServletRequest req,
+                                    HttpServletResponse resp,
+                                    String userId,
+                                    boolean isAzkabanAdmin)
+                                    throws ServletException {
+    String requestBody = HttpRequestUtils.getBody(req);
+    ImageRampRuleRequestDTO rampRuleRequestDTO;
+    try {
+      // while converting to requestDTO, validation on json/required parameters would be performed.
+      rampRuleRequestDTO = utils.convertToDTO(requestBody, ImageRampRuleRequestDTO.class);
+      rampRuleRequestDTO.setCreatedBy(userId);
+      imageRampRuleService.createRule(rampRuleRequestDTO, userId, isAzkabanAdmin);
+      resp.setStatus(HttpStatus.SC_CREATED);
+    } catch (ImageMgmtException e) {
+      LOG.error("failed to create a rampRule: " + requestBody);
+      resp.setStatus(e.getErrorCode().getCode(), e.getMessage());
+    }
+  }
+
+
+}

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.servlets;
 
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
-import azkaban.imagemgmt.exception.ErrorCode;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.services.ImageRampRuleService;
 import azkaban.imagemgmt.utils.ConverterUtils;
 import azkaban.server.HttpRequestUtils;
 import azkaban.server.session.Session;
+import azkaban.user.User;
 import azkaban.webapp.AzkabanWebServer;
 import azkaban.webapp.servlet.LoginAbstractAzkabanServlet;
 import java.io.IOException;
@@ -19,7 +34,15 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * This servlet exposes the REST APIs such as create, delete and update rampup for image type.
+ * Currently only supports:
+ * Create Image Ramp Rule API: POST /imageRampRule/createRule
+ * Create Image Ramp Rule API for HP flows: POST /imageRampRule/createHPFlowRule
+ * Add managed flows into rule: POST /imageRampRule/addFlowsToRule
+ * Modify image version on Rule: POST /imageRampRule/updateVersionOnRule
+ * Delete rule: POST /imageRampRule/deleteRule
+ */
 public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
   private static final Logger LOG = LoggerFactory.getLogger(ImageRampRuleServlet.class);
 
@@ -50,30 +73,31 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
   protected void handlePost(HttpServletRequest req, HttpServletResponse resp, Session session)
       throws ServletException, IOException {
       String requestURI = req.getRequestURI();
-      String userId = session.getUser().getUserId();
-      boolean isAzkabanAdmin = isAzkabanAdmin(session.getUser());
+      User user = session.getUser();
       if (CREATE_RULE_URI.equals(requestURI)) {
         LOG.info("handle request from post uri: " + requestURI);
-        handleCreateRampRule(req, resp, userId, isAzkabanAdmin);
+        handleCreateRampRule(req, resp, user);
       }
   }
 
-  // create an exclusive rule for a certain version of the image,
-  // any failure would be wrapped into ImageMgmtException with different ErrorCode,
-  // as long with the detailed error message back to the client.
-  // Successful call would return CREATED(201)
+  /**
+   * create an exclusive rule for a certain version of the image,
+   * Successful call would return CREATED(201).
+   *
+   * @throws ImageMgmtException with different ErrorCode, and the detailed error message.
+   **/
   private void handleCreateRampRule(HttpServletRequest req,
                                     HttpServletResponse resp,
-                                    String userId,
-                                    boolean isAzkabanAdmin)
+                                    User user)
                                     throws ServletException {
     String requestBody = HttpRequestUtils.getBody(req);
     ImageRampRuleRequestDTO rampRuleRequestDTO;
     try {
       // while converting to requestDTO, validation on json/required parameters would be performed.
       rampRuleRequestDTO = utils.convertToDTO(requestBody, ImageRampRuleRequestDTO.class);
-      rampRuleRequestDTO.setCreatedBy(userId);
-      imageRampRuleService.createRule(rampRuleRequestDTO, userId, isAzkabanAdmin);
+      rampRuleRequestDTO.setCreatedBy(user.getUserId());
+      rampRuleRequestDTO.setModifiedBy(user.getUserId());
+      imageRampRuleService.createRule(rampRuleRequestDTO, user);
       resp.setStatus(HttpStatus.SC_CREATED);
     } catch (ImageMgmtException e) {
       LOG.error("failed to create a rampRule: " + requestBody);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageTypeServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageTypeServlet.java
@@ -22,6 +22,7 @@ import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
 import azkaban.imagemgmt.exception.ImageMgmtInvalidPermissionException;
 import azkaban.imagemgmt.exception.ImageMgmtValidationException;
+import azkaban.imagemgmt.permission.PermissionManager;
 import azkaban.imagemgmt.services.ImageTypeService;
 import azkaban.imagemgmt.utils.ConverterUtils;
 import azkaban.server.HttpRequestUtils;
@@ -66,6 +67,7 @@ public class ImageTypeServlet extends LoginAbstractAzkabanServlet {
       String.format("/imageTypes/{%s}", IMAGE_TYPE_ID_KEY));
   private ImageTypeService imageTypeService;
   private ConverterUtils converterUtils;
+  private PermissionManager permissionManager;
 
   private static final Logger log = LoggerFactory.getLogger(ImageTypeServlet.class);
 
@@ -79,6 +81,7 @@ public class ImageTypeServlet extends LoginAbstractAzkabanServlet {
     final AzkabanWebServer server = (AzkabanWebServer) getApplication();
     this.imageTypeService = server.getImageTypeService();
     this.converterUtils = server.getConverterUtils();
+    this.permissionManager = server.getPermissionManager();
   }
 
   @Override
@@ -150,7 +153,7 @@ public class ImageTypeServlet extends LoginAbstractAzkabanServlet {
 
   private void getAllImageTypeDTOs(final HttpServletResponse resp, final Session session)
       throws IOException {
-    if (!isAzkabanAdmin(session.getUser())) {
+    if (!permissionManager.isAzkabanAdmin(session.getUser())) {
       throw new ImageMgmtInvalidPermissionException(ErrorCode.FORBIDDEN, FORBIDDEN_USER_ERR_MSG);
     }
     List<ImageTypeDTO> imageTypesDTO =

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -37,9 +37,11 @@ import azkaban.flowtrigger.FlowTriggerService;
 import azkaban.flowtrigger.quartz.FlowTriggerScheduler;
 import azkaban.imagemgmt.permission.PermissionManager;
 import azkaban.imagemgmt.services.ImageMgmtCommonService;
+import azkaban.imagemgmt.services.ImageRampRuleService;
 import azkaban.imagemgmt.services.ImageRampupService;
 import azkaban.imagemgmt.services.ImageTypeService;
 import azkaban.imagemgmt.services.ImageVersionService;
+import azkaban.imagemgmt.servlets.ImageRampRuleServlet;
 import azkaban.imagemgmt.servlets.ImageRampupServlet;
 import azkaban.imagemgmt.servlets.ImageTypeServlet;
 import azkaban.imagemgmt.servlets.ImageVersionServlet;
@@ -525,6 +527,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
       routesMap.put("/imageTypes/*", new ImageTypeServlet());
       routesMap.put("/imageVersions/*", new ImageVersionServlet());
       routesMap.put("/imageRampup/*", new ImageRampupServlet());
+      routesMap.put("/imageRampRule/*", new ImageRampRuleServlet());
     }
     return routesMap;
   }
@@ -790,6 +793,10 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
 
   public ImageRampupService getImageRampupService() {
     return SERVICE_PROVIDER.getInstance(ImageRampupService.class);
+  }
+
+  public ImageRampRuleService getImageRampRuleService() {
+    return SERVICE_PROVIDER.getInstance(ImageRampRuleService.class);
   }
 
   public PermissionManager getPermissionManager() {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -50,6 +50,8 @@ import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginException;
 import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginManager;
 import azkaban.imagemgmt.services.ImageMgmtCommonService;
 import azkaban.imagemgmt.services.ImageMgmtCommonServiceImpl;
+import azkaban.imagemgmt.services.ImageRampRuleService;
+import azkaban.imagemgmt.services.ImageRampRuleServiceImpl;
 import azkaban.imagemgmt.services.ImageRampupService;
 import azkaban.imagemgmt.services.ImageRampupServiceImpl;
 import azkaban.imagemgmt.services.ImageTypeService;
@@ -189,6 +191,7 @@ public class AzkabanWebServerModule extends AbstractModule {
       bind(VersionSetLoader.class).to(JdbcVersionSetLoader.class).in(Scopes.SINGLETON);
       bind(ImageVersionMetadataService.class).to(ImageVersionMetadataServiceImpl.class).in(Scopes.SINGLETON);
       bind(ImageMgmtCommonService.class).to(ImageMgmtCommonServiceImpl.class).in(Scopes.SINGLETON);
+      bind(ImageRampRuleService.class).to(ImageRampRuleServiceImpl.class).in(Scopes.SINGLETON);
     }
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -738,33 +738,18 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
    */
   protected boolean hasImageManagementPermission(final String imageTypeName, final User user,
       final Permission.Type type) {
+    // Check image management APIs access permission for other users.
+    final PermissionManager permissionManager = getApplication().getPermissionManager();
     /**
      * Azkaban ADMIN role must have full permission to access image management APIs. Hence, no
      * further permission check is required.
      */
-    if (isAzkabanAdmin(user)) {
+    if (permissionManager.isAzkabanAdmin(user)) {
       return true;
     }
-    // Check image management APIs access permission for other users.
-    final PermissionManager permissionManager = getApplication().getPermissionManager();
     return permissionManager.hasPermission(imageTypeName, user.getUserId(), type);
   }
 
-  /**
-   * Method to check if user is Azkaban Admin.
-   *
-   * @param user
-   * @return boolean
-   */
-  protected boolean isAzkabanAdmin(final User user) {
-    final UserManager userManager = getApplication().getUserManager();
-    for (final String roleName : user.getRoles()) {
-      final Role role = userManager.getRole(roleName);
-      if (role.getPermission().isPermissionSet(Permission.Type.ADMIN)) {
-        return true;
-      }
-    }
-    return false;
-  }
+
 }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -747,8 +747,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
     }
     // Check image management APIs access permission for other users.
     final PermissionManager permissionManager = getApplication().getPermissionManager();
-    final UserManager userManager = getApplication().getUserManager();
-    return permissionManager.hasPermission(userManager, imageTypeName, user.getUserId(), type);
+    return permissionManager.hasPermission(imageTypeName, user.getUserId(), type);
   }
 
   /**

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package azkaban.imagemgmt.services;
 
 import azkaban.imagemgmt.daos.ImageTypeDao;
@@ -9,7 +24,12 @@ import azkaban.imagemgmt.daos.RampRuleDaoImpl;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
 import azkaban.imagemgmt.models.ImageOwnership;
 import azkaban.imagemgmt.models.ImageType;
+import azkaban.imagemgmt.permission.PermissionManager;
+import azkaban.imagemgmt.permission.PermissionManagerImpl;
 import azkaban.imagemgmt.utils.ConverterUtils;
+import azkaban.user.Permission;
+import azkaban.user.Role;
+import azkaban.user.User;
 import azkaban.user.UserManager;
 import azkaban.user.XmlUserManager;
 import azkaban.utils.JSONUtils;
@@ -29,6 +49,8 @@ public class ImageRampRuleServiceImplTest {
   private ImageVersionDao _imageVersionDao;
   private UserManager _userManager;
   private ImageRampRuleService _rampRuleService;
+  private PermissionManager _permissionManager;
+
   private ConverterUtils _converterUtils;
 
   @Before
@@ -37,24 +59,31 @@ public class ImageRampRuleServiceImplTest {
     this._imageTypeDao = mock(ImageTypeDaoImpl.class);
     this._imageVersionDao = mock(ImageVersionDaoImpl.class);
     this._userManager = mock(XmlUserManager.class);
-    this._rampRuleService = new ImageRampRuleServiceImpl(_rampRuleDao, _imageTypeDao, _imageVersionDao, _userManager);
+    this._permissionManager = new PermissionManagerImpl(_imageTypeDao, _userManager);
+    this._rampRuleService =
+        new ImageRampRuleServiceImpl(_rampRuleDao, _imageTypeDao, _imageVersionDao, _permissionManager);
     this._converterUtils = new ConverterUtils(new ObjectMapper());
   }
 
   @Test
   public void testCreateRule() {
-    String user = "user1";
+    User user = new User("testUser");
     final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule.json");
     final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
     when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.of(new ImageType()));
     when(_imageVersionDao.isInvalidVersion(requestDTO.getImageName(), requestDTO.getImageVersion())).thenReturn(true);
     ImageOwnership ownership = new ImageOwnership();
-    ownership.setOwner(user);
+    Role role = new Role(user.getUserId(), new Permission(Permission.Type.ADMIN));
+    user.addRole("admin");
+    ownership.setOwner(user.getUserId());
+    ownership.setRole(ImageOwnership.Role.ADMIN);
     when(_imageTypeDao.getImageTypeOwnership(requestDTO.getImageName())).thenReturn(Collections.singletonList(ownership));
+
+    when(_userManager.getRole(any())).thenReturn(role);
     when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(true);
     when(_userManager.validateGroup(any())).thenReturn(true);
     when(_rampRuleDao.addRampRule(any())).thenReturn(1);
-    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user, false)).doesNotThrowAnyException();
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user)).doesNotThrowAnyException();
   }
 
   @Test
@@ -62,7 +91,7 @@ public class ImageRampRuleServiceImplTest {
     final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule_invalid.json");
     final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
     when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.empty());
-    assertThatCode(() -> _rampRuleService.createRule(requestDTO, "user", false))
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, new User("testUser")))
         .hasMessageContaining("Invalid image type");
   }
 
@@ -72,13 +101,13 @@ public class ImageRampRuleServiceImplTest {
     final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
     when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.of(new ImageType()));
     when(_imageVersionDao.isInvalidVersion(requestDTO.getImageName(), requestDTO.getImageVersion())).thenReturn(false);
-    assertThatCode(() -> _rampRuleService.createRule(requestDTO, "user", false))
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, new User("testUser")))
         .hasMessageContaining("Invalid image version");
   }
 
   @Test
   public void testNotAuthorizedUser() {
-    String user = "user";
+    User user = new User("testUser");
     String group = "group";
     final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule.json");
     final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
@@ -88,7 +117,7 @@ public class ImageRampRuleServiceImplTest {
     ownership.setOwner(group);
     when(_imageTypeDao.getImageTypeOwnership(requestDTO.getImageName())).thenReturn(Collections.singletonList(ownership));
     when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(false);
-    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user, false))
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user))
         .hasMessageContaining("unauthorized user");
   }
 

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
@@ -1,0 +1,96 @@
+package azkaban.imagemgmt.services;
+
+import azkaban.imagemgmt.daos.ImageTypeDao;
+import azkaban.imagemgmt.daos.ImageTypeDaoImpl;
+import azkaban.imagemgmt.daos.ImageVersionDao;
+import azkaban.imagemgmt.daos.ImageVersionDaoImpl;
+import azkaban.imagemgmt.daos.RampRuleDao;
+import azkaban.imagemgmt.daos.RampRuleDaoImpl;
+import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.models.ImageOwnership;
+import azkaban.imagemgmt.models.ImageType;
+import azkaban.imagemgmt.utils.ConverterUtils;
+import azkaban.user.UserManager;
+import azkaban.user.XmlUserManager;
+import azkaban.utils.JSONUtils;
+import java.util.Collections;
+import java.util.Optional;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+public class ImageRampRuleServiceImplTest {
+  private RampRuleDao _rampRuleDao;
+  private ImageTypeDao _imageTypeDao;
+  private ImageVersionDao _imageVersionDao;
+  private UserManager _userManager;
+  private ImageRampRuleService _rampRuleService;
+  private ConverterUtils _converterUtils;
+
+  @Before
+  public void setup() {
+    this._rampRuleDao = mock(RampRuleDaoImpl.class);
+    this._imageTypeDao = mock(ImageTypeDaoImpl.class);
+    this._imageVersionDao = mock(ImageVersionDaoImpl.class);
+    this._userManager = mock(XmlUserManager.class);
+    this._rampRuleService = new ImageRampRuleServiceImpl(_rampRuleDao, _imageTypeDao, _imageVersionDao, _userManager);
+    this._converterUtils = new ConverterUtils(new ObjectMapper());
+  }
+
+  @Test
+  public void testCreateRule() {
+    String user = "user1";
+    final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule.json");
+    final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
+    when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.of(new ImageType()));
+    when(_imageVersionDao.isInvalidVersion(requestDTO.getImageName(), requestDTO.getImageVersion())).thenReturn(true);
+    ImageOwnership ownership = new ImageOwnership();
+    ownership.setOwner(user);
+    when(_imageTypeDao.getImageTypeOwnership(requestDTO.getImageName())).thenReturn(Collections.singletonList(ownership));
+    when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(true);
+    when(_userManager.validateGroup(any())).thenReturn(true);
+    when(_rampRuleDao.addRampRule(any())).thenReturn(1);
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user, false)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testInvalidImageName() {
+    final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule_invalid.json");
+    final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
+    when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.empty());
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, "user", false))
+        .hasMessageContaining("Invalid image type");
+  }
+
+  @Test
+  public void testInvalidImageVersion() {
+    final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule_invalid.json");
+    final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
+    when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.of(new ImageType()));
+    when(_imageVersionDao.isInvalidVersion(requestDTO.getImageName(), requestDTO.getImageVersion())).thenReturn(false);
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, "user", false))
+        .hasMessageContaining("Invalid image version");
+  }
+
+  @Test
+  public void testNotAuthorizedUser() {
+    String user = "user";
+    String group = "group";
+    final String json = JSONUtils.readJsonFileAsString("image_management/image_ramp_rule.json");
+    final ImageRampRuleRequestDTO requestDTO = _converterUtils.convertToDTO(json, ImageRampRuleRequestDTO.class);
+    when(_imageTypeDao.getImageTypeByName(requestDTO.getImageName())).thenReturn(Optional.of(new ImageType()));
+    when(_imageVersionDao.isInvalidVersion(requestDTO.getImageName(), requestDTO.getImageVersion())).thenReturn(true);
+    ImageOwnership ownership = new ImageOwnership();
+    ownership.setOwner(group);
+    when(_imageTypeDao.getImageTypeOwnership(requestDTO.getImageName())).thenReturn(Collections.singletonList(ownership));
+    when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(false);
+    assertThatCode(() -> _rampRuleService.createRule(requestDTO, user, false))
+        .hasMessageContaining("unauthorized user");
+  }
+
+
+}

--- a/azkaban-web-server/src/test/resources/image_management/image_ramp_rule.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_ramp_rule.json
@@ -1,0 +1,5 @@
+{
+  "ruleId": "daliSparkExclude",
+  "imageName": "az-platform-image",
+  "imageVersion": "0.0.421"
+}

--- a/azkaban-web-server/src/test/resources/image_management/image_ramp_rule.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_ramp_rule.json
@@ -1,5 +1,5 @@
 {
-  "ruleId": "daliSparkExclude",
+  "ruleName": "daliSparkExclude",
   "imageName": "az-platform-image",
   "imageVersion": "0.0.421"
 }

--- a/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_invalid.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_invalid.json
@@ -1,4 +1,4 @@
 {
-  "ruleId": "daliSparkExclude",
+  "ruleName": "daliSparkExclude",
   "imageName": "null"
 }

--- a/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_invalid.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_invalid.json
@@ -1,0 +1,4 @@
+{
+  "ruleId": "daliSparkExclude",
+  "imageName": "null"
+}


### PR DESCRIPTION
Support a Rest request to specify a rule_id, image_name, and image_version, in order to fill in denyList for the rule.
Exception would be thrown on:
- Missing requirements rule_id, image_name, image_version
- Not Authorized if creator is not the owner of image_type
- Duplicate rule_id

End2End tests including above failure cases have been operated and validated on Holdem6.
Success request would return:
< HTTP/1.1 201 Created
Otherwise would return:
HTTP/1.1 <ErrorCode> <Error Message>
for example:
HTTP/1.1 404 Unable to fetch image version metadata. Invalid image version: 0.1.169.