### PR TITLE
remove schedule global lock

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -20,6 +20,7 @@ import azkaban.utils.Pair;
 import azkaban.utils.TimeUtils;
 import azkaban.utils.Utils;
 import java.util.Date;
+import java.util.concurrent.locks.ReentrantLock;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
@@ -44,6 +45,8 @@ public class Schedule {
   private int scheduleId;
   private long nextExecTime;
   private ExecutionOptions executionOptions;
+
+  private ReentrantLock lock = new ReentrantLock();
 
   public Schedule(final int scheduleId,
       final int projectId,
@@ -242,5 +245,13 @@ public class Schedule {
 
   public long getEndSchedTime() {
     return this.endSchedTime;
+  }
+
+  public void lock() {
+    this.lock.lock();
+  }
+
+  public void unlock() {
+    this.lock.unlock();
   }
 }

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
@@ -17,6 +17,7 @@
 package azkaban.scheduler;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleLoader {
 
@@ -29,4 +30,5 @@ public interface ScheduleLoader {
   public void updateNextExecTime(Schedule s) throws ScheduleManagerException;
 
   public List<Schedule> loadUpdatedSchedules() throws ScheduleManagerException;
+  public Optional<Schedule> loadUpdateSchedule(Schedule s) throws ScheduleManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -21,11 +21,13 @@ import azkaban.trigger.TriggerAgent;
 import azkaban.trigger.TriggerStatus;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.NotNull;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTimeZone;
 import org.joda.time.ReadablePeriod;
@@ -48,9 +50,9 @@ public class ScheduleManager implements TriggerAgent {
   private final ScheduleLoader loader;
 
   private final Map<Integer, Schedule> scheduleIDMap =
-      new LinkedHashMap<>();
+      new ConcurrentHashMap<>();
   private final Map<Pair<Integer, String>, Schedule> scheduleIdentityPairMap =
-      new LinkedHashMap<>();
+      new ConcurrentHashMap<>();
 
   /**
    * Give the schedule manager a loader class that will properly load the schedule.
@@ -68,14 +70,16 @@ public class ScheduleManager implements TriggerAgent {
   }
 
   // only do this when using external runner
-  private synchronized void updateLocal() throws ScheduleManagerException {
+  private void updateLocal() throws ScheduleManagerException {
     final List<Schedule> updates = this.loader.loadUpdatedSchedules();
     for (final Schedule s : updates) {
+      s.lock();
       if (s.getStatus().equals(TriggerStatus.EXPIRED.toString())) {
         onScheduleExpire(s);
       } else {
         internalSchedule(s);
       }
+      s.unlock();
     }
   }
 
@@ -94,9 +98,8 @@ public class ScheduleManager implements TriggerAgent {
   /**
    * Retrieves a copy of the list of schedules.
    */
-  public synchronized List<Schedule> getSchedules()
+  public List<Schedule> getSchedules()
       throws ScheduleManagerException {
-
     updateLocal();
     return new ArrayList<>(this.scheduleIDMap.values());
   }
@@ -106,9 +109,10 @@ public class ScheduleManager implements TriggerAgent {
    */
   public Schedule getSchedule(final int projectId, final String flowId)
       throws ScheduleManagerException {
-    updateLocal();
-    return this.scheduleIdentityPairMap.get(new Pair<>(projectId,
+    // for one specific schedule refresh, we only need to update that schedule
+    Schedule s = this.scheduleIdentityPairMap.get(new Pair<>(projectId,
         flowId));
+    return s == null ? null : updateSingleSchedule(s);
   }
 
   /**
@@ -117,15 +121,16 @@ public class ScheduleManager implements TriggerAgent {
    * @param scheduleId Schedule ID
    */
   public Schedule getSchedule(final int scheduleId) throws ScheduleManagerException {
-    updateLocal();
-    return this.scheduleIDMap.get(scheduleId);
+    Schedule s = this.scheduleIDMap.get(scheduleId);
+    return s == null ? null : updateSingleSchedule(s);
   }
 
 
   /**
    * Removes the flow from the schedule if it exists.
    */
-  public synchronized void removeSchedule(final Schedule sched) {
+  public void removeSchedule(final Schedule sched) {
+    sched.lock();
     final Pair<Integer, String> identityPairMap = sched.getScheduleIdentityPair();
 
     final Schedule schedule = this.scheduleIdentityPairMap.get(identityPairMap);
@@ -139,6 +144,8 @@ public class ScheduleManager implements TriggerAgent {
       this.loader.removeSchedule(sched);
     } catch (final ScheduleManagerException e) {
       logger.error(e);
+    } finally {
+      sched.unlock();
     }
   }
 
@@ -198,7 +205,7 @@ public class ScheduleManager implements TriggerAgent {
   /**
    * Schedules the flow, but doesn't save the schedule afterwards.
    */
-  private synchronized void internalSchedule(final Schedule s) {
+  private void internalSchedule(@NotNull final Schedule s) {
     this.scheduleIDMap.put(s.getScheduleId(), s);
     this.scheduleIdentityPairMap.put(s.getScheduleIdentityPair(), s);
   }
@@ -206,10 +213,11 @@ public class ScheduleManager implements TriggerAgent {
   /**
    * Adds a flow to the schedule.
    */
-  public synchronized void insertSchedule(final Schedule s) {
-    final Schedule exist = this.scheduleIdentityPairMap.get(s.getScheduleIdentityPair());
-    if (s.updateTime()) {
-      try {
+  public void insertSchedule(final Schedule s) {
+    s.lock();
+    try {
+      final Schedule exist = this.scheduleIdentityPairMap.get(s.getScheduleIdentityPair());
+      if (s.updateTime()) {
         if (exist == null) {
           this.loader.insertSchedule(s);
           internalSchedule(s);
@@ -218,13 +226,13 @@ public class ScheduleManager implements TriggerAgent {
           this.loader.updateSchedule(s);
           internalSchedule(s);
         }
-      } catch (final ScheduleManagerException e) {
-        logger.error(e);
+      } else {
+        logger.error("The provided schedule is non-recurring and the scheduled time already passed. " + s.getScheduleName());
       }
-    } else {
-      logger
-          .error("The provided schedule is non-recurring and the scheduled time already passed. "
-              + s.getScheduleName());
+    } catch (final ScheduleManagerException e) {
+      logger.error(e);
+    } finally {
+      s.unlock();
     }
   }
 
@@ -237,5 +245,31 @@ public class ScheduleManager implements TriggerAgent {
   @Override
   public String getTriggerSource() {
     return SIMPLE_TIME_TRIGGER;
+  }
+
+  /**
+   * fetch from TriggerManager to see if the desired trigger is being updated or not.
+   * if updated, update schedule metadata;
+   * if not being updated, return the original schedule.
+   *
+   * @param s, original schedule
+   * @return latest schedule metadata
+   * */
+  private Schedule updateSingleSchedule(@NotNull Schedule s) throws ScheduleManagerException {
+    s.lock();
+    try {
+      Optional<Schedule> updatedSchedule = loader.loadUpdateSchedule(s);
+      if (updatedSchedule.isPresent()) {
+        if (s.getStatus().equals(TriggerStatus.EXPIRED.toString())) {
+          onScheduleExpire(s);
+        } else {
+          internalSchedule(s);
+        }
+        return updatedSchedule.get();
+      }
+      return s;
+    } finally {
+      s.unlock();
+    }
   }
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerImpl.java
@@ -108,11 +108,8 @@ public class JdbcTriggerImpl implements TriggerLoader {
     }
   }
 
-  /**
-   * TODO: Don't understand why we need synchronized here.
-   */
   @Override
-  public synchronized void addTrigger(final Trigger t) throws TriggerLoaderException {
+  public void addTrigger(final Trigger t) throws TriggerLoaderException {
     logger.info("Inserting trigger " + t.toString() + " into db.");
 
     final SQLTransaction<Long> insertAndGetLastID = transOperator -> {

--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 
@@ -50,6 +51,8 @@ public class Trigger {
   private boolean resetOnExpire = true;
 
   private long nextCheckTime = -1;
+
+  private ReentrantLock lock = new ReentrantLock();
 
   private Trigger() throws TriggerManagerException {
     throw new TriggerManagerException("Triggers should always be specified");
@@ -320,6 +323,14 @@ public class Trigger {
 
   public List<TriggerAction> getTriggerActions() {
     return this.actions;
+  }
+
+  public void lock() {
+    this.lock.lock();
+  }
+
+  public void unlock() {
+    this.lock.unlock();
   }
 
   public Map<String, Object> toJson() {

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManagerAdapter.java
@@ -18,6 +18,8 @@ package azkaban.trigger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 
 public interface TriggerManagerAdapter {
 
@@ -29,11 +31,10 @@ public interface TriggerManagerAdapter {
   public void updateTrigger(Trigger t, String user)
       throws TriggerManagerException;
 
-  public List<Trigger> getAllTriggerUpdates(long lastUpdateTime)
-      throws TriggerManagerException;
-
   public List<Trigger> getTriggerUpdates(String triggerSource,
-      long lastUpdateTime) throws TriggerManagerException;
+      Map<Integer, Long> triggerToLastCheckTime) throws TriggerManagerException;
+
+  public Optional<Trigger> getUpdatedTriggerById(final int triggerId, final long lastUpdateTime);
 
   public List<Trigger> getTriggers(String trigegerSource);
 


### PR DESCRIPTION
Previously Schedule system's lock is pretty strict.
- synchronized keywords ensures only one user would getSchedule, and even if viewing a single schedule would require updates the whole schedules.
- syncObj make sure only one trigger can be updated at a time, and it's conflicting with trigger scanning process. 

These locks makes schedule system unable to handle large load as only one of hundreds would acquire the lock and do the operation while all other requests would need to wait for the lock to release, even if those requests are totally irrelevant with each other. (One should be able to update its schedule, while less rely on other schedule updates) 

This PR removes all sync keywords and the global lock to lower the lock level to individual schedule/triggers instead of keeping all of them in the global synchronized stage. ScheduleManager is the entry point that links schedule and trigger, it will maintain its own checkTime for each individual trigger with its lastModifyTime as evidence to check if a schedule/trigger is getting updated.