### PR TITLE
UpdateVersion and deleteRule API for RampManager

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -93,6 +93,16 @@ public interface RampRuleDao {
    */
   int addFlowDenyInfo(final List<ProjectFlow> flowIds, final String ruleName);
 
+  /**
+   * Update version on the rule, both table flow_deny_lists and ramp_rules got refreshed data.
+   *
+   * @param version - new version to be updated
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @param user
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  void updateVersionOnRule(final String version, final String ruleName, String user);
+
   enum DenyMode {
     ALL, // deny all versions, used for HP flow ramp rule
     PARTIAL // deny partial versions, versions need to be specified in normal ramp rule

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
@@ -244,9 +244,8 @@ public class RampRuleDaoImpl implements RampRuleDao {
       return transOperator.getLastInsertId();
     };
     // end SQL transaction operator
-    int batchInsertId;
     try {
-      batchInsertId = this.databaseOperator.transaction(fetchRampRuleAndUpdateDenyList).intValue();
+      int batchInsertId = this.databaseOperator.transaction(fetchRampRuleAndUpdateDenyList).intValue();
       if (batchInsertId == 0) {
         LOG.warn(String.format("creating no new flow deny list based on rule: %s, "
                 + "flowList: %s. Might due to deny rule already exists", ruleName, flowIds));

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDaoImpl.java
@@ -20,6 +20,7 @@ import azkaban.db.SQLTransaction;
 import azkaban.imagemgmt.dto.RampRuleFlowsDTO.ProjectFlow;
 import azkaban.imagemgmt.exception.ErrorCode;
 import azkaban.imagemgmt.exception.ImageMgmtDaoException;
+import azkaban.imagemgmt.exception.ImageMgmtInvalidInputException;
 import azkaban.imagemgmt.models.ImageRampRule;
 import azkaban.imagemgmt.models.RampRuleDenyList;
 import java.sql.ResultSet;
@@ -55,8 +56,19 @@ public class RampRuleDaoImpl implements RampRuleDao {
   private static final String UPDATE_RULE_OWNERSHIP = "UPDATE ramp_rules "
       + "SET owners=?, modified_by=?, modified_on=? WHERE rule_name=?";
 
+  private static final String UPDATE_VERSION_ON_RAMP_RULE = "UPDATE ramp_rules "
+      + "SET image_version=?, modified_by=?, modified_on=? WHERE rule_name=?";
+
+  private static final String DELETE_RULE_ON_RAMP_RULE = "DELETE from ramp_rules where rule_name = ?";
+
+  private static final String DELETE_FLOW_DENY_LIST = "DELETE from flow_deny_lists where rule_name = ?";
+
+  private static final String UPDATE_VERSION_ON_DENY_LIST = "UPDATE flow_deny_lists "
+      + "SET deny_version=? WHERE rule_name=?";
+
   private static final String INSERT_FLOW_DENY_LIST = "INSERT into flow_deny_lists "
       + "(flow_id, deny_mode, deny_version, rule_name) values (?, ?, ?, ?)";
+
   private static final String INSERT_HP_DENY_LIST = "INSERT into flow_deny_lists "
       + "(flow_id, deny_mode, rule_name) values (?, ?, ?)";
 
@@ -155,7 +167,7 @@ public class RampRuleDaoImpl implements RampRuleDao {
           new FetchRampRuleHandler(), ruleName);
       if (rampRule == null) {
         LOG.error("Can not find ramp rule at the ruleName: " + ruleName);
-        throw new ImageMgmtDaoException("ramp rule not found with ruleName: " + ruleName);
+        throw new ImageMgmtDaoException(ErrorCode.BAD_REQUEST, "ramp rule not found with ruleName: " + ruleName);
       }
       return rampRule;
     } catch (SQLException e) {
@@ -166,7 +178,18 @@ public class RampRuleDaoImpl implements RampRuleDao {
 
   @Override
   public void deleteRampRule(final String ruleName) {
-
+    final SQLTransaction<Long> deleteRampRuleAndFlowDenyList = transOperator -> {
+      transOperator.update(DELETE_RULE_ON_RAMP_RULE, ruleName);
+      transOperator.update(DELETE_FLOW_DENY_LIST, ruleName);
+      transOperator.getConnection().commit();
+      return transOperator.getLastInsertId();
+    };
+    try {
+      databaseOperator.transaction(deleteRampRuleAndFlowDenyList);
+    } catch (SQLException e) {
+      LOG.error("failed to delete ramp rule: " + ruleName);
+      throw new ImageMgmtDaoException("Error in deleting data based on ramp rule: " + ruleName);
+    }
   }
 
   /**
@@ -221,7 +244,7 @@ public class RampRuleDaoImpl implements RampRuleDao {
       return transOperator.getLastInsertId();
     };
     // end SQL transaction operator
-    int batchInsertId = 0;
+    int batchInsertId;
     try {
       batchInsertId = this.databaseOperator.transaction(fetchRampRuleAndUpdateDenyList).intValue();
       if (batchInsertId == 0) {
@@ -242,6 +265,38 @@ public class RampRuleDaoImpl implements RampRuleDao {
     } catch (final SQLException e) {
       LOG.error("Unable to create the flow deny list metadata", e);
       throw new ImageMgmtDaoException("Exception while creating the flow deny list metadata: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Update version on the rule, both table flow_deny_lists and ramp_rules got refreshed data.
+   * It will fetch ramp_rules to get metadata and operate UPDATE on both in a single transaction.
+   *
+   * @param newVersion
+   * @param ruleName - ruleName in {@see ImageRampRule}
+   * @param user
+   * @throws azkaban.imagemgmt.exception.ImageMgmtDaoException
+   */
+  @Override
+  public void updateVersionOnRule(final String newVersion, final String ruleName, final String user) {
+    final SQLTransaction<Long> fetchRampRuleAndUpdateDenyList = transOperator -> {
+      final ImageRampRule imageRampRule =
+          transOperator.query(FetchRampRuleHandler.FETCH_RAMP_RULE_BY_ID, new FetchRampRuleHandler(), ruleName);
+      final String newDenyVersion = String.join(":", imageRampRule.getImageName(), newVersion);
+      if (!newVersion.equals(imageRampRule.getImageVersion())) {
+        transOperator.update(UPDATE_VERSION_ON_RAMP_RULE,
+            newVersion, user, Timestamp.valueOf(LocalDateTime.now()), ruleName);
+        transOperator.update(UPDATE_VERSION_ON_DENY_LIST, newDenyVersion, ruleName);
+      }
+      transOperator.getConnection().commit();
+      return transOperator.getLastInsertId();
+    };
+    // end SQL transaction operator
+    try {
+      this.databaseOperator.transaction(fetchRampRuleAndUpdateDenyList);
+    } catch (final SQLException e) {
+      LOG.error("Unable to update the ramp rule metadata", e);
+      throw new ImageMgmtDaoException("Unable to update the ramp rule version: " + e.getMessage());
     }
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/services/ImageRampRuleService.java
@@ -18,6 +18,7 @@ package azkaban.imagemgmt.services;
 import azkaban.imagemgmt.dto.RampRuleFlowsDTO.ProjectFlow;
 import azkaban.imagemgmt.dto.RampRuleOwnershipDTO;
 import azkaban.imagemgmt.dto.ImageRampRuleRequestDTO;
+import azkaban.imagemgmt.exception.ImageMgmtDaoException;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageRampRule;
 import azkaban.user.User;
@@ -64,7 +65,14 @@ public interface ImageRampRuleService {
   String updateRuleOwnership(final RampRuleOwnershipDTO RuleOwnershipDTO, final User user,
       final OperationType operationType);
 
-  void deleteRule(final String ruleName);
+  /**
+   * Delete ramp rule by given ruleName.
+   *
+   * @param ruleName - ruleName in {@link ImageRampRule}
+   * @param user - user must have the permission to delete
+   * @throws ImageMgmtDaoException - failures occur in DB transaction
+   * */
+  void deleteRule(final String ruleName, final User user);
 
   /**
    * add flows into ramp rules. Validation will be performed based on owner list, active project and valid flows.
@@ -76,7 +84,15 @@ public interface ImageRampRuleService {
    * */
   void addFlowsToRule(final List<ProjectFlow> flowIds, final String ruleName, final User user);
 
-  void updateVersionOnRule(final String newVersion, final String ruleName);
+  /**
+   * Update normal ramp rule's version based on given ruleName.
+   *
+   * @param ruleName - ruleName in {@link ImageRampRule}
+   * @param newVersion- new version to be updated
+   * @param user - user must have the permission to operate
+   * @throws ImageMgmtException - failures on updating HPFlowRule or DB transaction
+   * */
+  void updateVersionOnRule(final String newVersion, final String ruleName, final User user);
 
   enum OperationType {
     ADD(),


### PR DESCRIPTION
Update Version for existing RampRule will update version metadata on DB directly; while delete rule will delete all metadata related to the rule. Both API would not introduce new insert but only update existing data. Failure would occur when:
- no existing rule
- input failed validation
- no user permission