### PR TITLE
CleanupManager Add YarnApplicationKillFail metrics

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -366,6 +366,7 @@ public class ContainerCleanupManager {
     } catch (Exception e) {
       logger.error("fail to get yarn applications by execution IDs from cluster "
           + cluster.getClusterId() + ", exiting", e);
+      containerizationMetrics.markYarnGetApplicationsFail();
       return;
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -338,7 +339,7 @@ public class ContainerCleanupManager {
 
       // For each of yarn clusters: find applications of the above executionIDs and kill them
       for (Entry<String, Cluster> entry : this.allClusters.entrySet()) {
-        logger.info("clean up yarn applications in cluster:" + entry.getValue().clusterId);
+        logger.info("clean up yarn applications in cluster:" + entry.getValue().getClusterId());
         cleanUpYarnApplicationsInCluster(toBeCleanedContainers, entry.getValue());
       }
     } catch (Throwable t) {
@@ -354,7 +355,7 @@ public class ContainerCleanupManager {
 
     List<ApplicationReport> aliveApplications;
     try {
-      logger.info("Getting all yarn apps for cluster:" + cluster.getClusterId());
+      logger.debug("Getting all yarn apps for cluster:" + cluster.getClusterId());
       YarnClient yarnClient = createYarnClient(cluster.getProperties(), apacheLogger);
       aliveApplications = getAllAliveAppReportsByExecIDs(
           yarnClient, toBeCleanedContainers, apacheLogger);
@@ -363,7 +364,8 @@ public class ContainerCleanupManager {
           aliveApplications.stream().map(app -> app.getApplicationId().toString())
               .collect(Collectors.joining(",")));
     } catch (Exception e) {
-      logger.error("fail to get yarn applications by execution IDs", e);
+      logger.error("fail to get yarn applications by execution IDs from cluster "
+          + cluster.getClusterId() + ", exiting", e);
       return;
     }
 
@@ -372,7 +374,8 @@ public class ContainerCleanupManager {
     aliveApplications.forEach(
         app -> appsSuccessfulKilled.put(app.getApplicationId().toString(), false));
 
-    ExecutorService yarnKillThreadPool = Executors.newFixedThreadPool(this.yarnAppKillParallelism);
+    ExecutorService yarnKillThreadPool = Executors.newFixedThreadPool(
+        this.yarnAppKillParallelism);
     aliveApplications.forEach(app ->
         yarnKillThreadPool.execute(new Runnable() {
           @Override
@@ -395,15 +398,19 @@ public class ContainerCleanupManager {
         logger.info("Yarn application killing threads not all terminated as expected");
       }
     } catch (InterruptedException e) {
-      logger.warn("Error awaiting the termination of all the Yarn application killing threads", e);
+      logger.warn("Error awaiting the termination of all the Yarn application killing threads",
+          e);
     }
 
     // report the kill results
-    logger.info("Successfully killed yarn applications: " + appsSuccessfulKilled.entrySet().stream()
-        .filter(Entry::getValue).map(Entry::getKey).collect(Collectors.joining(",")));
+    logger.info(
+        "Successfully killed yarn applications: " + appsSuccessfulKilled.entrySet().stream()
+            .filter(Entry::getValue).map(Entry::getKey).collect(Collectors.joining(",")));
     if (appsSuccessfulKilled.containsValue(false)) {
-      logger.warn("Failed to kill Yarn applications: " + appsSuccessfulKilled.entrySet().stream()
-          .filter(entry -> !entry.getValue()).map(Entry::getKey).collect(Collectors.joining(",")));
+      List<String> failed = appsSuccessfulKilled.entrySet().stream()
+          .filter(entry -> !entry.getValue()).map(Entry::getKey).collect(Collectors.toList());
+      logger.warn("Failed to kill Yarn applications: " + String.join(",", failed));
+      containerizationMetrics.markYarnApplicationKillFail(failed.size());
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -109,7 +109,12 @@ public interface ContainerizationMetrics {
   void markVPARecommenderFail();
 
   /**
-   * Record number of vpa recommender get recommendation failure
+   * Record number of get yarn application failure
+   */
+  void markYarnGetApplicationsFail();
+
+  /**
+   * Record number of killing yarn application failure
    */
   void markYarnApplicationKillFail(long n);
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -107,4 +107,9 @@ public interface ContainerizationMetrics {
    * Record number of vpa recommender get recommendation failure
    */
   void markVPARecommenderFail();
+
+  /**
+   * Record number of vpa recommender get recommendation failure
+   */
+  void markYarnApplicationKillFail(long n);
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -34,7 +34,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
       appContainerStarting, podReady, podInitFailure, podAppFailure;
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
   private Meter executionStopped, oomKilled, containerDispatchFail, vpaRecommenderFail,
-      yarnApplicationKillFail;
+      yarnGetApplicationsFail, yarnApplicationKillFail;
   private Histogram timeToDispatch;
   private volatile boolean isInitialized = false;
 
@@ -61,6 +61,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.oomKilled = this.metricsManager.addMeter("OOM-Killed-Meter");
     this.containerDispatchFail = this.metricsManager.addMeter("Container-Dispatch-Fail-Meter");
     this.vpaRecommenderFail = this.metricsManager.addMeter("VPA-Recommender-Fail-Meter");
+    this.yarnGetApplicationsFail = this.metricsManager.addMeter("Yarn-Get-Applications-Fail-Meter");
     this.yarnApplicationKillFail = this.metricsManager.addMeter("Yarn-Application-Kill-Fail-Meter");
   }
 
@@ -154,6 +155,11 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   @Override
   public void markVPARecommenderFail() {
     vpaRecommenderFail.mark();
+  }
+
+  @Override
+  public void markYarnGetApplicationsFail() {
+    this.yarnGetApplicationsFail.mark();
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -159,7 +159,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
   @Override
   public void markYarnGetApplicationsFail() {
-    this.yarnGetApplicationsFail.mark();
+    yarnGetApplicationsFail.mark();
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -33,7 +33,8 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Meter podCompleted, podRequested, podScheduled, initContainerRunning,
       appContainerStarting, podReady, podInitFailure, podAppFailure;
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
-  private Meter executionStopped, oomKilled, containerDispatchFail, vpaRecommenderFail;
+  private Meter executionStopped, oomKilled, containerDispatchFail, vpaRecommenderFail,
+      yarnApplicationKillFail;
   private Histogram timeToDispatch;
   private volatile boolean isInitialized = false;
 
@@ -60,6 +61,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.oomKilled = this.metricsManager.addMeter("OOM-Killed-Meter");
     this.containerDispatchFail = this.metricsManager.addMeter("Container-Dispatch-Fail-Meter");
     this.vpaRecommenderFail = this.metricsManager.addMeter("VPA-Recommender-Fail-Meter");
+    this.yarnApplicationKillFail = this.metricsManager.addMeter("Yarn-Application-Kill-Fail-Meter");
   }
 
   @Override
@@ -104,7 +106,9 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   }
 
   @Override
-  public void markPodReady() { this.podReady.mark(); }
+  public void markPodReady() {
+    this.podReady.mark();
+  }
 
   @Override
   public void markPodInitFailure() {
@@ -118,23 +122,42 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
 
 
   @Override
-  public void addTimeToDispatch(final long time) { timeToDispatch.update(time); }
+  public void addTimeToDispatch(final long time) {
+    timeToDispatch.update(time);
+  }
 
   @Override
-  public void markFlowSubmitToExecutor() { flowSubmitToExecutor.mark(); }
+  public void markFlowSubmitToExecutor() {
+    flowSubmitToExecutor.mark();
+  }
 
   @Override
-  public void markFlowSubmitToContainer() { flowSubmitToContainer.mark(); }
+  public void markFlowSubmitToContainer() {
+    flowSubmitToContainer.mark();
+  }
 
   @Override
-  public void markExecutionStopped() { executionStopped.mark(); }
+  public void markExecutionStopped() {
+    executionStopped.mark();
+  }
 
   @Override
-  public void markOOMKilled() { oomKilled.mark(); }
+  public void markOOMKilled() {
+    oomKilled.mark();
+  }
 
   @Override
-  public void markContainerDispatchFail() { containerDispatchFail.mark(); }
+  public void markContainerDispatchFail() {
+    containerDispatchFail.mark();
+  }
 
   @Override
-  public void markVPARecommenderFail() { vpaRecommenderFail.mark(); }
+  public void markVPARecommenderFail() {
+    vpaRecommenderFail.mark();
+  }
+
+  @Override
+  public void markYarnApplicationKillFail(long n) {
+    yarnApplicationKillFail.mark(n);
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -100,6 +100,11 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
   }
 
   @Override
+  public void markYarnGetApplicationsFail() {
+
+  }
+
+  @Override
   public void markYarnApplicationKillFail(long n) {
   }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -98,4 +98,8 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
   @Override
   public void markVPARecommenderFail() {
   }
+
+  @Override
+  public void markYarnApplicationKillFail(long n) {
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -67,7 +67,7 @@ public class ContainerCleanupManagerTest {
   private ContainerizedImpl containerImpl;
   private ContainerizedDispatchManager containerizedDispatchManager;
   private ContainerCleanupManager cleaner;
-  private DummyContainerizationMetricsImpl metrics;
+  private DummyContainerizationMetricsImpl metrics = new DummyContainerizationMetricsImpl();
   private ClusterRouter clusterRouter;
 
   @Before


### PR DESCRIPTION
**Why need this**: emit metrics of counter of yarn getApplication failure and counter of failed-to-killed yarn application, so as can create dashboard and alert amongst this

**Test done**: deployed in our test web server, and verified the metrics was emitted from ingraph