### PR TITLE
Implement AddFlowsToRule for RampManager

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -15,7 +15,11 @@
  */
 package azkaban.imagemgmt.daos;
 
+import azkaban.executor.ExecutableFlow;
+import azkaban.imagemgmt.dto.RampRuleFlowsDTO;
 import azkaban.imagemgmt.models.ImageRampRule;
+import azkaban.imagemgmt.dto.RampRuleFlowsDTO.ProjectFlow;
+import java.util.List;
 import java.util.Set;
 
 
@@ -64,6 +68,14 @@ public interface RampRuleDao {
   Set<String> getOwners(final String ruleName);
 
   /**
+   * Query table ramp_rules to get image ramp rule associated with given ruleName.
+   *
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @return image ramp rule.
+   */
+  ImageRampRule getRampRule(final String ruleName);
+
+  /**
    * delete the ramp_rules to get owners of Ramp rule.
    *
    * @param ruleName - ruleName in {@see ImageRampRule}
@@ -71,4 +83,18 @@ public interface RampRuleDao {
    */
   void deleteRampRule(final String ruleName);
 
+  /**
+   * create one to one mappings from flow to deny image information into table flow_deny_lists.
+   * flowIds will be converted into format project.flow to match {@link ExecutableFlow#getFlowName()}.
+   *
+   * @param flowIds - list of flowIds in {@link ProjectFlow}
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  int addFlowDenyInfo(final List<ProjectFlow> flowIds, final String ruleName);
+
+  enum DenyMode {
+    ALL, // deny all versions, used for HP flow ramp rule
+    PARTIAL // deny partial versions, versions need to be specified in normal ramp rule
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleFlowsDTO.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/dto/RampRuleFlowsDTO.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.imagemgmt.dto;
+
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import org.apache.htrace.shaded.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class represents adding flows to ramp rule request.
+ */
+public class RampRuleFlowsDTO extends BaseDTO {
+  // the name of ramp rule
+  @JsonProperty("ruleName")
+  @NotNull
+  public String ruleName;
+  // flowIds associated with rule
+  @JsonProperty("flowIds")
+  @NotNull
+  @NotEmpty
+  public List<ProjectFlow> flowIds;
+
+  public String getRuleName() {
+    return ruleName;
+  }
+
+  public void setRuleName(String ruleName) {
+    this.ruleName = ruleName;
+  }
+
+  public List<ProjectFlow> getFlowIds() {
+    return flowIds;
+  }
+
+  public void setFlowIds(List<ProjectFlow> flowIds) {
+    this.flowIds = flowIds;
+  }
+
+  public static class ProjectFlow {
+    @JsonProperty("projectName")
+    public String projectName;
+    @JsonProperty("flowName")
+    public String flowName;
+
+    @Override
+    public String toString() {
+      return String.join(".", projectName, flowName);
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/RampRuleDenyList.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/RampRuleDenyList.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.imagemgmt.models;
+
+import azkaban.imagemgmt.daos.RampRuleDao.DenyMode;
+import javax.annotation.Nullable;
+
+/**
+ * This class represents flows with excluded executable mode or image versions from image ramp rules.
+ * */
+public class RampRuleDenyList extends BaseModel {
+
+  // in the format of projectName.flowName
+  final String flowId;
+  // deny mode for current flow, see explanation in {@link DenyMode}
+  final DenyMode denyMode;
+  // deny versions, only exists when DenyMode is PARTIAL
+  @Nullable
+  String denyVersion;
+  // rule name that regulates this flow deny list
+  final String ruleName;
+
+  public RampRuleDenyList(final String flowId,
+      final DenyMode denyMode,
+      @Nullable String denyVersion,
+      final String ruleName,
+      final String createdBy,
+      final String createdOn ,
+      final String modifiedBy,
+      final String modifiedOn) {
+    this.ruleName = ruleName;
+    this.flowId = flowId;
+    this.denyMode = denyMode;
+    this.denyVersion = denyVersion;
+    super.createdBy = createdBy;
+    super.createdOn = createdOn;
+    super.modifiedBy = modifiedBy;
+    super.modifiedOn = modifiedOn;
+  }
+
+  public String getRuleName() {
+    return ruleName;
+  }
+
+  public String getFlowId() {
+    return flowId;
+  }
+
+  public DenyMode getDenyMode() {
+    return denyMode;
+  }
+
+  @Nullable
+  public String getDenyVersion() {
+    return denyVersion;
+  }
+
+  public static class Builder {
+    // in the format of projectName.flowName
+    String flowId;
+    // deny mode for current flow, see explanation in {@link DenyMode}
+    DenyMode denyMode;
+    // deny versions, only exists when DenyMode is PARTIAL
+    String denyVersion;
+    // rule name that regulates this flow deny list
+    String ruleName;
+    // Created by user
+    String createdBy;
+    // Created Time
+    String createdOn;
+    // Modified by user
+    String modifiedBy;
+    // Modified Time
+    String modifiedOn;
+
+    public Builder setRuleName(String ruleName) {
+      this.ruleName = ruleName;
+      return this;
+    }
+
+    public Builder setFlowId(String imageName) {
+      this.flowId = imageName;
+      return this;
+    }
+
+    public Builder setDenyMode(String denyMode) {
+      this.denyMode = DenyMode.valueOf(denyMode);
+      return this;
+    }
+
+    public Builder setDenyVersion(String denyVersion) {
+      this.denyVersion = denyVersion;
+      return this;
+    }
+
+    public Builder setCreatedBy(String createdBy) {
+      this.createdBy = createdBy;
+      return this;
+    }
+
+    public Builder setCreatedOn(String createdOn) {
+      this.createdOn = createdOn;
+      return this;
+    }
+
+    public Builder setModifiedBy(String modifiedBy) {
+      this.modifiedBy = modifiedBy;
+      return this;
+    }
+
+    public Builder setModifiedOn(String modifiedOn) {
+      this.modifiedOn = modifiedOn;
+      return this;
+    }
+
+    public RampRuleDenyList build() {
+      return new RampRuleDenyList(flowId, denyMode, denyVersion, ruleName,
+          createdBy, createdOn, modifiedBy, modifiedOn);
+    }
+  }
+}
+

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -1070,6 +1070,24 @@ public class JdbcProjectImpl implements ProjectLoader {
     return !data.isEmpty();
   }
 
+  @Override
+  public boolean isFlowInProject(String projectName, String flowId) {
+    Project project = fetchProjectByName(projectName);
+    if (project == null) {
+      logger.info("Can not find active project " + projectName);
+      return false;
+    }
+    try {
+      List<Flow> flow = dbOperator.query(ProjectFlowsResultHandler.SELECT_PROJECT_FLOW,
+          new ProjectFlowsResultHandler(), project.getId(),
+          project.getVersion(), flowId);
+      return flow != null && !flow.isEmpty();
+    } catch (SQLException e) {
+      logger.error(e);
+      throw new ProjectManagerException("Failing to get flow " + flowId + " in project: " + projectName, e);
+    }
+  }
+
   /**
    * Returns list of Projects with ids that match with any id specified in the list of ids passed as
    * a parameter.

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -234,6 +234,15 @@ public interface ProjectLoader {
       throws ProjectManagerException;
 
   /**
+   * Check if given flow is included in given project.
+   * The project must be active.
+   *
+   * @return true, if the flow exists in the project;
+   *         false, otherwise
+   * */
+  boolean isFlowInProject(String projectName, String flowId);
+
+  /**
    * Retrieve projects corresponding to ids specified in a list.
    */
   List<Project> fetchProjectById(List<Integer> ids) throws ProjectManagerException;

--- a/azkaban-db/src/main/sql/create.flow_deny_lists.sql
+++ b/azkaban-db/src/main/sql/create.flow_deny_lists.sql
@@ -1,0 +1,16 @@
+CREATE TABLE flow_deny_lists (
+    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    flow_id VARCHAR(100) NOT NULL,
+    deny_mode VARCHAR(10) NOT NULL ,
+    deny_version VARCHAR (100),
+    rule_name VARCHAR (100) NOT NULL
+);
+
+CREATE INDEX idx_flow_id
+    ON flow_deny_lists (flow_id);
+CREATE INDEX idx_flow_deny_rule_name
+    ON flow_deny_lists (rule_name);
+CREATE INDEX idx_flow_id_deny_mode
+    ON flow_deny_lists (flow_id, deny_mode);
+CREATE INDEX idx_flow_id_deny_version
+    ON flow_deny_lists (flow_id, deny_version);

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -15,6 +15,7 @@
  */
 package azkaban.imagemgmt.services;
 
+import azkaban.imagemgmt.dto.RampRuleFlowsDTO.ProjectFlow;
 import azkaban.imagemgmt.dto.RampRuleOwnershipDTO;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
 import azkaban.imagemgmt.exception.ImageMgmtException;
@@ -58,13 +59,22 @@ public interface ImageRampRuleService {
    * @param user
    * @param operationType
    * @throws ImageMgmtException
-   * @return*/
+   * @return owners of ramp rule
+   * */
   String updateRuleOwnership(final RampRuleOwnershipDTO RuleOwnershipDTO, final User user,
       final OperationType operationType);
 
   void deleteRule(final String ruleName);
 
-  void addFlowsToRule(final List<String> flowIds, final String ruleName);
+  /**
+   * add flows into ramp rules. Validation will be performed based on owner list, active project and valid flows.
+   * call Dao layer to insert flow to image deny metadata into DB.
+   *
+   * @param flowIds - flows to be added into ramp rule
+   * @param ruleName - name in {@link ImageRampRule}
+   * @param user - used to validate
+   * */
+  void addFlowsToRule(final List<ProjectFlow> flowIds, final String ruleName, final User user);
 
   void updateVersionOnRule(final String newVersion, final String ruleName);
 

--- a/azkaban-web-server/src/test/resources/image_management/add_flows_to_rule.json
+++ b/azkaban-web-server/src/test/resources/image_management/add_flows_to_rule.json
@@ -1,0 +1,13 @@
+{
+  "ruleName": "daliSparkExclude",
+  "flowIds": [
+    {
+      "projectName": "testProject1",
+      "flowName": "testFlow1"
+    },
+    {
+      "projectName": "testProject2",
+      "flowName": "testFlow2"
+    }
+  ]
+}

--- a/azkaban-web-server/src/test/resources/image_management/add_flows_to_rule_invalid.json
+++ b/azkaban-web-server/src/test/resources/image_management/add_flows_to_rule_invalid.json
@@ -1,0 +1,9 @@
+{
+  "ruleName": "testInvalid",
+  "flowIds": [
+    {
+      "projectName": "null",
+      "flowName": "testFlow1"
+    }
+  ]
+}


### PR DESCRIPTION
This API supports adding flows into ramp rules. In order to query conveniently in execution layer, the DB format will use flowId (project.flow) which is formatted by ExecutableFlow.getFlowName, with its image deny metadata. For HP flow ramp rules, DB would store flowId with DenyMode.ALL; For normal ramp rules, DB would store flowId with DenyMode.PARTIAL and detailed denyVersion.

Successful request would be return 200 OK.
Failure case would include:
- Unable to authorize: user is not admin or does not pass PermissionManager validation
- Invalid inputs: inactive project or wrong flowName
- No rule created before insert flows.