### PR TITLE
CleanupManager - yarn app killing features wrap-ups

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -503,8 +503,14 @@ public class ContainerCleanupManager {
         this.executionCleanupIntervalMin, TimeUnit.MINUTES);
     this.cleanupService.scheduleAtFixedRate(this::cleanUpContainersInTerminalStatuses, 0L,
         this.containerCleanupIntervalMin, TimeUnit.MINUTES);
-    this.cleanupService.scheduleAtFixedRate(this::cleanUpDanglingYarnApplications, 0L,
-        this.yarnAppCleanupIntervalMin, TimeUnit.MINUTES);
+    if (this.yarnAppCleanupIntervalMin <= 0) {
+      logger.warn("Yarn application cleanup schedule not started: "
+          + "invalid time interval " + this.yarnAppCleanupIntervalMin + ", please correct value "
+          + ContainerizedDispatchManagerProperties.CONTAINERIZED_YARN_APPLICATION_CLEANUP_INTERVAL_MIN);
+    } else {
+      this.cleanupService.scheduleAtFixedRate(this::cleanUpDanglingYarnApplications, 0L,
+          this.yarnAppCleanupIntervalMin, TimeUnit.MINUTES);
+    }
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -179,7 +179,6 @@ public class ContainerCleanupManager {
         .build();
 
     // get yarn config for instance without robin enabled
-    logger.info("AzkProps: hadoop.conf.dir.path=" + azkProps.getString(HADOOP_CONF_DIR_PATH, ""));
 
     // get config in instance using robin, so as can connect to multiple yarn cluster RMs
     for (Entry<String, Cluster> entry : this.clusterRouter.getAllClusters().entrySet()) {
@@ -195,6 +194,17 @@ public class ContainerCleanupManager {
       if (!allClusters.containsKey(yarnConfDir)) {
         allClusters.put(yarnConfDir, cluster);
       }
+    }
+    if (allClusters.isEmpty()) {
+      String hadoopConfDir = azkProps.getString(HADOOP_CONF_DIR_PATH, "");
+      if (hadoopConfDir.isEmpty()) {
+        logger.warn("No Cluster config or default hadoop-conf-dir-path specified,"
+            + " yarn app cleanup will not work");
+        return;
+      }
+      logger.info("AzkProps: hadoop.conf.dir.path=" + hadoopConfDir);
+      Props defaultClusterProps = Props.of(YARN_CONF_DIRECTORY_PROPERTY, hadoopConfDir);
+      allClusters.put(hadoopConfDir, new Cluster("default", defaultClusterProps));
     }
   }
 


### PR DESCRIPTION
**What's in this** 
1. when robin not enabled, use default `hadoop-conf-dir-path` for yarn cluster connection
2. use `yarn.application.cleanup.interval.min` as feature flag: non-positive value won't start the yarn-kill schedule
3. handle unexpected throwables for all methods, so as 1 failure won't terminate the following runs