### PR TITLE
Remove misleading ProcessFailureException from job logs and fix NPE during Noop job creation.

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/AbstractHadoopJavaProcessJob.java
@@ -62,10 +62,6 @@ public abstract class AbstractHadoopJavaProcessJob extends JavaProcessJob implem
   public void run() throws Exception {
     try {
       super.run();
-    } catch (Throwable t) {
-      t.printStackTrace();
-      getLog().error("caught error running the job", t);
-      throw t;
     } finally {
       hadoopProxy.cancelHadoopTokens(getLog());
     }

--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/HadoopShell.java
@@ -50,10 +50,6 @@ public class HadoopShell extends ProcessJob implements IHadoopJob {
 
     try {
       super.run();
-    } catch (Throwable e) {
-      e.printStackTrace();
-      getLog().error("caught error running the job");
-      throw e;
     } finally {
       hadoopProxy.cancelHadoopTokens(getLog());
     }

--- a/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
+++ b/azkaban-common/src/main/java/azkaban/jobtype/JobTypeManager.java
@@ -463,8 +463,12 @@ public class JobTypeManager {
       jobProps.putAll(nonOverriddableClusterProps);
       jobProps = PropsUtils.resolveProps(jobProps);
 
-      return new JobParams(jobTypeClass, jobProps, pluginSet.getPluginPrivateProps(jobType),
-          pluginLoadPropsCopy, jobContextClassLoader);
+      Props pluginPrivateProps = pluginSet.getPluginPrivateProps(jobType);
+      if(pluginPrivateProps == null) { // some jobtypes (ie: noop) don't have private properties.
+        pluginPrivateProps = new Props();
+      }
+      return new JobParams(jobTypeClass, jobProps, pluginPrivateProps, pluginLoadPropsCopy,
+          jobContextClassLoader);
     } catch (final Exception e) {
       logger.error("Failed to build job executor for job " + jobId
           + e.getMessage());


### PR DESCRIPTION
Exceptions like below in the Job logs, often make users think that that was the reason for failure (which is not in most cases if not all). Also, for some jobtypes these exceptions are repeatedly logged. 
Therefore, we are removing them from the job logs and only logging them in the executor server logs. 
```
04-04-2023 19:46:48 PDT my-job ERROR - caught error running the job
java.lang.RuntimeException: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:317)
	at azkaban.jobtype.AbstractHadoopJavaProcessJob.run(AbstractHadoopJavaProcessJob.java:64)
	at com.linkedin.spark.HadoopSparkJob.runSparkJob(HadoopSparkJob.java:365)
	at com.linkedin.spark.HadoopSparkJob.run(HadoopSparkJob.java:261)
	at azkaban.execapp.JobRunner.runJob(JobRunner.java:937)
	at azkaban.execapp.JobRunner.doRun(JobRunner.java:651)
	at azkaban.execapp.JobRunner.run(JobRunner.java:602)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: azkaban.jobExecutor.utils.process.ProcessFailureException: Process exited with code 1
	at azkaban.jobExecutor.utils.process.AzkabanProcess.run(AzkabanProcess.java:125)
	at azkaban.jobExecutor.ProcessJob.run(ProcessJob.java:309)
	... 11 more
```

This PR also fixes below NullPointerException when creating Noop jobs.
```
... WARN - Ctor with private properties failed, will try one without. e = 
java.lang.NullPointerException
    at azkaban.utils.Utils.getTypes(Utils.java:290)
    at azkaban.utils.Utils.callConstructor(Utils.java:278)
    at azkaban.jobtype.JobTypeManager.createJob(JobTypeManager.java:545)
    at azkaban.execapp.JobRunner.prepareJob(JobRunner.java:774)
    at azkaban.execapp.JobRunner.doRun(JobRunner.java:640)
    at azkaban.execapp.JobRunner.run(JobRunner.java:601)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```