### PR TITLE
Return null instead of exception when job output prop does not exist …

### DIFF
--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1201,9 +1201,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     while (variableMatcher.find()) {
       final String value = findValueForJobVariable(node, variableMatcher.group(1),
           variableMatcher.group(2));
-      if (value != null) {
-        replaced = replaced.replace(variableMatcher.group(), "'" + value + "'");
-      }
+      replaced = replaced.replace(variableMatcher.group(), "'" + value + "'");
       this.logger.info("Resolved condition of " + node.getId() + " is " + replaced);
     }
 
@@ -1211,9 +1209,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     return evaluateExpression(replaced);
   }
 
-  @Nonnull
-  private String findValueForJobVariable(final ExecutableNode node, final String jobName, final
-  String variable) {
+  private String findValueForJobVariable(final ExecutableNode node, final String jobName,
+      final String variable) {
     // Get job output props
     final ExecutableNode target = node.getParentFlow().getExecutableNode(jobName);
     if (target == null) {
@@ -1224,10 +1221,12 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
 
     final Props outputProps = target.getOutputProps();
     if (outputProps == null) {
-      throw new IllegalStateException("No output properties were generated for job " + jobName + ".");
+      this.logger.warn("No output properties were generated for job " + jobName + ".");
+      return null;
     }
     if (!outputProps.containsKey(variable)) {
-      throw new IllegalStateException("No variable named " + variable + " found in job " + jobName + " output parameters. Properties: " + outputProps);
+      this.logger.warn("No variable named " + variable + " found in job " + jobName + " output parameters. Properties: " + outputProps);
+      return null;
     }
 
     return outputProps.get(variable);

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalFlowTest.java
@@ -100,7 +100,7 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
   }
 
   @Test
-  public void flowShouldFailWhenConditionalParameterDoesntExist() throws Exception {
+  public void flowShouldBeKilledWhenConditionalParameterDoesntExist() throws Exception {
     final HashMap<String, String> flowProps = new HashMap<>();
     setUp(CONDITIONAL_FLOW_8, flowProps);
     final ExecutableFlow flow = this.runner.getExecutableFlow();
@@ -110,9 +110,9 @@ public class FlowRunnerConditionalFlowTest extends FlowRunnerTestBase {
     generatedProperties.put("key2", "value2");
     InteractiveTestJob.getTestJob("jobA").succeedJob(generatedProperties);
     assertStatus(flow, "jobA", Status.SUCCEEDED);
-    assertStatus(flow, "jobC", Status.READY);
-    assertStatus(flow, "jobD", Status.READY);
-    assertFlowStatus(flow, Status.FAILED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.CANCELLED);
+    assertFlowStatus(flow, Status.KILLED);
   }
 
   @Test

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerConditionalJobsTest.java
@@ -141,6 +141,21 @@ public class FlowRunnerConditionalJobsTest extends FlowRunnerTestBase {
     assertFlowStatus(flow, Status.SUCCEEDED);
   }
 
+  @Test
+  public void runFlowOnMissingJobOutputProp() throws Exception {
+    final HashMap<String, String> flowProps = new HashMap<>();
+    setUp(CONDITIONAL_FLOW_7, flowProps, "jobD");
+    final ExecutableFlow flow = this.runner.getExecutableFlow();
+    // Don't put any output prop here to simulate missing job output prop scenario
+    final Props generatedProperties = new Props();
+    InteractiveTestJob.getTestJob((CONDITIONAL_FLOW_7 + ":") + "jobA").succeedJob(generatedProperties);
+    assertStatus(flow, "jobA", Status.SUCCEEDED);
+    assertStatus(flow, "jobB", Status.CANCELLED);
+    assertStatus(flow, "jobC", Status.CANCELLED);
+    assertStatus(flow, "jobD", Status.SUCCEEDED);
+    assertFlowStatus(flow, Status.SUCCEEDED);
+  }
+
   /**
    * JobB has defined "condition: var fImport = new JavaImporter(java.io.File); with(fImport) { var
    * f = new File('new'); f.createNewFile(); }"

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -31,7 +31,7 @@
   <script type="text/javascript" src="${context}/js/flowstats-no-data.js"></script>
 
   <script type="text/javascript" src="${context}/js/azkaban/util/job-list-common.js?v=1570835891"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1570835891"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/flow-execution-list.js?v=1662765226"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-trigger-list.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>

--- a/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/flow-execution-list.js
@@ -94,10 +94,6 @@ azkaban.ExecutionListView = Backbone.View.extend({
     for (var i = 0; i < nodes.length; ++i) {
       var node = nodes[i].changedNode ? nodes[i].changedNode : nodes[i];
 
-      if (node.status == 'READY') {
-        continue;
-      }
-
       //var nodeId = node.id.replace(".", "\\\\.");
       var row = node.joblistrow;
       if (!row) {

--- a/test/execution-test-data/conditionalflowtest/conditional_flow7/jobA.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow7/jobA.job
@@ -1,0 +1,2 @@
+type=test
+seconds=0

--- a/test/execution-test-data/conditionalflowtest/conditional_flow7/jobB.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow7/jobB.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:unknownprops} == 'foo'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow7/jobC.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow7/jobC.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=${jobA:unknownprops} == 'bar'
+dependencies=jobA

--- a/test/execution-test-data/conditionalflowtest/conditional_flow7/jobD.job
+++ b/test/execution-test-data/conditionalflowtest/conditional_flow7/jobD.job
@@ -1,0 +1,5 @@
+type=test
+fail=false
+seconds=0
+condition=one_success
+dependencies=jobA,jobB,jobC


### PR DESCRIPTION
…and show READY jobs in UI.

In Azkaban partial execution for a conditional flow/job, if parent job's output prop that is depended by some child job is missing, the flow will be marked as FAILED directly even though some other children jobs are okay to proceed if they do not have dependency over the missing output prop.

As the fix, if output prop is missing, we will still continue processing the jobs that do not depend on the missing output prop instead of marking the flow as FAILED immediately. Such output prop missing info will still be printed out in flow logs to notify users.