### PR TITLE
Added a heartbeat metric in cron scheduler

### DIFF
--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerDeadlockTest.java
@@ -60,6 +60,7 @@ public class TriggerManagerDeadlockTest {
   private AlerterHolder alertHolder;
   private ExecutionFinalizer executionFinalizer;
   private CommonMetrics commonMetrics;
+  private MetricsManager metricsManager;
 
   @Before
   public void setup() throws ExecutorManagerException, TriggerManagerException {
@@ -71,6 +72,7 @@ public class TriggerManagerDeadlockTest {
     this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
     this.offlineExecutionLogsLoader = new MockExecutionLogsLoader();
     this.apiGateway = mock(ExecutorApiGateway.class);
+    this.metricsManager = mock(MetricsManager.class);
     this.runningExecutions = new RunningExecutions();
     this.updaterStage = new ExecutorManagerUpdaterStage();
     this.alertHolder = mock(AlerterHolder.class);
@@ -78,7 +80,7 @@ public class TriggerManagerDeadlockTest {
         this.updaterStage, this.alertHolder, this.runningExecutions);
     this.commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
     final ExecutorManager executorManager = getExecutorManager(props);
-    this.triggerManager = new TriggerManager(props, this.loader, executorManager);
+    this.triggerManager = new TriggerManager(props, this.loader, executorManager, metricsManager);
   }
 
   private ExecutorManager getExecutorManager(final Props props) throws ExecutorManagerException {

--- a/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/trigger/TriggerManagerTest.java
@@ -25,6 +25,7 @@ import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.flow.Flow;
+import azkaban.metrics.MetricsManager;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.trigger.builtin.BasicTimeChecker;
@@ -52,12 +53,14 @@ public class TriggerManagerTest {
   private static ExecutorManagerAdapter executorManagerAdapter;
   private static ProjectManager projectManager;
   private TriggerManager triggerManager;
+  private static MetricsManager metricsManager;
 
   @BeforeClass
   public static void prepare() {
     triggerLoader = new MockTriggerLoader();
     executorManagerAdapter = mock(ExecutorManagerAdapter.class);
     projectManager = mock(ProjectManager.class);
+    metricsManager = mock(MetricsManager.class);
   }
 
   @Before
@@ -73,7 +76,7 @@ public class TriggerManagerTest {
     ExecuteFlowAction.setTriggerManager(this.triggerManager);
     final Props props = new Props();
     props.put("trigger.scan.interval", 300);
-    this.triggerManager = new TriggerManager(props, triggerLoader, executorManagerAdapter);
+    this.triggerManager = new TriggerManager(props, triggerLoader, executorManagerAdapter, metricsManager);
     this.triggerManager.registerCheckerType(ThresholdChecker.type,
         ThresholdChecker.class);
     this.triggerManager.registerActionType(DummyTriggerAction.type,


### PR DESCRIPTION
This change adds a meter that acts like a heartbeat for the cron scheduler. verified that metrics are emitted. This metric can be one of the signals to check the health of the scheduler.