### PR TITLE
Add sanity check in FlowRunner to skip finished flows and kill pod wh…

### DIFF
--- a/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/EventCollectorListener.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.util.Assert;
 
 public class EventCollectorListener implements EventListener<Event> {
 
@@ -68,5 +69,9 @@ public class EventCollectorListener implements EventListener<Event> {
         .map(event -> event.getType())
         .toArray();
     assertThat(captured).isEqualTo(expected);
+  }
+
+  public void assertNoEvents() {
+    Assert.isTrue(eventList.isEmpty());
   }
 }

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -271,6 +271,23 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
     eventCollector.assertEvents(EventType.FLOW_STARTED, EventType.FLOW_STATUS_CHANGED, EventType.FLOW_FINISHED);
   }
 
+  @Test
+  public void exec1FlowKilledInitially() throws Exception {
+    final EventCollectorListener eventCollector = new EventCollectorListener();
+    this.runner = this.testUtil.createFromFlowFile(eventCollector, "exec1");
+    this.runner.getExecutableFlow().setStatus(Status.KILLED);
+
+    FlowRunnerTestUtil.startThread(this.runner);
+    assertThreadShutDown();
+    assertFlowStatus(this.runner.getExecutableFlow(), Status.KILLED);
+    compareFinishedRuntime(this.runner);
+
+    // Check flowVersion
+    assertFlowVersion(this.runner.getExecutableFlow(), 1.0);
+    Assert.assertFalse(this.runner.getLogger().getAllAppenders().hasMoreElements());
+    eventCollector.assertNoEvents();
+  }
+
   @Test(expected = IllegalStateException.class)
   public void cancelThenPause() throws Exception {
     final EventCollectorListener eventCollector = new EventCollectorListener();

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestBase.java
@@ -46,19 +46,19 @@ public class FlowRunnerTestBase {
   public void assertThreadShutDown() {
     waitFlowRunner(
         runner -> Status.isStatusFinished(runner.getExecutableFlow().getStatus())
-            && !runner.isRunnerThreadAlive());
+            && runner.isRunnerThreadShutdown());
   }
 
   public void assertThreadShutDown(final FlowRunner flowRunner) {
     waitFlowRunner(flowRunner,
         runner -> Status.isStatusFinished(runner.getExecutableFlow().getStatus())
-            && !runner.isRunnerThreadAlive());
+            && runner.isRunnerThreadShutdown());
   }
 
   public void assertThreadRunning() {
     waitFlowRunner(
         runner -> Status.isStatusRunning(runner.getExecutableFlow().getStatus())
-            && runner.isRunnerThreadAlive());
+            && !runner.isRunnerThreadShutdown());
   }
 
   public void waitFlowRunner(final Function<FlowRunner, Boolean> statusCheck) {


### PR DESCRIPTION
…en canceling flows

There is a bug introduced by containerized azkaban when killing/canceling an execution. At that time, execution will have negative elapse time. The gap is:
1. Before FlowContainer java process is up, Azkaban web server kills the execution and do NOP to the underlining pod b/c its FlowContainer process is not up yet. — end time is marked for the execution
2. When FlowContainer in the pod starts, it does not check the flow status == KILLED or not, but directly continue all the flow related operations (for job node, it is fine b/c we have job status == KILLED check). — start time is marked for the execution which is later than end time

The fix is to:
1. Kill pod when execution is killed/canceled
2. Have sanity check in FlowRunner to skip processing root flows if flow status is not valid in the first place.