### PR TITLE
tuning gradle build parameters on travis CI to reduce test OOM failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ notifications:
 
 env:
   global:
-    # Reduce the memory pressure on Travis CI to reduce build failures.
-    - GRADLE_OPTS="-Xms512m -Xmx512m"
+    - GRADLE_OPTS="-Xms512m -Xmx4096m"
 
 after_success:
-  - travis_wait 30 ./gradlew coveralls --no-daemon
+  # avoid to double trigger test and increase build time
+  - travis_wait 30 ./gradlew coveralls -x test --no-daemon
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,6 @@ subprojects {
       // NOTE! For some reason anything more than 1 doesn't work well for azkaban build:
       // any maxParallelForks > 1 seems to make `./gradlew cleanTest test` ~4 times slower
       maxParallelForks = 1
-      maxHeapSize '4g'
     }
   }
 
@@ -256,7 +255,7 @@ if (System.env.TRAVIS == 'true') {
       // Reduce the memory pressure on the Travis CI to reduce build failures.
       maxParallelForks = 2
       minHeapSize = '512m'
-      maxHeapSize '4g'
+      maxHeapSize = '4g'
       outputs.upToDateWhen { false }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ plugins {
 
 // https://docs.gradle.com/enterprise/gradle-plugin/#connecting_to_scans_gradle_com
 gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-    }
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+  }
 }
 
 apply plugin: 'com.cinnober.gradle.semver-git'
@@ -141,10 +141,10 @@ ext.deps = [
     jasypt               : 'org.jasypt:jasypt:1.9.2',
     jacksonCore          : 'com.fasterxml.jackson.core:jackson-core:2.9.2',
     jsonassert           : 'org.skyscreamer:jsonassert:1.5.0',
-    systemRules         : 'com.github.stefanbirkner:system-rules:1.19.0',
+    systemRules          : 'com.github.stefanbirkner:system-rules:1.19.0',
     javaxValidation      : 'javax.validation:validation-api:2.0.1.Final',
     hibernateValidator   : 'org.hibernate:hibernate-validator:6.1.5.Final',
-    failsafe             : 'dev.failsafe:failsafe:3.2.4' ]
+    failsafe             : 'dev.failsafe:failsafe:3.2.4']
 
 subprojects {
   apply plugin: 'java'
@@ -204,7 +204,7 @@ subprojects {
       // NOTE! For some reason anything more than 1 doesn't work well for azkaban build:
       // any maxParallelForks > 1 seems to make `./gradlew cleanTest test` ~4 times slower
       maxParallelForks = 1
-      maxHeapSize '2g'
+      maxHeapSize '4g'
     }
   }
 
@@ -221,7 +221,6 @@ subprojects {
   tasks.withType(JavaCompile) {
     options.compilerArgs += ["-Werror"]
   }
-
 
   /**
    * Print test execution summary when informational logging is enabled.*/
@@ -256,8 +255,8 @@ if (System.env.TRAVIS == 'true') {
     tasks.withType(Test) {
       // Reduce the memory pressure on the Travis CI to reduce build failures.
       maxParallelForks = 2
-      minHeapSize = '128m'
-      maxHeapSize '2g'
+      minHeapSize = '512m'
+      maxHeapSize '4g'
       outputs.upToDateWhen { false }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 #
-
 group=com.linkedin
 # optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
 # optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha>-SNAPSHOT"
@@ -32,3 +31,4 @@ org.gradle.parallel=true
 #Allows generation of idea/eclipse metadata for a specific subproject and its upstream project dependencies
 ide.recursive=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
This PR focus on to reduce build time and fix test failures caused by OutOfMemoryException:
- increase maximum JVM allocation to 4g. (our current travis VM ubuntu has 7.5G memory)
- remove double trigger test process during test coverage report generation.
Subsequent PRs would be placed to fix other flaky tests.

First build succeed within 16m58s
Second build failed with K8sWatchTest, rerun finished in 15min 13s.
tripple time faster than other builds succeeds at 48 min 9 sec. https://app.travis-ci.com/github/azkaban/azkaban/jobs/590570434
