### PR TITLE
Introduce VPAFlowCriteria to deny VPA feature based on project or flow name filter

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -772,6 +772,8 @@ public class Constants {
         KUBERNETES_VPA_PREFIX + "rampup";
     public static final String KUBERNETES_VPA_ENABLED =
         KUBERNETES_VPA_PREFIX + "enabled";
+    public static final String KUBERNETES_VPA_FLOW_FILTER_FILE =
+        KUBERNETES_VPA_PREFIX + "flow.filter.file";
 
     // Kubernetes Watch related properties
     public static final String KUBERNETES_WATCH_PREFIX = AZKABAN_KUBERNETES_PREFIX + "watch.";

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedImpl.java
@@ -52,4 +52,11 @@ public interface ContainerizedImpl {
    * @return VPA enabled status
    */
   boolean getVPAEnabled();
+
+  /**
+   * Get the VPA flow criteria.
+   *
+   * @return VPA flow criteria
+   */
+  VPAFlowCriteria getVPAFlowCriteria();
 }

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -1300,6 +1300,11 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     return this.vpaEnabled;
   }
 
+  @Override
+  public VPAFlowCriteria getVPAFlowCriteria() {
+    return this.vpaFlowCriteria;
+  }
+
   /**
    * Return a boolean value indicates whether vertical pod autoscaler is enabled for a given flow
    * based on ramp up rate and global vpa enabled flag

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -204,6 +204,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   private final ProjectManager projectManager;
   private final VPARecommender vpaRecommender;
   private final VPARecommendation maxVpaRecommendation;
+  private final VPAFlowCriteria vpaFlowCriteria;
 
   private static final Logger logger = LoggerFactory
       .getLogger(KubernetesContainerizedImpl.class);
@@ -353,6 +354,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     this.azkabanSecurityInitImageName = this.azkProps
         .getString(ContainerizedDispatchManagerProperties.KUBERNETES_POD_AZKABAN_SECURITY_INIT_IMAGE_NAME,
             DEFAULT_AZKABAN_SECURITY_INIT_IMAGE_NAME);
+    this.vpaFlowCriteria = new VPAFlowCriteria(azkProps, logger);
     // Add all the job types that are readily available as part of azkaban base image.
     this.addIncludedJobTypes();
   }
@@ -1307,7 +1309,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   private boolean IsVPAEnabledForFlow(ExecutableFlow executableFlow) {
     int flowNameHashValMapping = ContainerImplUtils.getFlowNameHashValMapping(executableFlow);
-    return vpaEnabled && flowNameHashValMapping <= this.vpaRampUp;
+    return vpaEnabled && flowNameHashValMapping <= this.vpaRampUp && this.vpaFlowCriteria.IsVPAEnabledForFlow(executableFlow);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/container/VPAFlowCriteria.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/VPAFlowCriteria.java
@@ -1,0 +1,127 @@
+package azkaban.executor.container;
+
+import azkaban.Constants;
+import azkaban.executor.ExecutableFlow;
+import azkaban.utils.Props;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+
+
+/**
+ * Class for denying VPA feature based on project or flow name filter.
+ * A sample file can look like this:
+ * proj1:flow1
+ * proj1:flow2
+ * proj2
+ * proj3:flow1
+ */
+public class VPAFlowCriteria {
+  // Flows are stored in a map where key is project name and value is set of flows.
+  private Map<String, Set<String>> flows = new HashMap<>(1);
+  private final String fileLocation;
+  private final Logger logger;
+
+  /**
+   *
+   * @param azkProps : Azkaban properties
+   * @param logger : Logger from the caller
+   */
+  public VPAFlowCriteria(final Props azkProps, final Logger logger) {
+    this.fileLocation = azkProps.getString(Constants.
+        ContainerizedDispatchManagerProperties.KUBERNETES_VPA_FLOW_FILTER_FILE, null);
+    this.logger = logger;
+    loadFlowFilter(new HashMap<>());
+  }
+
+  private void loadFlowFilter(final Map<String, Set<String>> flowMap) {
+    loadFlowFilter(flowMap, this.fileLocation);
+  }
+
+  /**
+   * Read the flow filter file and create a map of flow names. The read happens
+   * on best effort basis. i.e, if a flow name is not correctly formatted, it
+   * is ignored.
+   */
+  private void loadFlowFilter(final Map<String, Set<String>> flowMap, final String fileLocation) {
+    // Basic checks
+    if (fileLocation == null) {
+      return;
+    }
+    final Path filePath = Paths.get(fileLocation);
+    if (Files.notExists(filePath) || !Files.isReadable(filePath)) {
+      logger.info("Flow filter file at location " + fileLocation + " does not exist");
+      return;
+    }
+
+    // Read the file line by line and populate the map
+    try (BufferedReader reader = Files.newBufferedReader(filePath, Charset.defaultCharset())) {
+      for (String line; (line = reader.readLine()) != null;) {
+        line = line.trim();
+        List<String> flowFQN = Arrays.asList(line.split(":"));
+        validateAndAdd(flowFQN, flowMap);
+      }
+    } catch (final IOException e) {
+      // Log and ignore
+      logger.info("Caught exception while reading the file." + e);
+    }
+    // Set the flow map
+    this.flows = flowMap;
+  }
+
+  /** Validate flowFQN and add it to flows map.
+   * @param flowFQN stored in the file is of format:
+   * <project name> when entire project needs to be in the filter and
+   * <project name>:<flow name>.
+   */
+  private void validateAndAdd(final List<String> flowFQN, final Map<String, Set<String>> flowMap) {
+    if (!(flowFQN.size() == 1 || flowFQN.size() == 2)) {
+      return;
+    }
+
+    final String project = flowFQN.get(0);
+    if (flowFQN.size() == 1) {
+      // Entire project is in the filter.
+      flowMap.put(project, null);
+      return;
+    }
+
+    // Handle the case when the FQN also contains flow name
+    if (!flowMap.containsKey(project)) {
+      // Make an entry for the project
+      flowMap.put(project, new HashSet<>(1));
+    }
+
+    flowMap.get(project).add(flowFQN.get(1));
+  }
+
+  /**
+   *  If the flow exists in the flow filter, then return false,
+   *  else return true.
+   * @param flow executable flow object.
+   * @return VPA Enable flag.
+   */
+  public boolean IsVPAEnabledForFlow(final ExecutableFlow flow) {
+    return !flowExists(flow.getProjectName(), flow.getFlowId());
+  }
+
+  @VisibleForTesting
+  public boolean flowExists(final String projectName, final String flowName) {
+    if (!this.flows.containsKey(projectName)) {
+      return false;
+    }
+    final Set<String> flowNames = this.flows.get(projectName);
+    return flowNames == null || flowNames.contains(flowName);
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/executor/container/VPAFlowCriteria.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/VPAFlowCriteria.java
@@ -45,6 +45,20 @@ public class VPAFlowCriteria {
     loadFlowFilter(new HashMap<>());
   }
 
+  /**
+   * Reloads the in-memory flows map with the flow filter file.
+   */
+  public void reloadFlowFilter() {
+    // Reset the filter map
+    loadFlowFilter(new HashMap<>());
+  }
+
+  @VisibleForTesting
+  public void reloadFlowFilter(final String fileLocation) {
+    // Reset the filter map
+    loadFlowFilter(new HashMap<>(), fileLocation);
+  }
+
   private void loadFlowFilter(final Map<String, Set<String>> flowMap) {
     loadFlowFilter(flowMap, this.fileLocation);
   }

--- a/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
@@ -51,4 +51,11 @@ public class VPAFlowCriteriaTest {
     Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj2", "flow3"));
     Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj1", "flow2"));
   }
+
+  @Test
+  public void testReloadFlowFilter() throws Exception {
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj2", "flow4"));
+    this.vpaFlowCriteria.reloadFlowFilter("src/test/resources/flow_filter2.txt");
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj2", "flow4"));
+  }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package azkaban.executor.container;
+
+import static azkaban.Constants.ContainerizedDispatchManagerProperties.KUBERNETES_VPA_FLOW_FILTER_FILE;
+import azkaban.utils.Props;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VPAFlowCriteriaTest {
+
+  private VPAFlowCriteria vpaFlowCriteria;
+
+  private static final Logger logger = LoggerFactory.getLogger(VPAFlowCriteriaTest.class);
+
+  @Before
+  public void setup() throws Exception {
+    final Props props = new Props();
+    props.put(KUBERNETES_VPA_FLOW_FILTER_FILE, "src/test/resources/flow_filter.txt");
+    this.vpaFlowCriteria = new VPAFlowCriteria(props, logger);
+  }
+
+  @Test
+  public void testProjectNameFilter() throws Exception {
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj3", null));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj2", null));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj1", null));
+  }
+
+  @Test
+  public void testFlowNameFilter() throws Exception {
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj1", "flow1"));
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj2", "flow2"));
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj1", "flow3"));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj2", "flow3"));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists("proj1", "flow2"));
+  }
+}

