### PR TITLE
Sync Schedule with Trigger when web sever is up

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleLoader.java
@@ -31,4 +31,5 @@ public interface ScheduleLoader {
 
   public List<Schedule> loadUpdatedSchedules() throws ScheduleManagerException;
   public Optional<Schedule> loadUpdateSchedule(Schedule s) throws ScheduleManagerException;
+  public List<Schedule> loadAllSchedules() throws ScheduleManagerException;
 }

--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -33,12 +33,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class TriggerBasedScheduleLoader implements ScheduleLoader {
 
-  private static final Logger logger = Logger
-      .getLogger(TriggerBasedScheduleLoader.class);
+  private static final Logger logger = LoggerFactory.getLogger(TriggerBasedScheduleLoader.class);
 
   private final TriggerManagerAdapter triggerManager;
 
@@ -221,8 +222,8 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
           Math.max(scheduleIdToLastCheckTime.getOrDefault(t.getTriggerId(), -1l), t.getLastModifyTime()));
       final Schedule s = triggerToSchedule(t);
       schedules.add(s);
-      logger.info("loaded schedule for "
-          + s.getProjectName() + " (project_ID: " + s.getProjectId() + ")");
+      logger.debug("loaded schedule for {} (project_id: {}, flow_id: {})",
+          s.getScheduleId(), s.getProjectId(), s.getFlowName());
     }
     return schedules;
   }
@@ -237,4 +238,19 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
     return Optional.empty();
   }
 
+  /**
+   * Loading all triggers from triggerManager and converted into Schedule.
+   * */
+  @Override
+  public List<Schedule> loadAllSchedules() throws ScheduleManagerException {
+    final List<Trigger> triggers = this.triggerManager.getTriggers();
+    final List<Schedule> schedules = new ArrayList<>();
+    for (final Trigger t : triggers) {
+      final Schedule s = triggerToSchedule(t);
+      schedules.add(s);
+      logger.debug("loaded schedule for {} (project_id: {}, flow_id: {})",
+          s.getScheduleId(), s.getProjectId(), s.getFlowName());
+    }
+    return schedules;
+  }
 }

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -171,6 +171,7 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
     }
   }
 
+  @Override
   public List<Trigger> getTriggers() {
     return new ArrayList<>(triggerIdMap.values());
   }

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManagerAdapter.java
@@ -38,6 +38,8 @@ public interface TriggerManagerAdapter {
 
   public List<Trigger> getTriggers(String trigegerSource);
 
+  public List<Trigger> getTriggers();
+
   public void start() throws TriggerManagerException;
 
   public void shutdown();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -478,6 +478,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
     // always have basic time trigger
     // TODO: find something else to do the job
     getTriggerManager().start();
+    getScheduleManager().start();
 
     // Set up api endpoint metrics
     // At the moment login action doesn't have a dedicated route, any route can be used to


### PR DESCRIPTION
Years ago, we separate schedule and trigger in favor to unify the use of trigger in the backend but aborted in the middle. It creates the sync issues between both. We have "TriggerBasedScheduleLoader" as the intermediate bridge to coordinate while trigger updates and ensure "schedule" updated to serve API request well and correctly. This PR is to fix the missing sync on web server just restart and loading all the triggers into schedule format so schedule API can serve request immediately on restart, no need to wait for refresh to update them.