### PR TITLE
Add customizable flow-level restart parameters & validation with Azkaban permitted restartable status config

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -559,6 +559,15 @@ public class Constants {
     // Job callback
     public static final String AZKABAN_EXECUTOR_JOBCALLBACK_ENABLED =
         "azkaban.executor.jobcallback.enabled";
+
+    // Executions are permitted to restart on this set of terminated statuses,
+    // normally includes EXECUTION_STOPPED and FAILED
+    public static final String AZKABAN_EXECUTION_RESTARTABLE_STATUS =
+        "azkaban.execution.restartable.status";
+
+    // Executions are permitted to restart this many of times, e.g. "...=3"
+    public static final String AZKABAN_EXECUTION_RESTART_LIMIT =
+        "azkaban.execution.restart.limit";
   }
 
   public static class FlowProperties {
@@ -874,5 +883,15 @@ public class Constants {
     public static final String FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED =
         "allow.restart.on.execution.stopped";
     public static final String PROXY_USER_PREFETCH_ALL = "proxy.user.prefetch.all";
+
+    // Constant to define allow restart on a set of terminated status, extends to more statuses
+    // e.g. "allow.restart.on.status=EXECUTION_STOPPED,FAILED"
+    public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "allow.execution.restart.on.status";
+
+    // Constant to define how many times can restart the flow to a new execution
+    public static final String FLOW_PARAM_RESTART_COUNT = "execution.restart.count";
+
+    // Constant to define the strategy to restart the execution, default to "restart_from_root",
+    public static final String FLOW_PARAM_RESTART_STRATEGY = "execution.restart.strategy";
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -1,0 +1,104 @@
+package azkaban.executor;
+
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTARTABLE_STATUS;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_COUNT;
+
+import azkaban.utils.Props;
+import com.google.common.collect.ImmutableMap;
+import javax.servlet.ServletException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutionOptionsTest {
+
+  public static Props testAzProps;
+
+  @Before
+  public void before(){
+    testAzProps = new Props();
+    testAzProps.put(AZKABAN_EXECUTION_RESTARTABLE_STATUS, "EXECUTION_STOPPED");
+    testAzProps.put(AZKABAN_EXECUTION_RESTART_LIMIT, 2);
+  }
+
+  @Test
+  public void testValidateFlowParamWithoutAnyFlowParameter() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithGood_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithDefaultAllowListAndGood_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+    ));
+
+    // if not defined, has default value to [EXECUTION_STOPPED, FAILED]
+    options.validate(new Props());
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithInvalid_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    // KILLED is not defined
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "KILLED"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithGood_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "1"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithNegative_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "-11"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithExceed_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "100000"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithAllValidSettings() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FLOW_PARAM_RESTART_COUNT, "2"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -90,6 +90,8 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
   private static final String API_RAMP = "ramp";
   private static final String API_UPDATE_PROP = "updateProp";
 
+  private final Props azProps = getApplication().getServerProps();
+
   private static final Logger logger = LoggerFactory.getLogger(ExecutorServlet.class.getName());
   private static final long serialVersionUID = 1L;
   private ProjectManager projectManager;
@@ -1012,6 +1014,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final ExecutionOptions options;
     try {
       options = HttpRequestUtils.parseFlowOptions(req, flowId);
+      options.validate(azProps);
     } catch (final ServletException e) {
       logger.info("parseFlowOptions failed", e);
       ret.put("error", "Error parsing flow options: " + e.getMessage());


### PR DESCRIPTION
**Why we need this**
This is the initial user-interface/contract definition for flow/execution-level restart when one fails.

**What's done**
Defined 3 flow-parameter keys that is exposed to users: 
- `allow.execution.restart.on.status` that describe a set of terminated status when an execution can restart
- `"execution.restart.count"` == how many times can an execution restarts
- `"execution.restart.strategy"` == the strategy (e.g. "restart_from _root", "disable_finished_nodes")

Also Azkaban side controlled config:
- `"azkaban.execution.restartable.status"` the restartable-status allowlist for user to pick from

Plus the cross-validation at execution creation time of the `user-input status list` against `Azkaban allowlist`.

**Tests done**
- unit tests
- tested in staging cluster
