### PR TITLE
Add ExecutionOption.executionMaxRetries to control flow retry

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -207,6 +207,7 @@ public class Constants {
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
     public static final String EXECUTION_RETRIED_BY_AZKABAN = "executionRetriedByAzkaban";
+    public static final String EXECUTION_MAX_RETRIES = "executionMaxRetries";
     public static final String IS_OOM_KILLED = "isOOMKilled";
     public static final String IS_POD_SIZE_AUTOSCALING_ENABLED = "isPodSizeAutoscaled";
     public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =
@@ -883,7 +884,7 @@ public class Constants {
     public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "flow.retry.statuses";
 
     // Constant to define at most how many times can restart the flow
-    public static final String FLOW_PARAM_RESTART_COUNT = "flow.max.retries";
+    public static final String FLOW_PARAM_MAX_RETRIES = "flow.max.retries";
 
     // Constant to define the strategy to restart the execution, default to "restart_from_root",
     public static final String FLOW_PARAM_RESTART_STRATEGY = "flow.retry.strategy";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -179,10 +179,16 @@ public class ExecutionControllerUtils {
    */
   public static void restartFlow(final ExecutableFlow flow, final Status originalStatus) {
     final ExecutionOptions options = flow.getExecutionOptions();
-    // flow can only be retried once
-    if (options == null || options.isExecutionRetried()) {
+    if (options == null) {
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has ExecutionOptions == null");
       return;
     }
+    // flow can only retry if not reach the limit
+    if (options.executionReachedRetryLimit()){
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has reached its retry limit");
+      return;
+    }
+
     // If the original execution status is restartable non-terminal status, it can be retried
     if (RESTARTABLE_NON_TERMINAL_STATUSES.contains(originalStatus)) {
       logger.info("Submitted flow for restart: " + flow.getExecutionId());
@@ -201,6 +207,7 @@ public class ExecutionControllerUtils {
 
     final Map<String, String> flowParams = options.getFlowParameters();
     if (flowParams == null || flowParams.isEmpty()) {
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has ExecutionOptions == null");
       return;
     }
     // user defined restart statuses list

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -17,6 +17,7 @@
 package azkaban.executor;
 
 import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN;
+import static azkaban.Constants.EventReporterConstants.EXECUTION_MAX_RETRIES;
 import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
 
 import azkaban.executor.mail.DefaultMailCreator;
@@ -68,6 +69,7 @@ public class ExecutionOptions {
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
   private boolean isExecutionRetried = false;
+  private int executionMaxRetries = 0;
   private Integer originalFlowExecutionIdBeforeRetry = null;
 
   private boolean notifyOnFirstFailure = true;
@@ -163,6 +165,7 @@ public class ExecutionOptions {
     options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRIED_BY_AZKABAN, false));
     options.setOriginalFlowExecutionIdBeforeRetry(wrapper.getInt(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
         options.originalFlowExecutionIdBeforeRetry));
+    options.setExecutionMaxRetries(wrapper.getInt(EXECUTION_MAX_RETRIES, 0));
 
     return options;
   }
@@ -314,6 +317,15 @@ public class ExecutionOptions {
   public void setExecutionRetried(boolean executionRetried) { this.isExecutionRetried =
       executionRetried; }
 
+  public int getExecutionMaxRetries() { return executionMaxRetries; }
+
+  public void setExecutionMaxRetries(int executionMaxRetries) { this.executionMaxRetries =
+      executionMaxRetries; }
+
+  public boolean executionReachedRetryLimit() { return executionMaxRetries <= 0; }
+
+  public void retryOneTime() { this.executionMaxRetries -= 1; }
+
   public Integer getOriginalFlowExecutionIdBeforeRetry() { return originalFlowExecutionIdBeforeRetry; }
 
   public void setOriginalFlowExecutionIdBeforeRetry(Integer originalFlowExecutionIdBeforeRetry) { this.originalFlowExecutionIdBeforeRetry =
@@ -340,6 +352,7 @@ public class ExecutionOptions {
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
     flowOptionObj.put(EXECUTION_RETRIED_BY_AZKABAN, this.isExecutionRetried);
+    flowOptionObj.put(EXECUTION_MAX_RETRIES, this.executionMaxRetries);
     flowOptionObj.put(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY, this.originalFlowExecutionIdBeforeRetry);
     return flowOptionObj;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -80,6 +80,8 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
     metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
         String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
+    metaData.put(EventReporterConstants.EXECUTION_MAX_RETRIES,
+        String.valueOf(flow.getExecutionOptions().getExecutionMaxRetries()));
     if (flow.isOOMKilled()) {
       metaData.put(EventReporterConstants.IS_OOM_KILLED,
           String.valueOf(flow.isOOMKilled()));

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -68,6 +68,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     options.setMailCreator(flow.getMailCreator());
     // Update the flow options so that the flow will be not retried again by Azkaban
     options.setExecutionRetried(true);
+    options.retryOneTime();
     // If a retried flow A gets retried again with a new execution id flow B, the original flow
     // execution id of flow B should be the same as flow A's original flow execution id.
     if (options.getOriginalFlowExecutionIdBeforeRetry() == null) {

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -214,20 +214,21 @@ public class HttpRequestUtils {
       flowParameters.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
           Strings.join(statuses, ","));
     }
-    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_COUNT)){
+    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_MAX_RETRIES)){
 
       // check restart count limit
       try {
-        validateIntegerParam(flowParameters, FlowParameters.FLOW_PARAM_RESTART_COUNT);
+        validateIntegerParam(flowParameters, FlowParameters.FLOW_PARAM_MAX_RETRIES);
         final int flowRestartCountLimit = azProps.getInt(
             AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RESTART_LIMIT);
-        final int flowRestartCount = Integer.parseInt(
-            flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
-        if (flowRestartCount > flowRestartCountLimit || flowRestartCount < 0){
+        final int flowMaxRetryLimit = Integer.parseInt(
+            flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
+        if (flowMaxRetryLimit > flowRestartCountLimit || flowMaxRetryLimit < 0){
           errMsg.add(String.format(
-              "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
-                  + "within [0, %d]\n", flowRestartCount, flowRestartCountLimit));
+              "Invalid `" + FlowParameters.FLOW_PARAM_MAX_RETRIES + " = %d`, value should be "
+                  + "within [0, %d]\n", flowMaxRetryLimit, flowRestartCountLimit));
         }
+        options.setExecutionMaxRetries(flowMaxRetryLimit);
       } catch (ExecutorManagerException e) {
         errMsg.add(e.getMessage());
       }

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -18,7 +18,7 @@ package azkaban.server;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
-import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_COUNT;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_MAX_RETRIES;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import azkaban.DispatchMethod;
@@ -357,7 +357,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithGood_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "1"
+        FLOW_PARAM_MAX_RETRIES, "1"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -367,7 +367,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithNegative_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "-11"
+        FLOW_PARAM_MAX_RETRIES, "-11"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -377,7 +377,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithExceed_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "100000"
+        FLOW_PARAM_MAX_RETRIES, "100000"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -388,7 +388,7 @@ public final class HttpRequestUtilsTest {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
         FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
-        FLOW_PARAM_RESTART_COUNT, "2"
+        FLOW_PARAM_MAX_RETRIES, "2"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -98,7 +98,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -1742,6 +1741,8 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(rootFlow.getSubmitTime()));
       metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
           String.valueOf(rootFlow.getExecutionOptions().isExecutionRetried()));
+      metaData.put(EventReporterConstants.EXECUTION_MAX_RETRIES,
+          String.valueOf(rootFlow.getExecutionOptions().getExecutionMaxRetries()));
       if (rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
         // original flow execution id is set when there is one
         metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,


### PR DESCRIPTION
**Why we need this**
Previously Azkaban use only `isExecutionRetried` boolean flag to record and control flow/execution retry info, we now want to allow retrying for a given number of times.

**What's done**
1. `isExecutionRetried` only means whether an execution is retried
2. At flow submit time, convert user input flow-parameter `flow.max.retries` to `ExecutionOption.executionMaxRetries` member variable
3. use `executionMaxRetries` to count down how many times can this execution retry

**Tests done**
1. unit tests
2. deploy the change to test cluster, launched an execution with `flow.max.retries=2` and trigger EXECUTION_STOPPED by killing the k8s pod:

The old execution got into EXECUTION_STOPPED and an new execution is being restarted:
<img width="1532" alt="Screenshot 2023-04-03 at 9 39 09 PM" src="https://user-images.githubusercontent.com/31334117/229891930-9974f2ce-3967-47dc-bdaf-678153535722.png">

The old execution with "flow.max.retries=2" while the retried new execution has "flow.max.retries=1"
![Screenshot 2023-04-03 at 9 30 02 PM](https://user-images.githubusercontent.com/31334117/229891819-4adeb2fb-1dfc-4351-8e8d-b45100b5444c.png)
![Screenshot 2023-04-03 at 9 30 18 PM](https://user-images.githubusercontent.com/31334117/229892345-cc575f9c-51a6-4122-aa2b-106e2edb5f3f.png)