### PR TITLE
Support custom alerters when defining SLAs with alert action.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/alert/Alerter.java
+++ b/azkaban-common/src/main/java/azkaban/alert/Alerter.java
@@ -22,6 +22,7 @@ import azkaban.executor.ExecutorManagerException;
 import azkaban.flow.Flow;
 import azkaban.project.Project;
 import azkaban.sla.SlaOption;
+import azkaban.utils.Emailer;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +34,13 @@ public interface Alerter {
 
   void alertOnFirstError(ExecutableFlow exflow) throws Exception;
 
-  void alertOnSla(SlaOption slaOption, String slaMessage) throws Exception;
+  @Deprecated
+  default void alertOnSla(SlaOption slaOption, String slaMessage) throws Exception { }
+
+  default void alertOnSla(ExecutableFlow exflow, SlaOption slaOption) throws Exception {
+    final String slaMessage = Emailer.createSlaMessage(exflow, slaOption, getAzkabanURL());
+    alertOnSla(slaOption, slaMessage);
+  }
 
   void alertOnFailedUpdate(Executor executor, List<ExecutableFlow> executions,
       ExecutorManagerException e);
@@ -44,5 +51,8 @@ public interface Alerter {
 
   void alertOnJobPropertyOverridden(Project project, Flow flow, Map<String, Object> metaData);
 
-  String getAzkabanURL();
+  @Deprecated
+  default String getAzkabanURL() {
+    return "";
+  };
 }

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOptionDeprecated.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOptionDeprecated.java
@@ -43,6 +43,7 @@ public class SlaOptionDeprecated {
   public static final String INFO_FLOW_NAME = "FlowName";
   public static final String INFO_JOB_NAME = "JobName";
   public static final String INFO_EMAIL_LIST = "EmailList";
+  public static final String INFO_ALERTERS_CONFIGS = "alertersConfigs";
 
   // always alert
   public static final String ALERT_TYPE = "SlaAlertType";
@@ -63,7 +64,6 @@ public class SlaOptionDeprecated {
   }
 
   public static SlaOptionDeprecated fromObject(final Object object) {
-
     final HashMap<String, Object> slaObj = (HashMap<String, Object>) object;
 
     final String type = (String) slaObj.get("type");
@@ -100,7 +100,6 @@ public class SlaOptionDeprecated {
 
   public Map<String, Object> toObject() {
     final HashMap<String, Object> slaObj = new HashMap<>();
-
     slaObj.put("type", this.type);
     slaObj.put("info", this.info);
     slaObj.put("actions", this.actions);

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/SlaAlertAction.java
@@ -103,19 +103,14 @@ public class SlaAlertAction implements TriggerAction {
   public void doAction() throws Exception {
     logger.info("Alerting on sla failure.");
     if (slaOption.hasAlert()) {
-      final Alerter alerter = this.alerters.get(SlaOption.ALERT_TYPE_EMAIL);
-      if (alerter != null) {
+      final ExecutableFlow flow = this.executorLoader.fetchExecutableFlow(this.execId);
+      this.alerters.forEach((String alerterName, Alerter alerter) -> {
         try {
-          final ExecutableFlow flow = this.executorLoader.fetchExecutableFlow(this.execId);
-          alerter.alertOnSla(this.slaOption, slaOption.createSlaMessage(flow, alerter.getAzkabanURL()));
+          alerter.alertOnSla(flow, this.slaOption);
         } catch (final Exception e) {
-          e.printStackTrace();
-          logger.error("Failed to alert by " + SlaOption.ALERT_TYPE_EMAIL);
+          logger.error("Failed to alert on SLA breach for execution " + flow.getExecutionId(), e);
         }
-      } else {
-        logger.error("Alerter type " + SlaOption.ALERT_TYPE_EMAIL
-            + " doesn't exist. Failed to alert.");
-      }
+      });
     }
   }
 

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -186,11 +186,11 @@ public final class HttpRequestUtilsTest {
     final List<SlaOption> slaOptions = options.getSlaOptions();
     final List<SlaOption> expected = Arrays.asList(
         new SlaOption(SlaType.FLOW_FINISH, "test-flow", "", Duration.ofMinutes(150),
-            ImmutableSet.of(SlaAction.ALERT), ImmutableList.of()),
+            ImmutableSet.of(SlaAction.ALERT), ImmutableList.of(), ImmutableMap.of()),
         new SlaOption(SlaType.JOB_SUCCEED, "test-flow", "test_job", Duration.ofMinutes(720),
-            ImmutableSet.of(SlaAction.KILL), ImmutableList.of()),
+            ImmutableSet.of(SlaAction.KILL), ImmutableList.of(), ImmutableMap.of()),
         new SlaOption(SlaType.FLOW_SUCCEED, "test-flow", "", Duration.ofMinutes(720),
-            ImmutableSet.of(SlaAction.ALERT, SlaAction.KILL), ImmutableList.of())
+            ImmutableSet.of(SlaAction.ALERT, SlaAction.KILL), ImmutableList.of(), ImmutableMap.of())
     );
     Assert.assertEquals(expected, slaOptions);
   }
@@ -204,7 +204,23 @@ public final class HttpRequestUtilsTest {
     final List<SlaOption> slaOptions = options.getSlaOptions();
     final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "test-flow",
         "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
-        ImmutableList.of("sla1@example.com", "sla2@example.com")));
+        ImmutableList.of("sla1@example.com", "sla2@example.com"), ImmutableMap.of()));
+    Assert.assertEquals(expected, slaOptions);
+  }
+
+  @Test
+  public void testParseFlowOptionsSlaWithAlertersConfigs() throws Exception {
+    final HttpServletRequest req = mockRequestWithSla(ImmutableMap.of(
+        "slaSettings[1]", ",FINISH,2:30,true,false",
+        "slaAlerters[email][recipients]", "sla1@example.com,sla2@example.com",
+        "slaAlerters[myAlerter][prop1]", "value1"));
+    final ExecutionOptions options = HttpRequestUtils.parseFlowOptions(req, "test-flow");
+    final List<SlaOption> slaOptions = options.getSlaOptions();
+    final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "test-flow",
+        "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
+        ImmutableList.of("sla1@example.com", "sla2@example.com"), ImmutableMap.of(
+            "myAlerter", ImmutableMap.of("prop1", "value1")
+    )));
     Assert.assertEquals(expected, slaOptions);
   }
 

