### PR TITLE
Adding exclude rule into Ramp Manager during image version fetch

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageVersionDaoImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/ImageVersionDaoImpl.java
@@ -39,6 +39,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/daos/RampRuleDao.java
@@ -16,7 +16,6 @@
 package azkaban.imagemgmt.daos;
 
 import azkaban.executor.ExecutableFlow;
-import azkaban.imagemgmt.dto.RampRuleFlowsDTO;
 import azkaban.imagemgmt.models.ImageRampRule;
 import azkaban.imagemgmt.dto.RampRuleFlowsDTO.ProjectFlow;
 import java.util.List;
@@ -30,13 +29,17 @@ import java.util.Set;
 public interface RampRuleDao {
 
   /**
-   * Query table ramp_rules to check whether a HPFlowRule .
+   * Query table flow_deny_lists to check whether a given flow is defined under a Ramp rule under two cases:
+   * - having {@link DenyMode#ALL}
+   * - having {@link DenyMode#PARTIAL} and with a deny_version (imageName.imageVersion)
    *
-   * @param ruleName - ruleName in {@see ImageRampRule}
-   * @return true - if ramp rule is setup for HP Flows, denying any ramp up plan;
-   *         false - if ramp rule is normal rule, regulate only on certain image version.
+   * @param flowName - flowName in {@link ExecutableFlow#getFlowName()}
+   * @param imageName - image type name
+   * @param imageVersion - image type version
+   * @return true - if given flow is regulated under a ramp rule;
+   *         false - otherwise.
    */
-  boolean isHPFlowRule(final String ruleName);
+  boolean isExcludedByRampRule(final String flowName, final String imageName, final String imageVersion);
 
   /**
    * Insert Image Ramp Rule metadata into DB.

--- a/azkaban-common/src/test/resources/image_management/image_type_rampups2.json
+++ b/azkaban-common/src/test/resources/image_management/image_type_rampups2.json
@@ -1,0 +1,15 @@
+{
+  "az-platform-image": [
+    {
+      "imageVersion": "0.1.200",
+      "rampupPercentage": "100"
+    }
+  ],
+  "azkaban_core": [
+    {
+      "imageVersion": "3.6.2",
+      "rampupPercentage": "100"
+    }
+  ]
+}
+

--- a/azkaban-common/src/test/resources/image_management/test_image_type_active_version.json
+++ b/azkaban-common/src/test/resources/image_management/test_image_type_active_version.json
@@ -1,0 +1,21 @@
+[
+  {
+    "imagePath": "path_az-platform-image",
+    "imageVersion": "0.1.199",
+    "imageType": "az-platform-image",
+    "description": "az platform image",
+    "versionState": "ACTIVE",
+    "releaseTag": "0.1.199"
+  },
+  {
+    "imagePath": "path_azkaban-core",
+    "imageVersion": "3.6.1",
+    "imageType": "azkaban_core",
+    "description": "az core image",
+    "versionState": "ACTIVE",
+    "releaseTag": "3.6.1"
+  }
+]
+
+
+


### PR DESCRIPTION
Currently Ramp Manager selects ramp image version based on ramp up plan and the remaining images using current active version. Apply Ramp rule during image version fetch stage would prevent the flows to run versions to be ruled out by ramp rules. Two case for denying selected ramp version:
- flow is inside a HP flow Rule, this is the most highest priority, means the flow would not using any ramping version;
- flow is inside a normal ramp rule, this is only targets certain ramp versions that defined in the ramp rule;