### PR TITLE
Fix formatting errors in some tables

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -85,7 +85,7 @@ Multiple Executor Mode Parameters
 |                                                      | list of hard filters  |                       |
 |                                                      | to be used while      |                       |
 |                                                      | dispatching. To be    |                       |
-|                                                      | chosen from          |                       |
+|                                                      | chosen from           |                       |
 |                                                      | StaticRemaining,      |                       |
 |                                                      | FlowSize,             |                       |
 |                                                      | MinimumFreeMemory and |                       |
@@ -314,18 +314,18 @@ Executor Server Properties
 |                                           | executions            |                       |
 +-------------------------------------------+-----------------------+-----------------------+
 | executor.flow.threads                     | The number of         | 30                    |
-|                                           | simultaneous flows     |                       |
+|                                           | simultaneous flows    |                       |
 |                                           | that can be run.      |                       |
 |                                           | These threads are     |                       |
 |                                           | mostly idle.          |                       |
-+-----------------------+-----------------------+-----------------------+
++-------------------------------------------+-----------------------+-----------------------+
 | job.log.chunk.size                        | For rolling job logs. | 5MB                   |
 |                                           | The chuck size for    |                       |
 |                                           | each roll over        |                       |
 +-------------------------------------------+-----------------------+-----------------------+
 | job.log.backup.index                      | The number of log     | 4                     |
 |                                           | chunks. The max size  |                       |
-|                                           | of each log is then  |                       |
+|                                           | of each log is then   |                       |
 |                                           | the index \*          |                       |
 |                                           | chunksize             |                       |
 +-------------------------------------------+-----------------------+-----------------------+


### PR DESCRIPTION
I've noticed that some tables (`Multiple Executor Mode Parameters` and `Executor Server Properties`) are missing from the config page.
Performing some tests with https://rubygems.org/gems/github-markup it turns out, that even a single formatting error within the table causes the whole table to be skipped by the RST2html converter.