### PR TITLE
Read config for feature flagging of Yarn App Killing module

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -41,8 +40,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.log4j.Logger;
+import org.apache.hadoop.fs.Path;
+import scala.util.parsing.combinator.testing.Str;
 
 
 /**
@@ -80,11 +84,20 @@ public class HadoopJobUtils {
   public static final String MAPREDUCE_JOB_OTHER_NAMENODES = "mapreduce.job.hdfs-servers";
   // MapReduce config for mapreduce job tags
   public static final String MAPREDUCE_JOB_TAGS = "mapreduce.job.tags";
+
+  public static final String YARN_KILL_VERSION = "yarn.kill.version";
+  // values of the yarn kill version flag
+  public static final String YARN_KILL_LEGACY = "legacy";
+  public static final String YARN_KILL_TOKEN_FIX = "token_copy";
+
   protected static final int APPLICATION_TAG_MAX_LENGTH = 100;
   // Root of folder in storage containing startup dependencies
   public static final String DEPENDENCY_STORAGE_ROOT_PATH_PROP = "dependency.storage.path.prefix";
   // Azkaban property for listing additional namenodes for delegation tokens
   private static final String OTHER_NAMENODES_PROPERTY = "other_namenodes";
+  //Yarn resource configuration directory for the cluster where the job is scheduled by the cluster router
+  private static final String YARN_CONF_DIRECTORY_PROPERTY = "env.YARN_CONF_DIR";
+  private static final String YARN_CONF_FILENAME = "yarn-site.xml";
 
   private HadoopJobUtils() {
   }
@@ -352,24 +365,50 @@ public class HadoopJobUtils {
     final Properties properties = new Properties();
     properties.putAll(jobProps.getFlattened());
 
-    try {
-      if (HadoopSecureWrapperUtils.shouldProxy(properties)) {
-        final UserGroupInformation proxyUser =
-            HadoopSecureWrapperUtils.setupProxyUserWithHSM(hadoopSecurityManager, properties,
-                tokenFile.getAbsolutePath(), log);
-        proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
-          @Override
-          public Void run() throws Exception {
-            findAndKillYarnApps(jobProps, log);
-            return null;
-          }
-        });
-      } else {
-        findAndKillYarnApps(jobProps, log);
+    // todo: use feature flag
+    String yarnKillVersion = jobProps.getString(YARN_KILL_VERSION, YARN_KILL_LEGACY);
+    if (YARN_KILL_LEGACY.equals(yarnKillVersion)) {
+      final String logFilePath = jobProps.getString(CommonJobProperties.JOB_LOG_FILE);
+      log.info("Log file path is: " + logFilePath);
+      try {
+        if (HadoopSecureWrapperUtils.shouldProxy(properties)) {
+          final UserGroupInformation proxyUser =
+              HadoopSecureWrapperUtils.setupProxyUser(properties,
+                  tokenFile.getAbsolutePath(), log);
+          proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
+            @Override
+            public Void run() throws Exception {
+              HadoopJobUtils.killAllSpawnedHadoopJobs(logFilePath, log, jobProps);
+              return null;
+            }
+          });
+        } else {
+          HadoopJobUtils.killAllSpawnedHadoopJobs(logFilePath, log, jobProps);
+        }
+      } catch (final Throwable t) {
+        log.warn("something happened while trying to kill all spawned jobs", t);
       }
-    } catch (final Throwable t) {
-      log.warn("something happened while trying to kill all spawned jobs", t);
+    } else if (YARN_KILL_TOKEN_FIX.equals(yarnKillVersion)){
+      try {
+        if (HadoopSecureWrapperUtils.shouldProxy(properties)) {
+          final UserGroupInformation proxyUser =
+              HadoopSecureWrapperUtils.setupProxyUserWithHSM(hadoopSecurityManager, properties,
+                  tokenFile.getAbsolutePath(), log);
+          proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
+            @Override
+            public Void run() throws Exception {
+              findAndKillYarnApps(jobProps, log);
+              return null;
+            }
+          });
+        } else {
+          findAndKillYarnApps(jobProps, log);
+        }
+      } catch (final Throwable t) {
+        log.warn("something happened while trying to kill all spawned jobs", t);
+      }
     }
+
   }
 
   private static void findAndKillYarnApps(Props jobProps, Logger log) {
@@ -378,6 +417,29 @@ public class HadoopJobUtils {
     Set<String> allSpawnedJobAppIDs = findApplicationIdFromLog(logFilePath, log);
     YarnClient yarnClient = YarnUtils.createYarnClient(jobProps, log);
     YarnUtils.killAllAppsOnCluster(yarnClient, allSpawnedJobAppIDs, log);
+  }
+
+  /**
+   * Pass in a log file, this method will find all the hadoop jobs it has launched, and kills it
+   * <p>
+   * Only works with Hadoop2
+   *
+   * @return a Set<String>. The set will contain the applicationIds that this job tried to kill.
+   */
+  public static Set<String> killAllSpawnedHadoopJobs(final String logFilePath, final Logger log,
+      final Props jobProps) {
+    final Set<String> allSpawnedJobs = findApplicationIdFromLog(logFilePath, log);
+    log.info("applicationIds to kill: " + allSpawnedJobs);
+
+    for (final String appId : allSpawnedJobs) {
+      try {
+        killJobOnCluster(appId, log, jobProps);
+      } catch (final Throwable t) {
+        log.warn("something happened while trying to kill this job: " + appId, t);
+      }
+    }
+
+    return allSpawnedJobs;
   }
 
   /**
@@ -460,6 +522,38 @@ public class HadoopJobUtils {
       }
     }
     return applicationIds;
+  }
+
+  /**
+   * <pre>
+   * Uses YarnClient to kill the job on HDFS.
+   * Using JobClient only works partially:
+   *   If yarn container has started but spark job haven't, it will kill
+   *   If spark job has started, the cancel will hang until the spark job is complete
+   *   If the spark job is complete, it will return immediately, with a job not found on job tracker
+   * </pre>
+   */
+  public static void killJobOnCluster(final String applicationId, final Logger log,
+      final Props jobProps)
+      throws YarnException,
+      IOException {
+
+    final YarnConfiguration yarnConf = new YarnConfiguration();
+    final YarnClient yarnClient = YarnClient.createYarnClient();
+    if (jobProps.containsKey(YARN_CONF_DIRECTORY_PROPERTY)) {
+      yarnConf.addResource(
+          new Path(jobProps.get(YARN_CONF_DIRECTORY_PROPERTY) + "/" + YARN_CONF_FILENAME));
+    }
+    yarnClient.init(yarnConf);
+    yarnClient.start();
+
+    final String[] split = applicationId.split("_");
+    final ApplicationId aid = ApplicationId.newInstance(Long.parseLong(split[1]),
+        Integer.parseInt(split[2]));
+
+    log.info("start klling application: " + aid);
+    yarnClient.killApplication(aid);
+    log.info("successfully killed application: " + aid);
   }
 
   /**

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -15,6 +15,8 @@
  */
 package azkaban.jobtype;
 
