### PR TITLE
fix the bug that returned the outdated schedule metadata for getSchedule call

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -270,12 +270,13 @@ public class ScheduleManager implements TriggerAgent {
     try {
       Optional<Schedule> updatedSchedule = loader.loadUpdateSchedule(s);
       if (updatedSchedule.isPresent()) {
-        if (s.getStatus().equals(TriggerStatus.EXPIRED.toString())) {
-          onScheduleExpire(s);
+        Schedule schedule = updatedSchedule.get();
+        if (schedule.getStatus().equals(TriggerStatus.EXPIRED.toString())) {
+          onScheduleExpire(schedule);
         } else {
-          internalSchedule(s);
+          internalSchedule(schedule);
         }
-        return updatedSchedule.get();
+        return schedule;
       }
       return s;
     } finally {

--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -26,6 +26,7 @@ import azkaban.trigger.TriggerManagerAdapter;
 import azkaban.trigger.TriggerManagerException;
 import azkaban.trigger.builtin.BasicTimeChecker;
 import azkaban.trigger.builtin.ExecuteFlowAction;
+import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
@@ -231,7 +232,12 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
   public Optional<Schedule> loadUpdateSchedule(Schedule s) throws ScheduleManagerException {
     long lastCheckTime = scheduleIdToLastCheckTime.getOrDefault(s.getScheduleId(), -1l);
     Optional<Trigger> trigger = this.triggerManager.getUpdatedTriggerById(s.getScheduleId(), lastCheckTime);
+    logger.debug("fetch trigger " + s.getScheduleId() + "with map's lastCheckTime" + new Date(lastCheckTime));
     if (trigger.isPresent()) {
+      Trigger triggerIst = trigger.get();
+      logger.debug("fetched updated trigger " + triggerIst.getTriggerId() +
+          "with lastModify in trigger: " + new Date(triggerIst.getLastModifyTime()) +
+          "and trigger's nextExecuteTime: " + new Date(triggerIst.getNextCheckTime()));
       scheduleIdToLastCheckTime.put(s.getScheduleId(), trigger.get().getLastModifyTime());
       return Optional.of(triggerToSchedule(trigger.get()));
     }

--- a/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerImpl.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/JdbcTriggerImpl.java
@@ -132,8 +132,9 @@ public class JdbcTriggerImpl implements TriggerLoader {
 
   @Override
   public void updateTrigger(final Trigger t) throws TriggerLoaderException {
-    logger.info("Updating trigger " + t.getTriggerId() + " into db.");
     t.setLastModifyTime(System.currentTimeMillis());
+    logger.info("Updating trigger " + t.getTriggerId() + " into db"
+        + " with nextCheckTime " + t.getNextCheckTime() + "and lastModifiedTime " + t.getLastModifyTime());
     updateTrigger(t, this.defaultEncodingType);
   }
 


### PR DESCRIPTION
For the legacy reason schedule and trigger are self-maintained and schedule itself maintains a cache to get trigger data more quickly especially when no update on trigger. 
The better and cleaner fix is to remove the schedule layer but link API to trigger directly, in this way we don't have to maintain the status of schedule. However to quickly mitigate this issue, in this PR:
- fix the bug that store new schedule in cache;
- enable more debug level log to help increase debug efficiency.

local build passed.