--- a/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
+++ b/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.sla.SlaOption.SlaOptionBuilder;
 import azkaban.utils.JSONUtils;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.util.Maps;
 import org.junit.Test;
 
 /** Test SlaOption */
@@ -44,29 +46,32 @@ public class SlaOptionTest {
     final Set<SlaAction> actions = Collections.singleton(SlaAction.ALERT);
     final List<String> emails = Collections.singletonList("test@email.com");
     final Duration duration = Duration.ofHours(1);
+    final Map<String, Map<String, String>> alertersConfigs = ImmutableMap.of(
+        "myAlerter", ImmutableMap.of("prop1", "value1"));
     // negative test: null flow
     assertThatThrownBy(() -> new SlaOption(SlaType.JOB_FINISH, null, job, duration,
-        actions, emails)).isInstanceOf(NullPointerException.class);
+        actions, emails, alertersConfigs)).isInstanceOf(NullPointerException.class);
 
     // negative test: null type
     assertThatThrownBy(() -> new SlaOption(null, flow, job, duration,
-        actions, emails)).isInstanceOf(NullPointerException.class);
+        actions, emails, alertersConfigs)).isInstanceOf(NullPointerException.class);
 
     // negative test: null action
     assertThatThrownBy(() -> new SlaOption(SlaType.JOB_FINISH, flow, job, duration,
-        null, emails)).isInstanceOf(NullPointerException.class);
+        null, emails, alertersConfigs)).isInstanceOf(NullPointerException.class);
 
     // negative test: null duration
     assertThatThrownBy(() -> new SlaOption(SlaType.JOB_FINISH, flow, job, null,
-        actions, emails)).isInstanceOf(NullPointerException.class);
+        actions, emails, alertersConfigs)).isInstanceOf(NullPointerException.class);
 
     // negative test: empty action
     assertThatThrownBy(() -> new SlaOption(SlaType.JOB_FINISH, flow, job, duration,
-        Collections.emptySet(), emails)).isInstanceOf(IllegalStateException.class);
+        Collections.emptySet(), emails, alertersConfigs)).isInstanceOf(IllegalStateException.class);
 
     SlaOption slaOption = new SlaOption(SlaType.JOB_FINISH, flow, job, duration,
-        actions, emails);
+        actions, emails, alertersConfigs);
     assertThat(slaOption.getEmails()).isEqualTo(emails);
