### PR TITLE
Use ExecutableFlow member variables to track and control flow-level retry

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -435,8 +435,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
       }
       this.slaOptionStr = slaBuilder.toString();
     }
-    this.userDefinedRetryCount = flowObj.getInt(USER_DEFINED_RETRY_COUNT_PARAM);
-    this.systemDefinedRetryCount = flowObj.getInt(SYSTEM_DEFINED_RETRY_COUNT_PARAM);
+    this.userDefinedRetryCount = flowObj.getInt(USER_DEFINED_RETRY_COUNT_PARAM, 0);
+    this.systemDefinedRetryCount = flowObj.getInt(SYSTEM_DEFINED_RETRY_COUNT_PARAM, 0);
 
     if (flowObj.containsKey(VERSIONSET_JSON_PARAM) && flowObj.containsKey(VERSIONSET_MD5HEX_PARAM) && flowObj.containsKey(VERSIONSET_ID_PARAM)) {
       // Checks if flow contains version set information

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -67,8 +67,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String VERSIONSET_ID_PARAM = "versionSetId";
   private static final String PARAM_OVERRIDE = "param.override.";
   private static final String PROJECT_FILE_UPLOAD_USER = "uploadUser";
-  private static final String CUSTOM_RETRIED_TIMES_PARAM = "customRetriedTimes";
-  private static final String SYSTEM_RETRIED_TIMES_PARAM = "systemRetriedTimes";
+  private static final String USER_DEFINED_RETRY_COUNT_PARAM = "userDefinedRetryCount";
+  private static final String SYSTEM_DEFINED_RETRY_COUNT_PARAM = "systemDefinedRetryCount";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
@@ -94,10 +94,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private String failedJobId = "unknown";
   private String modifiedBy = "unknown";
   private DispatchMethod dispatchMethod;
-  // how many times has flow level retry happened - retry defined by user's final status
-  private int customRetriedTimes = 0;
-  // retry due to stuck on "Dispatch/Preparing/Ready" status
-  private int systemRetriedTimes = 0;
+  // how many times flow level retry happened over user defined final status
+  private int userDefinedRetryCount = 0;
+  // how many times flow level retry happened due to stuck in "Dispatch/Preparing/Ready" status
+  private int systemDefinedRetryCount = 0;
 
   // For slaOption information
   private String slaOptionStr = "null";
@@ -315,20 +315,20 @@ public class ExecutableFlow extends ExecutableFlowBase {
     return slaOptionStr;
   }
 
-  public int getCustomRetriedTimes() {
-    return customRetriedTimes;
+  public int getUserDefinedRetryCount() {
+    return userDefinedRetryCount;
   }
 
-  public void setCustomRetriedTimes(int customRetriedTimes) {
-    this.customRetriedTimes = customRetriedTimes;
+  public void setUserDefinedRetryCount(int userDefinedRetryCount) {
+    this.userDefinedRetryCount = userDefinedRetryCount;
   }
 
-  public int getSystemRetriedTimes() {
-    return systemRetriedTimes;
+  public int getSystemDefinedRetryCount() {
+    return systemDefinedRetryCount;
   }
 
-  public void setSystemRetriedTimes(int systemRetriedTimes) {
-    this.systemRetriedTimes = systemRetriedTimes;
+  public void setSystemDefinedRetryCount(int systemDefinedRetryCount) {
+    this.systemDefinedRetryCount = systemDefinedRetryCount;
   }
 
   @Override
@@ -369,8 +369,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
     }
 
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
-    flowObj.put(CUSTOM_RETRIED_TIMES_PARAM, this.customRetriedTimes);
-    flowObj.put(SYSTEM_RETRIED_TIMES_PARAM, this.systemRetriedTimes);
+    flowObj.put(USER_DEFINED_RETRY_COUNT_PARAM, this.userDefinedRetryCount);
+    flowObj.put(SYSTEM_DEFINED_RETRY_COUNT_PARAM, this.systemDefinedRetryCount);
 
     flowObj.put(IS_LOCKED_PARAM, this.isLocked);
     flowObj.put(IS_OOM_Killed_PARAM, this.isOOMKilled);
@@ -435,8 +435,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
       }
       this.slaOptionStr = slaBuilder.toString();
     }
-    this.customRetriedTimes = flowObj.getInt(CUSTOM_RETRIED_TIMES_PARAM);
-    this.systemRetriedTimes = flowObj.getInt(SYSTEM_RETRIED_TIMES_PARAM);
+    this.userDefinedRetryCount = flowObj.getInt(USER_DEFINED_RETRY_COUNT_PARAM);
+    this.systemDefinedRetryCount = flowObj.getInt(SYSTEM_DEFINED_RETRY_COUNT_PARAM);
 
     if (flowObj.containsKey(VERSIONSET_JSON_PARAM) && flowObj.containsKey(VERSIONSET_MD5HEX_PARAM) && flowObj.containsKey(VERSIONSET_ID_PARAM)) {
       // Checks if flow contains version set information

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -67,8 +67,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String VERSIONSET_ID_PARAM = "versionSetId";
   private static final String PARAM_OVERRIDE = "param.override.";
   private static final String PROJECT_FILE_UPLOAD_USER = "uploadUser";
-  private static final String USER_DEFINED_RETRY_COUNT_PARAM = "userDefinedRetryCount";
-  private static final String SYSTEM_DEFINED_RETRY_COUNT_PARAM = "systemDefinedRetryCount";
+  private static final String USER_DEFINED_FLOW_RETRY_COUNT_PARAM = "userDefinedFlowRetryCount";
+  private static final String SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM = "systemDefinedFlowRetryCount";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
@@ -369,8 +369,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
     }
 
     flowObj.put(SLAOPTIONS_PARAM, slaOptions);
-    flowObj.put(USER_DEFINED_RETRY_COUNT_PARAM, this.userDefinedRetryCount);
-    flowObj.put(SYSTEM_DEFINED_RETRY_COUNT_PARAM, this.systemDefinedRetryCount);
+    flowObj.put(USER_DEFINED_FLOW_RETRY_COUNT_PARAM, this.userDefinedRetryCount);
+    flowObj.put(SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM, this.systemDefinedRetryCount);
 
     flowObj.put(IS_LOCKED_PARAM, this.isLocked);
     flowObj.put(IS_OOM_Killed_PARAM, this.isOOMKilled);
@@ -435,8 +435,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
       }
       this.slaOptionStr = slaBuilder.toString();
     }
