### PR TITLE
Adding upload user information in project object metadata during Pod dispatch phase

### DIFF
--- a/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
+++ b/az-reportal/src/main/java/azkaban/viewer/reportal/ReportalServlet.java
@@ -1178,6 +1178,7 @@ public class ReportalServlet extends LoginAbstractAzkabanServlet {
     final ExecutableFlow exflow = new ExecutableFlow(project, flow);
     exflow.setSubmitUser(user.getUserId());
     exflow.addAllProxyUsers(project.getProxyUsers());
+    exflow.setUploadUser(project.getUploadUser());
     exflow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
 
     final ExecutionOptions options = exflow.getExecutionOptions();

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -63,6 +63,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String VERSIONSET_MD5HEX_PARAM = "versionSetMd5Hex";
   public static final String VERSIONSET_ID_PARAM = "versionSetId";
   private static final String PARAM_OVERRIDE = "param.override.";
+  private static final String PROJECT_FILE_UPLOAD_USER = "uploadUser";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
@@ -75,6 +76,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private long submitTime = -1;
   private long lastModifiedTimestamp;
   private String submitUser;
+  private String uploadUser;
   private String executionPath;
   private ExecutionOptions executionOptions;
   private double azkabanFlowVersion;
@@ -101,6 +103,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.scheduleId = -1;
     this.lastModifiedTimestamp = project.getLastModifiedTimestamp();
     this.lastModifiedUser = project.getLastModifiedUser();
+    this.uploadUser = project.getUploadUser();
     setAzkabanFlowVersion(flow.getAzkabanFlowVersion());
     setLocked(flow.isLocked());
     setFlowLockErrorMessage(flow.getFlowLockErrorMessage());
@@ -285,6 +288,12 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public void setFlowLockErrorMessage(final String flowLockErrorMessage) {
     this.flowLockErrorMessage = flowLockErrorMessage;
   }
+  public String getUploadUser() {
+    return this.uploadUser;
+  }
+  public void setUploadUser(final String uploadUser) {
+    this.uploadUser = uploadUser;
+  }
 
   public String getSlaOptionStr() {
     return slaOptionStr;
@@ -317,6 +326,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     flowObj.put(PROXYUSERS_PARAM, proxyUserList);
 
     flowObj.put(SUBMITTIME_PARAM, this.submitTime);
+    flowObj.put(PROJECT_FILE_UPLOAD_USER, this.uploadUser);
 
     final List<Map<String, Object>> slaOptions = new ArrayList<>();
     List<SlaOption> slaOptionList = this.executionOptions.getSlaOptions();
@@ -360,6 +370,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.version = flowObj.getInt(VERSION_PARAM);
     this.lastModifiedTimestamp = flowObj.getLong(LASTMODIFIEDTIME_PARAM);
     this.lastModifiedUser = flowObj.getString(LASTMODIFIEDUSER_PARAM);
+    this.uploadUser = flowObj.getString(PROJECT_FILE_UPLOAD_USER);
     this.submitTime = flowObj.getLong(SUBMITTIME_PARAM);
     this.azkabanFlowVersion = flowObj.getDouble(AZKABANFLOWVERSION_PARAM);
 

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -72,6 +72,7 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
           props.getString(JETTY_HOSTNAME, "localhost")));
     }
     metaData.put(EventReporterConstants.PROJECT_NAME, flow.getProjectName());
+    metaData.put(EventReporterConstants.PROJECT_FILE_UPLOAD_USER, flow.getUploadUser());
     metaData.put(EventReporterConstants.SUBMIT_USER, flow.getSubmitUser());
     metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(flow.getExecutionId()));
     metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -56,6 +56,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
     executableFlow.setSubmitUser(exFlow.getSubmitUser());
     executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