+    assertThat(slaOption.getAlertersConfigs()).isEqualTo(alertersConfigs);
     assertThat(slaOption.getType()).isEqualTo(SlaType.JOB_FINISH);
     assertThat(slaOption.getDuration()).isEqualTo(duration);
     assertThat(slaOption.getFlowName()).isEqualTo(flow);
@@ -135,6 +140,7 @@ public class SlaOptionTest {
     deprecatedInfo.put(SlaOptionDeprecated.INFO_JOB_NAME, "job");
     deprecatedInfo.put(SlaOptionDeprecated.INFO_DURATION, "60m");
     deprecatedInfo.put(SlaOptionDeprecated.INFO_EMAIL_LIST, emails);
+    deprecatedInfo.put(SlaOptionDeprecated.INFO_ALERTERS_CONFIGS, ImmutableMap.of());
 
     SlaOptionDeprecated slaOptionDeprecated = new SlaOptionDeprecated(SlaOptionDeprecated
         .TYPE_JOB_FINISH, deprecatedActions, deprecatedInfo);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -207,9 +207,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
         return;
       }
 
-      final String emailStr = getParam(req, PARAM_SLA_EMAILS);
-      final Map<String, String> settings = getParamGroup(req, PARAM_SETTINGS);
-      final List<SlaOption> slaOptions = SlaRequestUtils.parseSlaOptions(sched.getFlowName(), emailStr, settings);
+      final List<SlaOption> slaOptions = SlaRequestUtils.parseSlaOptions(req, sched.getFlowName(), PARAM_SETTINGS);
 
       if (slaOptions.isEmpty()) {
         throw new ScheduleManagerException(

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ExecutorServletTest.java
@@ -35,6 +35,7 @@ import azkaban.sla.SlaOption;
 import azkaban.sla.SlaType;
 import azkaban.utils.Props;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import java.util.Arrays;
@@ -88,7 +89,7 @@ public class ExecutorServletTest extends LoginAbstractAzkabanServletTestBase {
     final List<SlaOption> slaOptions = this.exFlow.getValue().getExecutionOptions().getSlaOptions();
     final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "testFlow",
         "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
-        ImmutableList.of("sla1@example.com", "sla2@example.com")));
+        ImmutableList.of("sla1@example.com", "sla2@example.com"), ImmutableMap.of()));
     Assert.assertEquals(expected, slaOptions);
   }
 


### PR DESCRIPTION
Before, SLA rules with action set to `ALERT` would only support email notifications. 
With this change SLA misses can also be notified via custom notification systems installed as plugins. When defining SLAs through the `setSla` or `executFlow` apis, users can now set configs for custom alerters. For example:

```
curl --location --request POST 'http://localhost:8081/schedule' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'ajax=setSla' \
--data-urlencode 'scheduleId=12345’ \
--data-urlencode 'settings[0]=,FINISH,00:01,true,false' \

--- new params -------------
--data-urlencode 'slaAlerters[myCustomAlerter][prop1]=value1' \ 
--data-urlencode 'slaAlerters[email][recipients]=abc@abc.com'
```

TODO: include the new custom alerter configs in the responses of APIs that retrieve SLA info.