### PR TITLE
Optimizing how proxy users are determinded prior to pod dispatch

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -738,6 +738,9 @@ public class Constants {
         KUBERNETES_FLOW_CONTAINER_PREFIX + "init.jobtypes.mount.path";
     public static final String PREFETCH_PROXY_USER_CERTIFICATES =
         AZKABAN_CONTAINERIZED_PREFIX + "prefetch.certificates";
+    // Format for the below string is (jobtype1, jobtype1_proxyuser ; jobtype2, jobtype2_proxyuser)
+    public static final String PREFETCH_JOBTYPE_PROXY_USER_MAP =
+        AZKABAN_CONTAINERIZED_PREFIX + "prefetch.jobtype.user.map";
     public static final String KUBERNETES_MOUNT_PATH_FOR_JOBTYPES =
         KUBERNETES_FLOW_CONTAINER_PREFIX + "jobtypes.mount.path";
     public static final String KUBERNETES_POD_TEMPLATE_PATH =

--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     testCompile deps.commonsCompress
 }
 
+test {
+    minHeapSize = "256m" // initial heap size
+    maxHeapSize = "2048m" // maximum heap size
+}
+
 tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }

--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
@@ -32,6 +32,7 @@ import io.kubernetes.client.openapi.models.V1VolumeBuilder;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.openapi.models.V1VolumeMountBuilder;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -95,6 +95,7 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
   // For Flows dispatched from a k8s pod
   private VersionSet versionSet;
+  private Set<String> proxyUsersFromFlowObj;
 
   public ExecutableFlow(final Project project, final Flow flow) {
     this.projectId = project.getId();
@@ -146,6 +147,12 @@ public class ExecutableFlow extends ExecutableFlowBase {
 
   public Set<String> getProxyUsers() {
     return new HashSet<>(this.proxyUsers);
+  }
+  public Set<String> getProxyUsersFromFlowObj(){
+    return this.proxyUsersFromFlowObj;
+  }
+  public void setProxyUsersFromFlowObj(Set<String> proxyUsersMap){
+    this.proxyUsersFromFlowObj = proxyUsersMap;
   }
 
   public ExecutionOptions getExecutionOptions() {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableNode.java
@@ -216,6 +216,9 @@ public class ExecutableNode {
   public String getJobSource() {
     return this.jobSource;
   }
+  public void setJobSource(String jobSource) {
+    this.jobSource = jobSource;
+  }
 
   public String getPropsSource() {
     return this.propsSource;


### PR DESCRIPTION
Security changes related to POLP commit https://github.com/azkaban/azkaban/pull/3216 and modified tests.

This commit has the following changes:

1. Determination of Proxy Users needed for the flow is optimized by taking it in the order of precedence ( Flow Param --> Job Override Property --> Node Property )

2. Add this HashMap of proxy users to the security init container.
3.  Added a test testPopulatingProxyUsersFromProject() to test this logic.
4. Added a list of jobtype specific users that might be needed getJobTypeUsersForFlow() and mentioned the format for the configuration.
5. Added a test for getJobTypeUsersForFlow to ensure we get the correct proxy users.


NOTE: Discarded PR https://github.com/azkaban/azkaban/pull/3236 and addressed comments from there.
