### PR TITLE
Move PermissionManager bindings from Common to WebServer

### DIFF
--- a/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
+++ b/azkaban-common/src/main/java/azkaban/AzkabanCommonModule.java
@@ -46,8 +46,6 @@ import azkaban.imagemgmt.daos.ImageVersionDao;
 import azkaban.imagemgmt.daos.ImageVersionDaoImpl;
 import azkaban.imagemgmt.daos.RampRuleDao;
 import azkaban.imagemgmt.daos.RampRuleDaoImpl;
-import azkaban.imagemgmt.permission.PermissionManager;
-import azkaban.imagemgmt.permission.PermissionManagerImpl;
 import azkaban.imagemgmt.rampup.ImageRampupManager;
 import azkaban.imagemgmt.rampup.ImageRampupManagerImpl;
 import azkaban.logs.JdbcExecutionLogsLoader;
@@ -228,7 +226,6 @@ public class AzkabanCommonModule extends AbstractModule {
       bind(ImageRampupManager.class).to(ImageRampupManagerImpl.class).in(Scopes.SINGLETON);
       bind(RampRuleDao.class).to(RampRuleDaoImpl.class).in(Scopes.SINGLETON);
       bind(ImageMgmtCommonDao.class).to(ImageMgmtCommonDaoImpl.class).in(Scopes.SINGLETON);
-      bind(PermissionManager.class).to(PermissionManagerImpl.class).in(Scopes.SINGLETON);
       bind(Converter.class).annotatedWith(Names.named(IMAGE_TYPE))
           .to(ImageTypeConverter.class).in(Scopes.SINGLETON);
       bind(Converter.class).annotatedWith(Names.named(IMAGE_VERSION))

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServerModule.java
@@ -48,6 +48,8 @@ import azkaban.flowtrigger.database.FlowTriggerInstanceLoader;
 import azkaban.flowtrigger.database.JdbcFlowTriggerInstanceLoaderImpl;
 import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginException;
 import azkaban.flowtrigger.plugin.FlowTriggerDependencyPluginManager;
+import azkaban.imagemgmt.permission.PermissionManager;
+import azkaban.imagemgmt.permission.PermissionManagerImpl;
 import azkaban.imagemgmt.services.ImageMgmtCommonService;
 import azkaban.imagemgmt.services.ImageMgmtCommonServiceImpl;
 import azkaban.imagemgmt.services.ImageRampRuleService;
@@ -192,6 +194,7 @@ public class AzkabanWebServerModule extends AbstractModule {
       bind(ImageVersionMetadataService.class).to(ImageVersionMetadataServiceImpl.class).in(Scopes.SINGLETON);
       bind(ImageMgmtCommonService.class).to(ImageMgmtCommonServiceImpl.class).in(Scopes.SINGLETON);
       bind(ImageRampRuleService.class).to(ImageRampRuleServiceImpl.class).in(Scopes.SINGLETON);
+      bind(PermissionManager.class).to(PermissionManagerImpl.class).in(Scopes.SINGLETON);
     }
   }
 


### PR DESCRIPTION
[Bug Fix]Move PermissionManager bindings from CommonModule to WebServerModule

This is caused by missing UserManager initializtion config in flow container and fail in pods. Webserver is configured to correct userManager so let's keep authorization in web server only.