### PR TITLE
Extend pod complete event handling to also check & retry execution in finalized status including FAILED

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -233,7 +233,7 @@ public class ExecutionControllerUtils {
 
     if (restartedStatuses.contains(originalStatus.name())) {
       logger.info("Submitted flow for restart: " + flow.getExecutionId()
-          + "from originalStatus: " + originalStatus);
+          + " from originalStatus: " + originalStatus);
       return flow;
     }
     return null;

--- a/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/watch/FlowStatusManagerListener.java
@@ -298,6 +298,12 @@ public class FlowStatusManagerListener extends EventHandler implements AzPodStat
       // Log event for cases where the flow was not already in a final state
       WatchEventLogger.logWatchEvent(event, "WatchEvent for finalization of execution-id " + executionId);
     }
+    else {
+      // for flow status already finished, can try if still restartable, e.g. FAILED
+      logger.info(String.format("Check and possibly restart flow %s of originalStatus %s",
+          executableFlow.getExecutionId(), originalStatus));
+      ExecutionControllerUtils.restartFlow(executableFlow, originalStatus);
+    }
     return Optional.of(originalStatus);
   }
 


### PR DESCRIPTION
**Why we need this**
Previously when the pod-complete event comes, only if the execution status in Azkaban DB is Non-Finalized, then the `restartFlow()` logic got triggered.
Now to support the flow-retry on `FAILED`, we need to trigger the logic when execution status is Finalized (FAILED is a finalized status).

**What's done**
Since the logic to check for the permitted retry-statuses is already implemented in `restartFlow()` method #3261, now we just need to enter this logic when the execution status is finalized.

**Tests done**
Tested in the staging cluster:

Started the original execution 786255 with `flow.retry.statuses=FAILED,EXECUTION_STOPPED` and `flow.max.retries=1` and failed the flow by killing the hadoop application, a new execution 786256 being retried:
![Screenshot 2023-04-04 at 4 33 41 PM](https://user-images.githubusercontent.com/31334117/229963857-be539782-eeb9-4d1d-a76a-fd4ebf064bac.png)

The webserver log for retrying 786255:
![Screenshot 2023-04-04 at 4 34 40 PM](https://user-images.githubusercontent.com/31334117/229963917-1d31d1d3-b240-42b8-b500-ae9d3ffc1ce1.png)

Failed the restarted execution 786256 and there's no further retry, since the `flow.max.retries` has reached `0`
![Screenshot 2023-04-04 at 7 19 27 PM](https://user-images.githubusercontent.com/31334117/229964337-8c883e3e-35dd-4dec-bd09-8d9b579c1a39.png)

The webserver log rejecting the retry of 786256:
![Screenshot 2023-04-04 at 4 41 57 PM](https://user-images.githubusercontent.com/31334117/229964351-a8314da8-11d2-4948-9a2b-ec93baf1704a.png)

