### PR TITLE
job status update on execution_stop

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -132,7 +132,7 @@ public class ExecutionControllerUtils {
         // If it's marked finished, we're good. If not, we fail everything and then mark it
         // finished.
         if (!isFinished(dsFlow)) {
-          failEverything(eventHandler, projectManager, dsFlow, finalFlowStatus);
+          failEverything(eventHandler, projectManager, dsFlow, finalFlowStatus, executorLoader);
           executorLoader.updateExecutableFlow(dsFlow);
         }
         // flow will be used for event reporter afterwards, thus the final status needs to be set
@@ -310,8 +310,8 @@ public class ExecutionControllerUtils {
    */
   @Deprecated
   public static void failEverything(final ExecutableFlow exFlow,
-      final Status finalFlowStatus) {
-    failEverything(null, null, exFlow, finalFlowStatus);
+      final Status finalFlowStatus, final ExecutorLoader executorLoader) {
+    failEverything(null, null, exFlow, finalFlowStatus, executorLoader);
   }
 
   /**
@@ -324,7 +324,7 @@ public class ExecutionControllerUtils {
    */
   public static void failEverything(final EventHandler eventHandler,
       final ProjectManager projectManager, final ExecutableFlow exFlow,
-      final Status finalFlowStatus) {
+      final Status finalFlowStatus, final ExecutorLoader executorLoader) {
     final long time = System.currentTimeMillis();
     final Map<ExecutableNode, Status> nodeToOrigStatus = new HashMap<>();
     final Queue<ExecutableNode> queue = new LinkedList<>();
@@ -372,6 +372,11 @@ public class ExecutionControllerUtils {
         }
         if (node.getEndTime() == -1) {
           node.setEndTime(time);
+        }
+        try {
+          executorLoader.updateExecutableNode(node);
+        } catch (ExecutorManagerException e) {
+          logger.error("fail to update job status in DB, ", e);
         }
       }
     }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFinalizer.java
@@ -69,7 +69,7 @@ public class ExecutionFinalizer {
         // then mark it finished.
         if (!ExecutionControllerUtils.isFinished(dsFlow)) {
           this.updaterStage.set("finalizing flow " + execId + " failing the flow");
-          ExecutionControllerUtils.failEverything(dsFlow, Status.FAILED);
+          ExecutionControllerUtils.failEverything(dsFlow, Status.FAILED, this.executorLoader);
           this.executorLoader.updateExecutableFlow(dsFlow);
         }
       }

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -165,6 +165,9 @@ public class MockExecutorLoader implements ExecutorLoader {
   public void updateExecutableNode(final ExecutableNode node)
       throws ExecutorManagerException {
     final ExecutableNode foundNode = this.nodes.get(node.getId());
+    if (foundNode == null) {
+      return;
+    }
     foundNode.setEndTime(node.getEndTime());
     foundNode.setStartTime(node.getStartTime());
     foundNode.setStatus(node.getStatus());


### PR DESCRIPTION
Update job status in DB when calling finalizing flows. Table execution_jobs will be updated with corresponding status in job history page.