### PR TITLE
Support configuration of alerter plugins via Web UI.

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -328,6 +328,9 @@ public class Constants {
     public static final String CUSTOM_METRICS_REPORTER_CONFIG_PATH =
         "azkaban.metrics.reporter.config.path";
 
+    // Supported separators in value lists of Alerter plugin parameters.
+    public static final String ALERTER_PARAM_VALUE_DELIMITER = "\\s*,\\s*|\\s*;\\s*";
+
     public static final String MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES = "azkaban.metrics"
         + ".min_age_for_classifying_a_flow_aged_minutes";
 

--- a/azkaban-common/src/main/java/azkaban/alert/Alerter.java
+++ b/azkaban-common/src/main/java/azkaban/alert/Alerter.java
@@ -23,6 +23,8 @@ import azkaban.flow.Flow;
 import azkaban.project.Project;
 import azkaban.sla.SlaOption;
 import azkaban.utils.Emailer;
+import azkaban.utils.HTMLFormElement;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,5 +56,13 @@ public interface Alerter {
   @Deprecated
   default String getAzkabanURL() {
     return "";
-  };
+  }
+
+  /**
+   * Parameters users should set to enable alerts on SLA misses via Web UI. Currently used to
+   * render the SLA definition page.
+   */
+  default List<HTMLFormElement> getViewParameters() {
+    return Collections.emptyList();
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -19,6 +19,7 @@ import static azkaban.server.HttpRequestUtils.getMapParamGroup;
 import static azkaban.server.HttpRequestUtils.getParam;
 import static azkaban.server.HttpRequestUtils.getParamGroup;
 
+import azkaban.Constants;
 import azkaban.sla.SlaAction;
 import azkaban.sla.SlaOption;
 import azkaban.sla.SlaOption.SlaOptionBuilder;
@@ -50,8 +51,7 @@ public class SlaRequestUtils {
     final Map<String, String> settings = getParamGroup(req, settingsParamName);
     final Map<String, Map<String, String>> alertersParams =
         getMapParamGroup(req, PARAM_SLA_ALERTERS);
-    final String slaEmailsStr = getParam(req, PARAM_SLA_EMAILS,
-        null);
+    final String slaEmailsStr = getParam(req, PARAM_SLA_EMAILS, null);
 
     // Don't allow combining old & new in the same request:
     // This ensures that there's no need to handle possible conflicts between 'slaEmails' and
@@ -112,18 +112,11 @@ public class SlaRequestUtils {
     if (str == null || str.trim().isEmpty()) {
       return Collections.emptyList();
     }
-    String delimRegex = "\\s*,\\s*|\\s*;\\s*";
+    String delimRegex = Constants.ConfigurationKeys.ALERTER_PARAM_VALUE_DELIMITER;
     if (spacesAreDelims) {
       delimRegex = "\\s*,\\s*|\\s*;\\s*|\\s+";
     }
     return Arrays.asList(str.trim().split(delimRegex));
-  }
-
-  public static Set<String> getSetFromString(final String val) {
-    if (val == null || val.trim().length() == 0) {
-      return Collections.emptySet();
-    }
-    return new HashSet<>(Arrays.asList(val.split("\\s*,\\s*")));
   }
 
   private static SlaOption parseSlaSetting(final String set, final String flowName,
@@ -171,8 +164,6 @@ public class SlaRequestUtils {
     if (actions.isEmpty()) {
       throw new ServletException("Unable to create SLA as there is no action set");
     }
-    logger.info("Parsing sla as id:" + id + " type:" + type + " sla:"
-        + rule + " Duration:" + duration + " actions:" + actions);
     return new SlaOptionBuilder(type, flowName, dur).setJobName(id).setActions(actions)
         .setEmails(emails).setAlertersConfigs(alertersConfigs).createSlaOption();
   }

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -93,6 +93,18 @@ public class SlaRequestUtils {
     return slaOptions;
   }
 
+  /**
+   * Transforms a String Map that looks like
+   * {
+   *  "key1", "value1,value2,value3"
+   *  "key2", "value4,value5,value6"
+   * }
+   * into a Map like this:
+   * {
+   *  "key1", ["value1", "value2", "value3"]
+   *  "key2", ["value4", "value5", "value6"]
+   * }
+   */
   private static Map<String, Map<String, List<String>>> getStringListMapFromStringMap(
       final Map<String, Map<String, String>> alertersConfsFromReqParams) {
     final Map<String, Map<String, List<String>>> result = new HashMap<>();
@@ -122,7 +134,6 @@ public class SlaRequestUtils {
   private static SlaOption parseSlaSetting(final String set, final String flowName,
       final List<String> emails,
       final Map<String, Map<String, List<String>>> alertersConfigs) throws ServletException {
-    logger.info("Trying to parse sla with the following set: " + set);
 
     final String[] parts = set.split(",", -1);
     final String id = parts[0];

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -164,6 +164,8 @@ public class SlaRequestUtils {
     if (actions.isEmpty()) {
       throw new ServletException("Unable to create SLA as there is no action set");
     }
+    logger.info("Parsing sla as id:" + id + " type:" + type + " sla:"
+        + rule + " Duration:" + duration + " actions:" + actions);
     return new SlaOptionBuilder(type, flowName, dur).setJobName(id).setActions(actions)
         .setEmails(emails).setAlertersConfigs(alertersConfigs).createSlaOption();
   }

--- a/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/SlaRequestUtils.java
@@ -23,12 +23,16 @@ import azkaban.sla.SlaAction;
 import azkaban.sla.SlaOption;
 import azkaban.sla.SlaOption.SlaOptionBuilder;
 import azkaban.sla.SlaType;
+import azkaban.utils.Emailer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.log4j.Logger;
@@ -44,38 +48,42 @@ public class SlaRequestUtils {
   public static List<SlaOption> parseSlaOptions(final HttpServletRequest req, final String flowName,
       final String settingsParamName) throws ServletException {
     final Map<String, String> settings = getParamGroup(req, settingsParamName);
-    final Map<String, Map<String, String>> alertersConfigs = getMapParamGroup(req, PARAM_SLA_ALERTERS);
-    String slaEmailsStr = getParam(req, PARAM_SLA_EMAILS, null);
+    final Map<String, Map<String, String>> alertersParams =
+        getMapParamGroup(req, PARAM_SLA_ALERTERS);
+    final String slaEmailsStr = getParam(req, PARAM_SLA_EMAILS,
+        null);
 
     // Don't allow combining old & new in the same request:
     // This ensures that there's no need to handle possible conflicts between 'slaEmails' and
     // 'slaAlerters[email][recipients]'.
-    if (slaEmailsStr != null && !alertersConfigs.isEmpty()) {
+    if (slaEmailsStr != null && !alertersParams.isEmpty()) {
       throw new ServletException("The legacy slaEmails param is not allowed in combination with "
           + "the slaAlerters param group. Please, set 'slaAlerters[email][recipients]' instead of "
           + "'slaEmails'.");
     }
 
-    // TODO ypadron: migrate legacy email alert handling to the alerter plugins approach.
-    //  Treat email is a built-in alerter.
-    final Map<String, String> emailAlerterConfigs = alertersConfigs.remove("email");
-    if (emailAlerterConfigs != null) {
-      slaEmailsStr = emailAlerterConfigs.get("recipients");
+    if (slaEmailsStr != null) {
+      alertersParams.put(Emailer.ALERTER_NAME, Collections.singletonMap(
+          Emailer.RECIPIENTS_VIEW_PARAM, slaEmailsStr));
     }
-
-    final List<String> emailAlerterRecipients;
-    if (slaEmailsStr == null) {
-      emailAlerterRecipients = Arrays.asList();
-    } else {
-      final String[] emailSplit = slaEmailsStr.split("\\s*,\\s*|\\s*;\\s*|\\s+");
-      emailAlerterRecipients = Arrays.asList(emailSplit);
+    final Map<String, Map<String, List<String>>> alertersConfigs =
+        getStringListMapFromStringMap(alertersParams);
+    // TODO ypadron: migrate legacy email alert handling to the alerter plugins approach.
+    //  Treat email as a built-in alerter.
+    List<String> emailAlerterRecipients = Collections.emptyList();
+    final Map<String, List<String>> emailAlerterConfigs =
+        alertersConfigs.remove(Emailer.ALERTER_NAME);
+    if (emailAlerterConfigs != null) {
+      emailAlerterRecipients = emailAlerterConfigs.getOrDefault(Emailer.RECIPIENTS_VIEW_PARAM,
+          Collections.emptyList());
     }
 
     final List<SlaOption> slaOptions = new ArrayList<>();
     for (final String set : settings.keySet()) {
       final SlaOption slaOption;
       try {
-        slaOption = parseSlaSetting(settings.get(set), flowName, emailAlerterRecipients, alertersConfigs);
+        slaOption = parseSlaSetting(settings.get(set), flowName, emailAlerterRecipients,
+            alertersConfigs);
       } catch (final Exception e) {
         throw new ServletException(
             "Error parsing SLA setting '" + settings.get(set) + "': " + e.toString(), e);
@@ -85,8 +93,42 @@ public class SlaRequestUtils {
     return slaOptions;
   }
 
-  private static SlaOption parseSlaSetting(final String set, final String flowName, final List<String> emails,
-      final Map<String, Map<String, String>> alertersConfigs) throws ServletException {
+  private static Map<String, Map<String, List<String>>> getStringListMapFromStringMap(
+      final Map<String, Map<String, String>> alertersConfsFromReqParams) {
+    final Map<String, Map<String, List<String>>> result = new HashMap<>();
+    for (final String alerter : alertersConfsFromReqParams.keySet()) {
+      final Map<String, String> alerterConfigs = alertersConfsFromReqParams.get(alerter);
+      final Map<String, List<String>> processedConfigs = new HashMap<>();
+      for (final String propKey : alerterConfigs.keySet()) {
+        processedConfigs.put(propKey, getListFromString(alerterConfigs.get(propKey),
+            alerter.equals(Emailer.ALERTER_NAME)));
+      }
+      result.put(alerter, processedConfigs);
+    }
+    return result;
+  }
+
+  private static List<String> getListFromString(final String str, final boolean spacesAreDelims) {
+    if (str == null || str.trim().isEmpty()) {
+      return Collections.emptyList();
+    }
+    String delimRegex = "\\s*,\\s*|\\s*;\\s*";
+    if (spacesAreDelims) {
+      delimRegex = "\\s*,\\s*|\\s*;\\s*|\\s+";
+    }
+    return Arrays.asList(str.trim().split(delimRegex));
+  }
+
+  public static Set<String> getSetFromString(final String val) {
+    if (val == null || val.trim().length() == 0) {
+      return Collections.emptySet();
+    }
+    return new HashSet<>(Arrays.asList(val.split("\\s*,\\s*")));
+  }
+
+  private static SlaOption parseSlaSetting(final String set, final String flowName,
+      final List<String> emails,
+      final Map<String, Map<String, List<String>>> alertersConfigs) throws ServletException {
     logger.info("Trying to parse sla with the following set: " + set);
 
     final String[] parts = set.split(",", -1);

--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -57,7 +57,7 @@ public class SlaOption {
   final private Duration duration;
   final private Set<SlaAction> actions;
   final private ImmutableList<String> emails;
-  final private ImmutableMap<String, Map<String, String>> alertersConfigs;
+  final private ImmutableMap<String, Map<String, List<String>>> alertersConfigs;
 
   /**
    * Constructor.
@@ -71,7 +71,7 @@ public class SlaOption {
    */
   public SlaOption(final SlaType type,
       String flowName, String jobName, Duration duration, Set<SlaAction> actions,
-      List<String> emails, Map<String, Map<String, String>> alertersConfigs) {
+      List<String> emails, Map<String, Map<String, List<String>>> alertersConfigs) {
     Preconditions.checkNotNull(type, "type is null");
     Preconditions.checkNotNull(actions, "actions is null");
     Preconditions.checkState(actions.size() > 0, "An action must be specified for the SLA");
@@ -137,8 +137,9 @@ public class SlaOption {
     this.emails = ImmutableList.copyOf(
         (List<String>) slaOption.getInfo().get(SlaOptionDeprecated.INFO_EMAIL_LIST));
 
-    Map<String, Map<String, String>> alertersConfs = (Map<String, Map<String, String>>) slaOption
-        .getInfo().getOrDefault(SlaOptionDeprecated.INFO_ALERTERS_CONFIGS, ImmutableMap.of());
+    Map<String, Map<String, List<String>>> alertersConfs =
+        (Map<String, Map<String, List<String>>>) slaOption.getInfo()
+            .getOrDefault(SlaOptionDeprecated.INFO_ALERTERS_CONFIGS, ImmutableMap.of());
     this.alertersConfigs = ImmutableMap.copyOf(alertersConfs);
   }
 
@@ -201,7 +202,7 @@ public class SlaOption {
     return emails;
   }
 
-  public Map<String, Map<String, String>> getAlertersConfigs() {
+  public Map<String, Map<String, List<String>>> getAlertersConfigs() {
     return this.alertersConfigs;
   }
 
@@ -377,7 +378,7 @@ public class SlaOption {
     final private Duration duration;
     private Set<SlaAction> actions;
     private List<String> emails = null;
-    private Map<String, Map<String, String>> alertersConfigs = null;
+    private Map<String, Map<String, List<String>>> alertersConfigs = null;
 
     public SlaOptionBuilder(SlaType type, String flowName, Duration duration) {
       this.type = type;
@@ -411,7 +412,7 @@ public class SlaOption {
       return this;
     }
 
-    public SlaOptionBuilder setAlertersConfigs(Map<String, Map<String, String>> alertersConfigs) {
+    public SlaOptionBuilder setAlertersConfigs(Map<String, Map<String, List<String>>> alertersConfigs) {
       this.alertersConfigs = alertersConfigs;
       return this;
     }

--- a/azkaban-common/src/main/java/azkaban/utils/Emailer.java
+++ b/azkaban-common/src/main/java/azkaban/utils/Emailer.java
@@ -34,12 +34,15 @@ import azkaban.metrics.CommonMetrics;
 import azkaban.project.Project;
 import azkaban.sla.SlaOption;
 import azkaban.sla.SlaType;
+import azkaban.utils.HTMLFormElement.HTMLFormElementBuilder;
+import azkaban.utils.HTMLFormElement.HTMLFormElementType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,6 +58,9 @@ import org.joda.time.format.DateTimeFormatter;
 @Singleton
 public class Emailer extends AbstractMailer implements Alerter {
 
+  public static final String ALERTER_NAME = "email";
+  public static final String RECIPIENTS_VIEW_PARAM = "recipients";
+
   private static final DateTimeFormatter fmt = DateTimeFormat.forPattern("MM/dd, YYYY HH:mm");
   private static final String HTTPS = "https";
   private static final String HTTP = "http";
@@ -65,6 +71,7 @@ public class Emailer extends AbstractMailer implements Alerter {
   private final String clientPortNumber;
   private final String azkabanName;
   private final ExecutorLoader executorLoader;
+  private final List<HTMLFormElement> htmlParameters;
 
   @Inject
   public Emailer(final Props props, final CommonMetrics commonMetrics,
@@ -96,11 +103,19 @@ public class Emailer extends AbstractMailer implements Alerter {
           props.getInt(ConfigurationKeys.AZKABAN_WEBSERVER_EXTERNAL_PORT,
               props.getInt(ConfigurationKeys.JETTY_PORT, Constants.DEFAULT_PORT_NUMBER)));
     }
+
+    this.htmlParameters = Arrays.asList(new HTMLFormElementBuilder("Recipients",
+        RECIPIENTS_VIEW_PARAM, HTMLFormElementType.TEXTAREA).createHTMLFormElement());
   }
 
   @Override
   public String getAzkabanURL() {
     return this.scheme + "://" + this.clientHostname + ":" + this.clientPortNumber;
+  }
+
+  @Override
+  public List<HTMLFormElement> getViewParameters() {
+    return this.htmlParameters;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/utils/HTMLFormElement.java
+++ b/azkaban-common/src/main/java/azkaban/utils/HTMLFormElement.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.utils;
+
+/**
+ * Represents an HTML form element. It's used to generate HTML dynamically. For example, custom
+ * alerter plugins specify their UI parameters as a list of these objects. That list is then
+ * processed when rendering the SLA definition page to generate form elements.
+ */
+public class HTMLFormElement {
+
+  public enum HTMLFormElementType {
+    TEXTAREA,
+    INPUT_TEXT,
+    INPUT_CHECKBOX,
+    SELECT
+  }
+
+  private String label;
+  private final String name;
+  private final HTMLFormElementType type;
+  private final String defaultValue;
+
+  private HTMLFormElement(final String label, final String name, final HTMLFormElementType type,
+      final String defaultValue) {
+    this.label = label;
+    this.name = name;
+    this.type = type;
+    this.defaultValue = defaultValue;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getLabel() {
+    return this.label;
+  }
+
+  public String getDefaultValue() {
+    return this.defaultValue;
+  }
+
+  public HTMLFormElementType getType() {
+    return this.type;
+  }
+
+  public static class HTMLFormElementBuilder {
+
+    private String label;
+    private String name;
+    private HTMLFormElementType type;
+    private String defaultValue = null;
+
+    public HTMLFormElementBuilder(final String label, final String name,
+        final HTMLFormElementType type) {
+      this.label = label;
+      this.name = name;
+      this.type = type;
+    }
+
+    public HTMLFormElementBuilder setLabel(final String label) {
+      this.label = label;
+      return this;
+    }
+
+    public HTMLFormElementBuilder setName(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public HTMLFormElementBuilder setType(final HTMLFormElementType type) {
+      this.type = type;
+      return this;
+    }
+
+    public HTMLFormElementBuilder setDefaultValue(final String defaultValue) {
+      this.defaultValue = defaultValue;
+      return this;
+    }
+
+    public HTMLFormElement createHTMLFormElement() {
+      return new HTMLFormElement(this.label, this.name, this.type, this.defaultValue);
+    }
+  }
+}
+

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -219,7 +219,7 @@ public final class HttpRequestUtilsTest {
     final List<SlaOption> expected = Arrays.asList(new SlaOption(SlaType.FLOW_FINISH, "test-flow",
         "", Duration.ofMinutes(150), ImmutableSet.of(SlaAction.ALERT),
         ImmutableList.of("sla1@example.com", "sla2@example.com"), ImmutableMap.of(
-            "myAlerter", ImmutableMap.of("prop1", "value1")
+            "myAlerter", ImmutableMap.of("prop1", ImmutableList.of("value1"))
     )));
     Assert.assertEquals(expected, slaOptions);
   }

--- a/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
+++ b/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.sla.SlaOption.SlaOptionBuilder;
 import azkaban.utils.JSONUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -46,8 +47,8 @@ public class SlaOptionTest {
     final Set<SlaAction> actions = Collections.singleton(SlaAction.ALERT);
     final List<String> emails = Collections.singletonList("test@email.com");
     final Duration duration = Duration.ofHours(1);
-    final Map<String, Map<String, String>> alertersConfigs = ImmutableMap.of(
-        "myAlerter", ImmutableMap.of("prop1", "value1"));
+    final Map<String, Map<String, List<String>>> alertersConfigs = ImmutableMap.of(
+        "myAlerter", ImmutableMap.of("prop1", ImmutableList.of("value1")));
     // negative test: null flow
     assertThatThrownBy(() -> new SlaOption(SlaType.JOB_FINISH, null, job, duration,
         actions, emails, alertersConfigs)).isInstanceOf(NullPointerException.class);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -27,6 +27,7 @@ import azkaban.Constants.ConfigurationKeys;
 import azkaban.DispatchMethod;
 import azkaban.cluster.ClusterModule;
 import azkaban.database.AzkabanDatabaseSetup;
+import azkaban.executor.AlerterHolder;
 import azkaban.executor.ExecutionController;
 import azkaban.executor.ExecutionControllerUtils;
 import azkaban.executor.ExecutorManager;
@@ -175,6 +176,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
   private final FlowTriggerScheduler flowTriggerScheduler;
   private final FlowTriggerService flowTriggerService;
   private Map<String, TriggerPlugin> triggerPlugins;
+  private final AlerterHolder alerterPlugins;
   private final ExecutionLogsCleaner executionLogsCleaner;
   private final ObjectMapper objectMapper;
   private final ContainerizationMetrics containerizationMetrics;
@@ -185,13 +187,14 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
       final Server server,
       final ExecutorManagerAdapter executorManagerAdapter,
       final ProjectManager projectManager,
+      final ScheduleManager scheduleManager,
       final TriggerManager triggerManager,
       final MissedSchedulesManager missedSchedulesManager,
       final WebMetrics webMetrics,
       final SessionCache sessionCache,
       final UserManager userManager,
-      final ScheduleManager scheduleManager,
       final VelocityEngine velocityEngine,
+      final AlerterHolder alerterPlugins,
       final FlowTriggerScheduler flowTriggerScheduler,
       final FlowTriggerService flowTriggerService,
       final StatusService statusService,
@@ -205,13 +208,14 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     this.executorManagerAdapter = requireNonNull(executorManagerAdapter,
         "executorManagerAdapter is null.");
     this.projectManager = requireNonNull(projectManager, "projectManager is null.");
-    this.missedSchedulesManager = requireNonNull(missedSchedulesManager, "missScheduleManager is null");
+    this.scheduleManager = requireNonNull(scheduleManager, "scheduleManager is null.");
     this.triggerManager = requireNonNull(triggerManager, "triggerManager is null.");
+    this.missedSchedulesManager = requireNonNull(missedSchedulesManager, "missScheduleManager is null");
     this.webMetrics = requireNonNull(webMetrics, "webMetrics is null.");
     this.sessionCache = requireNonNull(sessionCache, "sessionCache is null.");
     this.userManager = requireNonNull(userManager, "userManager is null.");
-    this.scheduleManager = requireNonNull(scheduleManager, "scheduleManager is null.");
     this.velocityEngine = requireNonNull(velocityEngine, "velocityEngine is null.");
+    this.alerterPlugins = alerterPlugins;
     this.statusService = statusService;
     this.flowTriggerScheduler = requireNonNull(flowTriggerScheduler, "scheduler is null.");
     this.flowTriggerService = requireNonNull(flowTriggerService, "flow trigger service is null");
@@ -726,6 +730,10 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
 
   private void setTriggerPlugins(final Map<String, TriggerPlugin> triggerPlugins) {
     this.triggerPlugins = triggerPlugins;
+  }
+
+  public AlerterHolder getAlerterPlugins() {
+    return this.alerterPlugins;
   }
 
   @Override

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/AbstractAzkabanServlet.java
@@ -19,6 +19,7 @@ import azkaban.Constants.ConfigurationKeys;
 import azkaban.server.AzkabanAPI;
 import azkaban.server.HttpRequestUtils;
 import azkaban.server.session.Session;
+import azkaban.utils.HTMLFormElement.HTMLFormElementType;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
 import azkaban.utils.TimeUtils;
@@ -294,6 +295,7 @@ public abstract class AbstractAzkabanServlet extends HttpServlet {
     page.add("System", System.class);
     page.add("TimeUtils", TimeUtils.class);
     page.add("WebUtils", WebUtils.class);
+    page.add("HTMLFormElementType_TEXTAREA", HTMLFormElementType.TEXTAREA);
 
     if (session != null && session.getUser() != null) {
       page.add("user_id", session.getUser().getUserId());

--- a/azkaban-web-server/src/main/less/flow.less
+++ b/azkaban-web-server/src/main/less/flow.less
@@ -446,3 +446,19 @@ li.tree-list-item {
   position: absolute;
   top: -3px;
 }
+
+.sla-alerters {
+  border-top: 1px solid #ece9e9;
+  border-image: linear-gradient(to right, #ece9e9 10%, transparent 30%) 100% 1;
+  padding: 0 0.8em 0.8em 0.8em;
+  margin: 0 0 1.5em 0;
+
+  legend {
+    text-align: left;
+    width: auto;
+    padding: 0 10px;
+    border: none;
+    font-size: 8pt;
+    margin-bottom: 10px;
+  }
+}

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/flowpage.vm
@@ -34,7 +34,7 @@
 
   <script type="text/javascript" src="${context}/js/azkaban/view/time-graph.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1588045179"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1677633459"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-stats.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow-execute-dialog.js?v=1624913123"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/flow.js?v=1620232349"></script>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/scheduledflowpage.vm
@@ -26,7 +26,7 @@
   <script type="text/javascript" src="${context}/js/moment.min.js"></script>
   <script type="text/javascript" src="${context}/js/bootstrap-datetimepicker.min.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/table-sort.js"></script>
-  <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1588045179"></script>
+  <script type="text/javascript" src="${context}/js/azkaban/view/schedule-sla.js?v=1677633459"></script>
   <script type="text/javascript" src="${context}/js/azkaban/view/scheduled.js"></script>
   <script type="text/javascript" src="${context}/js/azkaban/util/schedule.js"></script>
   <script type="text/javascript" src="${context}/js/jquery/jquery.tablesorter.js"></script>
@@ -152,7 +152,7 @@
                   </button>
                 </td>
                 <td>
-                  <button type="button" id="addSlaBtn" class="btn btn-sm btn-primary"
+                  <button type="button" class="btn btn-sm btn-primary addSlaBtn"
                           onclick="slaView.initFromSched(${sched.scheduleId}, '${sched.flowName}')">
                     Set SLA
                   </button>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/slapanel.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/slapanel.vm
@@ -19,24 +19,32 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">SLA Options</h4>
+        <h4 class="modal-title">SLA Definition</h4>
       </div>
       <div class="modal-body">
-        <h4>SLA Alert Emails</h4>
-        <fieldset>
-          <div class="form-group">
-            <label>SLA Alert Emails</label>
-            <textarea id="slaEmails" class="form-control"></textarea>
-          </div>
-        </fieldset>
-        <h4>Flow SLA Rules</h4>
+        <h4>SLA Alert Settings</h4>
+        #foreach ($alerter in $alerterPlugins.keySet())
+          #foreach ($elem in $alerterPlugins.get($alerter))
+            <fieldset class="sla-alerters">
+              <legend>${alerter} alerts</legend>
+              <div class="form-group">
+                #if($HTMLFormElementType_TEXTAREA == $elem.type)
+                  <label>$elem.label</label>
+                  <textarea name="slaAlerters[$alerter][$elem.name]"
+                          class="form-control">${elem.defaultValue|''}</textarea>
+                #end
+              </div>
+            </fieldset>
+          #end
+        #end
+        <h4>SLA Rules</h4>
         <table class="table table-striped" id="flowRulesTbl">
           <thead>
           <tr>
-            <th>Flow/Job</th>
-            <th>Sla Rule</th>
+            <th>Node</th>
+            <th>Status</th>
             <th>Duration(In HH:MM eg. kill in 10 minutes is 00:10)</th>
-            <th>Email Action</th>
+            <th>Alert Action</th>
             <th>Kill Action</th>
           </tr>
           </thead>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/style.vm
@@ -20,7 +20,7 @@
 <link rel="shortcut icon" href="${context}/favicon.ico"/>
 <!-- Bootstrap core CSS -->
 <link href="/css/bootstrap.css" rel="stylesheet">
-<link href="/css/azkaban.css?v=1621010355" rel="stylesheet">
+<link href="/css/azkaban.css?v=1676488120" rel="stylesheet">
 <style type="text/css">
   .navbar-enviro .navbar-enviro-name {
     color: ${azkaban_color};


### PR DESCRIPTION
This is a follow up on https://github.com/azkaban/azkaban/pull/3232. It:
-adds custom alerter configurations to the responses of `slaInfo` API.
-allows custom alerters to be configured via UI for SLA miss events. Flow execution failure alerts are configured via properties so no UI changes are required to support those. 

Assuming there is custom alerter plugin named `myCustom` which can be enabled by configuring a parameter called `myCustomAlerterParam` here is how the SLA definition page will be rendered.

 
<img width="1371" alt="Screenshot 2023-02-28 at 10 36 33 PM" src="https://user-images.githubusercontent.com/44478711/222230488-d6fd3270-9140-41c7-a309-07cac9c61577.png">

Tested the changes in a local Azkaban instance. Verified that SLA miss alerts are set through UI successfully and that the feature doesn't break existing SLAs. In addition, I verified that the custom alerters configs are added correctly to the `slaInfo` responses. Here is an example response:

```
{
    "settings": [
        {
            "duration": "1m",
            "rule": "SUCCEED",
            "id": "",
            "actions": [
                "EMAIL",
                "KILL"
            ]
        }
    ],
    "slaEmails": [
        "ypadron@ypadron.com"
    ],
    "slaAlerters": {
        "myCustom": {
            "myCustomAlerterParam": [
                "Some value"
            ]
        },
        "email": {
            "recipients": [
                "ypadron@ypadron.com"
            ]
        }
    },
    "allJobNames": [
        "myFlow",
        "job1"
    ]
}
```
