### PR TITLE
Allowing images versions in all statuses to run for dev pods

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -543,10 +543,10 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
               // the overridden version exists/registered on Azkaban database. Hence, it follows a
               // fail fast mechanism to throw exception if the version does not exist for the
               // given image type.
-              final Set<State> imageVersionState = getImageVersionState(flowParams);
+              final Set<State> allowedImageStates = getImageVersionState(flowParams);
               final VersionInfo versionInfo = this.imageRampupManager.getVersionInfo(imageType,
                   flowParams.get(imageTypeOverrideParam(imageType)),
-                  imageVersionState);
+                  allowedImageStates);
               overlayMap.put(imageType, versionInfo);
               logger.info("User overridden image type {} of version {} is used", imageType,
                   versionInfo.getVersion());
@@ -612,9 +612,10 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
               logger.info("User overridden image type {} of version {} is used", imageType,
                   versionInfo.getVersion());
             } else {
+              final Set<State> allowedImageStates = getImageVersionState(flowParams);
               versionInfo = this.imageRampupManager.getVersionInfo(imageType,
                   flowParams.get(imageTypeVersionOverrideParam),
-                  State.getNewAndActiveStateFilter());
+                  allowedImageStates);
               overlayMap.put(imageType, versionInfo);
               logger.info("User overridden image type {} of version {} is used", imageType,
                   versionInfo.getVersion());
@@ -1279,9 +1280,9 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
 
   private final Set<State> getImageVersionState(Map<String, String> flowParams) {
     if (isDevPod(flowParams)) {
-      return new HashSet<State>();
-    } else {
       return State.getAllStates();
+    } else {
+      return State.getNewAndActiveStateFilter();
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -543,9 +543,10 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
               // the overridden version exists/registered on Azkaban database. Hence, it follows a
               // fail fast mechanism to throw exception if the version does not exist for the
               // given image type.
+              final Set<State> imageVersionState = getImageVersionState(flowParams);
               final VersionInfo versionInfo = this.imageRampupManager.getVersionInfo(imageType,
                   flowParams.get(imageTypeOverrideParam(imageType)),
-                  State.getNewAndActiveStateFilter());
+                  imageVersionState);
               overlayMap.put(imageType, versionInfo);
               logger.info("User overridden image type {} of version {} is used", imageType,
                   versionInfo.getVersion());
@@ -860,8 +861,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   private void setupDevPod(final Map<String, String> envVariables,
       final Map<String, String> flowParam) {
-    if (flowParam != null && !flowParam.isEmpty() && flowParam
-        .containsKey(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD)) {
+    if (isDevPod(flowParam)) {
       envVariables.put(ContainerizedDispatchManagerProperties.ENV_ENABLE_DEV_POD,
           flowParam.get(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD));
     }
@@ -1025,8 +1025,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private static void logPodSpecYaml(final int executionId, final Object podObject,
       final Map<String, String> flowParam, String message) {
     final String podSpecYaml = Yaml.dump(podObject).trim();
-    if (flowParam != null && !flowParam.isEmpty() && flowParam
-        .containsKey(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD)) {
+    if (isDevPod(flowParam)) {
       logger.info(message, executionId, podSpecYaml);
     } else {
       logger.debug(message, executionId, podSpecYaml);
@@ -1276,5 +1275,21 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   private String getPodName(final int executionId) {
     return String.join("-", this.podPrefix, this.clusterName, String.valueOf(executionId));
+  }
+
+  private final Set<State> getImageVersionState(Map<String, String> flowParams) {
+    if (isDevPod(flowParams)) {
+      return new HashSet<State>();
+    } else {
+      return State.getAllStates();
+    }
+  }
+
+  private static final boolean isDevPod(Map<String, String> flowParam) {
+    if (flowParam != null && !flowParam.isEmpty() && flowParam
+        .containsKey(FlowParameters.FLOW_PARAM_ENABLE_DEV_POD)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
@@ -198,7 +198,11 @@ public class ImageVersion extends BaseModel {
       return newActiveAndTestState;
     }
 
-
+    /**
+     * A Set of All States
+     *
+     * @return Set<State>
+     */
     public static Set<State> getAllStates() {
       return Arrays.stream(State.values()).collect(Collectors.toSet());
     }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/models/ImageVersion.java
@@ -197,5 +197,11 @@ public class ImageVersion extends BaseModel {
     public static Set<State> getNewActiveAndTestStateFilter() {
       return newActiveAndTestState;
     }
+
+
+    public static Set<State> getAllStates() {
+      return Arrays.stream(State.values()).collect(Collectors.toSet());
+    }
   }
+
 }

--- a/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/rampup/ImageRampupManagerImpl.java
@@ -201,8 +201,14 @@ public class ImageRampupManagerImpl implements ImageRampupManager {
       return new VersionInfo(optionalImageVersion.get().getVersion(),
           optionalImageVersion.get().getPath(), optionalImageVersion.get().getState());
     } else {
+      if(stateFilter.isEmpty() || stateFilter == null) {
+        throw new ImageMgmtException(String.format("Unable to get VersionInfo for image type: %s, "
+            + "image version: %s", imageType, imageVersion));
+      }
+      String states = stateFilter.stream().map(i -> i.toString()).collect(Collectors.joining(","));
       throw new ImageMgmtException(String.format("Unable to get VersionInfo for image type: %s, "
-          + "image version: %s with NEW or ACTIVE state.", imageType, imageVersion));
+          + "image version: %s that is in one of the following states: %s.", imageType,
+          imageVersion, states));
     }
   }
 


### PR DESCRIPTION
In order to expedite testing and development, any version of an image should be able to launch a pod, when enable.dev.pod is true.