### PR TITLE
Extract all yarn related methods to azkaban-common as shared util library

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -109,10 +109,9 @@ public class HadoopJobUtils {
   }
 
   /**
-   * The same as {@link #addAdditionalNamenodesToProps}, but assumes that the
-   * calling job is MapReduce-based and so uses the
-   * {@link #MAPREDUCE_JOB_OTHER_NAMENODES} from a {@link Configuration} object
-   * to get the list of additional namenodes.
+   * The same as {@link #addAdditionalNamenodesToProps}, but assumes that the calling job is
+   * MapReduce-based and so uses the {@link #MAPREDUCE_JOB_OTHER_NAMENODES} from a {@link
+   * Configuration} object to get the list of additional namenodes.
    *
    * @param props Props to add the new Namenode URIs to.
    * @see #addAdditionalNamenodesToProps(Props, String)
@@ -128,14 +127,14 @@ public class HadoopJobUtils {
   }
 
   /**
-   * Takes the list of other Namenodes from which to fetch delegation tokens,
-   * the {@link #OTHER_NAMENODES_PROPERTY} property, from Props and inserts it
-   * back with the addition of the the potentially JobType-specific Namenode URIs
-   * from additionalNamenodes. Modifies props in-place.
+   * Takes the list of other Namenodes from which to fetch delegation tokens, the {@link
+   * #OTHER_NAMENODES_PROPERTY} property, from Props and inserts it back with the addition of the
+   * the potentially JobType-specific Namenode URIs from additionalNamenodes. Modifies props
+   * in-place.
    *
-   * @param props Props to add the new Namenode URIs to.
-   * @param additionalNamenodes Comma-separated list of Namenode URIs from which to fetch
-   * delegation tokens.
+   * @param props               Props to add the new Namenode URIs to.
+   * @param additionalNamenodes Comma-separated list of Namenode URIs from which to fetch delegation
+   *                            tokens.
    */
   public static void addAdditionalNamenodesToProps(final Props props,
       final String additionalNamenodes) {
@@ -336,20 +335,17 @@ public class HadoopJobUtils {
   }
 
   /**
-   * This method is a decorator around the KillAllSpawnedHadoopJobs method.
-   * This method takes additional parameters to determine whether KillAllSpawnedHadoopJobs needs to
-   * be executed
-   * using doAs as a different user
-   * @param jobProps Azkaban job props
+   * This method is a decorator around the KillAllSpawnedHadoopJobs method. This method takes
+   * additional parameters to determine whether KillAllSpawnedHadoopJobs needs to be executed using
+   * doAs as a different user
+   *
+   * @param jobProps  Azkaban job props
    * @param tokenFile Pass in the tokenFile if value is known.  It is ok to skip if the token file
-   * is in the environmental variable
-   * @param log a usable logger
+   *                  is in the environmental variable
+   * @param log       a usable logger
    */
   public static void proxyUserKillAllSpawnedHadoopJobs(final Props jobProps,
       final File tokenFile, final Logger log) {
-
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    log.info("Log file path is: " + logFilePath);
 
     final Properties properties = new Properties();
     properties.putAll(jobProps.getFlattened());
@@ -362,19 +358,21 @@ public class HadoopJobUtils {
         proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
           @Override
           public Void run() throws Exception {
-            findAndKillYarnApps(logFilePath, log, jobProps);
+            findAndKillYarnApps(jobProps, log);
             return null;
           }
         });
       } else {
-        findAndKillYarnApps(logFilePath, log, jobProps);
+        findAndKillYarnApps(jobProps, log);
       }
     } catch (final Throwable t) {
       log.warn("something happened while trying to kill all spawned jobs", t);
     }
   }
 
