### PR TITLE
Kill flow and its yarn Applications: correct the proxyUser token loading with DEBUG logs added

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopJobUtils.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -44,6 +45,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -376,9 +378,57 @@ public class HadoopJobUtils {
         final UserGroupInformation proxyUser =
             HadoopSecureWrapperUtils.setupProxyUserWithHSM(hadoopSecurityManager, properties,
                 tokenFile.getAbsolutePath(), log);
+
+        // todo: print tokens in proxyUser
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.proxyUser = " + proxyUser);
+        for (Token<?> token : proxyUser.getCredentials().getAllTokens()) {
+          log.debug(String.format("proxyUserKillAllSpawnedHadoopJobs.proxyUser.Token = %s, %s",
+              token.getKind(), token.getService()));
+        }
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.proxyUser.Token --- end");
+
+        UserGroupInformation ugi0 = UserGroupInformation.getCurrentUser();
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.getCurrentUser = " + ugi0);
+        for (Token<?> token : ugi0.getCredentials().getAllTokens()) {
+          log.debug(String.format("proxyUserKillAllSpawnedHadoopJobs.getCurrentUser.Token = %s, %s",
+              token.getKind(), token.getService()));
+        }
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.getCurrentUser.Token --- end");
+
+        ugi0 = UserGroupInformation.getLoginUser();
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.getLoginUser = " + ugi0);
+        for (Token<?> token : ugi0.getCredentials().getAllTokens()) {
+          log.debug(String.format("proxyUserKillAllSpawnedHadoopJobs.getLoginUser.Token = %s, %s",
+              token.getKind(), token.getService()));
+        }
+        log.debug("proxyUserKillAllSpawnedHadoopJobs.getLoginUser.Token --- end");
+
         proxyUser.doAs(new PrivilegedExceptionAction<Void>() {
           @Override
           public Void run() throws Exception {
+            log.debug("doAs.run.proxyUser = " + proxyUser);
+            for (Token<?> token : proxyUser.getCredentials().getAllTokens()) {
+              log.debug(String.format("doAs.run.proxyUser.Token = %s, %s", token.getKind(),
+                  token.getService()));
+            }
+            log.debug("doAs.run.proxyUser.Token --- end");
+
+            UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+            log.debug("doAs.run.getCurrentUser = " + ugi);
+            for (Token<?> token : ugi.getCredentials().getAllTokens()) {
+              log.debug(String.format("doAs.run.getCurrentUser.Token = %s, %s", token.getKind(),
+                  token.getService()));
+            }
+            log.debug("doAs.run.getCurrentUser.Token --- end");
+
+            ugi = UserGroupInformation.getLoginUser();
+            log.debug("doAs.run.getLoginUser = " + ugi);
+            for (Token<?> token : ugi.getCredentials().getAllTokens()) {
+              log.debug(String.format("doAs.run.getLoginUser.Token = %s, %s", token.getKind(),
+                  token.getService()));
+            }
+            log.debug("doAs.run.getLoginUser.Token --- end");
+
             findAndKillYarnApps(jobProps, log);
             return null;
           }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopSecureWrapperUtils.java
@@ -76,7 +76,12 @@ public class HadoopSecureWrapperUtils {
       log.info(String.format("Token = %s, %s, %s ", token.getKind(), token.getService(),
           Arrays.toString(token.getIdentifier())));
     }
-    proxyUser.addCredentials(loginUser.getCredentials());
+
+    log.debug("after copy from login User");
+    for (Token<?> token : proxyUser.getCredentials().getAllTokens()) {
+      log.debug(String.format("proxyUser.Token = %s, %s", token.getKind(), token.getService()));
+    }
+    log.debug("after copy from login User --- end");
 
     // read tokens from the file and put into proxyUser
     if (hadoopSecurityManager != null) {
@@ -85,11 +90,16 @@ public class HadoopSecureWrapperUtils {
           proxyUser));
       for (Token<?> token : creds.getAllTokens()) {
         proxyUser.addToken(token);
-        log.info(String.format("Token = %s, %s, %s ", token.getKind(), token.getService(),
-            Arrays.toString(token.getIdentifier())));
+        log.info(String.format("Token = %s, %s", token.getKind(), token.getService()));
       }
-      proxyUser.addCredentials(creds);
     }
+
+    log.debug("after copy from token file");
+    for (Token<?> token : proxyUser.getCredentials().getAllTokens()) {
+      log.debug(String.format("proxyUser.Token = %s, %s", token.getKind(), token.getService()));
+    }
+    log.debug("after copy from token file --- end");
+
 
     log.info("token copy finished for " + loginUser.getUserName());
     return proxyUser;

--- a/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
+++ b/azkaban-common/src/main/java/azkaban/utils/YarnUtils.java
@@ -154,6 +154,20 @@ public class YarnUtils {
   public static void killAppOnCluster(final YarnClient yarnClient, final String applicationId,
       final Logger log) throws YarnException, IOException {
 
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    log.info("killAppOnCluster.getCurrentUser = " + ugi);
+    for (Token<?> token : ugi.getCredentials().getAllTokens()) {
+      log.info(String.format("killAppOnCluster.getCurrentUser.Token = %s, %s", token.getKind(), token.getService()));
+    }
+    log.info("killAppOnCluster.getCurrentUser.Token --- end");
+
+    ugi = UserGroupInformation.getLoginUser();
+    log.info("killAppOnCluster.getLoginUser = " + ugi);
+    for (Token<?> token : ugi.getCredentials().getAllTokens()) {
+      log.info(String.format("killAppOnCluster.getLoginUser.Token = %s, %s", token.getKind(), token.getService()));
+    }
+    log.info("killAppOnCluster.getLoginUser.Token --- end");
+
     final String[] split = applicationId.split("_");
     final ApplicationId aid = ApplicationId.newInstance(Long.parseLong(split[1]),
         Integer.parseInt(split[2]));


### PR DESCRIPTION
**What is this**
Fix the token related bug that the `yarnClient.killApplication()` jammed for 15 mins and error out with credential exception.

**Tests done**
Tested in multiple flows in the container, the yarn kill application function works well, directly return result and no more blocking.