### PR TITLE
Don't delete the token file so as it can be used when killing yarn apps

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -143,9 +143,6 @@ public class HadoopProxy {
     } catch (Exception e) {
       logger.error(e.getCause() + e.getMessage());
     }
-    if (tokenFile.exists()) {
-      tokenFile.delete();
-    }
   }
 
   /**


### PR DESCRIPTION
If we delete the token file before `killAllSpawnedHadoopJobs` is called, the proxyUser cannot get the tokens from the file, and thus the kill application call will not work.

This PR is to fix this.