-  private static void findAndKillYarnApps(String logFilePath, Logger log, Props jobProps) {
+  private static void findAndKillYarnApps(Props jobProps, Logger log) {
+    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
+    log.info("Log file path is: " + logFilePath);
     Set<String> allSpawnedJobAppIDs = findApplicationIdFromLog(logFilePath, log);
     YarnClient yarnClient = YarnUtils.createYarnClient(jobProps);
     YarnUtils.killAllAppsOnCluster(yarnClient, allSpawnedJobAppIDs, log);
@@ -484,10 +482,10 @@ public class HadoopJobUtils {
    * Filter a collection of String commands to match a whitelist regex and not match a blacklist
    * regex.
    *
-   * @param commands Collection of commands to be filtered
+   * @param commands       Collection of commands to be filtered
    * @param whitelistRegex whitelist regex to work as inclusion criteria
    * @param blacklistRegex blacklist regex to work as exclusion criteria
-   * @param log logger to report violation
+   * @param log            logger to report violation
    * @return filtered list of matching. Empty list if no command match all the criteria.
    */
   public static List<String> filterCommands(final Collection<String> commands,
@@ -531,7 +529,7 @@ public class HadoopJobUtils {
    * Construct a CSV of tags for the Hadoop application.
    *
    * @param props job properties
-   * @param keys list of keys to construct tags from.
+   * @param keys  list of keys to construct tags from.
    * @return a CSV of tags
    */
   public static String constructHadoopTags(final Props props, final String[] keys) {

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -20,9 +20,7 @@ import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_
 import java.io.File;
 
 import azkaban.utils.Utils;
-import joptsimple.internal.Strings;
 import org.apache.log4j.Logger;
-import azkaban.flow.CommonJobProperties;
 import azkaban.security.commons.HadoopSecurityManager;
 import azkaban.security.commons.HadoopSecurityManagerException;
 import azkaban.utils.Props;
@@ -160,10 +158,6 @@ public class HadoopProxy {
     if (tokenFile == null) {
       return; // do null check for tokenFile
     }
-
-    final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
-    logger.info("Log file path is: " + logFilePath);
-
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(logFilePath, jobProps, tokenFile, logger);
+    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(jobProps, tokenFile, logger);
   }
 }

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compileOnly deps.hadoopAuth
     compileOnly deps.hadoopCommon
     compileOnly deps.hadoopHdfs
+    compile deps.hadoopMRClientCommon
+    compile deps.hadoopMRClientCore
     compile deps.httpclient
     compile deps.jetty
     compile deps.jettyUtil

--- a/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.utils;
+
+import java.io.IOException;
+import java.util.Set;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+
+public class YarnUtils {
+
+  //Yarn resource configuration directory for the cluster where the job is scheduled by the cluster router
+  private static final String YARN_CONF_DIRECTORY_PROPERTY = "env.YARN_CONF_DIR";
+  private static final String YARN_CONF_FILENAME = "yarn-site.xml";
+
+  /**
+   * Uses YarnClient to kill the jobs one by one
+   */
+  public static void killAllAppsOnCluster(YarnClient yarnClient, Set<String> applicationIDs,
+      Logger log) {
+    log.info(String.format("Killing applications: %s", applicationIDs));
+
+    for (final String appId : applicationIDs) {
+      try {
+        YarnUtils.killAppOnCluster(yarnClient, appId, log);
+      } catch (final Throwable t) {
+        log.warn("something happened while trying to kill this job: " + appId, t);
+      }
+    }
+  }
+
+  /**
+   * <pre>
+   * Uses YarnClient to kill the job on the Hadoop Yarn Cluster.
+   * Using JobClient only works partially:
+   *   If yarn container has started but spark job haven't, it will kill
+   *   If spark job has started, the cancel will hang until the spark job is complete
+   *   If the spark job is complete, it will return immediately, with a job not found on job tracker
+   * </pre>
+   */
+  public static void killAppOnCluster(final YarnClient yarnClient, final String applicationId,
+      final Logger log) throws YarnException, IOException {
+
+    final String[] split = applicationId.split("_");
+    final ApplicationId aid = ApplicationId.newInstance(Long.parseLong(split[1]),
+        Integer.parseInt(split[2]));
+    log.info("start killing application: " + aid);
+    yarnClient.killApplication(aid);
+    log.info("successfully killed application: " + aid);
+  }
+
+  /**
+   * Create, initialize and start a YarnClient connecting to the Yarn Cluster (resource manager),
+   * using the resources passed in with props.
+   *
+   * @param props the properties to create a YarnClient, the path to the "yarn-site.xml" to be used
+   */
+  public static YarnClient createYarnClient(Props props) {
+    final YarnConfiguration yarnConf = new YarnConfiguration();
+    if (props.containsKey(YARN_CONF_DIRECTORY_PROPERTY)) {
+      yarnConf.addResource(
+          new Path(props.get(YARN_CONF_DIRECTORY_PROPERTY) + "/" + YARN_CONF_FILENAME));
+    }
+    final YarnClient yarnClient = YarnClient.createYarnClient();
+    yarnClient.init(yarnConf);
+    yarnClient.start();
+    return yarnClient;
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
@@ -1,0 +1,63 @@
+package azkaban.utils;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+public class YarnUtilsTest {
+
+  final private Logger log = Logger.getLogger(YarnUtilsTest.class);
+
+  @Test
+  public void testKillAppOnCluster() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doNothing().when(mockClient).killApplication(any());
+    YarnUtils.killAppOnCluster(mockClient, "application_123_456", log);
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testKillAppOnClusterInvalidAppID() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doNothing().when(mockClient).killApplication(any());
+    YarnUtils.killAppOnCluster(mockClient, "application+++123===456", log);
+  }
+
+  @Test(expected = YarnException.class)
+  public void testKillAppOnClusterYarnFail() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doThrow(new YarnException("ops")).when(mockClient).killApplication(any());
+    YarnUtils.killAppOnCluster(mockClient, "application_123_456", log);
+  }
+
+  @Test
+  public void testKillAllAppsOnCluster() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doNothing().when(mockClient).killApplication(any());
+    YarnUtils.killAllAppsOnCluster(mockClient,
+        ImmutableSet.of("application_123_456", "application_456_123"), log);
+  }
+
+  @Test
+  public void testKillAllAppsOnClusterFail() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doNothing().when(mockClient).killApplication(any());
+    doThrow(new YarnException("ops")).when(mockClient).killApplication(
+        eq(ApplicationId.newInstance(4560, 1230)));
+
+    // log the error but not throw
+    YarnUtils.killAllAppsOnCluster(mockClient,
+        ImmutableSet.of("application_123_456", "application_4560_1230"), log);
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
@@ -1,5 +1,20 @@
-package azkaban.utils;
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
+package azkaban.utils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;


### PR DESCRIPTION
**Issue to solve**: A part of the fixing / upgrade of the yarn application killing logic: make it easier to add and reuse "call yarn cluster for application ids" method later on

**Changes made**: Some simple refactor of the code, extract all the yarn-client related methods to an azkaban-common util s class

**Testing done**: 

- Added unit tests for killAppOnCluster() method;
- Tested in the bare metal exec-server on a spark flow:

1. upload both jar for az-hadoop-jobtype-plugin.jar and azkaban-common.jar to a cluster machine
2. restarted a exec-server
3. trigger the sparkFlow execution and kill it after the yarn application is created
4. verify the job log that the yarn app is killed