### PR TITLE
Use flowSubmitTime instead of flowStartTime for log timebox querying

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -463,11 +463,11 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       return LogData.createLogDataFromObject(result);
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), "", 0,
-          offset, length, exFlow.getStartTime(), exFlow.getEndTime());
+          offset, length, exFlow.getSubmitTime(), exFlow.getEndTime());
       // Return offline logs if nearline logs are empty
       if (offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() && logData == null) {
         return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), "", 0,
-            offset, length, exFlow.getStartTime(), exFlow.getEndTime());
+            offset, length, exFlow.getSubmitTime(), exFlow.getEndTime());
       }
       return logData;
     }
@@ -494,11 +494,11 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
       return LogData.createLogDataFromObject(result);
     } else {
       LogData logData = this.nearlineExecutionLogsLoader.fetchLogs(exFlow.getExecutionId(), jobId,
-          attempt, offset, length, exFlow.getStartTime(), exFlow.getEndTime());
+          attempt, offset, length, exFlow.getSubmitTime(), exFlow.getEndTime());
       // Return offline logs if nearline logs are empty
       if (!nearlineOnly && offlineLogsLoaderEnabled && offlineExecutionLogsLoader.isPresent() && logData == null) {
         return this.offlineExecutionLogsLoader.get().fetchLogs(exFlow.getExecutionId(), jobId,
-            attempt, offset, length, exFlow.getStartTime(), exFlow.getEndTime());
+            attempt, offset, length, exFlow.getSubmitTime(), exFlow.getEndTime());
       }
       return logData;
     }

--- a/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/ExecutionLogsLoader.java
@@ -12,9 +12,9 @@ public interface ExecutionLogsLoader {
   // FlowEndTime is needed for offline logs to tell if the logs are complete or not considering
   // every offline logging platform has decent amount of delay from when log-is-sent to when
   // log-is-available.
-  // FlowStartTime and FlowEndTime timeboxing can help accelerate log search/query.
+  // flowSubmitTime and FlowEndTime timeboxing can help accelerate log search/query.
   LogData fetchLogs(int execId, String name, int attempt, int startByte,
-      int length, long flowStartTime, long flowEndTime) throws ExecutorManagerException;
+      int length, long flowSubmitTime, long flowEndTime) throws ExecutorManagerException;
 
   int removeExecutionLogsByTime(long millis, int recordCleanupLimit)
       throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
+++ b/azkaban-common/src/main/java/azkaban/logs/JdbcExecutionLogsLoader.java
@@ -17,7 +17,7 @@ public class JdbcExecutionLogsLoader implements ExecutionLogsLoader {
 
   @Override
   public LogData fetchLogs(final int execId, final String name, final int attempt,
-      final int startByte, final int length, final long flowStartTime, final long flowEndTime) throws ExecutorManagerException {
+      final int startByte, final int length, final long flowSubmitTime, final long flowEndTime) throws ExecutorManagerException {
 
     return this.executionLogsDao.fetchLogs(execId, name, attempt, startByte, length);
   }


### PR DESCRIPTION
In most cases, the timestamp for Azkaban flow logs and job logs is ahead of the flowStartTime (when flow status is set to RUNNING) b/c there are also other logs before we want to mark flow status to RUNNING.