+    executableFlow.setUploadUser(project.getUploadUser());
     // Set up flow ExecutionOptions
     final ExecutionOptions options = exFlow.getExecutionOptions();
     if(!options.isFailureEmailsOverridden()) {

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
@@ -50,9 +50,10 @@ class JdbcProjectHandlerSet {
   public static class ProjectResultHandler implements ResultSetHandler<List<Project>> {
 
     private static final String BASE_QUERY = "SELECT "
-      + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj.last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
-      + "prm.name, prm.permissions, prm.isGroup "
-      + "FROM projects prj ";
+        + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj"
+        + ".last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
+        + "prm.name, prm.permissions, prm.isGroup, prjver.uploader "
+        + "FROM projects prj LEFT JOIN project_versions prjver ON prj.id = prjver.project_id ";
 
     // Still return the project if it has no associated permissions
     public static final String SELECT_PROJECT_BY_ID = BASE_QUERY + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.id=?";
@@ -129,6 +130,11 @@ class JdbcProjectHandlerSet {
         final String username = rs.getString(11);
         final int permissionFlag = rs.getInt(12);
         final boolean isGroup = rs.getBoolean(13);
+        final String uploader = rs.getString(14);
+        // Setting upload user in project Object
+        if (uploader != null) {
+          projects.get(id).setUploadUser(uploader);
+        }
         // If username is not null, add the permission to the project
         // If username is null, we can assume that this row was returned without any associated permission
         // i.e. this project had no associated permissions.

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -1186,8 +1186,9 @@ public class JdbcProjectImpl implements ProjectLoader {
     final String name = StringUtils.join(ids, ',').toString();
     final String SELECT_PROJECT_BY_IDS = "SELECT "
         + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj.last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
-        + "prm.name, prm.permissions, prm.isGroup "
+        + "prm.name, prm.permissions, prm.isGroup, prjver.uploader "
         + "FROM projects prj "
+        + "LEFT JOIN project_versions prjver ON prj.id = prjver.project_id "
         + "LEFT JOIN project_permissions prm ON prj.id = prm.project_id WHERE prj.id in (" + name
         + ")";
     try {

--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -55,6 +55,7 @@ public class Project extends EventHandler {
   private long createTimestamp;
   private long lastModifiedTimestamp;
   private String lastModifiedUser;
+  private String uploadUser;
   private String source;
   private Map<String, Flow> flows = new HashMap<>();
   // flowResourceRecommendations map shouldn't be ImmutableMap.
@@ -87,6 +88,7 @@ public class Project extends EventHandler {
     final String description = (String) projectObject.get("description");
     final String lastModifiedUser = (String) projectObject.get("lastModifiedUser");
     final long createTimestamp = coerceToLong(projectObject.get("createTimestamp"));
+    final String uploadUser = (String) projectObject.get("uploadUser");
     final long lastModifiedTimestamp =
         coerceToLong(projectObject.get("lastModifiedTimestamp"));
     final String source = (String) projectObject.get("source");
@@ -103,6 +105,7 @@ public class Project extends EventHandler {
     project.setLastModifiedTimestamp(lastModifiedTimestamp);
     project.setLastModifiedUser(lastModifiedUser);
     project.setActive(active);
+    project.setUploadUser(uploadUser);
 
     if (source != null) {
       project.setSource(source);
@@ -339,6 +342,7 @@ public class Project extends EventHandler {
     projectObject.put("lastModifiedTimestamp", this.lastModifiedTimestamp);
     projectObject.put("lastModifiedUser", this.lastModifiedUser);
     projectObject.put("version", this.version);
+    projectObject.put("uploadUser", this.uploadUser);
 
     if (!this.active) {
       projectObject.put("active", false);
@@ -364,6 +368,13 @@ public class Project extends EventHandler {
 
   public void setLastModifiedUser(final String lastModifiedUser) {
     this.lastModifiedUser = lastModifiedUser;
+  }
+
+  public void setUploadUser(final String uploadUser) {
+    this.uploadUser = uploadUser;
+  }
+  public String getUploadUser() {
+    return this.uploadUser;
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/ExecuteFlowAction.java
@@ -208,7 +208,7 @@ public class ExecuteFlowAction implements TriggerAction {
     }
 
     exflow.setExecutionOptions(this.executionOptions);
-
+    exflow.setUploadUser(project.getUploadUser());
     logger.info("Invoking flow " + project.getName() + "." + this.flowName);
     executorManagerAdapter.submitExecutableFlow(exflow, this.submitUser);
     logger.info("Invoked flow " + project.getName() + "." + this.flowName);

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/TriggerInstanceProcessor.java
@@ -72,6 +72,7 @@ public class TriggerInstanceProcessor {
       final ExecutableFlow executableFlow = FlowUtils.createExecutableFlow(project, flow);
       // execute the flow with default execution option(concurrency option being "ignore
       // currently running")
+      executableFlow.setUploadUser(project.getUploadUser());
       executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_EVENT);
       this.executorManager.submitExecutableFlow(executableFlow, triggerInst.getSubmitUser());
       triggerInst.setFlowExecId(executableFlow.getExecutionId());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1005,6 +1005,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     }
 
     final ExecutableFlow exflow = FlowUtils.createExecutableFlow(project, flow);
+    exflow.setUploadUser(project.getUploadUser());
     exflow.setSubmitUser(user.getUserId());
     exflow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
 


### PR DESCRIPTION
Modifying the DB query while reading Project Object metadata to ensure the project upload user information is included within it. 
Currently this is not present in the Project table and one extra JOIN us required. Since this read only once during the active project load phase it should add constant memory overhead.
