### PR TITLE
UpdateProperty endpoint: if not admin, directly return error message and no further operation

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1065,6 +1065,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       if (!HttpRequestUtils.hasPermission(this.userManager, user, Type.ADMIN)) {
         ret.put("error", String.format("User %s doesn't have ADMIN permission for updating "
             + "property", user));
+        return;
       }
       String propType = getParam(req, "propType");
       if (propType.equals("containerDispatch")) {


### PR DESCRIPTION
**What's the problem**
The old code leaves a security hole which allow anyone to hit the UpdateProperty endpoint.

**What's done**
directly return error message, no further operation

**Test done**
Tested in a test cluster, asked some non-admin person to hit the endpoint, and the request is blocked, the property is not changed from status page