### PR TITLE
[Plugins] Support validateLdapGroup in RampManager Ownership Management

### DIFF
--- a/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManagerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/imagemgmt/permission/PermissionManagerImpl.java
@@ -127,7 +127,7 @@ public class PermissionManagerImpl implements PermissionManager {
   @Override
   public void validateIdentity(List<String> ids) {
     Set<String> invalids = ids.stream()
-        .filter(id -> !userManager.validateGroup(id) && !userManager.validateUser(id))
+        .filter(id -> !userManager.validateLdapGroup(id) && !userManager.validateUser(id))
         .collect(Collectors.toSet());
     if (!invalids.isEmpty()) {
       log.error("Invalid identity: " + invalids);

--- a/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/imagemgmt/services/ImageRampRuleServiceImplTest.java
@@ -91,7 +91,7 @@ public class ImageRampRuleServiceImplTest {
 
     when(_userManager.getRole(any())).thenReturn(role);
     when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(true);
-    when(_userManager.validateGroup(any())).thenReturn(true);
+    when(_userManager.validateLdapGroup(any())).thenReturn(true);
     when(_rampRuleDao.addRampRule(any())).thenReturn(1);
     assertThatCode(() -> _rampRuleService.createRule(requestDTO, user)).doesNotThrowAnyException();
   }
@@ -109,7 +109,7 @@ public class ImageRampRuleServiceImplTest {
 
     when(_userManager.getRole(any())).thenReturn(role);
     when(_userManager.validateUserGroupMembership(any(), any())).thenReturn(true);
-    when(_userManager.validateGroup(any())).thenReturn(true);
+    when(_userManager.validateLdapGroup(any())).thenReturn(true);
     when(_rampRuleDao.addRampRule(any())).thenReturn(1);
     assertThatCode(() -> _rampRuleService.createHpFlowRule(requestDTO, user)).doesNotThrowAnyException();
   }
@@ -125,7 +125,7 @@ public class ImageRampRuleServiceImplTest {
     ownership.setOwner(user.getUserId());
     ownership.setRole(ImageOwnership.Role.ADMIN);
     when(_userManager.getRole(any())).thenReturn(role);
-    when(_userManager.validateGroup(any())).thenReturn(true);
+    when(_userManager.validateLdapGroup(any())).thenReturn(true);
 
     String existingOwner1 = "user2";
     String existingOwner2 = "user3";
@@ -151,7 +151,7 @@ public class ImageRampRuleServiceImplTest {
     ownership.setOwner(user.getUserId());
     ownership.setRole(ImageOwnership.Role.ADMIN);
     when(_userManager.getRole(any())).thenReturn(role);
-    when(_userManager.validateGroup(any())).thenReturn(true);
+    when(_userManager.validateLdapGroup(any())).thenReturn(true);
 
     String existingOwner1 = "user2";
     String existingOwner2 = "user3";


### PR DESCRIPTION
Replace placeholder validateGroup to validateLdapGroup in validateIndentity for RampManager APIs, as LdapUserManager has implemented validateLdapGroup in plugins.

Test done by mlearning2 cluster, from both web server and flow execution perspective.
See details in plugins RB [#3688246].