### PR TITLE
Load tokens from HADOOP_TOKEN_FILE_LOCATION file and add to proxy user UGI for permission

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -344,7 +345,8 @@ public class HadoopJobUtils {
    *                  is in the environmental variable
    * @param log       a usable logger
    */
-  public static void proxyUserKillAllSpawnedHadoopJobs(final Props jobProps,
+  public static void proxyUserKillAllSpawnedHadoopJobs(
+      HadoopSecurityManager hadoopSecurityManager, final Props jobProps,
       final File tokenFile, final Logger log) {
 
     final Properties properties = new Properties();
@@ -353,7 +355,7 @@ public class HadoopJobUtils {
     try {
       if (HadoopSecureWrapperUtils.shouldProxy(properties)) {
         final UserGroupInformation proxyUser =
-            HadoopSecureWrapperUtils.setupProxyUser(properties,
+            HadoopSecureWrapperUtils.setupProxyUserWithHSM(hadoopSecurityManager, properties,
                 tokenFile.getAbsolutePath(), log);
         proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
           @Override
@@ -374,7 +376,7 @@ public class HadoopJobUtils {
     final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
     log.info("Log file path is: " + logFilePath);
     Set<String> allSpawnedJobAppIDs = findApplicationIdFromLog(logFilePath, log);
-    YarnClient yarnClient = YarnUtils.createYarnClient(jobProps);
+    YarnClient yarnClient = YarnUtils.createYarnClient(jobProps, log);
     YarnUtils.killAllAppsOnCluster(yarnClient, allSpawnedJobAppIDs, log);
   }
 

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -158,6 +158,7 @@ public class HadoopProxy {
     if (tokenFile == null) {
       return; // do null check for tokenFile
     }
-    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(jobProps, tokenFile, logger);
+    HadoopJobUtils.proxyUserKillAllSpawnedHadoopJobs(this.hadoopSecurityManager, jobProps,
+        tokenFile, logger);
   }
 }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -16,12 +16,15 @@
 package azkaban.jobtype;
 
 import azkaban.Constants;
+import azkaban.security.commons.HadoopSecurityManagerException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.log4j.Logger;
@@ -47,9 +50,11 @@ public class HadoopSecureWrapperUtils {
    * @return a UserGroupInformation object for the specified userToProxy, which will also contain
    * the logged in user's tokens
    */
-  private static UserGroupInformation createSecurityEnabledProxyUser(String userToProxy,
+  private static UserGroupInformation createSecurityEnabledProxyUser(
+      HadoopSecurityManager hadoopSecurityManager, String userToProxy,
       String fileLocation, Logger log
-  ) throws IOException {
+  ) throws IOException, HadoopSecurityManagerException {
+    log.info("createSecurityEnabledProxyUser starts");
 
     if (!new File(fileLocation).exists()) {
       throw new RuntimeException("hadoop token file doesn't exist.");
@@ -59,32 +64,61 @@ public class HadoopSecureWrapperUtils {
         + " to " + fileLocation);
     System.setProperty(HadoopSecurityManager.MAPREDUCE_JOB_CREDENTIALS_BINARY, fileLocation);
 
-    UserGroupInformation loginUser = null;
-
-    loginUser = UserGroupInformation.getLoginUser();
-    log.info("Current logged in user is " + loginUser.getUserName());
+    // log the tokens of getLoginUser() and monitor the copying
+    UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
+    log.info("Current logged in user is " + loginUser);
 
     UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(userToProxy, loginUser);
 
+    log.info(String.format("Copy from loginUser [%s] to proxyUser [%s]", loginUser, proxyUser));
     for (Token<?> token : loginUser.getTokens()) {
       proxyUser.addToken(token);
+      log.info(String.format("Token = %s, %s, %s ", token.getKind(), token.getService(),
+          Arrays.toString(token.getIdentifier())));
     }
     proxyUser.addCredentials(loginUser.getCredentials());
+
+    // read tokens from the file and put into proxyUser
+    if (hadoopSecurityManager != null) {
+      Credentials creds = hadoopSecurityManager.getTokens(new File(fileLocation), log);
+      log.info(String.format("Loading tokens from file [%s] to proxyUser [%s]", fileLocation,
+          proxyUser));
+      for (Token<?> token : creds.getAllTokens()) {
+        proxyUser.addToken(token);
+        log.info(String.format("Token = %s, %s, %s ", token.getKind(), token.getService(),
+            Arrays.toString(token.getIdentifier())));
+      }
+      proxyUser.addCredentials(creds);
+    }
+
+    log.info("token copy finished for " + loginUser.getUserName());
     return proxyUser;
   }
 
   /**
-   * Sets up the UserGroupInformation proxyUser object so that calling code can do doAs returns null
-   * if the jobProps does not call for a proxyUser
+   * Sets up the UserGroupInformation proxyUser object without tokens from token file loaded by
+   * hadoopSecurityManager
+   */
+  public static UserGroupInformation setupProxyUser(Properties jobProps,
+      String tokenFile, Logger log) {
+    return setupProxyUserWithHSM(null, jobProps, tokenFile, log);
+  }
+
+  /**
+   * Sets up the UserGroupInformation proxyUser object with tokens from loginUser and from the
+   * stored token file so that calling code can do doAs(),
+   * returns null if the jobProps does not call for a proxyUser
    *
-   * @param jobProps job properties
+   * @param hadoopSecurityManager Nullable, the security manager that provides token file and load
+   *                              tokens
+   * @param jobProps  job properties
    * @param tokenFile pass tokenFile if known. Pass null if the tokenFile is in the environmental
-   * variable
-   * already.
+   *                  variable already.
    * @return returns null if no need to run as proxyUser, otherwise returns valid proxyUser that can
    * doAs
    */
-  public static UserGroupInformation setupProxyUser(Properties jobProps,
+  public static UserGroupInformation setupProxyUserWithHSM(
+      HadoopSecurityManager hadoopSecurityManager, Properties jobProps,
       String tokenFile, Logger log) {
     UserGroupInformation proxyUser = null;
 
@@ -103,19 +137,21 @@ public class HadoopSecureWrapperUtils {
       String userToProxy = null;
       userToProxy = jobProps.getProperty(HadoopSecurityManager.USER_TO_PROXY);
       if (securityEnabled) {
+        log.info("security enabled, proxying as user " + userToProxy);
+
         proxyUser =
             HadoopSecureWrapperUtils.createSecurityEnabledProxyUser(
+                hadoopSecurityManager,
                 userToProxy, tokenFile, log);
-        log.info("security enabled, proxying as user " + userToProxy);
       } else {
+        log.info("security not enabled, proxying as user " + userToProxy);
+
         proxyUser = UserGroupInformation.createRemoteUser(userToProxy);
         if (jobProps.getProperty(Constants.JobProperties.ENABLE_OAUTH, "false").equals("true")) {
           proxyUser.addCredentials(UserGroupInformation.getLoginUser().getCredentials());
         }
-
-        log.info("security not enabled, proxying as user " + userToProxy);
       }
-    } catch (IOException e) {
+    } catch (IOException | HadoopSecurityManagerException e) {
       log.error("HadoopSecureWrapperUtils.setupProxyUser threw an IOException",
           e);
     }

--- a/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
@@ -71,10 +71,12 @@ public class YarnUtils {
    * using the resources passed in with props.
    *
    * @param props the properties to create a YarnClient, the path to the "yarn-site.xml" to be used
+   * @param log
    */
-  public static YarnClient createYarnClient(Props props) {
+  public static YarnClient createYarnClient(Props props, Logger log) {
     final YarnConfiguration yarnConf = new YarnConfiguration();
     if (props.containsKey(YARN_CONF_DIRECTORY_PROPERTY)) {
+      log.info("Job yarn conf dir: " + props.get(YARN_CONF_DIRECTORY_PROPERTY));
       yarnConf.addResource(
           new Path(props.get(YARN_CONF_DIRECTORY_PROPERTY) + "/" + YARN_CONF_FILENAME));
     }

--- a/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
+++ b/azkaban-hadoop-security-plugin/src/main/java/azkaban/security/commons/HadoopSecurityManager.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.security.KeyStore;
 import java.util.Properties;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.log4j.Logger;
 
@@ -100,6 +101,9 @@ public abstract class HadoopSecurityManager {
 
   public abstract void cancelTokens(File tokenFile, String userToProxy,
       Logger logger) throws HadoopSecurityManagerException;
+
+  public abstract Credentials getTokens(File tokenFile, Logger logger)
+      throws HadoopSecurityManagerException;
 
   public abstract void prefetchToken(File tokenFile, Props props, Logger logger)
       throws HadoopSecurityManagerException;


### PR DESCRIPTION
**What need to be fixed:**
Yarn Client killApplication() call never succeeds in in containerization, as the proxyUser UGI never have proper token loaded.
And this RP in combination to #3164, the yarn application kill function works correctly in containerization.

**What is being done:**
When creating the proxyUser, use HadoopSecurityManager to get tokens from the previously stored tokenFile from file system, and grand them into the proxyUser.

**Tests done:**

- Tested with multiple different flows across different clusters, 
- kill yarn application works correctly, 
- verified in yarnUI that the call is being made from the pod as the proxyUser
