### PR TITLE
CleanupManager: add metrics of heartbeat and timer for all cleanup schedule tasks

### DIFF
--- a/az-core/src/main/java/azkaban/metrics/MetricsManager.java
+++ b/az-core/src/main/java/azkaban/metrics/MetricsManager.java
@@ -79,7 +79,7 @@ public class MetricsManager {
     this.registry.register(name, (Gauge<T>) gaugeFunc::get);
   }
 
-  /*
+  /**
    * A {@link azkaban.metrics.CounterGauge} is a custom gauge which reports the number of events
    * in the last reporting interval.
    */

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -209,12 +209,18 @@ public class ContainerCleanupManager {
   }
 
   public void cleanUpStaleFlows() {
+    long startTime = System.currentTimeMillis();
     try {
       this.validityMap.entrySet().stream().filter(e -> !e.getValue().getFirst().isNegative()).map(
           Entry::getKey).forEach(this::cleanUpStaleFlows);
+
+      this.containerizationMetrics.sendCleanupStaleFlowHeartBeat();
     } catch (Throwable t) {
       logger.warn("Encounter unexpected throwable during cleanup stale flows, "
           + "skipping one schedule run", t);
+    } finally {
+      this.containerizationMetrics.recordCleanupStaleFlowTimer(
+          System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
     }
   }
 
@@ -222,6 +228,7 @@ public class ContainerCleanupManager {
    * Delete the still alive pods & services of those terminated flows to release resources
    */
   public void cleanUpContainersInTerminalStatuses() {
+    long startTime = System.currentTimeMillis();
     try {
       logger.info("Cleaning up pods of terminated flow executions");
       Set<Integer> containers = getContainersOfTerminatedFlows();
@@ -231,9 +238,14 @@ public class ContainerCleanupManager {
             executionId);
         deleteContainerQuietly(executionId);
       }
+
+      this.containerizationMetrics.sendCleanupContainerHeartBeat();
     } catch (Throwable t) {
       logger.warn("Encounter unexpected throwable during cleanup containers in terminal statuses, "
           + "skipping one schedule run", t);
+    } finally {
+      this.containerizationMetrics.recordCleanupContainerTimer(
+          System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
     }
   }
 
@@ -307,6 +319,8 @@ public class ContainerCleanupManager {
    * killed yarn applications, and kill them.
    */
   public void cleanUpDanglingYarnApplications() {
+    long startTime = System.currentTimeMillis();
+
     /*
       1. find those executions of status EXECUTION_STOPPED status within a recent period
       2. find those executions being killed but the pod is still unfinished, and delete the pods
@@ -342,9 +356,15 @@ public class ContainerCleanupManager {
         logger.info("clean up yarn applications in cluster:" + entry.getValue().getClusterId());
         cleanUpYarnApplicationsInCluster(toBeCleanedContainers, entry.getValue());
       }
+
+      this.containerizationMetrics.sendCleanupYarnApplicationHeartBeat();
     } catch (Throwable t) {
       logger.warn("Encounter unexpected throwable during cleanup dangling yarn app, "
           + "skipping one schedule run", t);
+    }
+    finally {
+      this.containerizationMetrics.recordCleanupYarnApplicationTimer(
+          System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS);
     }
   }
 

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -17,6 +17,7 @@
 package azkaban.metrics;
 
 import azkaban.utils.Props;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Defines all the metrics emitted by containerized executions
@@ -117,4 +118,16 @@ public interface ContainerizationMetrics {
    * Record number of killing yarn application failure
    */
   void markYarnApplicationKillFail(long n);
+
+  void sendCleanupContainerHeartBeat();
+
+  void sendCleanupStaleFlowHeartBeat();
+
+  void sendCleanupYarnApplicationHeartBeat();
+
+  void recordCleanupStaleFlowTimer(long duration, TimeUnit unit);
+
+  void recordCleanupContainerTimer(long duration, TimeUnit unit);
+
+  void recordCleanupYarnApplicationTimer(long duration, TimeUnit unit);
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -19,7 +19,9 @@ package azkaban.metrics;
 import azkaban.utils.Props;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import com.google.inject.Inject;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +37,8 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Meter flowSubmitToExecutor, flowSubmitToContainer;
   private Meter executionStopped, oomKilled, containerDispatchFail, vpaRecommenderFail,
       yarnGetApplicationsFail, yarnApplicationKillFail;
+  private Meter cleanupStaleFlowHeartBeat, cleanupContainerHeartBeat, cleanupYarnAppHeartBeat;
+  private Timer cleanupStaleFlowTimer, cleanupContainerTimer, cleanupYarnAppTimer;
   private Histogram timeToDispatch;
   private volatile boolean isInitialized = false;
 
@@ -63,6 +67,15 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.vpaRecommenderFail = this.metricsManager.addMeter("VPA-Recommender-Fail-Meter");
     this.yarnGetApplicationsFail = this.metricsManager.addMeter("Yarn-Get-Applications-Fail-Meter");
     this.yarnApplicationKillFail = this.metricsManager.addMeter("Yarn-Application-Kill-Fail-Meter");
+    this.cleanupStaleFlowHeartBeat = this.metricsManager.addMeter("Cleanup-Stale-Flow-Heartbeat"
+        + "-Meter");
+    this.cleanupContainerHeartBeat = this.metricsManager.addMeter("Cleanup-Container-Heartbeat"
+        + "-Meter");
+    this.cleanupYarnAppHeartBeat = this.metricsManager.addMeter("Cleanup-Yarn-Application-Heartbeat"
+        + "-Meter");
+    this.cleanupStaleFlowTimer = this.metricsManager.addTimer("Cleanup-Stale-Flow-Timer");
+    this.cleanupContainerTimer = this.metricsManager.addTimer("Cleanup-Container-Timer");
+    this.cleanupYarnAppTimer = this.metricsManager.addTimer("Cleanup-Yarn-Application-Timer");
   }
 
   @Override
@@ -165,5 +178,35 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   @Override
   public void markYarnApplicationKillFail(long n) {
     yarnApplicationKillFail.mark(n);
+  }
+
+  @Override
+  public void sendCleanupStaleFlowHeartBeat() {
+    cleanupStaleFlowHeartBeat.mark();
+  }
+
+  @Override
+  public void sendCleanupContainerHeartBeat() {
+    cleanupContainerHeartBeat.mark();
+  }
+
+  @Override
+  public void sendCleanupYarnApplicationHeartBeat() {
+    cleanupYarnAppHeartBeat.mark();
+  }
+
+  @Override
+  public void recordCleanupStaleFlowTimer(long duration, TimeUnit unit){
+    cleanupStaleFlowTimer.update(duration, unit);
+  }
+
+  @Override
+  public void recordCleanupContainerTimer(long duration, TimeUnit unit){
+    cleanupContainerTimer.update(duration, unit);
+  }
+
+  @Override
+  public void recordCleanupYarnApplicationTimer(long duration, TimeUnit unit){
+    cleanupYarnAppTimer.update(duration, unit);
   }
 }

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -16,6 +16,7 @@
 package azkaban.metrics;
 
 import azkaban.utils.Props;
+import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 
 /**
@@ -106,5 +107,35 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
 
   @Override
   public void markYarnApplicationKillFail(long n) {
+  }
+
+  @Override
+  public void sendCleanupContainerHeartBeat() {
+    
+  }
+
+  @Override
+  public void sendCleanupStaleFlowHeartBeat() {
+
+  }
+
+  @Override
+  public void sendCleanupYarnApplicationHeartBeat() {
+
+  }
+
+  @Override
+  public void recordCleanupStaleFlowTimer(long duration, TimeUnit unit) {
+
+  }
+
+  @Override
+  public void recordCleanupContainerTimer(long duration, TimeUnit unit) {
+
+  }
+
+  @Override
+  public void recordCleanupYarnApplicationTimer(long duration, TimeUnit unit) {
+
   }
 }


### PR DESCRIPTION
**Why we need this**
So as we can know whether the cleanup manager is alive and functioning well, and get alerted if not, to prevent outages.

**Tests done**
Launched in a test web-server, able to see all the metrics in the graph dashboard.