### PR TITLE
Use flowParameters.executionMaxRetries to control flow retry

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -883,7 +883,7 @@ public class Constants {
     public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "flow.retry.statuses";
 
     // Constant to define at most how many times can restart the flow
-    public static final String FLOW_PARAM_RESTART_COUNT = "flow.max.retries";
+    public static final String FLOW_PARAM_MAX_RETRIES = "flow.max.retries";
 
     // Constant to define the strategy to restart the execution, default to "restart_from_root",
     public static final String FLOW_PARAM_RESTART_STRATEGY = "flow.retry.strategy";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -168,22 +168,18 @@ public class ExecutionControllerUtils {
   }
 
   /**
-   * This method tries to restart the flow for certain statuses otherwise simply return. There are
-   * three scenarios that this method is called: 1. a flow is cleaned up by ContainerCleanupManager;
-   * 2. a flow has dispatch failure; 3. a flow encounters pod failure Each flow execution can be
-   * retried once. If the original status is EXECUTION_STOPPED, then it will be retried only if
-   * allow.restart.on.execution.stopped is set to true
+   * This method tries to determine whether the flow should be restarted for certain statuses
+   * otherwise simply return.
+   * There are three scenarios that this method is called:
+   * 1. a flow is cleaned up by ContainerCleanupManager;
+   * 2. a flow has dispatch failure;
+   * 3. a flow encounters pod failure Each flow execution can be retried once.
+   * If the original status is EXECUTION_STOPPED or FAILED, then it will be retried only if
+   * "flow.retry.statuses" is defined with the status.
    *
    * @param flow
    * @param originalStatus
    */
-  public static void restartFlow(final ExecutableFlow flow, final Status originalStatus) {
-    ExecutableFlow flowToRestart = getFlowToRestart(flow, originalStatus);
-    if (flowToRestart != null){
-      ExecutionControllerUtils.submitRestartFlow(flowToRestart);
-    }
-  }
-
   static ExecutableFlow getFlowToRestart(final ExecutableFlow flow,
       final Status originalStatus){
     final ExecutionOptions options = flow.getExecutionOptions();
@@ -241,6 +237,13 @@ public class ExecutionControllerUtils {
       return flow;
     }
     return null;
+  }
+
+  public static void restartFlow(final ExecutableFlow flow, final Status originalStatus) {
+    ExecutableFlow flowToRestart = getFlowToRestart(flow, originalStatus);
+    if (flowToRestart != null){
+      ExecutionControllerUtils.submitRestartFlow(flowToRestart);
+    }
   }
 
   private static void submitRestartFlow(final ExecutableFlow flow) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -178,16 +178,40 @@ public class ExecutionControllerUtils {
    * @param originalStatus
    */
   public static void restartFlow(final ExecutableFlow flow, final Status originalStatus) {
-    final ExecutionOptions options = flow.getExecutionOptions();
-    // flow can only be retried once
-    if (options == null || options.isExecutionRetried()) {
-      return;
+    ExecutableFlow flowToRestart = getFlowToRestart(flow, originalStatus);
+    if (flowToRestart != null){
+      ExecutionControllerUtils.submitRestartFlow(flowToRestart);
     }
+  }
+
+  static ExecutableFlow getFlowToRestart(final ExecutableFlow flow,
+      final Status originalStatus){
+    final ExecutionOptions options = flow.getExecutionOptions();
+    if (options == null) {
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has ExecutionOptions == null");
+      return null;
+    }
+    final Map<String, String> flowParams = options.getFlowParameters();
+    if (flowParams == null || flowParams.isEmpty()) {
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has ExecutionOptions == null");
+      return null;
+    }
+
+    // flow can only retry if not reach the limit
+    final int flowMaxRetryLimit = Integer.parseInt(
+        flowParams.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
+    if (flowMaxRetryLimit <= 0) {
+      logger.warn("ExecutableFlow: " + flow.getExecutionId() + " has exceed retry limit, count = "
+          + flowMaxRetryLimit);
+      return null;
+    }
+    // reduce the count
+    flowParams.put(FlowParameters.FLOW_PARAM_MAX_RETRIES, String.valueOf(flowMaxRetryLimit - 1));
+
     // If the original execution status is restartable non-terminal status, it can be retried
     if (RESTARTABLE_NON_TERMINAL_STATUSES.contains(originalStatus)) {
       logger.info("Submitted flow for restart: " + flow.getExecutionId());
-      ExecutionControllerUtils.submitRestartFlow(flow);
-      return;
+      return flow;
     }
 
     // if the original execution status is restartable but is terminal status, we will need to
@@ -196,13 +220,9 @@ public class ExecutionControllerUtils {
     // detects there's an invalid pod state transition and flow is terminated before final states)
     // - Or some other status defined in flow parameters can also be restarted
     if (!RESTARTABLE_TERMINAL_STATUSES.contains(originalStatus)) {
-      return;
+      return null;
     }
 
-    final Map<String, String> flowParams = options.getFlowParameters();
-    if (flowParams == null || flowParams.isEmpty()) {
-      return;
-    }
     // user defined restart statuses list
     final Set<String> restartedStatuses = new HashSet<>(Arrays.asList(flowParams
         .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
@@ -215,13 +235,12 @@ public class ExecutionControllerUtils {
       restartedStatuses.add(Status.EXECUTION_STOPPED.name());
     }
 
-    // TODO: check the "flow.max.retries" number and -= 1
-
     if (restartedStatuses.contains(originalStatus.name())) {
       logger.info("Submitted flow for restart: " + flow.getExecutionId()
           + "from originalStatus: " + originalStatus);
-      ExecutionControllerUtils.submitRestartFlow(flow);
+      return flow;
     }
+    return null;
   }
 
   private static void submitRestartFlow(final ExecutableFlow flow) {

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -214,19 +214,19 @@ public class HttpRequestUtils {
       flowParameters.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
           Strings.join(statuses, ","));
     }
-    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_COUNT)){
+    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_MAX_RETRIES)){
 
       // check restart count limit
       try {
-        validateIntegerParam(flowParameters, FlowParameters.FLOW_PARAM_RESTART_COUNT);
+        validateIntegerParam(flowParameters, FlowParameters.FLOW_PARAM_MAX_RETRIES);
         final int flowRestartCountLimit = azProps.getInt(
             AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RESTART_LIMIT);
-        final int flowRestartCount = Integer.parseInt(
-            flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_RESTART_COUNT, "0"));
-        if (flowRestartCount > flowRestartCountLimit || flowRestartCount < 0){
+        final int flowMaxRetryLimit = Integer.parseInt(
+            flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
+        if (flowMaxRetryLimit > flowRestartCountLimit || flowMaxRetryLimit < 0){
           errMsg.add(String.format(
-              "Invalid `" + FlowParameters.FLOW_PARAM_RESTART_COUNT + " = %d`, value should be "
-                  + "within [0, %d]\n", flowRestartCount, flowRestartCountLimit));
+              "Invalid `" + FlowParameters.FLOW_PARAM_MAX_RETRIES + " = %d`, value should be "
+                  + "within [0, %d]\n", flowMaxRetryLimit, flowRestartCountLimit));
         }
       } catch (ExecutorManagerException e) {
         errMsg.add(e.getMessage());

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -232,6 +232,13 @@ public class HttpRequestUtils {
         errMsg.add(e.getMessage());
       }
     }
+    // doesn't contain FlowParameters.FLOW_PARAM_MAX_RETRIES
+    else if (!options.isExecutionRetried()
+        && flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
+      // if the MAX_RETRIES parameter is empty but set some retry_statuses, default to
+      // give 1 restart
+      flowParameters.put(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1");
+    }
 
     // throw exception if there's any error message
     if (!errMsg.isEmpty()) {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -1,5 +1,6 @@
 package azkaban.executor;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
@@ -47,6 +47,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
   private static final int projectId = 1;
   private OnExecutionEventListener listener;
 
+  @Before
   public void setup() throws Exception {
     // Set up project and flow
     this.project = new Project(projectId, "testProject");
@@ -84,21 +85,21 @@ public class ExecutionControllerUtilsRestartFlowTest {
     ExecutionControllerUtils.onExecutionEventListener = this.listener;
   }
 
+  @Test
   public void testRestartOnExecutionStopped() throws Exception {
     this.flow1.setStatus(Status.EXECUTION_STOPPED);
 
     ExecutionControllerUtils.restartFlow(this.flow1);
 
     final ExecutableFlow restartedExFlow = this.executorLoader.fetchExecutableFlow(-1);
-    assertTrue(restartedExFlow.getFlowId().equals(this.flow1.getFlowId()));
-    assertTrue(restartedExFlow.getProjectName().equals(this.project.getName()));
-    assertTrue(restartedExFlow.getSubmitUser().equals(this.flow1.getSubmitUser()));
-    assertTrue(restartedExFlow.getDispatchMethod().equals(DispatchMethod.CONTAINERIZED));
+    assertEquals(restartedExFlow.getFlowId(), this.flow1.getFlowId());
+    assertEquals(restartedExFlow.getProjectName(), this.project.getName());
+    assertEquals(restartedExFlow.getSubmitUser(), this.flow1.getSubmitUser());
+    assertEquals(restartedExFlow.getDispatchMethod(), DispatchMethod.CONTAINERIZED);
+    final ExecutionOptions options2 = restartedExFlow.getExecutionOptions();
+    assertTrue(options2.isExecutionRetried());
 
     final ExecutionOptions options1 = this.flow1.getExecutionOptions();
     assertTrue(options1.isExecutionRetried());
-    final ExecutableFlow flow2 = this.executorLoader.fetchExecutableFlow(executionId);
-    final ExecutionOptions options2 = this.flow1.getExecutionOptions();
-    assertTrue(options2.isExecutionRetried());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -425,4 +425,17 @@ public final class HttpRequestUtilsTest {
         result.get(FLOW_PARAM_ALLOW_RESTART_ON_STATUS).contains("EXECUTION_STOPPED"));
   }
 
+  @Test
+  public void testValidatePreprocessFlowParamWithEmptyMaxRetries()
+      throws ServletException {
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED"
+    ));
+
+    HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
+    Map<String, String> result = options.getFlowParameters();
+    Assert.assertEquals("1", result.get(FLOW_PARAM_MAX_RETRIES));
+  }
+
 }

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -18,7 +18,7 @@ package azkaban.server;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
-import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_COUNT;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_MAX_RETRIES;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import azkaban.DispatchMethod;
@@ -357,7 +357,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithGood_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "1"
+        FLOW_PARAM_MAX_RETRIES, "1"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -367,7 +367,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithNegative_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "-11"
+        FLOW_PARAM_MAX_RETRIES, "-11"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -377,7 +377,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithExceed_RESTART_COUNT() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_RESTART_COUNT, "100000"
+        FLOW_PARAM_MAX_RETRIES, "100000"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -388,7 +388,7 @@ public final class HttpRequestUtilsTest {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
         FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
-        FLOW_PARAM_RESTART_COUNT, "2"
+        FLOW_PARAM_MAX_RETRIES, "2"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);


### PR DESCRIPTION
**Why we need this**
Previously Azkaban use only `isExecutionRetried` boolean flag to record and control flow/execution retry info, we now want to allow retrying for a number of times defined by the user.

**What's done**
1. `isExecutionRetried` only means whether an execution is retried
2. At flow submit time, if the `flow.retry.statuses` is set, then `flow.max.retries` fallback value is `1` if not set
3. use `flow.max.retries` to determine how many times can this execution retry at `restartFlow` method

**Tests done**
1. unit tests
2. deploy the change to test cluster, launched an execution with `flow.max.retries=2` and trigger EXECUTION_STOPPED by killing the k8s pod:

The old execution got into EXECUTION_STOPPED and an new execution is being restarted:
<img width="1532" alt="Screenshot 2023-04-03 at 9 39 09 PM" src="https://user-images.githubusercontent.com/31334117/229891930-9974f2ce-3967-47dc-bdaf-678153535722.png">

The old execution with "flow.max.retries=2" while the retried new execution has "flow.max.retries=1"
![Screenshot 2023-04-03 at 9 30 02 PM](https://user-images.githubusercontent.com/31334117/229891819-4adeb2fb-1dfc-4351-8e8d-b45100b5444c.png)
![Screenshot 2023-04-03 at 9 30 18 PM](https://user-images.githubusercontent.com/31334117/229892345-cc575f9c-51a6-4122-aa2b-106e2edb5f3f.png)