### PR TITLE
Implement CreateHPFlowRule and updateOwnerships

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -16,6 +16,7 @@
 package azkaban.imagemgmt.daos;
 
 import azkaban.imagemgmt.models.ImageRampRule;
+import java.util.Set;
 
 
 /**
@@ -43,12 +44,24 @@ public interface RampRuleDao {
   int addRampRule(final ImageRampRule rule);
 
   /**
+   * Update owners metadata into table ramp_rules.
+   *
+   * @param newOwners
+   * @param ruleName
+   * @param modifiedBy
+   * @return int - id of the DB entry
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  int updateOwnerships(final String newOwners, final String ruleName, final String modifiedBy);
+
+  /**
    * Query table ramp_rules to get owners of Ramp rule.
+   * Serves as the source of truth for rule ownership management.
    *
    * @param ruleName - ruleName in {@see ImageRampRule}
    * @return owners of the ramp rule.
    */
-  String getOwners(final String ruleName);
+  Set<String> getOwners(final String ruleName);
 
   /**
    * delete the ramp_rules to get owners of Ramp rule.

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleOwnershipDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleOwnershipDTO.java
@@ -15,22 +15,21 @@
  */
 package azkaban.imagemgmt.dto;
 
-import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 
-public class RampRuleOwnershipRequestDTO extends BaseDTO {
+public class RampRuleOwnershipDTO extends BaseDTO {
   // Represents the name of the Ramp rule
   @JsonProperty("ruleName")
   @NotBlank(message = "ruleName cannot be blank.", groups = ValidationOnCreate.class)
-  @NotNull(message = "ruleName cannot be null.")
+  @NotNull(message = "ruleName cannot be null.", groups = ValidationOnCreate.class)
   private String ruleName;
   // Represents the name of the ownerships for the rule
   @JsonProperty("ownerships")
   @NotBlank(message = "rule ownerships cannot be blank.", groups = ValidationOnCreate.class)
-  @NotNull(message = "rule ownerships cannot be null.")
+  @NotNull(message = "rule ownerships cannot be null.", groups = ValidationOnCreate.class)
   private String ownerships;
 
   public void setRuleName(String ruleName) {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleOwnershipRequestDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleOwnershipRequestDTO.java
@@ -20,50 +20,25 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-/**
- * This class represents ImageRampRule Request when receiving request body from user.
- * */
-public class ImageRampRuleRequestDTO extends BaseDTO {
+
+public class RampRuleOwnershipRequestDTO extends BaseDTO {
   // Represents the name of the Ramp rule
   @JsonProperty("ruleName")
   @NotBlank(message = "ruleName cannot be blank.", groups = ValidationOnCreate.class)
   @NotNull(message = "ruleName cannot be null.")
   private String ruleName;
-  // Represents the name of the image type for the rule
-  @JsonProperty("imageName")
-  @NotBlank(message = "imageName cannot be blank.", groups = {ValidationOnCreate.class})
-  @NotNull(message = "imageName cannot be null.")
-  private String imageName;
-  // Represents the name of the image version for the rule
-  @JsonProperty("imageVersion")
-  @NotBlank(message = "imageVersion cannot be blank.", groups = {ValidationOnCreate.class})
-  @NotNull(message = "imageVersion cannot be null.")
-  private String imageVersion;
+  // Represents the name of the ownerships for the rule
   @JsonProperty("ownerships")
+  @NotBlank(message = "rule ownerships cannot be blank.", groups = ValidationOnCreate.class)
+  @NotNull(message = "rule ownerships cannot be null.")
   private String ownerships;
 
   public void setRuleName(String ruleName) {
     this.ruleName = ruleName;
   }
 
-  public void setImageName(String imageName) {
-    this.imageName = imageName;
-  }
-
-  public void setImageVersion(String imageVersion) {
-    this.imageVersion = imageVersion;
-  }
-
   public String getRuleName() {
     return ruleName;
-  }
-
-  public String getImageName() {
-    return imageName;
-  }
-
-  public String getImageVersion() {
-    return imageVersion;
   }
 
   public void setOwnerships(String ownerships) {

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManager.java
@@ -19,7 +19,7 @@ package azkaban.imagemgmt.permission;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
-import azkaban.user.UserManager;
+import java.util.List;
 import java.util.Set;
 
 
@@ -36,7 +36,7 @@ public interface PermissionManager {
    * @param type
    * @return boolean
    */
-  public boolean hasPermission(final String imageTypeName, final String userId, final Type type)
+  public boolean hasPermissionForImageType(final String imageTypeName, final String userId, final Type type)
       throws ImageMgmtException;
 
   /**
@@ -58,4 +58,22 @@ public interface PermissionManager {
    *         false otherwise
    */
   public boolean isAzkabanAdmin(final User user);
+
+  /**
+   * Checks if all the identities are all legit;
+   *
+   * @throws ImageMgmtException if failed to validate a single Ldap
+   * */
+  public void validateIdentity(final List<String> ids) throws ImageMgmtException;
+
+  /**
+   * Checks if current user has permission to make changes on Ramp rule
+   *
+   * @param user
+   * @param currentOwners
+   * @return true if azkaban admin or validated permission,
+   *         false otherwise
+   * @throws ImageMgmtException if failed to validate a single Ldap
+   * */
+  public boolean hasPermission(final User user, final Set<String> currentOwners);
 }

--- a/azkaban-db/src/main/sql/create.ramp_rules.sql
+++ b/azkaban-db/src/main/sql/create.ramp_rules.sql
@@ -1,13 +1,13 @@
 CREATE TABLE ramp_rules (
     rule_name VARCHAR(100) NOT NULL,
-    image_name VARCHAR(200) NOT NULL,
-    image_version VARCHAR (100) NOT NULL,
+    image_name VARCHAR(200),
+    image_version VARCHAR (100),
     owners VARCHAR (1000) NOT NULL,
     is_HP BIT NOT NULL,
     created_by VARCHAR(20) NOT NULL,
     created_on DATE NOT NULL,
-    modified_by VARCHAR(20),
-    modified_on DATE,
+    modified_by VARCHAR(20) NOT NULL,
+    modified_on DATE NOT NULL,
     PRIMARY KEY (rule_name)
 );
 

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -15,6 +15,7 @@
  */
 package azkaban.imagemgmt.services;
 
+import azkaban.imagemgmt.dto.RampRuleOwnershipRequestDTO;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageRampRule;
@@ -29,7 +30,8 @@ public interface ImageRampRuleService {
 
   /**
    * Create a normal exclusive Rule for a certain version of an image type,
-   * validation performed before insert into DB.
+   * validation performed based on {@link ImageRampRuleRequestDTO} and convert to {@link ImageRampRule}
+   * before insert into DB.
    *
    * @param rampRuleRequestDTO
    * @param ldapUser
@@ -37,11 +39,37 @@ public interface ImageRampRuleService {
    * */
   void createRule(final ImageRampRuleRequestDTO rampRuleRequestDTO, final User ldapUser);
 
-  void createHpFlowRule(final ImageRampRule rule);
+  /**
+   * Create an HP Flow exclusive Rule to denying all image Types,
+   * validation performed based on {@link RampRuleOwnershipRequestDTO} and convert to {@link ImageRampRule}
+   *
+   * @param hpFlowRuleRequestDTO
+   * @param user
+   * @throws ImageMgmtException
+   * */
+  void createHpFlowRule(final RampRuleOwnershipRequestDTO hpFlowRuleRequestDTO, final User user);
+
+  /**
+   * Update the rule with ownerships, only existing owners have the permission to add/remove new owners,
+   * ownerships should be provided using "," as delimiter, otherwise validation will fail.
+   * validation performed based on {@link RampRuleOwnershipRequestDTO} and invoke DB.
+   *
+   * @param RuleOwnershipDTO
+   * @param user
+   * @param operationType
+   * @throws ImageMgmtException
+   * */
+  void updateOwnership(final RampRuleOwnershipRequestDTO RuleOwnershipDTO, final User user,
+      final OperationType operationType);
 
   void deleteRule(final String ruleName);
 
   void addFlowsToRule(final List<String> flowIds, final String ruleName);
 
   void updateVersionOnRule(final String newVersion, final String ruleName);
+
+  enum OperationType {
+    ADD(),
+    REMOVE()
+  }
 }

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -43,11 +43,11 @@ public interface ImageRampRuleService {
    * Create an HP Flow exclusive Rule to denying all image Types,
    * validation performed based on {@link RampRuleOwnershipDTO} and convert to {@link ImageRampRule}
    *
-   * @param hpFlowRuleRequestDTO
+   * @param hpFlowRuleOwnershipRequestDTO
    * @param user
    * @throws ImageMgmtException
    * */
-  void createHpFlowRule(final RampRuleOwnershipDTO hpFlowRuleRequestDTO, final User user);
+  void createHpFlowRule(final RampRuleOwnershipDTO hpFlowRuleOwnershipRequestDTO, final User user);
 
   /**
    * Update the rule with ownerships, only existing owners have the permission to add/remove new owners,
@@ -59,7 +59,7 @@ public interface ImageRampRuleService {
    * @param operationType
    * @throws ImageMgmtException
    * @return*/
-  String updateOwnership(final RampRuleOwnershipDTO RuleOwnershipDTO, final User user,
+  String updateRuleOwnership(final RampRuleOwnershipDTO RuleOwnershipDTO, final User user,
       final OperationType operationType);
 
   void deleteRule(final String ruleName);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -15,7 +15,7 @@
  */
 package azkaban.imagemgmt.services;
 
-import azkaban.imagemgmt.dto.RampRuleOwnershipRequestDTO;
+import azkaban.imagemgmt.dto.RampRuleOwnershipDTO;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageRampRule;
@@ -41,25 +41,25 @@ public interface ImageRampRuleService {
 
   /**
    * Create an HP Flow exclusive Rule to denying all image Types,
-   * validation performed based on {@link RampRuleOwnershipRequestDTO} and convert to {@link ImageRampRule}
+   * validation performed based on {@link RampRuleOwnershipDTO} and convert to {@link ImageRampRule}
    *
    * @param hpFlowRuleRequestDTO
    * @param user
    * @throws ImageMgmtException
    * */
-  void createHpFlowRule(final RampRuleOwnershipRequestDTO hpFlowRuleRequestDTO, final User user);
+  void createHpFlowRule(final RampRuleOwnershipDTO hpFlowRuleRequestDTO, final User user);
 
   /**
    * Update the rule with ownerships, only existing owners have the permission to add/remove new owners,
    * ownerships should be provided using "," as delimiter, otherwise validation will fail.
-   * validation performed based on {@link RampRuleOwnershipRequestDTO} and invoke DB.
+   * validation performed based on {@link RampRuleOwnershipDTO} and invoke DB.
    *
    * @param RuleOwnershipDTO
    * @param user
    * @param operationType
    * @throws ImageMgmtException
-   * */
-  void updateOwnership(final RampRuleOwnershipRequestDTO RuleOwnershipDTO, final User user,
+   * @return*/
+  String updateOwnership(final RampRuleOwnershipDTO RuleOwnershipDTO, final User user,
       final OperationType operationType);
 
   void deleteRule(final String ruleName);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleServiceImpl.java
@@ -112,25 +112,26 @@ public class ImageRampRuleServiceImpl implements ImageRampRuleService {
    * Create HP Flow rule converted from HPFlowRule request, validate input ownerships.
    * Then call for {@link RampRuleDao} to insert the entry into DB.
    *
-   * @param hpFlowRuleRequestDTO
+   * @param hpFlowRuleOwnershipRequestDTO
    * @param user
    * @throws ImageMgmtDaoException when DB insertion fail
    * @throws ImageMgmtValidationException when user does not have permission
    * */
   @Override
-  public void createHpFlowRule(final RampRuleOwnershipDTO hpFlowRuleRequestDTO, final User user) {
-    if (hpFlowRuleRequestDTO.getOwnerships() == null || hpFlowRuleRequestDTO.getOwnerships().isEmpty()) {
+  public void createHpFlowRule(final RampRuleOwnershipDTO hpFlowRuleOwnershipRequestDTO, final User user) {
+    if (hpFlowRuleOwnershipRequestDTO.getOwnerships() == null
+        || hpFlowRuleOwnershipRequestDTO.getOwnerships().isEmpty()) {
       throw new ImageMgmtInvalidInputException(ErrorCode.BAD_REQUEST,
           "missing ownerships, please specify valid ldap user");
     }
-    List<String> ruleOwners = Arrays.asList(hpFlowRuleRequestDTO.getOwnerships().split(","));
+    List<String> ruleOwners = Arrays.asList(hpFlowRuleOwnershipRequestDTO.getOwnerships().split(","));
     permissionManager.validateIdentity(ruleOwners);
     ImageRampRule rampRule = new ImageRampRule.Builder()
-        .setRuleName(hpFlowRuleRequestDTO.getRuleName())
+        .setRuleName(hpFlowRuleOwnershipRequestDTO.getRuleName())
         .setOwners(new HashSet<>(ruleOwners))
         .setHPRule(true)
-        .setCreatedBy(hpFlowRuleRequestDTO.getCreatedBy())
-        .setModifiedBy(hpFlowRuleRequestDTO.getModifiedBy())
+        .setCreatedBy(hpFlowRuleOwnershipRequestDTO.getCreatedBy())
+        .setModifiedBy(hpFlowRuleOwnershipRequestDTO.getModifiedBy())
         .build();
     rampRuleDao.addRampRule(rampRule);
   }
@@ -147,7 +148,7 @@ public class ImageRampRuleServiceImpl implements ImageRampRuleService {
    * @throws ImageMgmtValidationException when user does not have permission
    * @return newOwners */
   @Override
-  public String updateOwnership(final RampRuleOwnershipDTO ruleOwnershipDTO, final User user,
+  public String updateRuleOwnership(final RampRuleOwnershipDTO ruleOwnershipDTO, final User user,
       final OperationType operationType) {
     Set<String> existingOwners = rampRuleDao.getOwners(ruleOwnershipDTO.getRuleName());
     // validate current user has permission to change owner

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
@@ -164,7 +164,7 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
       // while converting to requestDTO, validation on json/required parameters would be performed.
       deltaOwnershipRequestDTO = utils.convertToDTO(requestBody, RampRuleOwnershipDTO.class);
       deltaOwnershipRequestDTO.setModifiedBy(user.getUserId());
-      String updatedOwners = imageRampRuleService.updateOwnership(deltaOwnershipRequestDTO, user, type);
+      String updatedOwners = imageRampRuleService.updateRuleOwnership(deltaOwnershipRequestDTO, user, type);
       // prepare response
       RampRuleOwnershipDTO responseModel = new RampRuleOwnershipDTO();
       responseModel.setOwnerships(updatedOwners);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageRampRuleServlet.java
@@ -15,6 +15,7 @@
  */
 package azkaban.imagemgmt.servlets;
 
+import azkaban.imagemgmt.dto.RampRuleOwnershipRequestDTO;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.services.ImageRampRuleService;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * Add managed flows into rule: POST /imageRampRule/addFlowsToRule
  * Modify image version on Rule: POST /imageRampRule/updateVersionOnRule
  * Delete rule: POST /imageRampRule/deleteRule
+ * Modify ownerships: POST /imageRampRule/addOwners or POST /imageRampRule/removeOwners
  */
 public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
   private static final Logger LOG = LoggerFactory.getLogger(ImageRampRuleServlet.class);
@@ -50,6 +52,9 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
   private ConverterUtils utils;
 
   private final static String CREATE_RULE_URI = "/imageRampRule/createRule";
+  private final static String CREATE_HP_FLOW_RULE_URI = "/imageRampRule/createHPFlowRule";
+  private final static String ADD_OWNERS_URI = "/imageRampRule/addOwners";
+  private final static String REMOVE_OWNERS_URI = "/imageRampRule/removeOwners";
 
   public ImageRampRuleServlet() {
     super(new ArrayList<>());
@@ -73,11 +78,23 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
   protected void handlePost(HttpServletRequest req, HttpServletResponse resp, Session session)
       throws ServletException, IOException {
       String requestURI = req.getRequestURI();
+      LOG.info("handle request from post uri: " + requestURI);
       User user = session.getUser();
-      if (CREATE_RULE_URI.equals(requestURI)) {
-        LOG.info("handle request from post uri: " + requestURI);
-        handleCreateRampRule(req, resp, user);
+      switch (requestURI) {
+        case CREATE_RULE_URI:
+          handleCreateRampRule(req, resp, user);
+          break;
+        case CREATE_HP_FLOW_RULE_URI:
+          handleCreateHPFlowRule(req, resp, user);
+          break;
+        case ADD_OWNERS_URI:
+          handleUpdateOwnerships(req, resp, user, ImageRampRuleService.OperationType.ADD);
+          break;
+        case REMOVE_OWNERS_URI:
+          handleUpdateOwnerships(req, resp, user, ImageRampRuleService.OperationType.REMOVE);
+          break;
       }
+
   }
 
   /**
@@ -105,5 +122,54 @@ public class ImageRampRuleServlet extends LoginAbstractAzkabanServlet {
     }
   }
 
+  /**
+   * create an exclusive rule for High priority flows which will deny all image Ramp Versions,
+   * Successful call would return CREATED(201).
+   *
+   * @throws ImageMgmtException with different ErrorCode, and the detailed error message.
+   **/
+  private void handleCreateHPFlowRule(final HttpServletRequest req,
+                                      final HttpServletResponse resp,
+                                      final User user)
+                                      throws ServletException {
+    String requestBody = HttpRequestUtils.getBody(req);
+    RampRuleOwnershipRequestDTO hpFlowRuleRequestDTO;
+    try {
+      // while converting to requestDTO, validation on json/required parameters would be performed.
+      hpFlowRuleRequestDTO = utils.convertToDTO(requestBody, RampRuleOwnershipRequestDTO.class);
+      hpFlowRuleRequestDTO.setCreatedBy(user.getUserId());
+      hpFlowRuleRequestDTO.setModifiedBy(user.getUserId());
+      imageRampRuleService.createHpFlowRule(hpFlowRuleRequestDTO, user);
+      resp.setStatus(HttpStatus.SC_CREATED);
+    } catch (ImageMgmtException e) {
+      LOG.error("failed to create a rampRule: " + requestBody);
+      resp.setStatus(e.getErrorCode().getCode(), e.getMessage());
+    }
+  }
+
+  /**
+   * Add/Remove owners for a ramp rule.
+   * Successful call would return CREATED(201).
+   *
+   * @throws ImageMgmtException with different ErrorCode, and the detailed error message.
+   **/
+  private void handleUpdateOwnerships(final HttpServletRequest req,
+                                      final HttpServletResponse resp,
+                                      final User user,
+                                      final ImageRampRuleService.OperationType type)
+                                      throws ServletException {
+    String requestBody = HttpRequestUtils.getBody(req);
+    RampRuleOwnershipRequestDTO deltaOwnershipRequestDTO;
+    try {
+      // while converting to requestDTO, validation on json/required parameters would be performed.
+      deltaOwnershipRequestDTO = utils.convertToDTO(requestBody, RampRuleOwnershipRequestDTO.class);
+      deltaOwnershipRequestDTO.setModifiedBy(user.getUserId());
+      imageRampRuleService.updateOwnership(deltaOwnershipRequestDTO, user, type);
+      resp.setStatus(HttpStatus.SC_OK);
+    } catch (ImageMgmtException e) {
+      LOG.error("failed to update ownerships: " + requestBody);
+      resp.setStatus(e.getErrorCode().getCode(), e.getMessage());
+    }
+  }
 
 }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -747,7 +747,7 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
     if (permissionManager.isAzkabanAdmin(user)) {
       return true;
     }
-    return permissionManager.hasPermission(imageTypeName, user.getUserId(), type);
+    return permissionManager.hasPermissionForImageType(imageTypeName, user.getUserId(), type);
   }
 
 

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
@@ -128,7 +128,7 @@ public class ImageRampRuleServiceImplTest {
     when(_rampRuleDao.getOwners(requestDTO.getRuleName())).thenReturn(existingOwners);
     when(_rampRuleDao.updateOwnerships(any(), any(), any())).thenReturn(1);
 
-    String updatedOwner = _rampRuleService.updateOwnership(requestDTO, user, ImageRampRuleService.OperationType.ADD);
+    String updatedOwner = _rampRuleService.updateRuleOwnership(requestDTO, user, ImageRampRuleService.OperationType.ADD);
     assertThat(updatedOwner).contains(existingOwner1, existingOwner2);
     assertThat(updatedOwner).contains("user1");
   }
@@ -154,7 +154,7 @@ public class ImageRampRuleServiceImplTest {
     when(_rampRuleDao.getOwners(requestDTO.getRuleName())).thenReturn(existingOwners);
     when(_rampRuleDao.updateOwnerships(any(), any(), any())).thenReturn(1);
 
-    String updatedOwner = _rampRuleService.updateOwnership(requestDTO, user, ImageRampRuleService.OperationType.REMOVE);
+    String updatedOwner = _rampRuleService.updateRuleOwnership(requestDTO, user, ImageRampRuleService.OperationType.REMOVE);
     assertThat(updatedOwner).contains(existingOwner2);
     assertThat(updatedOwner).doesNotContain("user1");
   }

--- a/azkaban-web-server/src/test/resources/image_management/flow_owners_update.json
+++ b/azkaban-web-server/src/test/resources/image_management/flow_owners_update.json
@@ -1,0 +1,4 @@
+{
+  "ruleName": "testUpdate",
+  "ownerships": "user1,user2"
+}

--- a/azkaban-web-server/src/test/resources/image_management/hp_flow_rule.json
+++ b/azkaban-web-server/src/test/resources/image_management/hp_flow_rule.json
@@ -1,0 +1,4 @@
+{
+  "ruleName": "testHP",
+  "ownerships": "shwei"
+}

--- a/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_without_owners.json
+++ b/azkaban-web-server/src/test/resources/image_management/image_ramp_rule_without_owners.json
@@ -1,6 +1,5 @@
 {
   "ruleName": "daliSparkExclude",
   "imageName": "az-platform-image",
-  "imageVersion": "0.0.421",
-  "ownerships": "shwei"
+  "imageVersion": "0.0.421"
 }


### PR DESCRIPTION
- Add implementation for creating ramp rule for high priority flows /createHPFlowRule Introducing "ownerships" directly in the rule creation for easy managing RampRule and serves as source of truth. For /createRule, missing ownerships would use default ImageType Owners; For /createHPFlowRule, ownerships parameter is madantory since current azkaban system does not maintain concept of high priotity flows ownership.
- Add two APIs to manage ownership management: /addOwners and /removeOwners. update ownership operation only can be done by existing owners or azkaban admin.

End to End test has been performed in the following cases success cases:
createRampRule w/ and w/o designated owners 201 Created createHPFlowRule 201 Created
add/removeOwners appropriate permission 200 OK
Failure cases:
Invalid ownerId (user and group) 400
updateOwners without being existing owner 401
updateOwners with non existing rule 400