### PR TITLE
Use ConcurrentHashMap to store in-memory project flowresourcerecommen…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -48,6 +48,7 @@ import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.custom.QuantityFormatException;
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -305,25 +306,38 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
     try {
       if (event.getFlowPodMetadata().isPresent() && event.getFlowPodMetadata().get().isOOMKilled()) {
         final Project project = this.projectManager.getProject(executableFlow.getProjectId());
+        final ConcurrentHashMap<String, FlowResourceRecommendation> flowResourceRecommendationMap =
+            project.getFlowResourceRecommendationMap();
         logger.info("Doubling memory recommendation for execId " + executableFlow.getExecutionId());
-        synchronized (project) {
-          final FlowResourceRecommendation flowResourceRecommendation = project
-              .getFlowResourceRecommendation(executableFlow.getFlowId());
-          if (flowResourceRecommendation != null && flowResourceRecommendation.getMemoryRecommendation() != null) {
-            final Quantity oldQuantity = new Quantity(flowResourceRecommendation.getMemoryRecommendation());
+        final FlowResourceRecommendation flowResourceRecommendation =
+            flowResourceRecommendationMap.computeIfPresent(executableFlow.getFlowId(),
+            (flowId, recommendation) -> {
+          // Do not update the same object while computing a new mapping.
+          final FlowResourceRecommendation clone = recommendation.clone();
+
+          if (clone.getMemoryRecommendation() != null) {
+            final Quantity oldQuantity = new Quantity(clone.getMemoryRecommendation());
             final Quantity newQuantity =
                 new Quantity(oldQuantity.getNumber().multiply(new BigDecimal(2)),
-                oldQuantity.getFormat());
+                    oldQuantity.getFormat());
 
-            flowResourceRecommendation.setMemoryRecommendation(newQuantity.toSuffixedString());
-            this.projectManager.updateFlowResourceRecommendation(flowResourceRecommendation);
+            clone.setMemoryRecommendation(newQuantity.toSuffixedString());
           }
+          return clone;
+        });
+
+        // present
+        if (flowResourceRecommendation != null) {
+          flowResourceRecommendationMap.put(executableFlow.getFlowId(),
+              flowResourceRecommendation);
+          this.projectManager.updateFlowResourceRecommendation(flowResourceRecommendation);
         }
       }
     } catch (Exception e) {
      logger.error("Failed to parse quantity when doubling memory recommendation for execId " + executableFlow.getExecutionId());
     }
   }
