### PR TITLE
YarnUtils: Add method to call yarn getApplication api to get alive app IDs

### DIFF
--- a/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
@@ -15,9 +15,17 @@
  */
 package azkaban.utils;
 
+import static azkaban.Constants.FlowProperties.AZKABAN_FLOW_EXEC_ID;
+
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.log4j.Logger;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
@@ -29,6 +37,44 @@ public class YarnUtils {
   //Yarn resource configuration directory for the cluster where the job is scheduled by the cluster router
   private static final String YARN_CONF_DIRECTORY_PROPERTY = "env.YARN_CONF_DIR";
   private static final String YARN_CONF_FILENAME = "yarn-site.xml";
+
+  public static final EnumSet<YarnApplicationState> YARN_APPLICATION_ALIVE_STATES = EnumSet.of(
+      YarnApplicationState.NEW,
+      YarnApplicationState.NEW_SAVING,
+      YarnApplicationState.SUBMITTED,
+      YarnApplicationState.ACCEPTED,
+      YarnApplicationState.RUNNING
+  );
+
+  public static Set<String> getAllAliveAppIDsByExecID(final YarnClient yarnClient,
+      final String flowExecID, final Logger log)
+      throws IOException, YarnException {
+    return getAllAliveAppReportsByExecID(yarnClient, flowExecID, log)
+        .stream()
+        .map(ApplicationReport::getApplicationId)
+        .map(ApplicationId::toString).collect(Collectors.toSet());
+  }
+
+  /**
+   * Use the yarnClient to query the unfinished yarn applications, then use the yarnClient to kill
+   * them sequentially
+   *
+   * @param yarnClient the yarnClient already connects to the cluster
+   * @param flowExecID the azkaban flow execution id whose yarn applications needs to be killed
+   * @return the set of all to-be-killed (alive) yarn applications' IDs
+   * @throws IOException   for RPC issue
+   * @throws YarnException for YARN server issue
+   */
+  public static List<ApplicationReport> getAllAliveAppReportsByExecID(final YarnClient yarnClient,
+      final String flowExecID, final Logger log)
+      throws IOException, YarnException {
+
+    // format: tagName:tagValue
+    Set<String> searchTags = ImmutableSet.of(AZKABAN_FLOW_EXEC_ID + ":" + flowExecID);
+
+    log.info(String.format("Searching for alive yarn application reports with tag %s", searchTags));
+    return yarnClient.getApplications(null, YARN_APPLICATION_ALIVE_STATES, searchTags);
+  }
 
   /**
    * Uses YarnClient to kill the jobs one by one

--- a/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/YarnUtilsTest.java
@@ -16,16 +16,23 @@
 
 package azkaban.utils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.log4j.Logger;
@@ -74,5 +81,33 @@ public class YarnUtilsTest {
     // log the error but not throw
     YarnUtils.killAllAppsOnCluster(mockClient,
         ImmutableSet.of("application_123_456", "application_4560_1230"), log);
+  }
+
+
+  @Test
+  public void testGetAllAliveAppIDsByExecID() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+
+    ApplicationReport report1 = mock(ApplicationReport.class);
+    ApplicationReport report2 = mock(ApplicationReport.class);
+    doReturn(ApplicationId.newInstance(1234, 1234)).when(report1).getApplicationId();
+    doReturn(ApplicationId.newInstance(6789, 6789)).when(report2).getApplicationId();
+
+    List<ApplicationReport> applicationReports = Lists.newArrayList(report1, report2);
+    doReturn(applicationReports).when(mockClient).getApplications(eq(null), any(), any());
+    Set<String> actual = YarnUtils.getAllAliveAppIDsByExecID(
+        mockClient, "dummy-exec-id-123", log);
+
+    assertEquals(2, actual.size());
+    assertTrue(actual.contains("application_1234_1234"));
+    assertTrue(actual.contains("application_6789_6789"));
+  }
+
+  @Test(expected = YarnException.class)
+  public void testGetAllAliveAppIDsByExecIDYarnFai() throws IOException, YarnException {
+    YarnClient mockClient = mock(YarnClient.class);
+    doThrow(new YarnException("ops")).when(mockClient).getApplications(eq(null), any(), any());
+    Set<String> actual = YarnUtils.getAllAliveAppIDsByExecID(
+        mockClient, "dummy-exec-id-123", log);
   }
 }


### PR DESCRIPTION
query applications with execution-id tag and un-finished application states

**Tests done**
Tested together with #3169, in the c15n pod by killing the flow after yarn apps created.