### PR TITLE
Added a env variable security init container to verify source of uplo…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
@@ -163,14 +163,18 @@ public class AzKubernetesV1SpecBuilder {
     }
     public AzKubernetesV1SpecBuilder addSecurityInitContainer(String image,
         ImagePullPolicy imagePullPolicy,
-        final InitContainerType initContainerType, Set<String> proxyUserList ) {
+        final InitContainerType initContainerType, Set<String> proxyUserList, String projectUploadUser ) {
         V1EnvVar proxyUserEnv = new V1EnvVarBuilder()
             .withName(initContainerType.mountPathKey)
             .withValue(String.join(",", proxyUserList))
             .build();
+        V1EnvVar projectUploadUserEnv = new V1EnvVarBuilder()
+            .withName("PROJECT_UPLOAD_USER")
+            .withValue(projectUploadUser)
+            .build();
         V1Container initContainer = new V1ContainerBuilder()
             .withName(initContainerType.initPrefix)
-            .addToEnv(proxyUserEnv)
+            .addToEnv(proxyUserEnv, projectUploadUserEnv)
             .withImagePullPolicy(imagePullPolicy.getPolicyVal())
             .withImage(image)
             .build();

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -1446,10 +1446,11 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     }
     if (this.prefetchAllCredentials) {
       try {
+        final String projectUploadUser = flow.getUploadUser();
         final String imageFullPath =
             versionSet.getVersion(this.azkabanSecurityInitImageName).get().pathWithVersion();
         v1SpecBuilder.addSecurityInitContainer(imageFullPath, ImagePullPolicy.IF_NOT_PRESENT,
-            InitContainerType.SECURITY, proxyUserList);
+            InitContainerType.SECURITY, proxyUserList, projectUploadUser);
       } catch (final Exception e) {
         throw new ExecutorManagerException("Did not find security image. Failed Proxy User Init "
             + "container");


### PR DESCRIPTION
…ad user

Objective here is to be able to see who the upload user was, for the project / code in order to allow /deny access to certain resources based on their credibility. This can be done by custom logic in the security init container if present. 

Tested on cluster to verify the environment variable is assigned to init container.