### PR TITLE
Emit isOOMKilled and isVPAEnabled metrics to Azkaban event reporter and Log isVPAEnabled in flow logs

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -199,6 +199,8 @@ public class Constants {
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
     public static final String EXECUTION_RETRIED_BY_AZKABAN = "executionRetriedByAzkaban";
+    public static final String IS_OOM_KILLED = "isOOMKilled";
+    public static final String IS_POD_SIZE_AUTOSCALING_ENABLED = "isPodSizeAutoscaled";
     public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =
         "originalFlowExecutionIdBeforeRetry";
     public static final String SLA_OPTIONS = "slaOptions";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -54,6 +54,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String SLAOPTIONS_PARAM = "slaOptions";
   public static final String AZKABANFLOWVERSION_PARAM = "azkabanFlowVersion";
   public static final String IS_LOCKED_PARAM = "isLocked";
+  public static final String IS_OOM_Killed_PARAM = "isOOMKilled";
+  public static final String IS_VPA_Enabled_PARAM = "isVPAEnabled";
   public static final String FLOW_LOCK_ERROR_MESSAGE_PARAM = "flowLockErrorMessage";
   public static final String EXECUTION_SOURCE = "executionSource";
   public static final String FLOW_DISPATCH_METHOD = "dispatch_method";
@@ -77,6 +79,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private ExecutionOptions executionOptions;
   private double azkabanFlowVersion;
   private boolean isLocked;
+  private boolean isOOMKilled = false;
+  private boolean isVPAEnabled = false;
   private ExecutableFlowRampMetadata executableFlowRampMetadata;
   private String flowLockErrorMessage;
   // For Flow_Status_Changed event
@@ -266,6 +270,14 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
   public void setLocked(boolean locked) { this.isLocked = locked; }
 
+  public boolean isOOMKilled() { return this.isOOMKilled; }
+
+  public void setOOMKilled(boolean oomKilled) { this.isOOMKilled = oomKilled; }
+
+  public boolean isVPAEnabled() { return this.isVPAEnabled; }
+
+  public void setVPAEnabled(boolean vpaEnabled) { this.isVPAEnabled = vpaEnabled; }
+
   public String getFlowLockErrorMessage() {
     return this.flowLockErrorMessage;
   }
@@ -317,6 +329,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
 
     flowObj.put(IS_LOCKED_PARAM, this.isLocked);
+    flowObj.put(IS_OOM_Killed_PARAM, this.isOOMKilled);
+    flowObj.put(IS_VPA_Enabled_PARAM, this.isVPAEnabled);
     flowObj.put(FLOW_LOCK_ERROR_MESSAGE_PARAM, this.flowLockErrorMessage);
     flowObj.put(FLOW_DISPATCH_METHOD, getDispatchMethod().getNumVal());
 
@@ -388,6 +402,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
     }
 
     this.setLocked(flowObj.getBool(IS_LOCKED_PARAM, false));
+    this.setOOMKilled(flowObj.getBool(IS_OOM_Killed_PARAM, false));
+    this.setVPAEnabled(flowObj.getBool(IS_VPA_Enabled_PARAM, false));
     this.setFlowLockErrorMessage(flowObj.getString(FLOW_LOCK_ERROR_MESSAGE_PARAM, null));
     // Dispatch Method default is POLL
     this.setDispatchMethod(DispatchMethod.fromNumVal(flowObj.getInt(FLOW_DISPATCH_METHOD,

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -79,6 +79,14 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
     metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
         String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
+    if (flow.isOOMKilled()) {
+      metaData.put(EventReporterConstants.IS_OOM_KILLED,
+          String.valueOf(flow.isOOMKilled()));
+    }
+    if (flow.isVPAEnabled()) {
+      metaData.put(EventReporterConstants.IS_POD_SIZE_AUTOSCALING_ENABLED,
+          String.valueOf(flow.isVPAEnabled()));
+    }
     // Add flow start time and end time, default value -1
     metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
     metaData.put(EventReporterConstants.END_TIME, String.valueOf(flow.getEndTime()));

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -806,6 +806,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         this.projectManager.updateFlowResourceRecommendation(flowResourceRecommendation);
       }
 
+      executableFlow.setVPAEnabled(true);
       return vpaRecommendation;
     } catch (ExecutorManagerException | ProjectManagerException e) {
       logger.error("Cannot apply resource recommendation from VPA for execId {}", executableFlow

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -287,7 +287,7 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
         logger.warn ("Containerization metrics are not initialized");
       }
 
-      doubleMemoryRecommendationIfOOMKilled(executableFlow, event);
+      handleOOMKilledIfNeeded(executableFlow, event);
 
       ExecutionControllerUtils.finalizeFlow(this, this.projectManager, executorLoader,
           alerterHolder, executableFlow, reason, null, Status.EXECUTION_STOPPED);
@@ -301,7 +301,7 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
     return Optional.of(originalStatus);
   }
 
-  private void doubleMemoryRecommendationIfOOMKilled(final ExecutableFlow executableFlow,
+  private void handleOOMKilledIfNeeded(final ExecutableFlow executableFlow,
       final AzPodStatusMetadata event) {
     try {
       if (event.getFlowPodMetadata().isPresent() && event.getFlowPodMetadata().get().isOOMKilled()) {
@@ -310,6 +310,8 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
         } else {
           logger.warn("Containerization metrics are not initialized");
         }
+
+        executableFlow.setOOMKilled(true);
 
         final Project project = this.projectManager.getProject(executableFlow.getProjectId());
         final ConcurrentHashMap<String, FlowResourceRecommendation> flowResourceRecommendationMap =

--- a/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/FlowContainer.java
@@ -351,6 +351,7 @@ public class FlowContainer implements IFlowRunnerManager, IMBeanRegistrable, Eve
 
     // Log the versionSet for this flow execution
     logVersionSet(flow);
+    logVPAEnabled(flow);
 
     createFlowRunner(flow);
     setResourceUtilization();
@@ -757,6 +758,18 @@ public class FlowContainer implements IFlowRunnerManager, IMBeanRegistrable, Eve
       logger.error("VersionSet is not set for the flow");
     } else {
       logger.info("VersionSet: " + ServerUtils.getVersionSetJsonString(versionSet));
+    }
+  }
+
+  /**
+   * Log if this flow execution pod is autoscaled by VPA
+   * @param flow Executable flow.
+   */
+  private void logVPAEnabled(final ExecutableFlow flow) {
+    if (flow.isVPAEnabled()) {
+      logger.info(String.format("This flow execution pod %s is autoscaled by Azkaban. If this "
+              + "execution ends with Out-Of-Memory Killed, please reach out to Azkaban team for "
+              + "help.", flow.getExecutionId()));
     }
   }
 


### PR DESCRIPTION
1. Emit isOOMKilled and isVPAEnabled metrics to Azkaban event reporter for better offline analysis; Before this PR, isOOMKilled is only emitted to real-time metrics system which is good for monitoring and alerting but hard for large scale offline analysis.
2. LogVPAEnabled message in execution flow log to better inform users about this feature.

Validation:
1. {'isPodSizeAutoscaled': 'true', 'isOOMKilled': 'true'} in azkaban event reporter events.
2. One addition line in flow log if VPA is enabled: `2022/11/21 21:27:37.624 +0000  INFO [FlowContainer] [main] [Azkaban] This flow execution pod 123456 is autoscaled by Azkaban. If this execution ends with Out-Of-Memory Killed, please reach out to Azkaban team for help.`
