### PR TITLE
Refactor Alerter plugins feature.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AlerterHolder.java
@@ -16,119 +16,118 @@
 package azkaban.executor;
 
 import azkaban.alert.Alerter;
+import azkaban.spi.AzkabanException;
 import azkaban.utils.Emailer;
 import azkaban.utils.FileIOUtils;
 import azkaban.utils.PluginUtils;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
-
+import java.util.function.BiConsumer;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class AlerterHolder {
 
-  private static final Logger logger = Logger.getLogger(AlerterHolder.class);
-  private Map<String, Alerter> alerters;
+  private static final Logger logger = LoggerFactory.getLogger(AlerterHolder.class);
+  private final Map<String, Alerter> alerters;
 
   @Inject
   public AlerterHolder(final Props props, final Emailer mailAlerter) {
-    try {
-      this.alerters = loadAlerters(props, mailAlerter);
-    } catch (final Exception ex) {
-      logger.error(ex);
-      this.alerters = new HashMap<>();
-    }
-  }
-
-  private Map<String, Alerter> loadAlerters(final Props props, final Emailer mailAlerter) {
     final Map<String, Alerter> allAlerters = new HashMap<>();
-    // load built-in alerters
+    // Load built-in alerters.
     allAlerters.put("email", mailAlerter);
-    // load all plugin alerters
-    final String pluginDir = props.getString("alerter.plugin.dir", "plugins/alerter");
-    allAlerters.putAll(loadPluginAlerters(pluginDir));
-    return allAlerters;
+    // Load additional alerter plugins if any.
+    final String customAlertersBaseDir = props.getString("alerter.plugin.dir", "plugins/alerter");
+    allAlerters.putAll(loadCustomAlerters(customAlertersBaseDir));
+    this.alerters = allAlerters;
+    logger.info("Alerter plugins loaded: {}", this.alerters.keySet());
   }
 
-  private Map<String, Alerter> loadPluginAlerters(final String pluginPath) {
-    final File alerterPluginPath = new File(pluginPath);
-    if (!alerterPluginPath.exists()) {
+  private Map<String, Alerter> loadCustomAlerters(final String alerterPluginsRootPath) {
+    final File pluginsRootPath = new File(alerterPluginsRootPath);
+    if (!pluginsRootPath.exists()) {
       return Collections.<String, Alerter>emptyMap();
     }
 
     final Map<String, Alerter> installedAlerterPlugins = new HashMap<>();
     final ClassLoader parentLoader = getClass().getClassLoader();
-    final File[] pluginDirs = alerterPluginPath.listFiles();
-    final ArrayList<String> jarPaths = new ArrayList<>();
+    final File[] pluginDirs = pluginsRootPath.listFiles();
 
     for (final File pluginDir : pluginDirs) {
-      // load plugin properties
-      final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
-      if (pluginProps == null) {
-        continue;
-      }
-
-      final String pluginName = pluginProps.getString("alerter.name");
-      final List<String> extLibClassPaths =
-          pluginProps.getStringList("alerter.external.classpaths",
-              (List<String>) null);
-
-      final String pluginClass = pluginProps.getString("alerter.class");
-      if (pluginClass == null) {
-        logger.error("Alerter class is not set.");
-        continue;
-      } else {
-        logger.info("Plugin class " + pluginClass);
-      }
-
-      Class<?> alerterClass =
-          PluginUtils.getPluginClass(pluginClass, pluginDir, extLibClassPaths, parentLoader);
-
-      if (alerterClass == null) {
-        continue;
-      }
-
-      final String source = FileIOUtils.getSourcePathFromClass(alerterClass);
-      logger.info("Source jar " + source);
-      jarPaths.add("jar:file:" + source);
-
-      Constructor<?> constructor = null;
       try {
-        constructor = alerterClass.getConstructor(Props.class);
-      } catch (final NoSuchMethodException e) {
-        logger.error("Constructor not found in " + pluginClass);
-        continue;
-      }
-
-      Object obj = null;
-      try {
-        obj = constructor.newInstance(pluginProps);
+        loadCustomAlerter(installedAlerterPlugins, parentLoader, pluginDir);
       } catch (final Exception e) {
-        logger.error(e);
+        logger.error(String.format("Failed to load alerter plugin in '%s'.", pluginDir), e);
       }
+    }
+    return installedAlerterPlugins;
+  }
 
-      if (!(obj instanceof Alerter)) {
-        logger.error("The object is not an Alerter");
-        continue;
-      }
-
-      final Alerter plugin = (Alerter) obj;
-      installedAlerterPlugins.put(pluginName, plugin);
+  private void loadCustomAlerter(final Map<String, Alerter> installedAlerterPlugins,
+      final ClassLoader parentLoader, final File pluginDir) {
+    // Load plugin properties.
+    final Props pluginProps = PropsUtils.loadPluginProps(pluginDir);
+    if (pluginProps == null) {
+      throw new AzkabanException("Plugin config properties could not be loaded.");
     }
 
-    return installedAlerterPlugins;
+    final String pluginName = pluginProps.getString("alerter.name", "").trim();
+    if (pluginName.isEmpty()) {
+      throw new AzkabanException("Alerter name is required.");
+    }
+
+    final List<String> extLibClassPaths = pluginProps.getStringList(
+        "alerter.external.classpaths", (List<String>) null);
+
+    final String pluginClass = pluginProps.getString("alerter.class", "").trim();
+    if (pluginClass.isEmpty()) {
+      throw new AzkabanException("Alerter class is required.");
+    }
+
+    final Class<?> alerterClass =
+        PluginUtils.getPluginClass(pluginClass, pluginDir, extLibClassPaths, parentLoader);
+    if (alerterClass == null) {
+      throw new AzkabanException(
+          String.format("Alerter class '%s' could not be loaded.", pluginClass));
+    }
+    logger.info("Loaded alerter class '{}' from '{}'.", pluginClass,
+        FileIOUtils.getSourcePathFromClass(alerterClass));
+
+    Constructor<?> constructor = null;
+    try {
+      constructor = alerterClass.getConstructor(Props.class);
+    } catch (final NoSuchMethodException e) {
+      throw new AzkabanException("Alerter class constructor wasn't found.", e);
+    }
+
+    final Object obj;
+    try {
+      obj = constructor.newInstance(pluginProps);
+    } catch (final Exception e) {
+      throw new AzkabanException(String.format("Alerter class '%s' could not be instantiated.",
+          pluginClass), e);
+    }
+
+    if (!(obj instanceof Alerter)) {
+      throw new AzkabanException("Instantiated object is not an Alerter.");
+    }
+    installedAlerterPlugins.put(pluginName, (Alerter) obj);
   }
 
   public Alerter get(final String alerterType) {
     return this.alerters.get(alerterType);
+  }
+
+  public void forEach(final BiConsumer<String, Alerter> consumer) {
+    this.alerters.forEach(consumer);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -131,6 +131,11 @@ public class Emailer extends AbstractMailer implements Alerter {
 
   @Override
   public void alertOnError(final ExecutableFlow flow, final String... extraReasons) {
+    final List<String> emailRecipients = flow.getExecutionOptions().getFailureEmails();
+    if (emailRecipients == null || emailRecipients.isEmpty()) {
+      return;
+    }
+
     final EmailMessage message = this.messageCreator.createMessage();
     final MailCreator mailCreator = getMailCreator(flow);
     List<ExecutableFlow> last72hoursExecutions = new ArrayList<>();
@@ -152,6 +157,11 @@ public class Emailer extends AbstractMailer implements Alerter {
 
   @Override
   public void alertOnSuccess(final ExecutableFlow flow) {
+    final List<String> emailRecipients = flow.getExecutionOptions().getSuccessEmails();
+    if (emailRecipients == null || emailRecipients.isEmpty()) {
+      return;
+    }
+
     final EmailMessage message = this.messageCreator.createMessage();
     final MailCreator mailCreator = getMailCreator(flow);
     final boolean mailCreated = mailCreator.createSuccessEmail(flow, message, this.azkabanName,

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorHealthCheckerTest.java
@@ -20,6 +20,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -27,6 +29,7 @@ import static org.mockito.Mockito.when;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
+import azkaban.utils.Emailer;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
@@ -66,8 +69,8 @@ public class ExecutorHealthCheckerTest {
     this.props.put(ConfigurationKeys.AZKABAN_EXECUTOR_MAX_FAILURE_COUNT, 2);
     this.props.put(ConfigurationKeys.AZKABAN_ADMIN_ALERT_EMAIL, AZ_ADMIN_ALERT_EMAIL);
     this.loader = mock(ExecutorLoader.class);
-    this.mailAlerter = mock(Alerter.class);
-    this.alerterHolder = mock(AlerterHolder.class);
+    this.mailAlerter = mock(Emailer.class);
+    this.alerterHolder = new AlerterHolder(this.props, (Emailer) this.mailAlerter);
     this.apiGateway = mock(ExecutorApiGateway.class);
     this.executorHealthChecker = new ExecutorHealthChecker(this.props, this.loader, this
         .apiGateway, this.alerterHolder);
@@ -82,7 +85,6 @@ public class ExecutorHealthCheckerTest {
     this.executor1 = new Executor(1, "localhost", 12345, true);
     this.executor2 = new Executor(2, "localhost", 5678, true);
     when(this.loader.fetchActiveFlows(any())).thenReturn(this.activeFlows);
-    when(this.alerterHolder.get("email")).thenReturn(this.mailAlerter);
   }
 
   /**
@@ -97,7 +99,7 @@ public class ExecutorHealthCheckerTest {
         .STATUS_PARAM, ConnectorParams.RESPONSE_ALIVE));
     this.executorHealthChecker.checkExecutorHealth();
     assertThat(this.flow1.getStatus()).isEqualTo(Status.RUNNING);
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
   }
 
   /**
@@ -127,35 +129,34 @@ public class ExecutorHealthCheckerTest {
     this.executorHealthChecker.checkExecutorHealth();
     verify(this.apiGateway).callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
         ConnectorParams.PING_ACTION, null, null, null, Optional.of(5000));
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
 
     // Pinged executor successfully. Failure count (=0) < MAX_FAILURE_COUNT (=2). Do not alert.
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
         ConnectorParams.PING_ACTION, null, null, null, Optional.of(5000))).thenReturn(ImmutableMap.of(ConnectorParams
         .STATUS_PARAM, ConnectorParams.RESPONSE_ALIVE));
     this.executorHealthChecker.checkExecutorHealth();
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
 
     // Failed to ping executor. Failure count (=1) < MAX_FAILURE_COUNT (=2). Do not alert.
     when(this.apiGateway.callWithExecutionId(this.executor1.getHost(), this.executor1.getPort(),
         ConnectorParams.PING_ACTION, null, null, null, Optional.of(5000))).thenReturn(null);
     this.executorHealthChecker.checkExecutorHealth();
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
 
     // Failed to ping executor again. Failure count (=2) = MAX_FAILURE_COUNT (=2). Alert AZ admin.
     when(this.loader.fetchExecutableFlow(flow1.getExecutionId())).thenReturn(flow1);
     this.executorHealthChecker.checkExecutorHealth();
-    verify((this.alerterHolder).get("email"))
-        .alertOnFailedExecutorHealthCheck(eq(this.executor1), eq(Arrays.asList(this.flow1)),
-            any(ExecutorManagerException.class),
-            eq(Arrays.asList(AZ_ADMIN_ALERT_EMAIL.split(","))));
+    verify(this.mailAlerter, times(1)).alertOnFailedExecutorHealthCheck(eq(this.executor1),
+        eq(Arrays.asList(this.flow1)), any(ExecutorManagerException.class),
+        eq(Arrays.asList(AZ_ADMIN_ALERT_EMAIL.split(","))));
 
     // Verify remediation tasks are performed for unreachable executors.
     // Flow should be finalized with alerts sent over email.
     assertThat(this.flow1.getStatus()).isEqualTo(Status.FAILED);
     String expectedReason = "Executor was unreachable, executor-id: 1, executor-host: localhost, "
         + "executor-port: 12345";
-    verify((this.alerterHolder).get("email")).alertOnError(eq(flow1), eq(expectedReason));
+    verify(this.mailAlerter, times(1)).alertOnError(eq(flow1), eq(expectedReason));
   }
 
   /**
@@ -171,7 +172,7 @@ public class ExecutorHealthCheckerTest {
 
     // this will throw, causing the test to fail in case the error is not caught correctly
     this.executorHealthChecker.checkExecutorHealthQuietly();
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
   }
 
   /**
@@ -200,7 +201,7 @@ public class ExecutorHealthCheckerTest {
         this.executor1.getPort(), ConnectorParams.PING_ACTION, null, null, null, Optional.of(5000));
     verify(this.apiGateway).callWithExecutionId(this.executor2.getHost(),
         this.executor2.getPort(), ConnectorParams.PING_ACTION, null, null, null, Optional.of(5000));
-    verifyZeroInteractions(this.alerterHolder);
+    verifyZeroInteractions(this.mailAlerter);
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -35,6 +35,7 @@ import azkaban.logs.MockExecutionLogsLoader;
 import azkaban.metrics.CommonMetrics;
 import azkaban.metrics.MetricsManager;
 import azkaban.user.User;
+import azkaban.utils.Emailer;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.TestUtils;
@@ -80,16 +81,15 @@ public class ExecutorManagerTest {
   private ExecutionReference ref2;
   private AlerterHolder alertHolder;
   private ExecutorApiGateway apiGateway;
-  private Alerter mailAlerter;
+  private Emailer mailAlerter;
   private RunningExecutions runningExecutions;
   private ExecutorManagerUpdaterStage updaterStage;
 
   @Before
   public void setup() {
     this.props = new Props();
-    this.mailAlerter = mock(Alerter.class);
-    this.alertHolder = mock(AlerterHolder.class);
-    when(this.alertHolder.get("email")).thenReturn(this.mailAlerter);
+    this.mailAlerter = mock(Emailer.class);
+    this.alertHolder = new AlerterHolder(this.props, this.mailAlerter);
     this.executorLoader = new MockExecutorLoader();
     this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
     this.offlineExecutionLogsLoader = new MockExecutionLogsLoader();

--- a/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/RunningExecutionsUpdaterTest.java
@@ -11,12 +11,15 @@ import static org.mockito.Mockito.when;
 import azkaban.DispatchMethod;
 import azkaban.alert.Alerter;
 import azkaban.metrics.CommonMetrics;
+import azkaban.utils.Emailer;
 import azkaban.utils.Pair;
+import azkaban.utils.Props;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.Email;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -33,18 +36,17 @@ public class RunningExecutionsUpdaterTest {
   @Mock
   ExecutorManagerUpdaterStage updaterStage;
   @Mock
-  AlerterHolder alerterHolder;
-  @Mock
   CommonMetrics commonMetrics;
   @Mock
   ExecutorApiGateway apiGateway;
   @Mock
   ExecutionFinalizer executionFinalizer;
   @Mock
-  private Alerter mailAlerter;
+  private Emailer mailAlerter;
   @Mock
   private ExecutorLoader executorLoader;
 
+  private AlerterHolder alerterHolder;
   private ExecutableFlow execution;
   private RunningExecutions runningExecutions;
   private Executor activeExecutor;
@@ -54,6 +56,7 @@ public class RunningExecutionsUpdaterTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
+    this.alerterHolder = new AlerterHolder(new Props(), this.mailAlerter);
     this.execution = new ExecutableFlow();
     this.execution.setExecutionId(EXECUTION_ID_77);
     this.activeExecutor = new Executor(1, "activeExecutor-1", 9999, true);
@@ -63,7 +66,6 @@ public class RunningExecutionsUpdaterTest {
     this.updater = new RunningExecutionsUpdater(this.updaterStage, this.alerterHolder,
         this.commonMetrics, this.apiGateway, this.runningExecutions, this.executionFinalizer,
         this.executorLoader);
-    when(this.alerterHolder.get("email")).thenReturn(this.mailAlerter);
   }
 
   @After

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTestUtil.java
@@ -213,8 +213,7 @@ public class FlowRunnerTestUtil {
     // Add version set to executable flow
     exFlow.setVersionSet(createVersionSet());
     final FlowRunner runner = createFromExecutableFlow(eventCollector, exFlow, options,
-        new HashMap<>(),
-        new Props());
+        new HashMap<>(), new Props(), mock(AlerterHolder.class));
     runner.setFlowWatcher(watcher);
     return runner;
   }
@@ -232,25 +231,25 @@ public class FlowRunnerTestUtil {
 
   public FlowRunner createFromFlowMap(final String flowName,
       final HashMap<String, String> flowParams) throws Exception {
-    return createFromFlowMap(null, flowName, null, flowParams, new Props());
+    return createFromFlowMap(null, flowName, null, flowParams, new Props(),
+        mock(AlerterHolder.class));
   }
 
   public FlowRunner createFromFlowMap(final String flowName, final ExecutionOptions options,
       final Map<String, String> flowParams, final Props azkabanProps) throws Exception {
     return createFromFlowMap(null, flowName, options, flowParams,
-        azkabanProps);
+        azkabanProps, mock(AlerterHolder.class));
   }
 
   public FlowRunner createFromFlowMap(final EventCollectorListener eventCollector,
-      final String flowName, final ExecutionOptions options,
-      final Map<String, String> flowParams, final Props azkabanProps)
-      throws Exception {
+      final String flowName, final ExecutionOptions options, final Map<String, String> flowParams,
+      final Props azkabanProps, final AlerterHolder alerterHolder) throws Exception {
     LOG.info("Creating a FlowRunner for flow '" + flowName + "'");
     final Flow flow = this.flowMap.get(flowName);
     final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
     exFlow.setSubmitUser("submitUser");
     return createFromExecutableFlow(eventCollector, exFlow, options, flowParams,
-        azkabanProps);
+        azkabanProps, alerterHolder);
   }
 
   public FlowRunner createFromFlowMap(final String flowName, final FailureAction action)
@@ -265,13 +264,13 @@ public class FlowRunnerTestUtil {
     final Map<String, String> flowParams = new HashMap<>();
     flowParams.put(InteractiveTestJob.JOB_ID_PREFIX, jobIdPrefix);
     return createFromFlowMap(new EventCollectorListener(), flowName, options, flowParams,
-        azkabanProps);
+        azkabanProps, mock(AlerterHolder.class));
   }
 
   private FlowRunner createFromExecutableFlow(final EventCollectorListener eventCollector,
       final ExecutableFlow exFlow, final ExecutionOptions options,
-      final Map<String, String> flowParams, final Props azkabanProps)
-      throws Exception {
+      final Map<String, String> flowParams, final Props azkabanProps,
+      final AlerterHolder alerterHolder) throws Exception {
     final int exId = id++;
     exFlow.setExecutionPath(this.workingDir.getPath());
     exFlow.setExecutionId(exId);
@@ -286,8 +285,7 @@ public class FlowRunnerTestUtil {
     final ExecMetrics execMetrics = new ExecMetrics(metricsManager);
     final FlowRunner runner =
         new FlowRunner(exFlow, this.executorLoader, this.executionLogsLoader, this.projectLoader,
-            this.jobtypeManager, azkabanProps, null, mock(AlerterHolder.class), commonMetrics,
-            execMetrics);
+            this.jobtypeManager, azkabanProps, null, alerterHolder, commonMetrics, execMetrics);
     if (eventCollector != null) {
       runner.addListener(eventCollector);
     }


### PR DESCRIPTION
Changes include:
-allowing multiple alerter plugins to be configured (not just one)
-failing initialization only for specific faulty plugins (not for all)
-simplifying plugin configuration (ie: by eliminating redundant config property `alert.type`) and triggering logic. Now when there is an alert-worthy event, control is passed to each installed alerter for it to decide whether something should be done or not.     
-adding more logging to plugin initialization for better troubleshooting
