### PR TITLE
Refactor 'Cluster' related classes and modules, so as webServer can also read cluster-specific conf

### DIFF
--- a/azkaban-common/src/main/java/azkaban/cluster/ClusterModule.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/ClusterModule.java
@@ -1,6 +1,5 @@
 package azkaban.cluster;
 
-import azkaban.execapp.AzkabanExecutorServer;
 import azkaban.utils.Props;
 import azkaban.utils.Utils;
 import com.google.inject.AbstractModule;
@@ -14,6 +13,10 @@ import org.apache.hadoop.fs.Path;
 
 public class ClusterModule extends AbstractModule {
 
+  public static final String CLUSTER_CONFIG_DIR = "azkaban.cluster.dir";
+  public static final String CLUSTER_ROUTER_CLASS = "azkaban.cluster.router";
+  public static final String CLUSTER_ROUTER_CONF = "azkaban.cluster.router.conf";
+
   @Override
   protected void configure() {
     bind(ClusterLoader.class).asEagerSingleton();
@@ -23,7 +26,7 @@ public class ClusterModule extends AbstractModule {
   @Provides
   @Named("clusterDir")
   public File getClusterDir(final Props props) {
-    final String clusterDir = props.getString(AzkabanExecutorServer.CLUSTER_CONFIG_DIR, "cluster");
+    final String clusterDir = props.getString(CLUSTER_CONFIG_DIR, "cluster");
     return new File(clusterDir);
   }
 
@@ -31,7 +34,7 @@ public class ClusterModule extends AbstractModule {
   public ClusterRouter getClusterRouter(final Props props, final ClusterRegistry clusterRegistry,
       final Configuration conf)
       throws ClassNotFoundException {
-    final String routerClass = props.getString(AzkabanExecutorServer.CLUSTER_ROUTER_CLASS,
+    final String routerClass = props.getString(CLUSTER_ROUTER_CLASS,
         DisabledClusterRouter.class.getName());
     final Class<?> routerClazz = Class.forName(routerClass);
     return (ClusterRouter) Utils.callConstructor(routerClazz, clusterRegistry, conf);
@@ -45,7 +48,7 @@ public class ClusterModule extends AbstractModule {
     for (Map.Entry<String, String> entry : props.getFlattened().entrySet()) {
       configuration.set(entry.getKey(), entry.getValue());
     }
-    final String routerConfPath = props.getString(AzkabanExecutorServer.CLUSTER_ROUTER_CONF,
+    final String routerConfPath = props.getString(CLUSTER_ROUTER_CONF,
         "router-conf.xml");
     configuration.addResource(new Path(routerConfPath));
     return configuration;

--- a/azkaban-common/src/main/java/azkaban/cluster/ClusterRegistry.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/ClusterRegistry.java
@@ -39,7 +39,7 @@ import javax.inject.Singleton;
 @Singleton
 public class ClusterRegistry {
 
-  private final Map<String, Cluster> clusterInfoMap;
+  protected final Map<String, Cluster> clusterInfoMap;
 
   @Inject
   public ClusterRegistry() {

--- a/azkaban-common/src/main/java/azkaban/cluster/ClusterRouter.java
+++ b/azkaban-common/src/main/java/azkaban/cluster/ClusterRouter.java
@@ -1,6 +1,7 @@
 package azkaban.cluster;
 
 import azkaban.utils.Props;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 
 import java.util.Collection;
@@ -20,4 +21,8 @@ public abstract class ClusterRouter {
   public abstract Cluster getCluster(final String jobId, final Props jobProps,
       final Logger jobLogger,
       final Collection<String> componentDependency);
+
+  public Map<String, Cluster> getAllClusters() {
+    return this.clusterRegistry.clusterInfoMap;
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -24,13 +24,13 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import azkaban.Constants;
+import azkaban.cluster.ClusterRouter;
 import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.OnContainerizedExecutionEventListener;
 import azkaban.executor.Status;
-import azkaban.metrics.ContainerizationMetrics;
 import azkaban.metrics.DummyContainerizationMetricsImpl;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableMap;
@@ -53,15 +53,18 @@ public class ContainerCleanupManagerTest {
   private ContainerizedDispatchManager containerizedDispatchManager;
   private ContainerCleanupManager cleaner;
   private DummyContainerizationMetricsImpl metrics;
+  private ClusterRouter clusterRouter;
 
   @Before
   public void setup() throws Exception {
     this.props = new Props();
     this.executorLoader = mock(ExecutorLoader.class);
     this.containerImpl = mock(ContainerizedImpl.class);
+    this.clusterRouter = mock(ClusterRouter.class);
+    when(this.clusterRouter.getAllClusters()).thenReturn(ImmutableMap.of());
     this.containerizedDispatchManager = mock(ContainerizedDispatchManager.class);
     this.cleaner = new ContainerCleanupManager(this.props, this.executorLoader,
-        this.containerImpl, this.containerizedDispatchManager, this.metrics);
+        this.clusterRouter, this.containerImpl, this.containerizedDispatchManager, this.metrics);
   }
 
   @Test

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AzkabanExecutorServer.java
@@ -83,9 +83,6 @@ public class AzkabanExecutorServer implements IMBeanRegistrable {
 
   public static final String JOBTYPE_PLUGIN_DIR = "azkaban.jobtype.plugin.dir";
   public static final String RAMPPOLICY_PLUGIN_DIR = "azkaban.ramppolicy.plugin.dir";
-  public static final String CLUSTER_CONFIG_DIR = "azkaban.cluster.dir";
-  public static final String CLUSTER_ROUTER_CLASS = "azkaban.cluster.router";
-  public static final String CLUSTER_ROUTER_CONF = "azkaban.cluster.router.conf";
 
   public static final String METRIC_INTERVAL = "executor.metric.milisecinterval.";
   private static final String CUSTOM_JMX_ATTRIBUTE_PROCESSOR_PROPERTY = "jmx.attribute.processor.class";

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -25,6 +25,7 @@ import azkaban.AzkabanCommonModule;
 import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
+import azkaban.cluster.ClusterModule;
 import azkaban.database.AzkabanDatabaseSetup;
 import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutionControllerUtils;
@@ -253,7 +254,8 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     /* Initialize Guice Injector */
     final Injector injector = Guice.createInjector(
         new AzkabanCommonModule(props),
-        new AzkabanWebServerModule(props)
+        new AzkabanWebServerModule(props),
+        new ClusterModule()
     );
     SERVICE_PROVIDER.setInjector(injector);
     launch(injector.getInstance(AzkabanWebServer.class));


### PR DESCRIPTION
**Why we need this**: WebServer need Cluster related config, so as the Cleanup Manager can get yarn related info so as later can kill dangling yarn apps.

**What's being done**: move `ClusterModule` to azkaban-common, inject to Web Server, and expose Cluster config mapping to Cleanup Manager.

**Tests done**: tested in container, successfully got the config and able to connect to yarn cluster