### PR TITLE
Fix TriggerScanner to prevent a blocking object.wait()

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -310,9 +310,9 @@ public class TriggerManager extends EventHandler implements
                 this.scannerInterval
                     - (System.currentTimeMillis() - TriggerManager.this.lastRunnerThreadCheckTime);
 
-            if (TriggerManager.this.runnerThreadIdleTime < 0) {
+            if (TriggerManager.this.runnerThreadIdleTime <= 0) {
               logger.error("Trigger manager thread " + this.getName()
-                  + " is too busy!");
+                  + " is too busy! Remaining idle time in ms: " + TriggerManager.this.runnerThreadIdleTime);
             } else {
               TriggerManager.this.syncObj.wait(TriggerManager.this.runnerThreadIdleTime);
             }


### PR DESCRIPTION
Currently the Trigger Scanner thread can enter a blocking wait when invoked with a timeout value of 0ms. The change prevents this indefinite blocking and adds additional logging around this.