### PR TITLE
Job level SLAs checks should only be set for/on the job the SLA rule matches.

### DIFF
--- a/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
+++ b/azkaban-common/src/main/java/azkaban/sla/SlaOption.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * SLA option, which can be associated with a flow or job.
@@ -62,12 +63,12 @@ public class SlaOption {
   /**
    * Constructor.
    *
-   * @param type the SLA type.
+   * @param type     the SLA type.
    * @param flowName The name of the flow.
-   * @param jobName The name of the job, if the SLA is for a job.
+   * @param jobName  The name of the job, if the SLA is for a job.
    * @param duration The duration (time to wait before the SLA would take effect).
-   * @param actions actions to take for the SLA.
-   * @param emails list of emails to send an alert to, for the SLA.
+   * @param actions  actions to take for the SLA.
+   * @param emails   list of emails to send an alert to, for the SLA.
    */
   public SlaOption(final SlaType type,
       String flowName, String jobName, Duration duration, Set<SlaAction> actions,
@@ -147,7 +148,9 @@ public class SlaOption {
     if (slaOptions != null) {
       final List<Object> slaOptionsObject = new ArrayList<>();
       for (final SlaOption sla : slaOptions) {
-        if (sla == null) continue;
+        if (sla == null) {
+          continue;
+        }
         slaOptionsObject.add(sla.toObject());
       }
       return slaOptionsObject;
@@ -212,7 +215,7 @@ public class SlaOption {
    * @param componentType component Type
    * @return true/false
    */
-  public boolean isComponentType (SlaType.ComponentType componentType) {
+  public boolean isComponentType(final SlaType.ComponentType componentType) {
     return this.type.getComponent() == componentType;
   }
 
@@ -312,23 +315,24 @@ public class SlaOption {
    * @param options a list of SLA options.
    * @return the job level SLA options.
    */
-  public static List<SlaOption> getJobLevelSLAOptions(List<SlaOption> options) {
-    return filterSLAOptionsByComponentType(options, ComponentType.JOB);
+  public static List<SlaOption> getJobLevelSLAOptions(final List<SlaOption> options,
+      final String jobId) {
+    return filterSLAOptions(options, ComponentType.JOB, jobId);
   }
 
   /**
    * @param options a list of SLA options.
    * @return the flow level SLA options.
    */
-  public static List<SlaOption> getFlowLevelSLAOptions(List<SlaOption> options) {
-    return filterSLAOptionsByComponentType(options, ComponentType.FLOW);
+  public static List<SlaOption> getFlowLevelSLAOptions(final List<SlaOption> options) {
+    return filterSLAOptions(options, ComponentType.FLOW, null);
   }
 
-  private static List<SlaOption> filterSLAOptionsByComponentType(
-      List<SlaOption> options, ComponentType componentType) {
-    return options.stream()
-        .filter(option -> option.isComponentType(componentType))
-        .collect(Collectors.toList());
+  private static List<SlaOption> filterSLAOptions(final List<SlaOption> options,
+      final ComponentType componentType, final String jobId) {
+    return options.stream().filter(
+        option -> option.isComponentType(componentType) && StringUtils.equals(option.getJobName(),
+            jobId)).collect(Collectors.toList());
   }
 
   @Override
@@ -376,7 +380,7 @@ public class SlaOption {
     final private String flowName;
     private String jobName = null;
     final private Duration duration;
-    private Set<SlaAction> actions;
+    private final Set<SlaAction> actions;
     private List<String> emails = null;
     private Map<String, Map<String, List<String>>> alertersConfigs = null;
 

--- a/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
+++ b/azkaban-common/src/test/java/azkaban/sla/SlaOptionTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import azkaban.sla.SlaOption.SlaOptionBuilder;
-import azkaban.utils.JSONUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -33,11 +32,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.assertj.core.util.Maps;
 import org.junit.Test;
 
-/** Test SlaOption */
+/**
+ * Test SlaOption
+ */
 public class SlaOptionTest {
 
   @Test
@@ -82,30 +81,34 @@ public class SlaOptionTest {
   }
 
   @Test
-  public void testSlaActionFiltering() {
-    List<SlaOption> slaOptions = new ArrayList<>();
+  public void testSlaOptionFiltering() {
+    final List<SlaOption> slaOptions = new ArrayList<>();
     slaOptions.add(new SlaOptionBuilder(SlaType.FLOW_FINISH, "flow1", Duration.ofHours(1))
         .setActions(Collections.singleton(SlaAction.KILL)).createSlaOption());
     slaOptions.add(new SlaOptionBuilder(SlaType.FLOW_SUCCEED, "flow2", Duration.ofHours(1))
-        .setActions(Collections.singleton(SlaAction.ALERT)).setEmails(Collections.singletonList
-            ("test@email.com")).createSlaOption());
+        .setActions(Collections.singleton(SlaAction.ALERT))
+        .setEmails(Collections.singletonList("test@email.com")).createSlaOption());
     slaOptions.add(new SlaOptionBuilder(SlaType.JOB_FINISH, "flow3", Duration.ofHours(1))
-        .setActions(Collections.singleton(SlaAction.KILL)).setJobName("job").createSlaOption());
-    slaOptions.add(new SlaOptionBuilder(SlaType.JOB_SUCCEED, "flow4", Duration.ofHours(1))
-        .setActions(Collections.singleton(SlaAction.KILL)).setJobName("job").createSlaOption());
+        .setActions(Collections.singleton(SlaAction.KILL)).setJobName("job1").createSlaOption());
+    slaOptions.add(new SlaOptionBuilder(SlaType.JOB_SUCCEED, "flow3", Duration.ofHours(1))
+        .setActions(Collections.singleton(SlaAction.KILL)).setJobName("job1").createSlaOption());
+    slaOptions.add(new SlaOptionBuilder(SlaType.JOB_SUCCEED, "flow3", Duration.ofHours(1))
+        .setActions(Collections.singleton(SlaAction.KILL)).setJobName("job2").createSlaOption());
 
-    List<SlaOption> flowOptions = SlaOption.getFlowLevelSLAOptions(slaOptions);
+    final List<SlaOption> flowOptions = SlaOption.getFlowLevelSLAOptions(slaOptions);
     assertThat(flowOptions.size()).isEqualTo(2);
-    Set<String> flowNames = flowOptions.stream().map(x -> x.getFlowName()).collect(Collectors.toSet
-        ());
+    final Set<String> flowNames =
+        flowOptions.stream().map(x -> x.getFlowName()).collect(Collectors.toSet());
     assertThat(flowNames.containsAll(Sets.newHashSet("flow1", "flow2"))).isTrue();
 
-    List<SlaOption> jobOptions = SlaOption.getJobLevelSLAOptions(slaOptions);
-    assertThat(flowOptions.size()).isEqualTo(2);
-    Set<String> jobFlowNames = jobOptions.stream().map(x -> x.getFlowName()).collect(Collectors
-        .toSet
-        ());
-    assertThat(jobFlowNames.containsAll(Sets.newHashSet("flow3", "flow4"))).isTrue();
+    final List<SlaOption> jobOptions1 = SlaOption.getJobLevelSLAOptions(slaOptions, "job1");
+    assertThat(jobOptions1.size()).isEqualTo(2);
+    final Set<String> jobNames =
+        jobOptions1.stream().map(x -> x.getJobName()).collect(Collectors.toSet());
+    assertThat(jobNames.containsAll(Collections.singletonList("job1"))).isTrue();
+
+    final List<SlaOption> jobOptions2 = SlaOption.getJobLevelSLAOptions(slaOptions, "inventedJob");
+    assertThat(jobOptions2.size()).isEqualTo(0);
   }
 
   @Test
@@ -118,11 +121,11 @@ public class SlaOptionTest {
         .setJobName("job").setActions(Collections.singleton(SlaAction.KILL))
         .setEmails(Collections.singletonList("test@email.com")).createSlaOption();
 
-    Map<String, Object> webObject = (Map<String, Object>)slaOption.toWebObject();
-    assertThat((String)webObject.get(SlaOption.WEB_DURATION)).isEqualTo(expectedDuration);
-    assertThat((String)webObject.get(SlaOption.WEB_STATUS)).isEqualTo(expectedStatus);
-    assertThat((String)webObject.get(SlaOption.WEB_ID)).isEqualTo(expectedId);
-    assertThat((List<String>)webObject.get(SlaOption.WEB_ACTIONS)).isEqualTo(expectedAction);
+    Map<String, Object> webObject = (Map<String, Object>) slaOption.toWebObject();
+    assertThat((String) webObject.get(SlaOption.WEB_DURATION)).isEqualTo(expectedDuration);
+    assertThat((String) webObject.get(SlaOption.WEB_STATUS)).isEqualTo(expectedStatus);
+    assertThat((String) webObject.get(SlaOption.WEB_ID)).isEqualTo(expectedId);
+    assertThat((List<String>) webObject.get(SlaOption.WEB_ACTIONS)).isEqualTo(expectedAction);
   }
 
   @Test
@@ -152,7 +155,9 @@ public class SlaOptionTest {
     compare(slaOption, slaOption2);
   }
 
-  /** Compare if two {@link SlaOption} are the same */
+  /**
+   * Compare if two {@link SlaOption} are the same
+   */
   private void compare(SlaOption option1, SlaOption option2) {
     assertThat(option1.getType()).isEqualTo(option2.getType());
     assertThat(option1.getDuration()).isEqualTo(option2.getDuration());

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1993,18 +1993,17 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
             }
           }
         }
+        // add job level SLA checker
+        final TriggerManager triggerManager = ServiceProvider.SERVICE_PROVIDER
+            .getInstance(TriggerManager.class);
+        triggerManager.addTrigger(FlowRunner.this.flow.getExecutionId(),
+            SlaOption.getJobLevelSLAOptions(
+                FlowRunner.this.flow.getExecutionOptions().getSlaOptions(), eventData.getNestedId()));
 
         if (FlowRunner.this.azkabanEventReporter != null) {
           final JobRunner jobRunner = (JobRunner) event.getRunner();
           FlowRunner.this.azkabanEventReporter.report(event.getType(), getJobMetadata(jobRunner));
         }
-        // add job level checker
-        final TriggerManager triggerManager = ServiceProvider.SERVICE_PROVIDER
-            .getInstance(TriggerManager.class);
-        triggerManager
-            .addTrigger(FlowRunner.this.flow.getExecutionId(),
-                SlaOption.getJobLevelSLAOptions(
-                    FlowRunner.this.flow.getExecutionOptions().getSlaOptions()));
       }
     }
 


### PR DESCRIPTION
Before all existing job level SLAs were set up for each job node in the DAG. In the logs we would see entries like this:
```
2023/03/01 22:38:01.172 -0800  INFO [TriggerManager] [JobRunner-jobZ-14213] [Azkaban] Adding sla trigger SlaOption{type=JOB_SUCCEED, flowName='myFlow', jobName='jobE', duration=PT1M, actions=[ALERT], emails=[abc@abc.com], alertersConfigs={}} to execution 14213, scheduled to trigger in 60 seconds

2023/03/01 22:41:51.873 -0800  INFO [TriggerManager] [JobRunner-jobE-14213] [Azkaban] Adding sla trigger SlaOption{type=JOB_SUCCEED, flowName='myFlow', jobName='jobE', duration=PT1M, actions=[ALERT], emails=[abc@abc.com], alertersConfigs={}} to execution 14213, scheduled to trigger in 60 seconds
```
Note that there is a job SLA rule defined for job `jobE` which is set up in `jobZ` even though that is not the target job.
 
Now job level SLAs checks are scheduled only for the job the SLA rule targets.