+
   /**
    * Delete the the flow pod and any other related objects (such as services).
    *

--- a/azkaban-common/src/main/java/azkaban/flow/FlowResourceRecommendation.java
+++ b/azkaban-common/src/main/java/azkaban/flow/FlowResourceRecommendation.java
@@ -1,6 +1,6 @@
 package azkaban.flow;
 
-public class FlowResourceRecommendation {
+public class FlowResourceRecommendation implements Cloneable {
   private int id;
   private int projectId;
   private String flowId;
@@ -75,4 +75,14 @@ public class FlowResourceRecommendation {
     this.diskRecommendation = diskRecommendation;
   }
 
+  // Deep copy
+  @Override
+  public FlowResourceRecommendation clone() {
+    try {
+      return (FlowResourceRecommendation) super.clone();
+    } catch (CloneNotSupportedException e) {
+      // this shouldn't happen, since we are Cloneable
+      throw new InternalError(e);
+    }
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/project/AbstractProjectCache.java
+++ b/azkaban-common/src/main/java/azkaban/project/AbstractProjectCache.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,15 +82,13 @@ public abstract class AbstractProjectCache implements ProjectCache {
       // Load the flows into the project objects
       for (final Map.Entry<Project, List<FlowResourceRecommendation>> entry : projectToFlowResourceRecommendations.entrySet()) {
         final Project project = entry.getKey();
-        synchronized (project) {
-          final List<FlowResourceRecommendation> flowResourceRecommendations = entry.getValue();
+        final List<FlowResourceRecommendation> flowResourceRecommendations = entry.getValue();
 
-          final HashMap<String, FlowResourceRecommendation> flowResourceRecommendationMap = new HashMap<>();
-          for (final FlowResourceRecommendation flowResourceRecommendation : flowResourceRecommendations) {
-            flowResourceRecommendationMap.put(flowResourceRecommendation.getFlowId(), flowResourceRecommendation);
-          }
-
-          project.setFlowResourceRecommendations(flowResourceRecommendationMap);
+        final ConcurrentHashMap<String, FlowResourceRecommendation> flowResourceRecommendationMap =
+            project.getFlowResourceRecommendationMap();
+        for (final FlowResourceRecommendation flowResourceRecommendation : flowResourceRecommendations) {
+          flowResourceRecommendationMap.put(flowResourceRecommendation.getFlowId(),
+              flowResourceRecommendation);
         }
       }
     } catch (final ProjectManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -807,7 +807,7 @@ public class JdbcProjectImpl implements ProjectLoader {
   @Override
   public synchronized FlowResourceRecommendation createFlowResourceRecommendation(final int projectId, final String flowId)
       throws ProjectManagerException {
-    logger.info("Creating flow resource recommendation " + flowId);
+    logger.info("Creating flow resource recommendation. ProjectId: " + projectId + ", FlowId: " + flowId);
     final String INSERT_FLOW_RESOURCE_RECOMMENDATION =
         "INSERT INTO project_flow_resource_recommendations (project_id, flow_id, modified_time) values (?,?,?)";
 
@@ -823,8 +823,8 @@ public class JdbcProjectImpl implements ProjectLoader {
     } catch (final SQLException ex) {
       // Possibly failed due to duplicate key. If not, fetchFlowResourceRecommendation will
       // return another exception back.
-      logger.warn("Insert flow resource recommendation " + flowId + " for existing "
-          + "project failed.", ex);
+      logger.warn("Insert flow resource recommendation projectId: " + projectId + ", flowId: " + flowId
+          + " for existing project failed.", ex);
     }
     return fetchFlowResourceRecommendation(projectId, flowId);
   }

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -821,9 +821,10 @@ public class JdbcProjectImpl implements ProjectLoader {
         throw new ProjectManagerException("No flow resource recommendations have been inserted.");
       }
     } catch (final SQLException ex) {
-      logger.error(INSERT_FLOW_RESOURCE_RECOMMENDATION + " failed.", ex);
-      throw new ProjectManagerException("Insert flow resource recommendation " + flowId + " for existing "
-          + "project failed. ", ex);
+      // Possibly failed due to duplicate key. If not, fetchFlowResourceRecommendation will
+      // return another exception back.
+      logger.warn("Insert flow resource recommendation " + flowId + " for existing "
+          + "project failed.", ex);
     }
     return fetchFlowResourceRecommendation(projectId, flowId);
   }

--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -26,6 +26,7 @@ import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Pair;
 import com.google.common.collect.ImmutableMap;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ public class Project extends EventHandler {
   private String source;
   private Map<String, Flow> flows = new HashMap<>();
   // flowResourceRecommendations map shouldn't be ImmutableMap.
-  private HashMap<String, FlowResourceRecommendation> flowResourceRecommendations = new HashMap<>();
+  private ConcurrentHashMap<String, FlowResourceRecommendation> flowResourceRecommendations = new ConcurrentHashMap<>();
   private Map<String, Object> metadata = new HashMap<>();
   private static final Logger logger = LoggerFactory.getLogger(Project.class);
   // Added event listener for sending project events
@@ -160,12 +161,8 @@ public class Project extends EventHandler {
     return this.flowResourceRecommendations.get(flowId);
   }
 
-  public Map<String, FlowResourceRecommendation> getFlowResourceRecommendationMap() {
+  public ConcurrentHashMap<String, FlowResourceRecommendation> getFlowResourceRecommendationMap() {
     return this.flowResourceRecommendations;
-  }
-
-  public void setFlowResourceRecommendations(@Nonnull final HashMap<String, FlowResourceRecommendation> flowResourceRecommendations) {
-    this.flowResourceRecommendations = flowResourceRecommendations;
   }
 
   public Permission getCollectivePermission(final User user) {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -163,8 +163,10 @@ public interface ProjectLoader {
       throws ProjectManagerException;
 
   /**
-   * Should create an empty flow resource recommendation with the given projectId and flowId and adds it to
-   * the data store. It will auto assign a unique id for this flow resource recommendation if successful.
+   * If not exist, should create an empty flow resource recommendation with the given projectId and
+   * flowId and adds it to the data store. It will auto assign a unique id for this flow resource
+   * recommendation if successful.
+   * If exist, fetch the flow resource recommendation directly.
    *
    * @param projectId project ID
    * @param flowId   flow id

--- a/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/KubernetesContainerizedImplTest.java
@@ -95,6 +95,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.AfterClass;
@@ -131,6 +132,10 @@ public class KubernetesContainerizedImplTest {
   private static final String MAX_ALLOWED_MEMORY = "32Gi";
   private static final FlowResourceRecommendation DEFAULT_FLOW_RECOMMENDATION =
       new FlowResourceRecommendation(1, 1, "flow", null, null, null);
+  private static final ConcurrentHashMap<String, FlowResourceRecommendation> DEFAULT_FLOW_RECOMMENDATION_MAP = new ConcurrentHashMap<String, FlowResourceRecommendation>() {{
+    put(DEFAULT_FLOW_RECOMMENDATION.getFlowId(), DEFAULT_FLOW_RECOMMENDATION);
+  }};
+
   public static final String DEPENDENCY1 = "dependency1";
   public static final int CPU_LIMIT_MULTIPLIER = 1;
   public static final int MEMORY_LIMIT_MULTIPLIER = 1;
@@ -451,9 +456,11 @@ public class KubernetesContainerizedImplTest {
     final VersionSet versionSet = this.kubernetesContainerizedImpl
         .fetchVersionSet(flow.getExecutionId(), flowParam, allImageTypes, flow);
     final V1PodSpec podSpec = this.kubernetesContainerizedImpl
-        .createPodSpec(flow, DEFAULT_FLOW_RECOMMENDATION, versionSet, jobTypes, dependencyTypes, flowParam);
+        .createPodSpec(flow, DEFAULT_FLOW_RECOMMENDATION, DEFAULT_FLOW_RECOMMENDATION_MAP,
+            versionSet, jobTypes, dependencyTypes, flowParam);
     final V1ObjectMeta podMetadata =
-        this.kubernetesContainerizedImpl.createPodMetadata(flow, DEFAULT_FLOW_RECOMMENDATION, flowParam);
+        this.kubernetesContainerizedImpl.createPodMetadata(flow, DEFAULT_FLOW_RECOMMENDATION.getId(),
+            flowParam);
     // Set custom labels and annotations
     ImmutableMap<String, String> annotations = ImmutableMap.of(
         "akey1", "aval1",

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -399,6 +399,19 @@ public class JdbcProjectImplTest {
   }
 
   @Test
+  public void testCreateFlowResourceRecommendationTwice() throws Exception {
+    final int projectId = 1;
+    final String flowId = "alwaysOk";
+    this.loader.createFlowResourceRecommendation(projectId, flowId);
+    final FlowResourceRecommendation flowResourceRecommendation = this.loader.createFlowResourceRecommendation(projectId, flowId);
+    Assert.assertEquals(flowResourceRecommendation.getProjectId(), projectId);
+    Assert.assertEquals(flowResourceRecommendation.getFlowId(), flowId);
+    Assert.assertNull(flowResourceRecommendation.getCpuRecommendation());
+    Assert.assertNull(flowResourceRecommendation.getMemoryRecommendation());
+    Assert.assertNull(flowResourceRecommendation.getDiskRecommendation());
+  }
+
+  @Test
   public void testUpdateFlowResourceRecommendation() throws Exception {
     final int projectId = 1;
     final String flowId = "alwaysOk1";


### PR DESCRIPTION
…dation map

After discussing internally, there is no need to use "synchronize(project)" to ensure the locking which is quite heavy operation (may block other thread for a long time: project upload will take a long time for huge project zips). Using ConcurrentHashMap is more lightweight and better.