### PR TITLE
Ensure image path is for correct image type

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
@@ -171,6 +171,14 @@ public class ImageVersionServlet extends LoginAbstractAzkabanServlet {
         throw new ImageMgmtValidationException(ErrorCode.BAD_REQUEST, "Required field imageType is"
             + " null. Must provide valid imageType to create image version.");
       }
+      // Validate Image Path, insuring path is for correct image
+      final String imagePath = imageVersion.getPath().toLowerCase();
+      if(!imagePath.contains(imageType.toLowerCase())) {
+        if(!imageType.equals("azkaban-config")) {
+          throw new ImageMgmtValidationException(ErrorCode.BAD_REQUEST, "The image type name must"
+              + " be included in the path");
+        }
+      }
       if (!hasImageManagementPermission(imageType, session.getUser(), Type.CREATE)) {
         log.debug(String.format("Invalid permission to create image version "
             + "for user: %s, image type: %s.", session.getUser().getUserId(), imageType));


### PR DESCRIPTION
Validation insuring the wrong imageType is not register for an imageVersion, which would prevent the possibility of activating a completely incorrect imageVersion for an ImageType.