### PR TITLE
Remove redundant project.setVersion line which is added by mistake

### DIFF
--- a/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/AzkabanProjectLoader.java
@@ -297,9 +297,6 @@ class AzkabanProjectLoader {
         });
       }
 
-      // Set the project version before upload of project files happens so that the files use
-      // new version.
-      project.setVersion(newProjectVersion);
       if (loader instanceof DirectoryFlowLoader) {
         final DirectoryFlowLoader directoryFlowLoader = (DirectoryFlowLoader) loader;
         log.info("Uploading Job properties for project " + archive.getName());


### PR DESCRIPTION
There is already a project.setVersion in the tail of this function.

A redundant project.setVersion prior to `uploading project property files` will introduce the bug described in this PR: https://github.com/azkaban/azkaban/pull/3149