+import static azkaban.jobtype.HadoopJobUtils.YARN_KILL_LEGACY;
+import static azkaban.jobtype.HadoopJobUtils.YARN_KILL_VERSION;
 import static org.apache.hadoop.security.UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION;
 
 import java.io.File;
@@ -55,6 +57,10 @@ public class HadoopProxy {
   private void init(Props sysProps, Props jobProps, final Logger logger) {
     shouldProxy = sysProps.getBoolean(HadoopSecurityManager.ENABLE_PROXYING, false);
     jobProps.put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
+    if (!jobProps.containsKey(YARN_KILL_VERSION)) {
+      String yarnKillVersion = sysProps.getString(YARN_KILL_VERSION, YARN_KILL_LEGACY);
+      jobProps.put(YARN_KILL_VERSION, yarnKillVersion);
+    }
     obtainTokens = sysProps.getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
     if (shouldProxy) {
       logger.info("Initiating hadoop security manager.");

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopProxy.java
@@ -59,8 +59,10 @@ public class HadoopProxy {
     jobProps.put(HadoopSecurityManager.ENABLE_PROXYING, Boolean.toString(shouldProxy));
     if (!jobProps.containsKey(YARN_KILL_VERSION)) {
       String yarnKillVersion = sysProps.getString(YARN_KILL_VERSION, YARN_KILL_LEGACY);
+      logger.info("sysProps.YARN_KILL_VERSION is:" + yarnKillVersion);
       jobProps.put(YARN_KILL_VERSION, yarnKillVersion);
     }
+    logger.info("jobProps.YARN_KILL_VERSION is set to:" + jobProps.getString(YARN_KILL_VERSION));
     obtainTokens = sysProps.getBoolean(HadoopSecurityManager.OBTAIN_BINARY_TOKEN, false);
     if (shouldProxy) {
       logger.info("Initiating hadoop security manager.");

--- a/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestAbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/test/java/azkaban/jobtype/TestAbstractHadoopJavaProcessJob.java
@@ -2,6 +2,7 @@ package azkaban.jobtype;
 
 import azkaban.flow.CommonJobProperties;
 import azkaban.utils.Props;
+import org.apache.log4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -9,6 +10,8 @@ import static org.assertj.core.api.Assertions.*;
 
 
 public class TestAbstractHadoopJavaProcessJob {
+
+  private static Logger logger = Logger.getLogger(TestAbstractHadoopJavaProcessJob.class);
 
   @BeforeClass
   public static void setUpClass() {
@@ -21,7 +24,7 @@ public class TestAbstractHadoopJavaProcessJob {
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.PROJECT_NAME, "project-name");
     props.put(CommonJobProperties.FLOW_ID, "flow-id");
-    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test", new Props(), props, null) {};
+    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test", new Props(), props, logger) {};
     job.setupHadoopJobProperties();
     assertThat(job.getJobProps().get(HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS))
         .isEqualTo("azkaban.flow.execid:123,azkaban.flow.flowid:flow-id"
@@ -38,7 +41,8 @@ public class TestAbstractHadoopJavaProcessJob {
     props.put(CommonJobProperties.EXEC_ID, "123");
     props.put(CommonJobProperties.PROJECT_NAME, "project-name");
     props.put(CommonJobProperties.FLOW_ID, flowIdBuffer.toString());
-    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test2", new Props(), props, null) {};
+    AbstractHadoopJavaProcessJob job = new AbstractHadoopJavaProcessJob("test2", new Props(),
+        props, logger) {};
     job.setupHadoopJobProperties();
     String[] actualTags = job.getJobProps().get(
         HadoopConfigurationInjector.INJECT_PREFIX + HadoopJobUtils.MAPREDUCE_JOB_TAGS)

--- a/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 public class YarnUtils {
 
   //Yarn resource configuration directory for the cluster where the job is scheduled by the cluster router
-  private static final String YARN_CONF_DIRECTORY_PROPERTY = "env.YARN_CONF_DIR";
-  private static final String YARN_CONF_FILENAME = "yarn-site.xml";
+  public static final String YARN_CONF_DIRECTORY_PROPERTY = "env.YARN_CONF_DIR";
+  public static final String YARN_CONF_FILENAME = "yarn-site.xml";
 
   /**
    * Uses YarnClient to kill the jobs one by one


### PR DESCRIPTION
**Why we need this**: 
In future roll out, this can help fasten mitigation if we need to fallback to the old approach. 
We only need to change the `.properties` file config and ping the new config version to switch the feature.

**What's in this**:
Bring back the old logic of yarn kill, and use a config flag from `System Props` to control which approach to use

**Tests done**:
Tested in containerization, setting runtime property in UI, and the value can be passed to the jobProps for feature flagging