### PR TITLE
add back execute support for miss schedule

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/Schedule.java
@@ -42,6 +42,7 @@ public class Schedule {
   private final long submitTime;
   private final String cronExpression;
   private final boolean skipPastOccurrences = true;
+  private final boolean backExecuteOnceOnMiss;
   private int scheduleId;
   private long nextExecTime;
   private ExecutionOptions executionOptions;
@@ -62,7 +63,8 @@ public class Schedule {
       final long submitTime,
       final String submitUser,
       final ExecutionOptions executionOptions,
-      final String cronExpression) {
+      final String cronExpression,
+      final boolean backExecuteOnceOnMiss) {
     this.scheduleId = scheduleId;
     this.projectId = projectId;
     this.projectName = projectName;
@@ -78,6 +80,7 @@ public class Schedule {
     this.submitTime = submitTime;
     this.executionOptions = executionOptions;
     this.cronExpression = cronExpression;
+    this.backExecuteOnceOnMiss = backExecuteOnceOnMiss;
   }
 
   public ExecutionOptions getExecutionOptions() {
@@ -92,6 +95,9 @@ public class Schedule {
     return this.projectName + "." + this.flowName + " (" + this.projectId + ")";
   }
 
+  public boolean isBackExecuteOnceOnMiss() {
+    return backExecuteOnceOnMiss;
+  }
   @Override
   public String toString() {
 

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -165,7 +165,7 @@ public class ScheduleManager implements TriggerAgent {
       final ExecutionOptions execOptions) {
     final Schedule sched = new Schedule(scheduleId, projectId, projectName, flowName, status,
         firstSchedTime, endSchedTime, timezone, period, lastModifyTime, nextExecTime,
-        submitTime, submitUser, execOptions, null);
+        submitTime, submitUser, execOptions, null, false);
     logger
         .info("Scheduling flow '" + sched.getScheduleName() + "' for "
             + this._dateFormat.print(firstSchedTime) + " with a period of " + (period == null
@@ -189,14 +189,16 @@ public class ScheduleManager implements TriggerAgent {
       final long submitTime,
       final String submitUser,
       final ExecutionOptions execOptions,
-      final String cronExpression) {
+      final String cronExpression,
+      final boolean backExecuteOnceOnMiss) {
     final Schedule sched =
         new Schedule(scheduleId, projectId, projectName, flowName, status,
             firstSchedTime, endSchedTime, timezone, null, lastModifyTime, nextExecTime,
-            submitTime, submitUser, execOptions, cronExpression);
+            submitTime, submitUser, execOptions, cronExpression, backExecuteOnceOnMiss);
     logger
         .info("Scheduling flow '" + sched.getScheduleName() + "' for "
-            + this._dateFormat.print(firstSchedTime) + " cron Expression = " + cronExpression);
+            + this._dateFormat.print(firstSchedTime) + " cron Expression = " + cronExpression
+            + " with back execute " + (backExecuteOnceOnMiss ? "enabled" : "disabled"));
 
     insertSchedule(sched);
     return sched;

--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -73,6 +73,7 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
     } else {
       t.setResetOnTrigger(false);
     }
+    t.setBackExecuteOnceOnMiss(s.isBackExecuteOnceOnMiss());
     return t;
   }
 
@@ -161,7 +162,8 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
           t.getSubmitTime(),
           t.getSubmitUser(),
           act.getExecutionOptions(),
-          triggerTimeChecker.getCronExpression());
+          triggerTimeChecker.getCronExpression(),
+          t.isBackExecuteOnceOnMiss());
     } else {
       logger.error("Failed to parse schedule from trigger!");
       throw new ScheduleManagerException(

--- a/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/Trigger.java
@@ -49,6 +49,7 @@ public class Trigger {
   private Map<String, Object> context = new HashMap<>();
   private boolean resetOnTrigger = true;
   private boolean resetOnExpire = true;
+  private boolean backExecuteOnceOnMiss = false;
 
   private long nextCheckTime = -1;
 
@@ -133,6 +134,7 @@ public class Trigger {
           Boolean.valueOf((String) jsonObj.get("resetOnTrigger"));
       final boolean resetOnExpire =
           Boolean.valueOf((String) jsonObj.get("resetOnExpire"));
+      final boolean backExecuteOnceOnMiss = Boolean.valueOf((String) jsonObj.get("backExecuteOnceOnMiss"));
       final String submitUser = (String) jsonObj.get("submitUser");
       final String source = (String) jsonObj.get("source");
       final long submitTime = Long.valueOf((String) jsonObj.get("submitTime"));
@@ -176,6 +178,7 @@ public class Trigger {
       trigger.setResetOnExpire(resetOnExpire);
       trigger.setResetOnTrigger(resetOnTrigger);
       trigger.setStatus(status);
+      trigger.setBackExecuteOnceOnMiss(backExecuteOnceOnMiss);
     } catch (final Exception e) {
       e.printStackTrace();
       logger.error("Failed to decode the trigger.", e);
@@ -262,6 +265,14 @@ public class Trigger {
     this.resetOnTrigger = resetOnTrigger;
   }
 
+  public void setBackExecuteOnceOnMiss(final boolean backExecuteOnceOnMiss) {
+    this.backExecuteOnceOnMiss = backExecuteOnceOnMiss;
+  }
+
+  public boolean isBackExecuteOnceOnMiss() {
+    return backExecuteOnceOnMiss;
+  }
+
   public boolean isResetOnExpire() {
     return this.resetOnExpire;
   }
@@ -307,7 +318,7 @@ public class Trigger {
       if (action instanceof ExecuteFlowAction) {
         // when successfully send task to missedScheduleManager, clear the missed schedule times
         if (missedSchedulesManager.addMissedSchedule(
-            this.triggerCondition.getMissedCheckTimes(), (ExecuteFlowAction) action, false)) {
+            this.triggerCondition.getMissedCheckTimes(), (ExecuteFlowAction) action, this.backExecuteOnceOnMiss)) {
           this.triggerCondition.getMissedCheckTimes().clear();
         } else {
           logger.error("failed to add miss schedule task for trigger " + this);
@@ -356,6 +367,7 @@ public class Trigger {
 
     jsonObj.put("resetOnTrigger", String.valueOf(this.resetOnTrigger));
     jsonObj.put("resetOnExpire", String.valueOf(this.resetOnExpire));
+    jsonObj.put("backExecuteOnceOnMiss", String.valueOf(this.backExecuteOnceOnMiss));
     jsonObj.put("submitUser", this.submitUser);
     jsonObj.put("source", this.source);
     jsonObj.put("submitTime", String.valueOf(this.submitTime));

--- a/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
@@ -219,7 +219,7 @@ public class ProjectManagerTest {
     final Schedule schedule =
             new Schedule(0, project.getId(), project.getName(), flowName, "schedule",
                     firstSchedTime.getMillis(), endSchedTime, timezone, null, DateTime.now().getMillis(),
-                    firstSchedTime.getMillis(), firstSchedTime.getMillis(), user.getUserId(), null, cronExpression);
+                    firstSchedTime.getMillis(), firstSchedTime.getMillis(), user.getUserId(), null, cronExpression, false);
     manager.postScheduleEvent(project, azkaban.spi.EventType.SCHEDULE_CREATED, user,
             schedule, null);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -580,7 +580,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     final Schedule schedule =
         this.scheduleManager.cronScheduleFlow(-1, projectId, projectName, flowName, "ready", firstSchedTime.getMillis(),
             endSchedTime, firstSchedTime.getZone(), DateTime.now().getMillis(), firstSchedTime.getMillis(),
-            firstSchedTime.getMillis(), user.getUserId(), flowOptions, cronExpression);
+            firstSchedTime.getMillis(), user.getUserId(), flowOptions, cronExpression, backExecutionOnceEnabled);
 
     logger.info("User '" + user.getUserId() + "' has scheduled " + "[" + projectName + flowName + " (" + projectId + ")"
         + "] with backExecuteOnceOnMiss " + (backExecutionOnceEnabled ? "enabled" : "disabled"));

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
@@ -71,13 +71,13 @@ public class ProjectManagerServletTest {
     final List<Schedule> schedules = new ArrayList<>();
     final long now = System.currentTimeMillis();
     final Schedule sched1 = new Schedule(1, 1, "myTestProject", "basic_flow_renamed", "ready", now,
-        now, null, null, now, now, now, "testUser1", null, null);
+        now, null, null, now, now, now, "testUser1", null, null, false);
     schedules.add(sched1);
     final Schedule sched2 = new Schedule(2, 1, "myTestProject", "basic_flow2", "ready", now + 20,
-        now + 20, null, null, now + 20, now + 20, now + 20, "testUser1", null, null);
+        now + 20, null, null, now + 20, now + 20, now + 20, "testUser1", null, null, false);
     schedules.add(sched2);
     final Schedule sched3 = new Schedule(3, 3, "anotherTestProject", "anotherFlow", "ready",
-        now + 30, now + 30, null, null, now + 30, now + 30, now + 30, "testUser3", null, null);
+        now + 30, now + 30, null, null, now + 30, now + 30, now + 30, "testUser3", null, null, false);
     schedules.add(sched3);
 
     when(this.scheduleManager.getSchedules()).thenReturn(new ArrayList<>(schedules));


### PR DESCRIPTION
Add a back execute flag in the missedScheduleManager as to execute the flow immediately if such flag is marked enabled. Once enabled, every miss detection will trigger an execution of flow, even if there are multiple missed schedule in a single detection. The detection reuses the same logic of previous PR #3209 of email notification.
This PR implements the backend logic of previous PR of #3218 . User can enable this feature by updating their schedule with "Back Execute Once When missed Schedule Detects." on azkaban UI.

