### PR TITLE
CleanupManager: check all recent termination status flow to clean yarn apps

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -389,7 +389,7 @@ public class Constants {
     // Max flow KILLING time in mins.
     public static final String AZKABAN_MAX_FLOW_KILLING_MINS = "azkaban.server.flow.max.killing.minutes";
     // Max flow EXECUTION_STOPPED time in mins.
-    public static final String AZKABAN_MAX_FLOW_EXEC_STOPPED_MINS = "azkaban.server.flow.max.exec_stopped.minutes";
+    public static final String AZKABAN_FLOW_RECENT_TERMINATION_MINS = "azkaban.server.flow.recent.termination.minutes";
 
     // Maximum number of tries to download a dependency (no more retry attempts will be made after this many download failures)
     public static final String AZKABAN_DEPENDENCY_MAX_DOWNLOAD_TRIES = "azkaban.dependency.max.download.tries";

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -309,7 +310,8 @@ public class ContainerCleanupManager {
         recentlyTerminatedFlows.addAll(
             flows.stream().map(ExecutableFlow::getExecutionId).collect(Collectors.toSet()));
         logger.info("Got recently terminated flows executions of Status " + status + ": " +
-            flows.stream().map(Object::toString).collect(Collectors.joining(",")));
+            flows.stream().map(ExecutableFlow::getExecutionId).map(Objects::toString)
+                .collect(Collectors.joining(",")));
       } catch (final ExecutorManagerException e) {
         logger.error("Unable to obtain current flows executions of Status " + status, e);
       }

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -336,17 +336,26 @@ public class ContainerCleanupManager {
       logger.info("cleanUpDanglingYarnApplications start ");
 
       Set<Integer> recentlyTerminatedFlows = getRecentlyTerminatedFlows();
+      StringBuffer sb1 = new StringBuffer();
+      recentlyTerminatedFlows.forEach(f -> {
+        sb1.append(f);
+        sb1.append(",");
+      });
+      logger.info("Get recentlyTerminatedFlows: " + sb1);
+
       // get those flows terminated but containers are still alive (failed to properly killed)
-      Set<Integer> toBeCleanedContainers = getContainersOfTerminatedFlows();
-      logger.info("Get terminatedContainers: " +
-          toBeCleanedContainers.stream().map(Object::toString).collect(Collectors.joining(",")));
+      Set<Integer> toBeCleanedFlows = getContainersOfTerminatedFlows();
+      StringBuffer sb2 = new StringBuffer();
+      toBeCleanedFlows.forEach(f -> {
+        sb2.append(f);
+        sb2.append(",");
+      });
+      logger.info("Get containersOfTerminatedFlows: " + sb2);
 
       // combine both sets
-      toBeCleanedContainers.addAll(recentlyTerminatedFlows);
-      logger.info("The whole set of all executions to clean yarn apps: " +
-          toBeCleanedContainers.stream().map(Object::toString).collect(Collectors.joining(",")));
+      toBeCleanedFlows.addAll(recentlyTerminatedFlows);
 
-      if (toBeCleanedContainers.isEmpty()) {
+      if (toBeCleanedFlows.isEmpty()) {
         logger.info("No execution needs to kill yarn application, exit");
         return;
       }
@@ -354,7 +363,7 @@ public class ContainerCleanupManager {
       // For each of yarn clusters: find applications of the above executionIDs and kill them
       for (Entry<String, Cluster> entry : this.allClusters.entrySet()) {
         logger.info("clean up yarn applications in cluster:" + entry.getValue().getClusterId());
-        cleanUpYarnApplicationsInCluster(toBeCleanedContainers, entry.getValue());
+        cleanUpYarnApplicationsInCluster(toBeCleanedFlows, entry.getValue());
       }
     } catch (Throwable t) {
       logger.warn("Encounter unexpected throwable during cleanup dangling yarn app, "

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -300,21 +300,21 @@ public class ContainerCleanupManager {
    * killing, failed, failed_finishing, failed_succeeded, canceled)
    */
   @NotNull
-  Set<Integer> getRecentTerminationFlows() {
-    Set<Integer> recentKilledFlows = new HashSet<>();
+  Set<Integer> getRecentlyTerminatedFlows() {
+    Set<Integer> recentlyTerminatedFlows = new HashSet<>();
     this.recentTerminatedStatusMap.forEach((status, value) -> {
       try {
         List<ExecutableFlow> flows = this.executorLoader.fetchFreshFlowsForStatus(
             status, this.recentTerminatedStatusMap);
-        recentKilledFlows.addAll(
+        recentlyTerminatedFlows.addAll(
             flows.stream().map(ExecutableFlow::getExecutionId).collect(Collectors.toSet()));
-        logger.error("Got recent termination flows executions of Status " + status + ": " +
+        logger.info("Got recently terminated flows executions of Status " + status + ": " +
             flows.stream().map(Object::toString).collect(Collectors.joining(",")));
       } catch (final ExecutorManagerException e) {
         logger.error("Unable to obtain current flows executions of Status " + status, e);
       }
     });
-    return recentKilledFlows;
+    return recentlyTerminatedFlows;
   }
 
   /**
@@ -333,14 +333,14 @@ public class ContainerCleanupManager {
     try {
       logger.info("cleanUpDanglingYarnApplications start ");
 
-      Set<Integer> recentTerminationFlows = getRecentTerminationFlows();
+      Set<Integer> recentlyTerminatedFlows = getRecentlyTerminatedFlows();
       // get those flows terminated but containers are still alive (failed to properly killed)
       Set<Integer> toBeCleanedContainers = getContainersOfTerminatedFlows();
       logger.info("Get terminatedContainers: " +
           toBeCleanedContainers.stream().map(Object::toString).collect(Collectors.joining(",")));
 
       // combine both sets
-      toBeCleanedContainers.addAll(recentTerminationFlows);
+      toBeCleanedContainers.addAll(recentlyTerminatedFlows);
       logger.info("The whole set of all executions to clean yarn apps: " +
           toBeCleanedContainers.stream().map(Object::toString).collect(Collectors.joining(",")));
 

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -209,32 +209,44 @@ public class ContainerCleanupManagerTest {
   }
 
   @Test
-  public void testGetExecutionStoppedFlows() throws ExecutorManagerException {
-    final ExecutableFlow flow = new ExecutableFlow();
-    flow.setExecutionId(1000);
-    flow.setStatus(Status.EXECUTION_STOPPED);
-    flow.setSubmitUser("dummy-user");
-    flow.setExecutionOptions(new ExecutionOptions());
-    final ArrayList<ExecutableFlow> executableFlows = new ArrayList<>();
-    executableFlows.add(flow);
+  public void testGetRecentKilledFlows() throws ExecutorManagerException {
+    final ExecutableFlow flow1 = new ExecutableFlow();
+    flow1.setExecutionId(1000);
+    flow1.setStatus(Status.EXECUTION_STOPPED);
+    flow1.setSubmitUser("dummy-user");
+    flow1.setExecutionOptions(new ExecutionOptions());
+    final ArrayList<ExecutableFlow> execStoppedFlows = new ArrayList<>();
+    execStoppedFlows.add(flow1);
+
+    final ExecutableFlow flow2 = new ExecutableFlow();
+    flow2.setExecutionId(2000);
+    flow2.setStatus(Status.FAILED);
+    flow2.setSubmitUser("dummy-user");
+    flow2.setExecutionOptions(new ExecutionOptions());
+    final ArrayList<ExecutableFlow> failedFlows = new ArrayList<>();
+    failedFlows.add(flow2);
 
     when(this.executorLoader
-        .fetchFreshFlowsForStatus(any(Status.class), any(ImmutableMap.class)))
-        .thenReturn(executableFlows);
+        .fetchFreshFlowsForStatus(eq(Status.EXECUTION_STOPPED), any(ImmutableMap.class)))
+        .thenReturn(execStoppedFlows);
+    when(this.executorLoader
+        .fetchFreshFlowsForStatus(eq(Status.FAILED), any(ImmutableMap.class)))
+        .thenReturn(failedFlows);
 
-    Set<Integer> executionStoppedFlows = this.cleaner.getExecutionStoppedFlows();
-    Assert.assertTrue(executionStoppedFlows.contains(1000));
-    Assert.assertEquals(1, executionStoppedFlows.size());
+    Set<Integer> recentKilledFlows = this.cleaner.getRecentKilledFlows();
+    Assert.assertTrue(recentKilledFlows.contains(1000));
+    Assert.assertTrue(recentKilledFlows.contains(2000));
+    Assert.assertEquals(2, recentKilledFlows.size());
   }
 
   @Test
-  public void testGetExecutionStoppedFlowsFail() throws ExecutorManagerException {
+  public void testGetRecentKilledFlowsException() throws ExecutorManagerException {
     when(this.executorLoader
         .fetchFreshFlowsForStatus(any(Status.class), any(ImmutableMap.class)))
         .thenThrow(new ExecutorManagerException("ops"));
 
-    Set<Integer> executionStoppedFlows = this.cleaner.getExecutionStoppedFlows();
-    Assert.assertTrue(executionStoppedFlows.isEmpty());
+    Set<Integer> recentKilledFlows = this.cleaner.getRecentKilledFlows();
+    Assert.assertTrue(recentKilledFlows.isEmpty());
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -233,10 +233,10 @@ public class ContainerCleanupManagerTest {
         .fetchFreshFlowsForStatus(eq(Status.FAILED), any(ImmutableMap.class)))
         .thenReturn(failedFlows);
 
-    Set<Integer> recentKilledFlows = this.cleaner.getRecentKilledFlows();
-    Assert.assertTrue(recentKilledFlows.contains(1000));
-    Assert.assertTrue(recentKilledFlows.contains(2000));
-    Assert.assertEquals(2, recentKilledFlows.size());
+    Set<Integer> recentTerminationFlows = this.cleaner.getRecentTerminationFlows();
+    Assert.assertTrue(recentTerminationFlows.contains(1000));
+    Assert.assertTrue(recentTerminationFlows.contains(2000));
+    Assert.assertEquals(2, recentTerminationFlows.size());
   }
 
   @Test
@@ -245,8 +245,8 @@ public class ContainerCleanupManagerTest {
         .fetchFreshFlowsForStatus(any(Status.class), any(ImmutableMap.class)))
         .thenThrow(new ExecutorManagerException("ops"));
 
-    Set<Integer> recentKilledFlows = this.cleaner.getRecentKilledFlows();
-    Assert.assertTrue(recentKilledFlows.isEmpty());
+    Set<Integer> recentTerminationFlows = this.cleaner.getRecentTerminationFlows();
+    Assert.assertTrue(recentTerminationFlows.isEmpty());
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -233,7 +233,7 @@ public class ContainerCleanupManagerTest {
         .fetchFreshFlowsForStatus(eq(Status.FAILED), any(ImmutableMap.class)))
         .thenReturn(failedFlows);
 
-    Set<Integer> recentTerminationFlows = this.cleaner.getRecentTerminationFlows();
+    Set<Integer> recentTerminationFlows = this.cleaner.getRecentlyTerminatedFlows();
     Assert.assertTrue(recentTerminationFlows.contains(1000));
     Assert.assertTrue(recentTerminationFlows.contains(2000));
     Assert.assertEquals(2, recentTerminationFlows.size());
@@ -245,7 +245,7 @@ public class ContainerCleanupManagerTest {
         .fetchFreshFlowsForStatus(any(Status.class), any(ImmutableMap.class)))
         .thenThrow(new ExecutorManagerException("ops"));
 
-    Set<Integer> recentTerminationFlows = this.cleaner.getRecentTerminationFlows();
+    Set<Integer> recentTerminationFlows = this.cleaner.getRecentlyTerminatedFlows();
     Assert.assertTrue(recentTerminationFlows.isEmpty());
   }
 


### PR DESCRIPTION
**Why we need this**
This is because we observe that in addition to "EXECUTION_STOPPED", other termination status flows could also have dangling yarn applications, we need to take care of them all.

**What's done**
Extend the current functions from only check for recent "EXECUTION_STOPPED", to check for recent flows of status in (execution_stopped, killed, killing, failed, failed_finishing, failed_succeeded, canceled).

**Tests done**
Updated & added unit tests;
Deployed and verified in staging cluster, everything works as expected