### PR TITLE
Previously we made it so that substitution properties that were not r…

### DIFF
--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -245,12 +245,13 @@ public class PropsUtils {
 
       resolvedProps.put(key, replacedValue);
     }
-    for(String key: resolvedProps.getKeySet()) {
-      String value = resolvedProps.get(key);
+    for(final String key: resolvedProps.getKeySet()) {
+      final String value = resolvedProps.get(key);
       if(value.contains("${")) {
         Matcher m = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
         if(m.find(0) && resolvedProps.containsKey(m.group(1))) {
-          String replacement = resolveVariableReplacement(value, resolvedProps, visitedVariables,
+          final String replacement = resolveVariableReplacement(value, resolvedProps,
+              visitedVariables,
               allowUndefined);
           resolvedProps.put(key, replacement);
         }

--- a/az-core/src/main/java/azkaban/utils/PropsUtils.java
+++ b/az-core/src/main/java/azkaban/utils/PropsUtils.java
@@ -245,6 +245,18 @@ public class PropsUtils {
 
       resolvedProps.put(key, replacedValue);
     }
+    for(String key: resolvedProps.getKeySet()) {
+      String value = resolvedProps.get(key);
+      if(value.contains("${")) {
+        Matcher m = VARIABLE_REPLACEMENT_PATTERN.matcher(value);
+        if(m.find(0) && resolvedProps.containsKey(m.group(1))) {
+          String replacement = resolveVariableReplacement(value, resolvedProps, visitedVariables,
+              allowUndefined);
+          resolvedProps.put(key, replacement);
+        }
+      }
+    }
+
 
     for (final String key : resolvedProps.getKeySet()) {
       final String value = resolvedProps.get(key);

--- a/az-core/src/test/java/azkaban/utils/PropsUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/PropsUtilsTest.java
@@ -50,7 +50,6 @@ public class PropsUtilsTest {
     props.put("res2", "${their} ${letter}");
     props.put("res7", "${my} ${res5}");
 
-
     propsParent.put("res3", "${your} ${their} ${res4}");
     propsGrandParent.put("res4", "${letter}");
     propsGrandParent.put("res5", "${their}");

--- a/az-core/src/test/java/azkaban/utils/PropsUtilsTest.java
+++ b/az-core/src/test/java/azkaban/utils/PropsUtilsTest.java
@@ -50,6 +50,7 @@ public class PropsUtilsTest {
     props.put("res2", "${their} ${letter}");
     props.put("res7", "${my} ${res5}");
 
+
     propsParent.put("res3", "${your} ${their} ${res4}");
     propsGrandParent.put("res4", "${letter}");
     propsGrandParent.put("res5", "${their}");
@@ -63,6 +64,22 @@ public class PropsUtilsTest {
     Assert.assertEquals("ears", resolved.get("res5"));
     Assert.assertEquals(" t eyes eyes ears ears", resolved.get("res6"));
     Assert.assertEquals("name ears", resolved.get("res7"));
+  }
+
+  @Test
+  public void testResolveProps() throws IOException {
+    final Props props = new Props();
+
+    props.put("spark.version.sparky", "2.3.0");
+    props.put("spark.version", "${spark.version.${spark.branch}}");
+    props.put("spark.branch", "${test}");
+    props.put("test", "sparky");
+    props.put("B", "${A}");
+    props.put("C", "${B}");
+    final Props resolved = PropsUtils.resolveProps(props, true);
+    Assert.assertEquals("${A}",resolved.get("B"));
+    Assert.assertEquals("${A}", resolved.get("C"));
+    Assert.assertEquals("2.3.0",resolved.get("spark.version"));
   }
 
   @Test


### PR DESCRIPTION
…eferenced would not result in an error. This resulted in certain terminal substituions not being supported, such as {foo.{bar}}. This change resolves final substitutions for variables that are contained within the props library