### PR TITLE
Add customizable flow-level restart parameters & validation with Azkaban config

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -560,14 +560,8 @@ public class Constants {
     public static final String AZKABAN_EXECUTOR_JOBCALLBACK_ENABLED =
         "azkaban.executor.jobcallback.enabled";
 
-    // Executions are permitted to restart on this set of terminated statuses,
-    // normally includes EXECUTION_STOPPED and FAILED
-    public static final String AZKABAN_EXECUTION_RESTARTABLE_STATUS =
-        "azkaban.execution.restartable.status";
-
     // Executions are permitted to restart this many of times, e.g. "...=3"
-    public static final String AZKABAN_EXECUTION_RESTART_LIMIT =
-        "azkaban.execution.restart.limit";
+    public static final String AZKABAN_EXECUTION_RESTART_LIMIT = "azkaban.flow.retry.limit";
   }
 
   public static class FlowProperties {
@@ -885,13 +879,13 @@ public class Constants {
     public static final String PROXY_USER_PREFETCH_ALL = "proxy.user.prefetch.all";
 
     // Constant to define allow restart on a set of terminated status, extends to more statuses
-    // e.g. "allow.restart.on.status=EXECUTION_STOPPED,FAILED"
-    public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "allow.execution.restart.on.status";
+    // e.g. "flow.retry.statuses=EXECUTION_STOPPED,FAILED"
+    public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "flow.retry.statuses";
 
-    // Constant to define how many times can restart the flow to a new execution
-    public static final String FLOW_PARAM_RESTART_COUNT = "execution.restart.count";
+    // Constant to define at most how many times can restart the flow
+    public static final String FLOW_PARAM_RESTART_COUNT = "flow.max.retries";
 
     // Constant to define the strategy to restart the execution, default to "restart_from_root",
-    public static final String FLOW_PARAM_RESTART_STRATEGY = "execution.restart.strategy";
+    public static final String FLOW_PARAM_RESTART_STRATEGY = "flow.retry.strategy";
   }
 }

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -559,6 +559,15 @@ public class Constants {
     // Job callback
     public static final String AZKABAN_EXECUTOR_JOBCALLBACK_ENABLED =
         "azkaban.executor.jobcallback.enabled";
+
+    // Executions are permitted to restart on this set of terminated statuses,
+    // normally includes EXECUTION_STOPPED and FAILED
+    public static final String AZKABAN_EXECUTION_RESTARTABLE_STATUS =
+        "azkaban.execution.restartable.status";
+
+    // Executions are permitted to restart this many of times, e.g. "...=3"
+    public static final String AZKABAN_EXECUTION_RESTART_LIMIT =
+        "azkaban.execution.restart.limit";
   }
 
   public static class FlowProperties {
@@ -874,5 +883,15 @@ public class Constants {
     public static final String FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED =
         "allow.restart.on.execution.stopped";
     public static final String PROXY_USER_PREFETCH_ALL = "proxy.user.prefetch.all";
+
+    // Constant to define allow restart on a set of terminated status, extends to more statuses
+    // e.g. "allow.restart.on.status=EXECUTION_STOPPED,FAILED"
+    public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "allow.execution.restart.on.status";
+
+    // Constant to define how many times can restart the flow to a new execution
+    public static final String FLOW_PARAM_RESTART_COUNT = "execution.restart.count";
+
+    // Constant to define the strategy to restart the execution, default to "restart_from_root",
+    public static final String FLOW_PARAM_RESTART_STRATEGY = "execution.restart.strategy";
   }
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -200,14 +200,26 @@ public class ExecutionOptions {
     }
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_COUNT)){
       // check restart count limit
-      final int flowRestartCountLimit = azProps.getInt(
-          AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RESTART_LIMIT);
-      final int flowRestartCount = Integer.parseInt(
-          flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
-      if (flowRestartCount > flowRestartCountLimit || flowRestartCount < 0){
+      try {
+        final int flowRestartCountLimit = azProps.getInt(
+            AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RESTART_LIMIT);
+        try {
+          final int flowRestartCount = Integer.parseInt(
+              flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
+          if (flowRestartCount > flowRestartCountLimit || flowRestartCount < 0){
+            errMsg.add(String.format(
+                "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
+                    + "within [0, %d]", flowRestartCount, flowRestartCountLimit));
+          }
+        } catch (NumberFormatException e) {
+          errMsg.add(String.format(
+              "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %s`, should be integer",
+              flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0")));
+        }
+      } catch (NumberFormatException e) {
         errMsg.add(String.format(
-            "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
-                + "within [0, %d]", flowRestartCount, flowRestartCountLimit));
+            "Invalid `" + AZKABAN_EXECUTION_RESTART_LIMIT + " = %s`, should be integer",
+            azProps.get(AZKABAN_EXECUTION_RESTART_LIMIT)));
       }
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -175,11 +175,14 @@ public class ExecutionOptions {
     return options;
   }
 
-  public void validate(Props azProps)
+  /**
+   * Validate the ExecutionOption's Flow-Parameters against the application level Properties
+   * @throws ServletException if any of the parameter is invalid
+   */
+  public void validateFlowParameters(Props azProps)
       throws ServletException {
     List<String> errMsg = new ArrayList<>();
 
-    // validate flow parameters
     Map<String, String> flowParameters = this.getFlowParameters();
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
       // allow list defined in azProps

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -186,31 +186,31 @@ public class ExecutionOptions {
     Map<String, String> flowParameters = this.getFlowParameters();
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
       // allow list defined in azProps
-      List<String> allowedStatues = azProps.getStringList(
+      final List<String> allowedStatuses = azProps.getStringList(
           AZKABAN_EXECUTION_RESTARTABLE_STATUS, DEFAULT_EXECUTION_RESTARTABLE_STATUS);
 
       // user defined list
-      String[] statuses = flowParameters
+      final String[] statuses = flowParameters
           .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
           .split("\\s*,\\s*");
 
       for (String s : statuses) {
-        if (!allowedStatues.contains(s)) {
+        if (!allowedStatuses.contains(s)) {
           errMsg.add(String.format("`%s` is not a valid restartable status, "
-              + "permitted status are %s", s, allowedStatues));
+              + "permitted status are %s", s, allowedStatuses));
         }
       }
     }
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_COUNT)){
       // check restart count limit
-      int azRestartCountLimit = azProps.getInt(
+      final int azFlowRestartCountLimit = azProps.getInt(
           AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_EXECUTION_RESTART_LIMIT);
-      int flowRestartCount = Integer.parseInt(
+      final int flowRestartCount = Integer.parseInt(
           flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
-      if (flowRestartCount > azRestartCountLimit || flowRestartCount < 0){
+      if (flowRestartCount > azFlowRestartCountLimit || flowRestartCount < 0){
         errMsg.add(String.format(
             "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
-                + "within [0, %d]", flowRestartCount, azRestartCountLimit));
+                + "within [0, %d]", flowRestartCount, azFlowRestartCountLimit));
       }
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -184,6 +184,9 @@ public class ExecutionOptions {
     List<String> errMsg = new ArrayList<>();
 
     Map<String, String> flowParameters = this.getFlowParameters();
+    if (flowParameters == null || flowParameters.isEmpty()) {
+      return;
+    }
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
       // allow list defined in azProps
       final List<String> allowedStatuses = azProps.getStringList(

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -203,14 +203,14 @@ public class ExecutionOptions {
     }
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_COUNT)){
       // check restart count limit
-      final int azFlowRestartCountLimit = azProps.getInt(
+      final int flowRestartCountLimit = azProps.getInt(
           AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_EXECUTION_RESTART_LIMIT);
       final int flowRestartCount = Integer.parseInt(
           flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
-      if (flowRestartCount > azFlowRestartCountLimit || flowRestartCount < 0){
+      if (flowRestartCount > flowRestartCountLimit || flowRestartCount < 0){
         errMsg.add(String.format(
             "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
-                + "within [0, %d]", flowRestartCount, azFlowRestartCountLimit));
+                + "within [0, %d]", flowRestartCount, flowRestartCountLimit));
       }
     }
 

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -54,6 +54,9 @@ public enum Status {
   public static final ImmutableSet<Status> RESTARTABLE_STATUSES =
       ImmutableSet.of(Status.READY, Status.DISPATCHING, Status.PREPARING, Status.EXECUTION_STOPPED);
 
+  public static final ImmutableSet<Status> RESTARTABLE_TERMINATED_STATUSES =
+      ImmutableSet.of(Status.EXECUTION_STOPPED, Status.FAILED);
+
   private final int numVal;
 
   Status(final int numVal) {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 LinkedIn, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package azkaban.executor;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTARTABLE_STATUS;
@@ -25,7 +41,7 @@ public class ExecutionOptionsTest {
   @Test
   public void testValidateFlowParamWithoutAnyFlowParameter() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test
@@ -35,7 +51,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test
@@ -46,7 +62,7 @@ public class ExecutionOptionsTest {
     ));
 
     // if not defined, has default value to [EXECUTION_STOPPED, FAILED]
-    options.validate(new Props());
+    options.validateFlowParameters(new Props());
   }
 
   @Test(expected = ServletException.class)
@@ -57,7 +73,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "KILLED"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test
@@ -67,7 +83,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_RESTART_COUNT, "1"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test(expected = ServletException.class)
@@ -77,7 +93,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_RESTART_COUNT, "-11"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test(expected = ServletException.class)
@@ -87,7 +103,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_RESTART_COUNT, "100000"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
   @Test
@@ -98,7 +114,7 @@ public class ExecutionOptionsTest {
         FLOW_PARAM_RESTART_COUNT, "2"
     ));
 
-    options.validate(testAzProps);
+    options.validateFlowParameters(testAzProps);
   }
 
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -1,0 +1,104 @@
+package azkaban.executor;
+
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTARTABLE_STATUS;
+import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_COUNT;
+
+import azkaban.utils.Props;
+import com.google.common.collect.ImmutableMap;
+import javax.servlet.ServletException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutionOptionsTest {
+
+  public static Props testAzProps;
+
+  @Before
+  public void before(){
+    testAzProps = new Props();
+    testAzProps.put(AZKABAN_EXECUTION_RESTARTABLE_STATUS, "EXECUTION_STOPPED");
+    testAzProps.put(AZKABAN_EXECUTION_RESTART_LIMIT, 2);
+  }
+
+  @Test
+  public void testValidateFlowParamWithoutAnyFlowParameter() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithGood_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithDefaultAllowListAndGood_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+    ));
+
+    // if not defined, has default value to [EXECUTION_STOPPED, FAILED]
+    options.validate(new Props());
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithInvalid_ALLOW_RESTART_ON_STATUS() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    // KILLED is not defined
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "KILLED"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithGood_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "1"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithNegative_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "-11"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test(expected = ServletException.class)
+  public void testValidateFlowParamWithExceed_RESTART_COUNT() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_RESTART_COUNT, "100000"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+  @Test
+  public void testValidateFlowParamWithAllValidSettings() throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FLOW_PARAM_RESTART_COUNT, "2"
+    ));
+
+    options.validate(testAzProps);
+  }
+
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -16,7 +16,6 @@
 
 package azkaban.executor;
 
-import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTARTABLE_STATUS;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_COUNT;
@@ -34,7 +33,6 @@ public class ExecutionOptionsTest {
   @Before
   public void before(){
     testAzProps = new Props();
-    testAzProps.put(AZKABAN_EXECUTION_RESTARTABLE_STATUS, "EXECUTION_STOPPED");
     testAzProps.put(AZKABAN_EXECUTION_RESTART_LIMIT, 2);
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1010,8 +1010,10 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     exflow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
 
     final ExecutionOptions options;
+    final Props azProps = getApplication().getServerProps();
     try {
       options = HttpRequestUtils.parseFlowOptions(req, flowId);
+      options.validate(azProps);
     } catch (final ServletException e) {
       logger.info("parseFlowOptions failed", e);
       ret.put("error", "Error parsing flow options: " + e.getMessage());

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1013,7 +1013,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     final Props azProps = getApplication().getServerProps();
     try {
       options = HttpRequestUtils.parseFlowOptions(req, flowId);
-      options.validate(azProps);
+      options.validateFlowParameters(azProps);
     } catch (final ServletException e) {
       logger.info("parseFlowOptions failed", e);
       ret.put("error", "Error parsing flow options: " + e.getMessage());


### PR DESCRIPTION
**Why we need this**
This is the initial user-interface/contract definition for flow/execution-level restart when one fails.

**What's done**
Defined 3 flow-parameter keys that is exposed to users: 
- `allow.execution.restart.on.status` that describe a set of terminated status when an execution can restart
- `"execution.restart.count"` == how many times can an execution restarts
- `"execution.restart.strategy"` == the strategy (e.g. "restart_from _root", "disable_finished_nodes")

Also Azkaban side controlled config:
- `"azkaban.execution.restartable.status"` the restartable-status allowlist for user to pick from
- `"azkaban.execution.restart.limit"` the limitation how many times an execution can restart

Plus the cross-validation at execution creation time:
- the `user-input status list` against `Azkaban allowlist`
- the `user-input restart count` against `Azkaban restart limit`

**Tests done**
- unit tests
- tested in staging cluster:
<img width="1174" alt="Screenshot 2023-03-22 at 5 47 38 PM" src="https://user-images.githubusercontent.com/31334117/227070585-e98fc22f-ee15-4dc0-8e35-b303a3e0e755.png">
<img width="1175" alt="Screenshot 2023-03-22 at 5 46 35 PM" src="https://user-images.githubusercontent.com/31334117/227070588-40274707-7453-4dd4-9153-3ccd31987ec0.png">

