### PR TITLE
Emit events for subflows and add subflow names for job life cycle events

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -178,6 +178,8 @@ public class Constants {
   public static class EventReporterConstants {
 
     public static final String FLOW_NAME = "flowName";
+    public static final String SUBFLOW_NAME = "subflowName";
+    public static final String IS_ROOT_FLOW = "isRootFlow";
     public static final String AZ_HOST = "azkabanHost";
     public static final String AZ_WEBSERVER = "azkabanWebserver";
     public static final String PROJECT_NAME = "projectName";

--- a/azkaban-common/src/main/java/azkaban/event/EventData.java
+++ b/azkaban-common/src/main/java/azkaban/event/EventData.java
@@ -8,6 +8,7 @@ import azkaban.executor.Status;
  */
 public class EventData {
 
+  private final ExecutableNode node;
   private final Status status;
   private final String nestedId;
   private final String jobId;
@@ -22,6 +23,7 @@ public class EventData {
    * @param node node.
    */
   public EventData(final ExecutableNode node) {
+    this.node = node;
     this.status = node.getStatus();
     this.nestedId = node.getNestedId();
     this.jobId = node.getId();
@@ -30,6 +32,10 @@ public class EventData {
     this.projectName = (node.getParentFlow() == null) ? null: node.getParentFlow().getProjectName();
     this.flowName = (node.getParentFlow() == null) ? null: node.getParentFlow().getFlowId();
     this.executionId = (node.getParentFlow() == null) ? -1: node.getParentFlow().getExecutionId();
+  }
+
+  public ExecutableNode getNode() {
+    return this.node;
   }
 
   public Status getStatus() {

--- a/azkaban-common/src/main/java/azkaban/event/EventData.java
+++ b/azkaban-common/src/main/java/azkaban/event/EventData.java
@@ -1,5 +1,7 @@
 package azkaban.event;
 
+import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutableFlowBase;
 import azkaban.executor.ExecutableNode;
 import azkaban.executor.Status;
 
@@ -36,6 +38,10 @@ public class EventData {
 
   public ExecutableNode getNode() {
     return this.node;
+  }
+
+  public boolean isRootFlowEvent() {
+    return this.node instanceof ExecutableFlow;
   }
 
   public Status getStatus() {

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -885,7 +885,7 @@ public class FlowContainer implements IFlowRunnerManager, IMBeanRegistrable, Eve
    */
   @Override
   public void handleEvent(final Event event) {
-    if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_STARTED) {
+    if (event.getData().isRootFlowEvent() && event.getType() == EventType.FLOW_STARTED) {
       final FlowRunner flowRunner = (FlowRunner) event.getRunner();
       final ExecutableFlow flow = flowRunner.getExecutableFlow();
 

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -885,7 +885,7 @@ public class FlowContainer implements IFlowRunnerManager, IMBeanRegistrable, Eve
    */
   @Override
   public void handleEvent(final Event event) {
-    if (event.getType() == EventType.FLOW_STARTED) {
+    if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_STARTED) {
       final FlowRunner flowRunner = (FlowRunner) event.getRunner();
       final ExecutableFlow flow = flowRunner.getExecutableFlow();
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRampManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRampManager.java
@@ -186,7 +186,8 @@ public class FlowRampManager implements EventListener<Event>, ThreadPoolExecutin
   public void handleEvent(Event event) {
     if (!isRampFeatureActivated()) return;
 
-    if (event.getType() == EventType.FLOW_STARTED || event.getType() == EventType.FLOW_FINISHED) {
+    if (event.getData().getNode() instanceof ExecutableFlow &&
+        (event.getType() == EventType.FLOW_STARTED || event.getType() == EventType.FLOW_FINISHED)) {
       final FlowRunner flowRunner = (FlowRunner) event.getRunner();
       logFlowEvent(flowRunner, event.getType());
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRampManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRampManager.java
@@ -186,7 +186,7 @@ public class FlowRampManager implements EventListener<Event>, ThreadPoolExecutin
   public void handleEvent(Event event) {
     if (!isRampFeatureActivated()) return;
 
-    if (event.getData().getNode() instanceof ExecutableFlow &&
+    if (event.getData().isRootFlowEvent() &&
         (event.getType() == EventType.FLOW_STARTED || event.getType() == EventType.FLOW_FINISHED)) {
       final FlowRunner flowRunner = (FlowRunner) event.getRunner();
       logFlowEvent(flowRunner, event.getType());

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -792,6 +792,12 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         }
         prepareJobProperties(flow);
 
+        // Only take care of subflow's events
+        if (!(node instanceof ExecutableFlow)) {
+          this.fireEventListeners(
+              Event.create(this, EventType.FLOW_STARTED, new EventData(node)));
+        }
+
         for (final String startNodeId : ((ExecutableFlowBase) node).getStartNodes()) {
           final ExecutableNode startNode = flow.getExecutableNode(startNodeId);
           runReadyJob(startNode);
@@ -925,6 +931,11 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         flow.setStatus(Status.SUCCEEDED);
         this.logger.info("Flow '" + id + "' is set to " + flow.getStatus().toString()
             + " in " + durationSec + " seconds");
+    }
+
+    // Only take care of subflow's events
+    if (!(flow instanceof ExecutableFlow)) {
+      this.fireEventListeners(Event.create(this, EventType.FLOW_FINISHED, new EventData(flow)));
     }
 
     // If the finalized flow is actually the top level flow, than we finish
@@ -1679,11 +1690,15 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     }
 
     @VisibleForTesting
-    synchronized Map<String, String> getFlowMetadata(final FlowRunner flowRunner) {
-      final ExecutableFlow flow = flowRunner.getExecutableFlow();
+    synchronized Map<String, String> getFlowMetadata(final FlowRunner flowRunner,
+        final ExecutableFlowBase flow) {
+      final ExecutableFlow rootFlow = flowRunner.getExecutableFlow();
       final Props props = ServiceProvider.SERVICE_PROVIDER.getInstance(Props.class);
       final Map<String, String> metaData = new HashMap<>();
-      metaData.put(EventReporterConstants.FLOW_NAME, flow.getId());
+      metaData.put(EventReporterConstants.FLOW_NAME, flow.getNestedId());
+      if (! (flow instanceof ExecutableFlow)) {
+        metaData.put(EventReporterConstants.IS_ROOT_FLOW, "false");
+      }
       // Azkaban executor hostname
       metaData.put(EventReporterConstants.AZ_HOST, props.getString(AZKABAN_SERVER_HOST_NAME,
           "unknown"));
@@ -1692,23 +1707,23 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.AZ_WEBSERVER,
           props.getString(AZKABAN_WEBSERVER_EXTERNAL_HOSTNAME,
               props.getString(JETTY_HOSTNAME, "localhost")));
-      metaData.put(EventReporterConstants.PROJECT_NAME, flow.getProjectName());
-      metaData.put(EventReporterConstants.SUBMIT_USER, flow.getSubmitUser());
-      metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(flow.getExecutionId()));
+      metaData.put(EventReporterConstants.PROJECT_NAME, rootFlow.getProjectName());
+      metaData.put(EventReporterConstants.SUBMIT_USER, rootFlow.getSubmitUser());
+      metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(rootFlow.getExecutionId()));
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
-      metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
+      metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(rootFlow.getSubmitTime()));
       metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
-          String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
-      if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
+          String.valueOf(rootFlow.getExecutionOptions().isExecutionRetried()));
+      if (rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
         // original flow execution id is set when there is one
         metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
-            String.valueOf(flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
+            String.valueOf(rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
       }
       // Flow_Status_Changed event attributes: flowVersion, failedJobId, modifiedBy
       metaData.put(EventReporterConstants.FLOW_VERSION,
-          String.valueOf(flow.getAzkabanFlowVersion()));
-      metaData.put(EventReporterConstants.FAILED_JOB_ID, flow.getFailedJobId());
-      metaData.put(EventReporterConstants.MODIFIED_BY, flow.getModifiedBy());
+          String.valueOf(rootFlow.getAzkabanFlowVersion()));
+      metaData.put(EventReporterConstants.FAILED_JOB_ID, rootFlow.getFailedJobId());
+      metaData.put(EventReporterConstants.MODIFIED_BY, rootFlow.getModifiedBy());
       // Flow_Status_Changed event elapsed time
       metaData.put(EventReporterConstants.FLOW_KILL_DURATION,
           String.valueOf(flowRunner.getFlowKillDuration()));
@@ -1717,20 +1732,20 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.FLOW_PREPARATION_DURATION,
           String.valueOf(flowRunner.getFlowCreateTime()));
       // FLow SLA option string
-      metaData.put(EventReporterConstants.SLA_OPTIONS, flow.getSlaOptionStr());
+      metaData.put(EventReporterConstants.SLA_OPTIONS, rootFlow.getSlaOptionStr());
       // Flow executor type by versionSet
-      if (flow.getVersionSet() != null) { // Flow version set is set when flow is
+      if (rootFlow.getVersionSet() != null) { // Flow version set is set when flow is
         // executed in a container
         metaData.put(EventReporterConstants.VERSION_SET,
-            ServerUtils.getVersionSetJsonString(flow.getVersionSet()));
+            ServerUtils.getVersionSetJsonString(rootFlow.getVersionSet()));
       }
-      if (flow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) { // Determine executor type
+      if (rootFlow.getDispatchMethod() == DispatchMethod.CONTAINERIZED) { // Determine executor type
         metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.KUBERNETES));
       } else {
         metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.BAREMETAL));
       }
       //Flow Trigger Information
-      metaData.put(EventReporterConstants.EXECUTION_SOURCE, flow.getExecutionSource());
+      metaData.put(EventReporterConstants.EXECUTION_SOURCE, rootFlow.getExecutionSource());
 
       // Project upload info
       final ProjectFileHandler handler = flowRunner.projectFileHandler;
@@ -1742,9 +1757,9 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
           String.valueOf(handler.getUploadTime()));
 
       // Propagate flow properties to Event Reporter
-      if (FlowLoaderUtils.isAzkabanFlowVersion20(flow.getAzkabanFlowVersion())) {
+      if (FlowLoaderUtils.isAzkabanFlowVersion20(rootFlow.getAzkabanFlowVersion())) {
         // In Flow 2.0, flow has designated properties (defined at its own level in Yaml)
-        FlowRunner.propagateMetadataFromProps(metaData, flow.getInputProps(), "flow", flow.getId(),
+        FlowRunner.propagateMetadataFromProps(metaData, flow.getInputProps(), "flow", flow.getNestedId(),
             FlowRunner.this.logger);
       } else {
         // In Flow 1.0, flow properties are combination of shared properties in individual files (order not defined,
@@ -1758,7 +1773,7 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         // In Flow 1.0, flow's inputProps contains overrides, so apply that as override to combined shared props
         combinedProps = new Props(combinedProps, flow.getInputProps());
 
-        FlowRunner.propagateMetadataFromProps(metaData, combinedProps, "flow", flow.getId(),
+        FlowRunner.propagateMetadataFromProps(metaData, combinedProps, "flow", flow.getNestedId(),
             FlowRunner.this.logger);
       }
 
@@ -1769,27 +1784,28 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
     public synchronized void handleEvent(final Event event) {
       if (event.getType().isFlowEventType()) {
         final FlowRunner flowRunner = (FlowRunner) event.getRunner();
-        final ExecutableFlow flow = flowRunner.getExecutableFlow();
+        final ExecutableFlow rootFlow = flowRunner.getExecutableFlow();
+        final ExecutableFlowBase flow = (ExecutableFlowBase) event.getData().getNode();
         if (event.getType() == EventType.FLOW_STARTED) {
           // Estimate flow wait time duration including time taken to create pod (for containerized
           // executions) and submit flowRunner, discrepancy caused by different system time in web
           // server (where executable flow is submitted) and executor/container.
-          if (flow.getSubmitTime() > 0 ) {
-            flowRunner.setFlowCreateTime(System.currentTimeMillis() - flow.getSubmitTime());
+          if (rootFlow.getSubmitTime() > 0 && flow == rootFlow) {
+            flowRunner.setFlowCreateTime(System.currentTimeMillis() - rootFlow.getSubmitTime());
           }
           FlowRunner.this.logger.info("Flow started: " + flow.getId());
-          FlowRunner.this.azkabanEventReporter.report(event.getType(), getFlowMetadata(flowRunner));
+          FlowRunner.this.azkabanEventReporter.report(event.getType(), getFlowMetadata(flowRunner, flow));
         } else if (event.getType() == EventType.FLOW_STATUS_CHANGED) {
           if (flow.getStatus() == Status.KILLING || flow.getStatus() == Status.KILLED) {
             FlowRunner.this.logger
                 .info("Flow is killed by " + flow.getModifiedBy() + ": " + flow.getId());
           }
-          final Map<String, String> flowMetadata = getFlowMetadata(flowRunner);
+          final Map<String, String> flowMetadata = getFlowMetadata(flowRunner, flow);
           flowMetadata.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
           FlowRunner.this.azkabanEventReporter.report(event.getType(), flowMetadata);
         } else if (event.getType() == EventType.FLOW_FINISHED) {
           FlowRunner.this.logger.info("Flow ended: " + flow.getId());
-          final Map<String, String> flowMetadata = getFlowMetadata(flowRunner);
+          final Map<String, String> flowMetadata = getFlowMetadata(flowRunner, flow);
           flowMetadata.put(EventReporterConstants.END_TIME, String.valueOf(flow.getEndTime()));
           flowMetadata.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
 
@@ -1849,6 +1865,9 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.EXECUTION_ID,
           String.valueOf(executableFlow.getExecutionId()));
       metaData.put(EventReporterConstants.FLOW_NAME, executableFlow.getId());
+      if (!(node.getParentFlow() instanceof ExecutableFlow)) {
+        metaData.put(EventReporterConstants.SUBFLOW_NAME, node.getParentFlow().getNestedId());
+      }
       metaData.put(EventReporterConstants.PROJECT_NAME, executableFlow.getProjectName());
 
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(node.getStartTime()));

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -694,6 +694,9 @@ public class FlowRunnerManager implements IFlowRunnerManager, EventListener<Even
 
   @Override
   public void handleEvent(final Event event) {
+    if (!(event.getData().getNode() instanceof ExecutableFlow)) {
+      return;
+    }
     if (event.getType() == EventType.FLOW_FINISHED || event.getType() == EventType.FLOW_STARTED) {
       final FlowRunner flowRunner = (FlowRunner) event.getRunner();
       final ExecutableFlow flow = flowRunner.getExecutableFlow();

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunnerManager.java
@@ -694,7 +694,7 @@ public class FlowRunnerManager implements IFlowRunnerManager, EventListener<Even
 
   @Override
   public void handleEvent(final Event event) {
-    if (!(event.getData().getNode() instanceof ExecutableFlow)) {
+    if (!(event.getData().isRootFlowEvent())) {
       return;
     }
     if (event.getType() == EventType.FLOW_FINISHED || event.getType() == EventType.FLOW_STARTED) {

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
@@ -21,6 +21,7 @@ import azkaban.event.EventData;
 import azkaban.event.EventListener;
 import azkaban.execapp.FlowRunner;
 import azkaban.execapp.JobRunner;
+import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutableNode;
 import azkaban.spi.EventType;
 
@@ -72,7 +73,7 @@ public class LocalFlowWatcher extends FlowWatcher {
           getLogger().info(node + " looks like " + node.getStatus());
           handleJobStatusChange(node.getNestedId(), node.getStatus());
         }
-      } else if (event.getType() == EventType.FLOW_FINISHED) {
+      } else if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_FINISHED) {
         stopWatcher();
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/event/LocalFlowWatcher.java
@@ -73,7 +73,7 @@ public class LocalFlowWatcher extends FlowWatcher {
           getLogger().info(node + " looks like " + node.getStatus());
           handleJobStatusChange(node.getNestedId(), node.getStatus());
         }
-      } else if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_FINISHED) {
+      } else if (event.getData().isRootFlowEvent() && event.getType() == EventType.FLOW_FINISHED) {
         stopWatcher();
       }
     }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
@@ -48,7 +48,7 @@ public class NumFailedFlowMetric extends TimeBasedReportingMetric<Integer> imple
    */
   @Override
   public synchronized void handleEvent(final Event event) {
-    if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_FINISHED) {
+    if (event.getData().isRootFlowEvent() && event.getType() == EventType.FLOW_FINISHED) {
       final FlowRunner runner = (FlowRunner) event.getRunner();
       if (runner != null && runner.getExecutableFlow().getStatus().equals(Status.FAILED)) {
         this.value = this.value + 1;

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/metric/NumFailedFlowMetric.java
@@ -19,6 +19,7 @@ package azkaban.execapp.metric;
 import azkaban.event.Event;
 import azkaban.event.EventListener;
 import azkaban.execapp.FlowRunner;
+import azkaban.executor.ExecutableFlow;
 import azkaban.executor.Status;
 import azkaban.metric.MetricException;
 import azkaban.metric.MetricReportManager;
@@ -47,7 +48,7 @@ public class NumFailedFlowMetric extends TimeBasedReportingMetric<Integer> imple
    */
   @Override
   public synchronized void handleEvent(final Event event) {
-    if (event.getType() == EventType.FLOW_FINISHED) {
+    if (event.getData().getNode() instanceof ExecutableFlow && event.getType() == EventType.FLOW_FINISHED) {
       final FlowRunner runner = (FlowRunner) event.getRunner();
       if (runner != null && runner.getExecutableFlow().getStatus().equals(Status.FAILED)) {
         this.value = this.value + 1;

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -357,7 +357,8 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     final VersionSet versionSet = this.runner.getExecutableFlow().getVersionSet();
 
     FlowRunner.FlowRunnerEventListener flowRunnerEventListener = this.runner.getFlowRunnerEventListener();
-    Map<String, String> flowMetadata = flowRunnerEventListener.getFlowMetadata(this.runner);
+    Map<String, String> flowMetadata = flowRunnerEventListener.getFlowMetadata(this.runner,
+        this.runner.getExecutableFlow());
 
     Assert.assertEquals("Event metadata not created as expected.", "localhost",
             flowMetadata.get(AZ_WEBSERVER));


### PR DESCRIPTION
It is a feature request.

1. If flow life cycle event is coming from subflows,  event object will have `isRootFlow=false` field
2. `subflowName` field will be attached to job life cycle events to represent the parent flow of the job
3. Use `event.getData().getNode() instanceof ExecutableFlow` to tell if an event is coming from root flow or subflow in azkaban main logic.