-    this.userDefinedRetryCount = flowObj.getInt(USER_DEFINED_RETRY_COUNT_PARAM, 0);
-    this.systemDefinedRetryCount = flowObj.getInt(SYSTEM_DEFINED_RETRY_COUNT_PARAM, 0);
+    this.userDefinedRetryCount = flowObj.getInt(USER_DEFINED_FLOW_RETRY_COUNT_PARAM, 0);
+    this.systemDefinedRetryCount = flowObj.getInt(SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM, 0);
 
     if (flowObj.containsKey(VERSIONSET_JSON_PARAM) && flowObj.containsKey(VERSIONSET_MD5HEX_PARAM) && flowObj.containsKey(VERSIONSET_ID_PARAM)) {
       // Checks if flow contains version set information

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -192,13 +192,13 @@ public class ExecutionControllerUtils {
     // If the original execution status is restartable non-terminal status, it can be retried
     // if the system-retry-times hasn't reached limit
     if (RESTARTABLE_NON_TERMINAL_STATUSES.contains(originalStatus)) {
-      if (flow.getSystemRetriedTimes() >= DEFAULT_SYSTEM_FLOW_RETRY_LIMIT){
+      if (flow.getSystemDefinedRetryCount() >= DEFAULT_SYSTEM_FLOW_RETRY_LIMIT){
         logger.info("ExecutableFlow: " + flow.getExecutionId() + " has reached max retry limit "
             + "for non-terminal status, ");
         return null;
       }
       logger.info("Submitting flow for restart: " + flow.getExecutionId());
-      flow.setSystemRetriedTimes(flow.getSystemRetriedTimes() + 1);
+      flow.setSystemDefinedRetryCount(flow.getSystemDefinedRetryCount() + 1);
       return flow;
     }
 
@@ -220,9 +220,9 @@ public class ExecutionControllerUtils {
     // flow can only retry if custom-retry-times not reach the limit
     final int flowMaxRetryLimit = Integer.parseInt(
         flowParams.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
-    if (flow.getCustomRetriedTimes() >= flowMaxRetryLimit) {
+    if (flow.getUserDefinedRetryCount() >= flowMaxRetryLimit) {
       logger.info("ExecutableFlow: " + flow.getExecutionId() + " has reached max retry limit, "
-          + "retried=" + flow.getCustomRetriedTimes() + ", limit= " + flowMaxRetryLimit);
+          + "retried=" + flow.getUserDefinedRetryCount() + ", limit= " + flowMaxRetryLimit);
       return null;
     }
 
@@ -241,7 +241,7 @@ public class ExecutionControllerUtils {
     if (restartedStatuses.contains(originalStatus.name())) {
       logger.info("Submitting flow for restart: " + flow.getExecutionId()
           + "from originalStatus: " + originalStatus);
-      flow.setCustomRetriedTimes(flow.getCustomRetriedTimes() + 1);
+      flow.setUserDefinedRetryCount(flow.getUserDefinedRetryCount() + 1);
       return flow;
     }
     return null;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -231,10 +231,17 @@ public class ExecutionControllerUtils {
 
     // flow can only retry if custom-retry-times not reach the limit
     // and for the case where the retry-times not defined, default to 1
-    int flowMaxRetryLimit = 1;
+    int flowMaxRetryLimit = 0;
     if (flowParams.containsKey(FlowParameters.FLOW_PARAM_MAX_RETRIES)){
-      flowMaxRetryLimit = Integer.parseInt(
-        flowParams.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
+      flowMaxRetryLimit = Integer.parseInt(flowParams.get(FlowParameters.FLOW_PARAM_MAX_RETRIES));
+    }
+    else if (!restartedStatuses.isEmpty()){
+      logger.info(String.format("ExecutableFlow: %s has `%s=%s but `%s` not set, "
+              + "default to retry once",
+          FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
+          FlowParameters.FLOW_PARAM_MAX_RETRIES,
+          flow.getExecutionId(), restartedStatuses));
+      flowMaxRetryLimit = 1;
     }
     if (flow.getUserDefinedRetryCount() >= flowMaxRetryLimit) {
       logger.info("ExecutableFlow: " + flow.getExecutionId() + " has reached max retry limit, "

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -218,9 +219,10 @@ public class ExecutionControllerUtils {
     }
 
     // user defined restart statuses list
-    final Set<String> restartedStatuses = new HashSet<>(Arrays.asList(flowParams
-        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
-        .split("\\s*,\\s*")));
+    final Set<String> restartedStatuses = Arrays.stream(
+        flowParams.getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
+            .split("\\s*,\\s*")
+    ).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
 
     // backwards compatible to flows that historically defined with
     // "allow.restart.on.execution.stopped"
@@ -238,9 +240,10 @@ public class ExecutionControllerUtils {
     else if (!restartedStatuses.isEmpty()){
       logger.info(String.format("ExecutableFlow: %s has `%s=%s but `%s` not set, "
               + "default to retry once",
+          flow.getExecutionId(),
           FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
           FlowParameters.FLOW_PARAM_MAX_RETRIES,
-          flow.getExecutionId(), restartedStatuses));
+          restartedStatuses));
       flowMaxRetryLimit = 1;
     }
     if (flow.getUserDefinedRetryCount() >= flowMaxRetryLimit) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -43,7 +43,6 @@ public class ExecutionOptions {
   /* override dispatcher selection and use executor id specified */
   public static final String USE_EXECUTOR = "useExecutor";
   public static final int DEFAULT_FLOW_PRIORITY = 5;
-  public static final int DEFAULT_FLOW_RESTART_LIMIT = 2;
 
   private static final String FLOW_PARAMETERS = "flowParameters";
   private static final String RUNTIME_PROPERTIES = "runtimeProperties";
@@ -67,7 +66,6 @@ public class ExecutionOptions {
   public static final String FAILURE_ACTION_OVERRIDE = "failureActionOverride";
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
-  private boolean isExecutionRetried = false;
   private Integer originalFlowExecutionIdBeforeRetry = null;
 
   private boolean notifyOnFirstFailure = true;
@@ -160,7 +158,6 @@ public class ExecutionOptions {
     // separately for the original JSON format. New formats should include slaOptions as
     // part of execution options.
 
-    options.setExecutionRetried(wrapper.getBool(EXECUTION_RETRIED_BY_AZKABAN, false));
     options.setOriginalFlowExecutionIdBeforeRetry(wrapper.getInt(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
         options.originalFlowExecutionIdBeforeRetry));
 
@@ -309,11 +306,6 @@ public class ExecutionOptions {
     this.slaOptions = slaOptions;
   }
 
-  public boolean isExecutionRetried() { return this.isExecutionRetried; }
-
-  public void setExecutionRetried(boolean executionRetried) { this.isExecutionRetried =
-      executionRetried; }
-
   public Integer getOriginalFlowExecutionIdBeforeRetry() { return originalFlowExecutionIdBeforeRetry; }
 
   public void setOriginalFlowExecutionIdBeforeRetry(Integer originalFlowExecutionIdBeforeRetry) { this.originalFlowExecutionIdBeforeRetry =
@@ -339,7 +331,6 @@ public class ExecutionOptions {
     flowOptionObj.put(FAILURE_ACTION_OVERRIDE, this.failureActionOverride);
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
-    flowOptionObj.put(EXECUTION_RETRIED_BY_AZKABAN, this.isExecutionRetried);
     flowOptionObj.put(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY, this.originalFlowExecutionIdBeforeRetry);
     return flowOptionObj;
   }

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -78,8 +78,6 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(flow.getSubmitTime()));
     metaData.put(EventReporterConstants.FLOW_VERSION, String.valueOf(flow.getAzkabanFlowVersion()));
     metaData.put(EventReporterConstants.FLOW_STATUS, flow.getStatus().name());
-    metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
-        String.valueOf(flow.getExecutionOptions().isExecutionRetried()));
     if (flow.isOOMKilled()) {
       metaData.put(EventReporterConstants.IS_OOM_KILLED,
           String.valueOf(flow.isOOMKilled()));

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -69,8 +69,8 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     // Update the flow options so that the flow will be not retried again by Azkaban
 
     // inherent the retry time counters
-    executableFlow.setCustomRetriedTimes(exFlow.getCustomRetriedTimes());
-    executableFlow.setSystemRetriedTimes(exFlow.getSystemRetriedTimes());
+    executableFlow.setUserDefinedRetryCount(exFlow.getUserDefinedRetryCount());
+    executableFlow.setSystemDefinedRetryCount(exFlow.getSystemDefinedRetryCount());
 
     // If a retried flow A gets retried again with a new execution id flow B, the original flow
     // execution id of flow B should be the same as flow A's original flow execution id.

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -67,7 +67,11 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     }
     options.setMailCreator(flow.getMailCreator());
     // Update the flow options so that the flow will be not retried again by Azkaban
-    options.setExecutionRetried(true);
+
+    // inherent the retry time counters
+    executableFlow.setCustomRetriedTimes(exFlow.getCustomRetriedTimes());
+    executableFlow.setSystemRetriedTimes(exFlow.getSystemRetriedTimes());
+
     // If a retried flow A gets retried again with a new execution id flow B, the original flow
     // execution id of flow B should be the same as flow A's original flow execution id.
     if (options.getOriginalFlowExecutionIdBeforeRetry() == null) {

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -16,7 +16,7 @@
 package azkaban.server;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
-import static azkaban.executor.ExecutionOptions.DEFAULT_FLOW_RESTART_LIMIT;
+import static azkaban.executor.ExecutableFlow.DEFAULT_FLOW_RETRY_LIMIT;
 import static azkaban.executor.ExecutionOptions.FAILURE_ACTION_OVERRIDE;
 import static azkaban.executor.Status.RESTARTABLE_TERMINAL_STATUSES;
 
@@ -220,7 +220,7 @@ public class HttpRequestUtils {
       try {
         validateIntegerParam(flowParameters, FlowParameters.FLOW_PARAM_MAX_RETRIES);
         final int flowRestartCountLimit = azProps.getInt(
-            AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RESTART_LIMIT);
+            AZKABAN_EXECUTION_RESTART_LIMIT, DEFAULT_FLOW_RETRY_LIMIT);
         final int flowMaxRetryLimit = Integer.parseInt(
             flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"));
         if (flowMaxRetryLimit > flowRestartCountLimit || flowMaxRetryLimit < 0){
@@ -233,8 +233,7 @@ public class HttpRequestUtils {
       }
     }
     // doesn't contain FlowParameters.FLOW_PARAM_MAX_RETRIES
-    else if (!options.isExecutionRetried()
-        && flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
+    else if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
       // if the MAX_RETRIES parameter is empty but set some retry_statuses, default to
       // give 1 restart
       flowParameters.put(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1");

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -232,12 +232,6 @@ public class HttpRequestUtils {
         errMsg.add(e.getMessage());
       }
     }
-    // doesn't contain FlowParameters.FLOW_PARAM_MAX_RETRIES
-    else if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
-      // if the MAX_RETRIES parameter is empty but set some retry_statuses, default to
-      // give 1 restart
-      flowParameters.put(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1");
-    }
 
     // throw exception if there's any error message
     if (!errMsg.isEmpty()) {

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -89,8 +89,8 @@ public class ExecutionControllerUtilsRestartFlowTest {
   public void testRestartOnExecutionStopped() throws Exception {
     this.flow1.setStatus(Status.EXECUTION_STOPPED);
     // should inherent the retry counts
-    this.flow1.setCustomRetriedTimes(2);
-    this.flow1.setSystemRetriedTimes(1);
+    this.flow1.setUserDefinedRetryCount(2);
+    this.flow1.setSystemDefinedRetryCount(1);
 
     ExecutionControllerUtils.restartFlow(this.flow1);
 
@@ -99,7 +99,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
     assertEquals(restartedExFlow.getProjectName(), this.project.getName());
     assertEquals(restartedExFlow.getSubmitUser(), this.flow1.getSubmitUser());
     assertEquals(restartedExFlow.getDispatchMethod(), DispatchMethod.CONTAINERIZED);
-    assertEquals(2, restartedExFlow.getCustomRetriedTimes());
-    assertEquals(1, restartedExFlow.getSystemRetriedTimes());
+    assertEquals(2, restartedExFlow.getUserDefinedRetryCount());
+    assertEquals(1, restartedExFlow.getSystemDefinedRetryCount());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -88,6 +88,9 @@ public class ExecutionControllerUtilsRestartFlowTest {
   @Test
   public void testRestartOnExecutionStopped() throws Exception {
     this.flow1.setStatus(Status.EXECUTION_STOPPED);
+    // should inherent the retry counts
+    this.flow1.setCustomRetriedTimes(2);
+    this.flow1.setSystemRetriedTimes(1);
 
     ExecutionControllerUtils.restartFlow(this.flow1);
 
@@ -96,10 +99,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
     assertEquals(restartedExFlow.getProjectName(), this.project.getName());
     assertEquals(restartedExFlow.getSubmitUser(), this.flow1.getSubmitUser());
     assertEquals(restartedExFlow.getDispatchMethod(), DispatchMethod.CONTAINERIZED);
-    final ExecutionOptions options2 = restartedExFlow.getExecutionOptions();
-    assertTrue(options2.isExecutionRetried());
-
-    final ExecutionOptions options1 = this.flow1.getExecutionOptions();
-    assertTrue(options1.isExecutionRetried());
+    assertEquals(2, restartedExFlow.getCustomRetriedTimes());
+    assertEquals(1, restartedExFlow.getSystemRetriedTimes());
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
@@ -352,7 +352,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.EXECUTION_STOPPED);
     assertNotNull(flowToRestart);
-    assertEquals(1, flowToRestart.getSystemRetriedTimes());
+    assertEquals(1, flowToRestart.getSystemDefinedRetryCount());
   }
 
 
@@ -371,7 +371,7 @@ public class ExecutionControllerUtilsTest {
   public void testGetFlowToRestartNoSystemRetriedExceed() {
     final ExecutableNode node = createExecutableNode("testJob", "spark", null);
     ExecutableFlow testFlow = createSingleNodeFlow(node);
-    when(testFlow.getSystemRetriedTimes()).thenReturn(1);
+    when(testFlow.getSystemDefinedRetryCount()).thenReturn(1);
     ExecutionOptions options = new ExecutionOptions();
     when(testFlow.getExecutionOptions()).thenReturn(options);
 
@@ -412,7 +412,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.PREPARING);
     assertNotNull(flowToRestart);
-    assertEquals(1, flowToRestart.getCustomRetriedTimes());
+    assertEquals(1, flowToRestart.getUserDefinedRetryCount());
     assertEquals("2",
         flowToRestart
             .getExecutionOptions()

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
@@ -343,7 +343,6 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = createSingleNodeFlow(node);
 
     ExecutionOptions options = new ExecutionOptions();
-    options.setExecutionRetried(false);
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
@@ -353,6 +352,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.EXECUTION_STOPPED);
     assertNotNull(flowToRestart);
+    assertEquals(1, flowToRestart.getSystemRetriedTimes());
   }
 
 
@@ -368,11 +368,11 @@ public class ExecutionControllerUtilsTest {
   }
 
   @Test
-  public void testGetFlowToRestartNoExecutionOptionsFlowParameters() {
+  public void testGetFlowToRestartNoSystemRetriedExceed() {
     final ExecutableNode node = createExecutableNode("testJob", "spark", null);
     ExecutableFlow testFlow = createSingleNodeFlow(node);
+    when(testFlow.getSystemRetriedTimes()).thenReturn(1);
     ExecutionOptions options = new ExecutionOptions();
-    options.setExecutionRetried(false);
     when(testFlow.getExecutionOptions()).thenReturn(options);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
@@ -386,7 +386,6 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = createSingleNodeFlow(node);
 
     ExecutionOptions options = new ExecutionOptions();
-    options.setExecutionRetried(false);
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
@@ -404,7 +403,6 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = createSingleNodeFlow(node);
 
     ExecutionOptions options = new ExecutionOptions();
-    options.setExecutionRetried(false);
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
@@ -414,7 +412,8 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.PREPARING);
     assertNotNull(flowToRestart);
-    assertEquals("1",
+    assertEquals(1, flowToRestart.getCustomRetriedTimes());
+    assertEquals("2",
         flowToRestart
             .getExecutionOptions()
             .getFlowParameters()
@@ -427,7 +426,6 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = createSingleNodeFlow(node);
 
     ExecutionOptions options = new ExecutionOptions();
-    options.setExecutionRetried(false);
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"
@@ -435,7 +433,7 @@ public class ExecutionControllerUtilsTest {
     when(testFlow.getExecutionOptions()).thenReturn(options);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
-        Status.PREPARING);
+        Status.EXECUTION_STOPPED);
     assertNull(flowToRestart);
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
@@ -339,29 +339,41 @@ public class ExecutionControllerUtilsTest {
 
   @Test
   public void testGetFlowToRestartSuccess_EXECUTION_STOPPED() {
-    final ExecutableNode node = createExecutableNode("testJob", "spark", null);
-    ExecutableFlow testFlow = createSingleNodeFlow(node);
-
+    ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
-    when(testFlow.getExecutionOptions()).thenReturn(options);
+    testFlow.setExecutionOptions(options);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.EXECUTION_STOPPED);
     assertNotNull(flowToRestart);
-    assertEquals(1, flowToRestart.getSystemDefinedRetryCount());
+    assertEquals(0, flowToRestart.getSystemDefinedRetryCount());
+    assertEquals(1, flowToRestart.getUserDefinedRetryCount());
   }
 
+  @Test
+  public void testGetFlowToRestartSuccessWithoutMaxRetry_EXECUTION_STOPPED() {
+    ExecutableFlow testFlow = new ExecutableFlow();
+    ExecutionOptions options = new ExecutionOptions();
+    options.addAllFlowParameters(ImmutableMap.of(
+        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED"
+    ));
+    testFlow.setExecutionOptions(options);
+
+    ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
+        Status.EXECUTION_STOPPED);
+    assertNotNull(flowToRestart);
+    assertEquals(0, flowToRestart.getSystemDefinedRetryCount());
+    assertEquals(1, flowToRestart.getUserDefinedRetryCount());
+  }
 
   @Test
   public void testGetFlowToRestartNoExecutionOptions() {
-    final ExecutableNode node = createExecutableNode("testJob", "spark", null);
-    ExecutableFlow testFlow = createSingleNodeFlow(node);
-    when(testFlow.getExecutionOptions()).thenReturn(null);
-
+    ExecutableFlow testFlow = new ExecutableFlow();
+    testFlow.setExecutionOptions(null);
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.PREPARING);
     assertNull(flowToRestart);
@@ -369,11 +381,9 @@ public class ExecutionControllerUtilsTest {
 
   @Test
   public void testGetFlowToRestartNoSystemRetriedExceed() {
-    final ExecutableNode node = createExecutableNode("testJob", "spark", null);
-    ExecutableFlow testFlow = createSingleNodeFlow(node);
-    when(testFlow.getSystemDefinedRetryCount()).thenReturn(1);
-    ExecutionOptions options = new ExecutionOptions();
-    when(testFlow.getExecutionOptions()).thenReturn(options);
+    ExecutableFlow testFlow = new ExecutableFlow();
+    testFlow.setExecutionOptions(new ExecutionOptions());
+    testFlow.setSystemDefinedRetryCount(1);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.PREPARING);
@@ -382,15 +392,13 @@ public class ExecutionControllerUtilsTest {
 
   @Test
   public void testGetFlowToRestart_NoOperation_NotIncludedStatus_KILLED() {
-    final ExecutableNode node = createExecutableNode("testJob", "spark", null);
-    ExecutableFlow testFlow = createSingleNodeFlow(node);
-
+    ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
-    when(testFlow.getExecutionOptions()).thenReturn(options);
+    testFlow.setExecutionOptions(options);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.KILLED);
@@ -400,19 +408,19 @@ public class ExecutionControllerUtilsTest {
   @Test
   public void testGetFlowToRestartSuccess_PREPARING() {
     final ExecutableNode node = createExecutableNode("testJob", "spark", null);
-    ExecutableFlow testFlow = createSingleNodeFlow(node);
-
+    ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
-    when(testFlow.getExecutionOptions()).thenReturn(options);
+    testFlow.setExecutionOptions(options);
 
     ExecutableFlow flowToRestart = ExecutionControllerUtils.getFlowToRestart(testFlow,
         Status.PREPARING);
     assertNotNull(flowToRestart);
-    assertEquals(1, flowToRestart.getUserDefinedRetryCount());
+    assertEquals(1, flowToRestart.getSystemDefinedRetryCount());
+    assertEquals(0, flowToRestart.getUserDefinedRetryCount());
     assertEquals("2",
         flowToRestart
             .getExecutionOptions()

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -435,7 +435,6 @@ public final class HttpRequestUtilsTest {
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
     Map<String, String> result = options.getFlowParameters();
-    Assert.assertEquals("1", result.get(FLOW_PARAM_MAX_RETRIES));
+    Assert.assertNull(result.get(FLOW_PARAM_MAX_RETRIES));
   }
-
 }

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1740,8 +1740,6 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(rootFlow.getExecutionId()));
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(rootFlow.getSubmitTime()));
-      metaData.put(EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN,
-          String.valueOf(rootFlow.getExecutionOptions().isExecutionRetried()));
       if (rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
         // original flow execution id is set when there is one
         metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,


### PR DESCRIPTION
**Why we need this**
Part of the flow-retry feature, and it's improving the implementation: 
* Remove modifying the user-input `ExecutionOptions`, keep them as is
* clearer model to count & control how many times can an execution retry, respectively for non- / terminal originalStatus

**What's done**
* remove `isExecutionRetried` from `ExecutionOptions` because it doesn't distinguish type of retry, and retry count should be execution level info.
* use `systemRetriedTimes` to count retries on `dispatch/preparing/ready` status executions (by default should retry by the system)
* use `customRetriedTimes` to count retries on finalized status `failed/execution_stopped` defined by users

**Tests done**
* updated unit tests 
* tested in a cluster: 

Launched the original execution 786575:
![Screenshot 2023-04-07 at 5 36 44 PM](https://user-images.githubusercontent.com/31334117/230963679-960b5c08-972c-4809-9c00-728c05e6008e.png)

Delete the k8s pod to trigger EXECUTION_STOPPED, and a new execution got retried:
![Screenshot 2023-04-07 at 5 39 50 PM](https://user-images.githubusercontent.com/31334117/230963734-bf9e1ee8-6de8-4741-9861-e5468d3f4eb2.png)
![Screenshot 2023-04-07 at 5 39 07 PM](https://user-images.githubusercontent.com/31334117/230963520-29beefc2-84a7-4990-a46a-976b4725a908.png)

The new execution has `customRetriedTimes=1`
![Screenshot 2023-04-07 at 5 36 44 PM](https://user-images.githubusercontent.com/31334117/230964238-9bf85e14-0c16-40e4-94ff-952019e17342.png)