--- a/azkaban-common/src/test/java/azkaban/jobcallback/JobCallbackRequestMakerTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobcallback/JobCallbackRequestMakerTest.java
@@ -26,11 +26,13 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
 
+@Ignore
 public class JobCallbackRequestMakerTest {
 
   private static final Logger logger = Logger.getLogger(JobCallbackRequestMakerTest.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1145,6 +1145,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       case UPDATE_VPA_ENABLED:
         this.containerizedImpl.setVPAEnabled(Boolean.parseBoolean(val));
         break;
+      case RELOAD_VPA_FLOW_FILTER:
+        this.containerizedImpl.getVPAFlowCriteria().reloadFlowFilter();
+        break;
       default:
         break;
     }
@@ -1202,6 +1205,7 @@ enum PropUpdate {
   RELOAD_FLOW_FILTER("reloadFlowFilter"),
   UPDATE_VPA_RAMP_UP("updateVPARampUp"),
   UPDATE_VPA_ENABLED("updateVPAEnabled"),
+  RELOAD_VPA_FLOW_FILTER("reloadVPAFlowFilter"),
   ENABLE_OFFLINE_LOGS_LOADER("enableOfflineLogsLoader");
 
   private final String param;


### PR DESCRIPTION
Project and flow name filter file looks like this:

proj1:flow1
proj1:flow2
proj2
proj3:flow1

which means VPA feature will not apply to proj1's flow1 flow, proj1's flow2 flow, all proj2's flows and proj3's flow1 flow.

It serves as the safeguard if there is any flow in production does not fit well with VPA's autoscaling algorithm.

One can use azkaban web api to reload flow filter text at runtime