### PR TITLE
Reduce memory pressure on WebServer by preventing loading unnecessary FlowProps from MySQL to Memory

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -143,9 +143,9 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     long startTime = System.currentTimeMillis();
     // TODO(anish-mal) FetchQueuedExecutableFlows does a lot of processing that is redundant, since
     // all we care about is the count. Write a new class that's more performant and can be used for
-    // metrics. this.executorLoader.fetchAgedQueuedFlows internally calls FetchQueuedExecutableFlows.
+    // metrics. this.executorLoader.selectAgedQueuedFlows internally calls SelectQueuedExecutableFlows.
     try {
-      size = this.executorLoader.fetchAgedQueuedFlows(Duration.ofMinutes(minimumAgeInMinutes))
+      size = this.executorLoader.selectAgedQueuedFlows(Duration.ofMinutes(minimumAgeInMinutes))
           .size();
       logger.info("Time taken to fetch size of queued flows is " + (System.currentTimeMillis() - startTime) / 1000);
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/AbstractExecutorManagerAdapter.java
@@ -141,9 +141,6 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
         ConfigurationKeys.MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES,
         Constants.DEFAULT_MIN_AGE_FOR_CLASSIFYING_A_FLOW_AGED_MINUTES);
     long startTime = System.currentTimeMillis();
-    // TODO(anish-mal) FetchQueuedExecutableFlows does a lot of processing that is redundant, since
-    // all we care about is the count. Write a new class that's more performant and can be used for
-    // metrics. this.executorLoader.selectAgedQueuedFlows internally calls SelectQueuedExecutableFlows.
     try {
       size = this.executorLoader.selectAgedQueuedFlows(Duration.ofMinutes(minimumAgeInMinutes))
           .size();
@@ -348,7 +345,7 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
     exflow.setSubmitTime(System.currentTimeMillis());
 
     // Get collection of running flows given a project and a specific flow name
-    final List<Integer> running = getRunningFlows(projectId, flowId);
+    final List<Integer> running = getRunningFlowIds(projectId, flowId);
 
     ExecutionOptions options = exflow.getExecutionOptions();
     if (options == null) {
@@ -421,10 +418,10 @@ public abstract class AbstractExecutorManagerAdapter extends EventHandler implem
    * Gets a list of all the unfinished (both dispatched and non-dispatched) executions for a given
    * project and flow {@inheritDoc}.
    *
-   * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows(int, java.lang.String)
+   * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlowIds(int, java.lang.String)
    */
   @Override
-  public List<Integer> getRunningFlows(final int projectId, final String flowId) {
+  public List<Integer> getRunningFlowIds(final int projectId, final String flowId) {
     try {
       return this.executorLoader.selectUnfinishedFlows(projectId, flowId);
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -150,19 +150,6 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
   }
 
   /**
-   * Get execution ids of all running (unfinished) flows from database.
-   */
-  public List<Integer> getRunningFlowIds() {
-    final List<Integer> allIds = new ArrayList<>();
-    try {
-      getExecutionIdsHelper(allIds, this.executorLoader.fetchUnfinishedFlows().values());
-    } catch (final ExecutorManagerException e) {
-      logger.error("Failed to get running flow ids.", e);
-    }
-    return allIds;
-  }
-
-  /**
    * Get execution ids of all non-dispatched flows from database.
    */
   public List<Integer> getQueuedFlowIds() {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionController.java
@@ -168,9 +168,6 @@ public class ExecutionController extends AbstractExecutorManagerAdapter {
   @Override
   public long getQueuedFlowSize() {
     long size = 0L;
-    // TODO(anish-mal) FetchQueuedExecutableFlows does a lot of processing that is redundant, since
-    // all we care about is the count. Write a new class that's more performant and can be used for
-    // metrics. this.executorLoader.fetchQueuedFlows internally calls FetchQueuedExecutableFlows.
     try {
       size = this.executorLoader.fetchQueuedFlows().size();
     } catch (final ExecutorManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -185,7 +185,7 @@ public class ExecutionFlowDao {
     // SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef
     // WHERE status=20 AND submit_time>0 AND submit_time<beforeInMillis
     final StringBuilder query = new StringBuilder()
-        .append(FetchExecutableFlows.FETCH_BASE_EXECUTABLE_FLOW_QUERY)
+        .append(FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_BASE_QUERY)
         .append(" WHERE status=? ")
         .append(" AND dispatch_method=?")
         .append(" AND " + validityFrom + ">0")
@@ -241,7 +241,7 @@ public class ExecutionFlowDao {
       final String flowNameContains, final String userNameContains, final int status,
       final long startTime, final long endTime, final int skip, final int num)
       throws ExecutorManagerException {
-    String query = FetchExecutableFlows.FETCH_BASE_EXECUTABLE_FLOW_QUERY;
+    String query = FetchExecutableFlows.FETCH_EXECUTABLE_FLOW_BASE_QUERY;
     final List<Object> params = new ArrayList<>();
 
     boolean first = true;
@@ -580,26 +580,18 @@ public class ExecutionFlowDao {
   public static class SelectFromExecutionFlows implements
       ResultSetHandler<List<Integer>> {
 
+    private static final String SELECT_EXECUTION_BASE_QUERY = "SELECT exec_id from execution_flows ";
     private static final String SELECT_EXECUTION_FOR_UPDATE_FORMAT =
-        "SELECT exec_id from execution_flows WHERE exec_id = (SELECT exec_id from execution_flows"
-            + " WHERE status = ? and dispatch_method = ?"
-            + " and executor_id is NULL and flow_data is NOT NULL %s"
-            + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC LIMIT 1) and "
-            + "executor_id is NULL FOR UPDATE";
+        SELECT_EXECUTION_BASE_QUERY + FOR_UPDATE_FORMAT;
 
     private static final String SELECT_EXECUTION_IN_BATCH_FOR_UPDATE_FORMAT =
-        "SELECT exec_id from execution_flows WHERE exec_id in (SELECT exec_id from execution_flows"
-            + " WHERE status = ? and dispatch_method = ?"
-            + " and executor_id is NULL and flow_data is NOT NULL %s ) "
-            + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC "
-            + " LIMIT ? FOR UPDATE";
+        SELECT_EXECUTION_BASE_QUERY + IN_BATCH_FOR_UPDATE_FORMAT;
 
-    public static final String SELECT_EXECUTION_FOR_UPDATE_ACTIVE =
-        String.format(SELECT_EXECUTION_FOR_UPDATE_FORMAT,
-            "and (use_executor is NULL or use_executor = ?)");
+    private static final String SELECT_EXECUTION_FOR_UPDATE_ACTIVE =
+        SELECT_EXECUTION_BASE_QUERY + FOR_UPDATE_ACTIVE;
 
-    public static final String SELECT_EXECUTION_FOR_UPDATE_INACTIVE =
-        String.format(SELECT_EXECUTION_FOR_UPDATE_FORMAT, "and use_executor = ?");
+    private static final String SELECT_EXECUTION_FOR_UPDATE_INACTIVE =
+        SELECT_EXECUTION_BASE_QUERY + FOR_UPDATE_INACTIVE;
 
     @Override
     public List<Integer> handle(final ResultSet rs) throws SQLException {
@@ -619,32 +611,22 @@ public class ExecutionFlowDao {
   public static class FetchExecutableFlows implements
       ResultSetHandler<List<ExecutableFlow>> {
 
-    static String FETCH_EXECUTABLE_FLOW_BY_START_TIME =
-        "SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef WHERE "
-            + "project_id=? AND flow_id=? AND start_time >= ? ORDER BY start_time DESC";
-    static String FETCH_BASE_EXECUTABLE_FLOW_QUERY =
-        "SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef";
-    private static final String FETCH_FLOWS_STARTED_BEFORE = FETCH_BASE_EXECUTABLE_FLOW_QUERY +
-        " WHERE start_time < ?";
-    static String FETCH_EXECUTABLE_FLOW =
-        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
-            + "WHERE exec_id=?";
-    static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
-        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
-            + "ORDER BY exec_id DESC LIMIT ?, ?";
-    static String FETCH_EXECUTABLE_FLOW_HISTORY =
-        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
-            + "WHERE project_id=? AND flow_id=? "
-            + "ORDER BY exec_id DESC LIMIT ?, ?";
-    static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
-        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows "
-            + "WHERE project_id=? AND flow_id=? AND status=? "
-            + "ORDER BY exec_id DESC LIMIT ?, ?";
+    private static String FETCH_EXECUTABLE_FLOW_BASE_QUERY =
+        "SELECT ef.exec_id, ef.enc_type, ef.flow_data, ef.status FROM execution_flows ef ";
+
+    private static String FETCH_EXECUTABLE_FLOW_BY_START_TIME =
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + BY_PROJECTID_FLOWID_STARTTIME;
+    private static String FETCH_EXECUTABLE_FLOW =
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + BY_EXECID;
+    private static String FETCH_ALL_EXECUTABLE_FLOW_HISTORY =
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + FOR_HISTORY;
+    private static String FETCH_EXECUTABLE_FLOW_HISTORY =
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + FOR_HISTORY_BY_PROJECTID_FLOWID;
+    private static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + FOR_HISTORY_BY_PROJECTID_FLOWID_STATUS;
     // Fetch flows that are in preparing state for more than a certain duration.
     private static final String FETCH_FLOWS_QUEUED_FOR_LONG_TIME =
-        "SELECT exec_id, enc_type, flow_data, status FROM execution_flows"
-            + " WHERE submit_time < ? AND status = "
-            + Status.PREPARING.getNumVal();
+        FETCH_EXECUTABLE_FLOW_BASE_QUERY + QUEUED_FOR_LONG_TIME;
 
     @Override
     public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {
@@ -759,4 +741,39 @@ public class ExecutionFlowDao {
       return execFlows;
     }
   }
+
+  private static final String FOR_UPDATE_FORMAT =
+      "WHERE exec_id = (SELECT exec_id from execution_flows"
+          + " WHERE status = ? and dispatch_method = ?"
+          + " and executor_id is NULL and flow_data is NOT NULL %s"
+          + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC LIMIT 1) and "
+          + "executor_id is NULL FOR UPDATE";
+
+  private static final String IN_BATCH_FOR_UPDATE_FORMAT =
+      "WHERE exec_id in (SELECT exec_id from execution_flows"
+          + " WHERE status = ? and dispatch_method = ?"
+          + " and executor_id is NULL and flow_data is NOT NULL %s ) "
+          + " ORDER BY flow_priority DESC, update_time ASC, exec_id ASC "
+          + " LIMIT ? FOR UPDATE";
+
+  private static final String FOR_UPDATE_ACTIVE =
+      String.format(FOR_UPDATE_FORMAT,
+          "and (use_executor is NULL or use_executor = ?)");
+
+  private static final String FOR_UPDATE_INACTIVE =
+      String.format(FOR_UPDATE_FORMAT, "and use_executor = ?");
+
+  private static final String BY_PROJECTID_FLOWID_STARTTIME =
+      "WHERE project_id=? AND flow_id=? AND start_time >= ? ORDER BY start_time DESC";
+  private static final String BY_EXECID =
+      "WHERE exec_id=?";
+  private static final String FOR_HISTORY =
+      "ORDER BY exec_id DESC LIMIT ?, ?";
+  private static final String FOR_HISTORY_BY_PROJECTID_FLOWID =
+      "WHERE project_id=? AND flow_id=? " + FOR_HISTORY;
+  private static final String FOR_HISTORY_BY_PROJECTID_FLOWID_STATUS =
+       "WHERE project_id=? AND flow_id=? AND status=? " + FOR_HISTORY;
+  // Fetch flows that are in preparing state for more than a certain duration.
+  private static final String QUEUED_FOR_LONG_TIME =
+      "WHERE submit_time < ? AND status = " + Status.PREPARING.getNumVal();
 }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -159,13 +159,13 @@ public class ExecutionFlowDao {
     }
   }
 
-  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+  public List<Integer> selectAgedQueuedFlows(final Duration minAge)
       throws ExecutorManagerException {
     try {
-      return this.dbOperator.query(FetchExecutableFlows.FETCH_FLOWS_QUEUED_FOR_LONG_TIME,
-          new FetchExecutableFlows(), System.currentTimeMillis() - minAge.toMillis());
+      return this.dbOperator.query(SelectFromExecutionFlows.SELECT_EXECUTIONS_QUEUED_FOR_LONG_TIME,
+          new SelectFromExecutionFlows(), System.currentTimeMillis() - minAge.toMillis());
     } catch (final SQLException e) {
-      throw new ExecutorManagerException("Error fetching aged queued flows", e);
+      throw new ExecutorManagerException("Error selecting aged queued flows", e);
     }
   }
 
@@ -641,6 +641,10 @@ public class ExecutionFlowDao {
     private static final String SELECT_QUEUED_EXECUTABLE_FLOW =
         SELECT_EXECUTION_BASE_QUERY + FOR_QUEUED_EXECUTABLE_FLOW;
 
+    // Select flows that are in preparing state for more than a certain duration.
+    private static final String SELECT_EXECUTIONS_QUEUED_FOR_LONG_TIME =
+        SELECT_EXECUTION_BASE_QUERY + QUEUED_FOR_LONG_TIME;
+
     @Override
     public List<Integer> handle(final ResultSet rs) throws SQLException {
       if (!rs.next()) {
@@ -672,9 +676,6 @@ public class ExecutionFlowDao {
         FETCH_EXECUTABLE_FLOW_BASE_QUERY + FOR_HISTORY_BY_PROJECTID_FLOWID;
     private static String FETCH_EXECUTABLE_FLOW_BY_STATUS =
         FETCH_EXECUTABLE_FLOW_BASE_QUERY + FOR_HISTORY_BY_PROJECTID_FLOWID_STATUS;
-    // Fetch flows that are in preparing state for more than a certain duration.
-    private static final String FETCH_FLOWS_QUEUED_FOR_LONG_TIME =
-        FETCH_EXECUTABLE_FLOW_BASE_QUERY + QUEUED_FOR_LONG_TIME;
 
     @Override
     public List<ExecutableFlow> handle(final ResultSet rs) throws SQLException {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionFlowDao.java
@@ -16,7 +16,7 @@
 
 package azkaban.executor;
 
-import static azkaban.executor.Status.TERMINATING_STATUSES;
+import static azkaban.executor.Status.TERMINAL_STATUSES;
 
 import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
@@ -119,7 +119,7 @@ public class ExecutionFlowDao {
     try {
       return this.dbOperator.query(SelectFromExecutionFlows.SELECT_EXECUTION_BASE_QUERY
               + "WHERE status NOT IN ("
-              + getTerminatingStatusesString() + ")",
+              + getTerminalStatusesString() + ")",
           new SelectFromExecutionFlows());
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Error fetching unfinished flows", e);
@@ -131,7 +131,7 @@ public class ExecutionFlowDao {
       return this.dbOperator.query(SelectFromExecutionFlows.SELECT_EXECUTION_BASE_QUERY
               + "WHERE project_id=? AND flow_id=? AND "
               + "status NOT IN ("
-              + getTerminatingStatusesString() + ")",
+              + getTerminalStatusesString() + ")",
           new SelectFromExecutionFlows(), projectId, flowId);
     } catch (final SQLException e) {
       throw new ExecutorManagerException("Error fetching unfinished flows", e);
@@ -831,8 +831,8 @@ public class ExecutionFlowDao {
    * Generates a string representing terminating flow status num values: "50, 60, 65, 70"
    * @return
    */
-  static String getTerminatingStatusesString() {
-    final List<Integer> list = TERMINATING_STATUSES.stream().map(Status::getNumVal).collect(
+  static String getTerminalStatusesString() {
+    final List<Integer> list = TERMINAL_STATUSES.stream().map(Status::getNumVal).collect(
         Collectors.toList());
     return StringUtils.join(list, ", ");
   }

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -238,14 +238,14 @@ public interface ExecutorLoader {
       throws ExecutorManagerException;
 
   /**
-   * This method is used to get flows fetched in Queue. Flows can be in queue in ready, dispatching
+   * This method is used to get flow ids fetched in Queue. Flows can be in queue in ready, dispatching
    * or preparing state while in queue. That is why it is expecting status in parameter.
    *
    * @param status
    * @return
    * @throws ExecutorManagerException
    */
-  List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows(Status status)
+  List<Integer> selectQueuedFlows(Status status)
       throws ExecutorManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -268,7 +268,7 @@ public interface ExecutorLoader {
       final ImmutableMap<Status, Pair<Duration, String>> validityMap)
       throws ExecutorManagerException;
 
-  List<ExecutableFlow> fetchAgedQueuedFlows(
+  List<Integer> selectAgedQueuedFlows(
       final Duration minAge) throws ExecutorManagerException;
 
   boolean updateExecutableReference(int execId, long updateTime)

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorLoader.java
@@ -42,8 +42,12 @@ public interface ExecutorLoader {
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchActiveFlows(DispatchMethod dispatchMethod)
       throws ExecutorManagerException;
 
+  Pair<ExecutionReference, ExecutableFlow> fetchUnfinishedFlow(final int executionId)
+      throws ExecutorManagerException;
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
       throws ExecutorManagerException;
+  List<Integer> selectUnfinishedFlows(final int projectId, final String flowId) throws ExecutorManagerException;
+  List<Integer> selectUnfinishedFlows() throws ExecutorManagerException;
 
   Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlowsMetadata()
       throws ExecutorManagerException;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -428,58 +429,14 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
     return flows;
   }
 
-  /**
-   * Checks whether the given flow has an active (running, non-dispatched) executions {@inheritDoc}
-   *
-   * @see azkaban.executor.ExecutorManagerAdapter#isFlowRunning(int, java.lang.String)
-   */
   @Override
-  public boolean isFlowRunning(final int projectId, final String flowId) {
-    boolean isRunning = false;
-    isRunning =
-        isRunning
-            || isFlowRunningHelper(projectId, flowId, this.queuedFlows.getAllEntries());
-    isRunning =
-        isRunning
-            || isFlowRunningHelper(projectId, flowId, this.runningExecutions.get().values());
-    return isRunning;
-  }
-
-  /**
-   * Get all active (running, non-dispatched) flows
-   * <p>
-   * {@inheritDoc}
-   *
-   * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows()
-   */
-  @Override
-  public List<ExecutableFlow> getRunningFlows() {
-    final ArrayList<ExecutableFlow> flows = new ArrayList<>();
-    getActiveFlowHelper(flows, this.queuedFlows.getAllEntries());
-    getActiveFlowHelper(flows, this.runningExecutions.get().values());
-    return flows;
-  }
-
-  /*
-   * Helper method to get all running flows from a Pair<ExecutionReference,
-   * ExecutableFlow collection
-   */
-  private void getActiveFlowHelper(final ArrayList<ExecutableFlow> flows,
-      final Collection<Pair<ExecutionReference, ExecutableFlow>> collection) {
-    for (final Pair<ExecutionReference, ExecutableFlow> ref : collection) {
-      flows.add(ref.getSecond());
-    }
-  }
-
-  /**
-   * Get execution Ids of all running (unfinished) flows
-   */
-  public String getRunningFlowIds() {
-    final List<Integer> allIds = new ArrayList<>();
-    getRunningFlowsIdsHelper(allIds, this.queuedFlows.getAllEntries());
-    getRunningFlowsIdsHelper(allIds, this.runningExecutions.get().values());
-    Collections.sort(allIds);
-    return allIds.toString();
+  public List<Integer> getRunningFlowIds() {
+    final ArrayList<Integer> flowIDs = new ArrayList<>();
+    flowIDs.addAll(this.queuedFlows.getAllEntries().stream().map(entry -> entry.getSecond().getExecutionId()).collect(
+        Collectors.toList()));
+    flowIDs.addAll(this.runningExecutions.get().values().stream().map(entry -> entry.getSecond().getExecutionId()).collect(
+        Collectors.toList()));
+    return flowIDs;
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManager.java
@@ -394,10 +394,10 @@ public class ExecutorManager extends AbstractExecutorManagerAdapter {
    * project and flow {@inheritDoc}. Results should be sorted as we assume this while setting up
    * pipelined execution Id.
    *
-   * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlows(int, java.lang.String)
+   * @see azkaban.executor.ExecutorManagerAdapter#getRunningFlowIds(int, java.lang.String)
    */
   @Override
-  public List<Integer> getRunningFlows(final int projectId, final String flowId) {
+  public List<Integer> getRunningFlowIds(final int projectId, final String flowId) {
     final List<Integer> executionIds = new ArrayList<>();
     executionIds.addAll(ExecutorUtils.getRunningFlowsHelper(projectId, flowId,
         this.queuedFlows.getAllEntries()));

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -34,14 +34,12 @@ public interface ExecutorManagerAdapter {
 
   public boolean isOfflineLogsLoaderEnabled();
 
-  public boolean isFlowRunning(int projectId, String flowId);
-
   public ExecutableFlow getExecutableFlow(int execId)
       throws ExecutorManagerException;
 
   public List<Integer> getRunningFlows(int projectId, String flowId);
 
-  public List<ExecutableFlow> getRunningFlows();
+  public List<Integer> getRunningFlowIds();
 
   public long getQueuedFlowSize();
 

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutorManagerAdapter.java
@@ -37,7 +37,7 @@ public interface ExecutorManagerAdapter {
   public ExecutableFlow getExecutableFlow(int execId)
       throws ExecutorManagerException;
 
-  public List<Integer> getRunningFlows(int projectId, String flowId);
+  public List<Integer> getRunningFlowIds(int projectId, String flowId);
 
   public List<Integer> getRunningFlowIds();
 

--- a/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FetchActiveFlowDao.java
@@ -16,7 +16,7 @@
 
 package azkaban.executor;
 
-import static azkaban.executor.Status.TERMINATING_STATUSES;
+import static azkaban.executor.Status.TERMINAL_STATUSES;
 
 import azkaban.DispatchMethod;
 import azkaban.db.DatabaseOperator;
@@ -195,8 +195,8 @@ public class FetchActiveFlowDao {
    * Generates a string representing terminating flow status num values: "50, 60, 65, 70"
    * @return
    */
-  static String getTerminatingStatusesString () {
-    final List<Integer> list = TERMINATING_STATUSES.stream().map(Status::getNumVal).collect(Collectors.toList());
+  static String getTerminalStatusesString () {
+    final List<Integer> list = TERMINAL_STATUSES.stream().map(Status::getNumVal).collect(Collectors.toList());
     return StringUtils.join(list, ", ");
   }
 
@@ -212,7 +212,7 @@ public class FetchActiveFlowDao {
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
             + " WHERE ex.status NOT IN ("
-            + FetchActiveFlowDao.getTerminatingStatusesString() + ")";
+            + FetchActiveFlowDao.getTerminalStatusesString() + ")";
 
     private static final String FETCH_UNFINISHED_EXECUTABLE_FLOW_BY_EXECID =
         FETCH_UNFINISHED_EXECUTABLE_FLOWS + " AND ex.exec_id = ?";
@@ -226,7 +226,7 @@ public class FetchActiveFlowDao {
             + " executors et ON ex.executor_id = et.id"
             + " WHERE dispatch_method = ? "
             + " AND ex.status NOT IN ("
-            + FetchActiveFlowDao.getTerminatingStatusesString() + ")"
+            + FetchActiveFlowDao.getTerminalStatusesString() + ")"
             // exclude queued flows that haven't been assigned yet -- this is the opposite of
             // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
             + " AND NOT ("
@@ -269,7 +269,7 @@ public class FetchActiveFlowDao {
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
             + " Where ex.status NOT IN ("
-            + FetchActiveFlowDao.getTerminatingStatusesString() + ")";
+            + FetchActiveFlowDao.getTerminalStatusesString() + ")";
 
     @Override
     public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> handle(
@@ -303,7 +303,7 @@ public class FetchActiveFlowDao {
             + " LEFT JOIN "
             + " executors et ON ex.executor_id = et.id"
             + " WHERE ex.exec_id = ? AND ex.status NOT IN ("
-            + FetchActiveFlowDao.getTerminatingStatusesString() + ")"
+            + FetchActiveFlowDao.getTerminalStatusesString() + ")"
             // exclude queued flows that haven't been assigned yet -- this is the opposite of
             // the condition in ExecutionFlowDao#FETCH_QUEUED_EXECUTABLE_FLOW
             + " AND NOT ("

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -115,9 +115,9 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
-  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+  public List<Integer> selectAgedQueuedFlows(final Duration minAge)
       throws ExecutorManagerException {
-    return this.executionFlowDao.fetchAgedQueuedFlows(minAge);
+    return this.executionFlowDao.selectAgedQueuedFlows(minAge);
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -91,13 +91,13 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   @Override
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows()
       throws ExecutorManagerException {
-    return fetchQueuedFlows(Status.PREPARING);
+    return this.executionFlowDao.fetchQueuedFlows(Status.PREPARING);
   }
 
   @Override
-  public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows(Status status)
+  public List<Integer> selectQueuedFlows(Status status)
       throws ExecutorManagerException {
-    return this.executionFlowDao.fetchQueuedFlows(status);
+    return this.executionFlowDao.selectQueuedFlows(status);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -136,9 +136,25 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchUnfinishedFlow(final int executionId)
+      throws ExecutorManagerException {
+    return this.fetchActiveFlowDao.fetchUnfinishedFlow(executionId);
+  }
+
+  @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlows()
       throws ExecutorManagerException {
     return this.fetchActiveFlowDao.fetchUnfinishedFlows();
+  }
+
+  @Override
+  public List<Integer> selectUnfinishedFlows(final int projectId, final String flowId) throws ExecutorManagerException {
+    return this.executionFlowDao.selectUnfinishedFlows(projectId, flowId);
+  }
+
+  @Override
+  public List<Integer> selectUnfinishedFlows() throws ExecutorManagerException {
+    return this.executionFlowDao.selectUnfinishedFlows();
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -19,6 +19,7 @@ package azkaban.executor;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -56,6 +57,9 @@ public enum Status {
 
   public static final ImmutableSet<Status> RESTARTABLE_TERMINAL_STATUSES =
       ImmutableSet.of(Status.EXECUTION_STOPPED, Status.FAILED);
+
+  public static final ImmutableSet<Status> TERMINATING_STATUSES = ImmutableSet.of(Status.SUCCEEDED,
+      Status.KILLED, Status.EXECUTION_STOPPED, Status.FAILED);
 
   private final int numVal;
 

--- a/azkaban-common/src/main/java/azkaban/executor/Status.java
+++ b/azkaban-common/src/main/java/azkaban/executor/Status.java
@@ -58,7 +58,7 @@ public enum Status {
   public static final ImmutableSet<Status> RESTARTABLE_TERMINAL_STATUSES =
       ImmutableSet.of(Status.EXECUTION_STOPPED, Status.FAILED);
 
-  public static final ImmutableSet<Status> TERMINATING_STATUSES = ImmutableSet.of(Status.SUCCEEDED,
+  public static final ImmutableSet<Status> TERMINAL_STATUSES = ImmutableSet.of(Status.SUCCEEDED,
       Status.KILLED, Status.EXECUTION_STOPPED, Status.FAILED);
 
   private final int numVal;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerizedDispatchManager.java
@@ -147,8 +147,8 @@ public class ContainerizedDispatchManager extends AbstractExecutorManagerAdapter
   public List<Integer> getQueuedFlowIds() {
     final List<Integer> allIds = new ArrayList<>();
     try {
-      getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.DISPATCHING));
-      getExecutionIdsHelper(allIds, this.executorLoader.fetchQueuedFlows(Status.PREPARING));
+      allIds.addAll(this.executorLoader.selectQueuedFlows(Status.DISPATCHING));
+      allIds.addAll(this.executorLoader.selectQueuedFlows(Status.PREPARING));
     } catch (final ExecutorManagerException e) {
       logger.error("Failed to get queued flow ids.", e);
     }

--- a/azkaban-common/src/main/java/azkaban/jmx/JmxContainerizedDispatchManager.java
+++ b/azkaban-common/src/main/java/azkaban/jmx/JmxContainerizedDispatchManager.java
@@ -29,7 +29,7 @@ public class JmxContainerizedDispatchManager implements JmxContainerizedDispatch
   }
   @Override
   public int getNumRunningFlows() {
-    return this.containerizedDispatchManager.getRunningFlows().size();
+    return this.containerizedDispatchManager.getRunningFlowIds().size();
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/jmx/JmxExecutionController.java
+++ b/azkaban-common/src/main/java/azkaban/jmx/JmxExecutionController.java
@@ -33,7 +33,7 @@ public class JmxExecutionController implements JmxExecutionControllerMBean {
 
   @Override
   public int getNumRunningFlows() {
-    return this.controller.getRunningFlows().size();
+    return this.controller.getRunningFlowIds().size();
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/jmx/JmxExecutorManager.java
+++ b/azkaban-common/src/main/java/azkaban/jmx/JmxExecutorManager.java
@@ -30,7 +30,7 @@ public class JmxExecutorManager implements JmxExecutorManagerMBean {
 
   @Override
   public int getNumRunningFlows() {
-    return this.manager.getRunningFlows().size();
+    return this.manager.getRunningFlowIds().size();
   }
 
   @Override
@@ -60,7 +60,7 @@ public class JmxExecutorManager implements JmxExecutorManagerMBean {
 
   @Override
   public String getRunningFlows() {
-    return this.manager.getRunningFlowIds();
+    return this.manager.getRunningFlowIds().toString();
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -159,7 +159,8 @@ public class ContainerizedDispatchManagerTest {
     when(this.executorLoader.fetchActiveFlowByExecId(flow1.getExecutionId())).thenReturn(
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(flow1.getExecutionId(), DispatchMethod.CONTAINERIZED), flow1));
     this.queuedFlows = ImmutableList.of(new Pair<>(this.ref1, this.flow1));
-    when(this.executorLoader.fetchQueuedFlows(Status.PREPARING)).thenReturn(this.queuedFlows);
+    when(this.executorLoader.selectQueuedFlows(Status.PREPARING)).thenReturn(this.queuedFlows.stream().map(f -> f.getSecond().getExecutionId()).collect(
+        Collectors.toList()));
 
     Pair<ExecutionReference, ExecutableFlow> executionReferencePair =
         new Pair<ExecutionReference, ExecutableFlow>(new ExecutionReference(

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -293,7 +293,7 @@ public class ContainerizedDispatchManagerTest {
     initializeContainerizedDispatchImpl();
     initializeUnfinishedFlows();
     final List<Integer> executions = this.containerizedDispatchManager
-        .getRunningFlows(this.flow2.getProjectId(), this.flow2.getFlowId());
+        .getRunningFlowIds(this.flow2.getProjectId(), this.flow2.getFlowId());
     assertThat(executions.contains(this.flow2.getExecutionId())).isTrue();
     assertThat(executions.contains(this.flow3.getExecutionId())).isTrue();
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -153,7 +153,7 @@ public class ExecutionControllerTest {
   public void testFetchActiveFlowByProject() throws Exception {
     initializeUnfinishedFlows();
     final List<Integer> executions = this.controller
-        .getRunningFlows(this.flow2.getProjectId(), this.flow2.getFlowId());
+        .getRunningFlowIds(this.flow2.getProjectId(), this.flow2.getFlowId());
     assertThat(executions.contains(this.flow2.getExecutionId())).isTrue();
     assertThat(executions.contains(this.flow3.getExecutionId())).isTrue();
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerTest.java
@@ -18,6 +18,8 @@ package azkaban.executor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,9 +51,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class ExecutionControllerTest {
@@ -128,14 +132,6 @@ public class ExecutionControllerTest {
   }
 
   @Test
-  public void testFetchAllActiveFlows() throws Exception {
-    initializeUnfinishedFlows();
-    final List<ExecutableFlow> flows = this.controller.getRunningFlows();
-    this.unfinishedFlows.values()
-        .forEach(pair -> assertThat(flows.contains(pair.getSecond())).isTrue());
-  }
-
-  @Test
   public void testFetchAllActiveFlowIds() throws Exception {
     initializeUnfinishedFlows();
     assertThat(this.controller.getRunningFlowIds())
@@ -160,10 +156,6 @@ public class ExecutionControllerTest {
         .getRunningFlows(this.flow2.getProjectId(), this.flow2.getFlowId());
     assertThat(executions.contains(this.flow2.getExecutionId())).isTrue();
     assertThat(executions.contains(this.flow3.getExecutionId())).isTrue();
-    assertThat(this.controller.isFlowRunning(this.flow2.getProjectId(), this.flow2.getFlowId()))
-        .isTrue();
-    assertThat(this.controller.isFlowRunning(this.flow3.getProjectId(), this.flow3.getFlowId()))
-        .isTrue();
   }
 
   @Test
@@ -327,10 +319,10 @@ public class ExecutionControllerTest {
 
   private void submitFlow(final ExecutableFlow flow, final ExecutionReference ref) throws
       Exception {
-    when(this.executorLoader.fetchUnfinishedFlows()).thenReturn(this.unfinishedFlows);
     when(this.executorLoader.fetchExecutableFlow(flow.getExecutionId())).thenReturn(flow);
     this.controller.submitExecutableFlow(flow, this.user.getUserId());
     this.unfinishedFlows.put(flow.getExecutionId(), new Pair<>(ref, flow));
+    initializeUnfinishedFlowMock();
   }
 
   private void initializeUnfinishedFlows() throws Exception {
@@ -338,6 +330,31 @@ public class ExecutionControllerTest {
         .of(this.flow1.getExecutionId(), new Pair<>(this.ref1, this.flow1),
             this.flow2.getExecutionId(), new Pair<>(this.ref2, this.flow2),
             this.flow3.getExecutionId(), new Pair<>(this.ref3, this.flow3));
+    initializeUnfinishedFlowMock();
+  }
+
+  private void initializeUnfinishedFlowMock() throws Exception {
     when(this.executorLoader.fetchUnfinishedFlows()).thenReturn(this.unfinishedFlows);
+    when(this.executorLoader.fetchUnfinishedFlow(anyInt())).thenAnswer(
+        (Answer<Pair<ExecutionReference, ExecutableFlow>>) invocation -> {
+          Object[] arguments = invocation.getArguments();
+          int executionId = (Integer) arguments[0];
+          List<Pair<ExecutionReference, ExecutableFlow>> list = unfinishedFlows.values().stream()
+              .filter(entry -> entry.getSecond().getExecutionId() == executionId)
+              .collect(Collectors.toList());
+          return (list.isEmpty()) ? null : list.get(0);
+        });
+    when(this.executorLoader.selectUnfinishedFlows(anyInt(), anyString())).thenAnswer(
+        (Answer<List<Integer>>) invocation -> {
+          Object[] arguments = invocation.getArguments();
+          int projectId = (Integer) arguments[0];
+          String flowId = (String) arguments[1];
+          return unfinishedFlows.values().stream()
+              .filter(entry -> entry.getSecond().getProjectId() == projectId && entry.getSecond().getFlowId().equals(flowId))
+              .map(entry -> entry.getSecond().getExecutionId())
+              .collect(Collectors.toList());
+        });
+    when(this.executorLoader.selectUnfinishedFlows()).thenReturn(
+        new ArrayList<>(this.unfinishedFlows.keySet()));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -1063,9 +1063,9 @@ public class ExecutionFlowDaoTest {
    * @throws Exception
    */
   @Test
-  public void testGetTerminatingStatusesString() throws Exception {
+  public void testGetTerminalStatusesString() throws Exception {
     final String target = "50, 60, 65, 70";
-    Assert.assertTrue(this.fetchActiveFlowDao.getTerminatingStatusesString().equals(target));
+    Assert.assertTrue(this.fetchActiveFlowDao.getTerminalStatusesString().equals(target));
   }
 
   /*

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -264,6 +264,20 @@ public class ExecutionFlowDaoTest {
   }
 
   @Test
+  public void testSelectQueuedFlows() throws Exception {
+    final ExecutableFlow flow1 = submitNewFlow("exectest1", "exec1", System.currentTimeMillis(),
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY, DispatchMethod.POLL);
+    final ExecutableFlow flow2 = submitNewFlow("exectest1", "exec2", System.currentTimeMillis(),
+        ExecutionOptions.DEFAULT_FLOW_PRIORITY, DispatchMethod.POLL);
+
+    final List<Integer> selectedQueuedFlows =
+        this.executionFlowDao.selectQueuedFlows(Status.PREPARING);
+    assertThat(selectedQueuedFlows.size()).isEqualTo(2);
+    assert(selectedQueuedFlows.get(0) == flow1.getExecutionId());
+    assert(selectedQueuedFlows.get(1) == flow2.getExecutionId());
+  }
+
+  @Test
   public void testFetchStaleFlows() throws IOException, ExecutorManagerException {
     // Flow executions in PREPARING state
     final long lessThan15Minutes = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionFlowDaoTest.java
@@ -397,6 +397,44 @@ public class ExecutionFlowDaoTest {
   }
 
   @Test
+  public void testFetchUnfinishedFlow() throws Exception {
+    final List<ExecutableFlow> flows = createExecutions();
+    final Pair<ExecutionReference, ExecutableFlow> unfinishedFlow =
+        this.fetchActiveFlowDao.fetchUnfinishedFlow(flows.get(0).getExecutionId());
+    assert(unfinishedFlow.getSecond().getExecutionId() == flows.get(0).getExecutionId());
+    assertTwoFlowSame(unfinishedFlow.getSecond(), flows.get(0));
+
+    final Pair<ExecutionReference, ExecutableFlow> finishedFlow =
+        this.fetchActiveFlowDao.fetchUnfinishedFlow(flows.get(3).getExecutionId());
+    assert(finishedFlow == null);
+  }
+
+  @Test
+  public void testSelectUnfinishedFlows() throws Exception {
+    final List<ExecutableFlow> flows = createExecutions();
+    final Set<Integer> unfinishedFlows =
+        new HashSet(this.executionFlowDao.selectUnfinishedFlows());
+
+    assert(unfinishedFlows.contains(flows.get(0).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(1).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(2).getExecutionId()));
+    assert(!unfinishedFlows.contains(flows.get(3).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(4).getExecutionId()));
+  }
+
+  @Test
+  public void testSelectUnfinishedFlowsWithProjectIdAndFlowId() throws Exception {
+    final List<ExecutableFlow> flows = createExecutions();
+    final List<Integer> unfinishedFlows = this.executionFlowDao.selectUnfinishedFlows(flows.get(0).getProjectId(), flows.get(0).getFlowId());
+
+    assert(unfinishedFlows.contains(flows.get(0).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(1).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(2).getExecutionId()));
+    assert(!unfinishedFlows.contains(flows.get(3).getExecutionId()));
+    assert(unfinishedFlows.contains(flows.get(4).getExecutionId()));
+  }
+
+  @Test
   public void testFetchUnfinishedFlowsMetadata() throws Exception {
     final List<ExecutableFlow> flows = createExecutions();
     final Map<Integer, Pair<ExecutionReference, ExecutableFlow>> unfinishedFlows =

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -449,7 +449,7 @@ public class ExecutorManagerTest {
   @Test
   public void testFetchActiveFlowByProject() throws Exception {
     testSetUpForRunningFlows();
-    final List<Integer> executions = this.manager.getRunningFlows(this.flow1.getProjectId(),
+    final List<Integer> executions = this.manager.getRunningFlowIds(this.flow1.getProjectId(),
         this.flow1.getFlowId());
     Assert.assertTrue(executions.contains(this.flow1.getExecutionId()));
   }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutorManagerTest.java
@@ -262,8 +262,7 @@ public class ExecutorManagerTest {
 
     // Verify running flows using old definition of "running" flows i.e. a
     // non-dispatched flow is also considered running
-    final List<Integer> managerActiveFlows = manager.getRunningFlows()
-        .stream().map(ExecutableFlow::getExecutionId).collect(Collectors.toList());
+    final List<Integer> managerActiveFlows = manager.getRunningFlowIds();
     Assert.assertTrue(managerActiveFlows.containsAll(testFlows)
         && testFlows.containsAll(managerActiveFlows));
 
@@ -300,7 +299,7 @@ public class ExecutorManagerTest {
         this.executorLoader.fetchExecutableFlow(flow1.getExecutionId());
     Assert.assertEquals(fetchedFlow.getStatus(), Status.FAILED);
 
-    Assert.assertFalse(manager.getRunningFlows().contains(flow1));
+    Assert.assertFalse(manager.getRunningFlowIds().contains(flow1.getExecutionId()));
   }
 
   /* Flow has been running on an executor but is not any more (for example because of restart) */
@@ -448,23 +447,11 @@ public class ExecutorManagerTest {
 
   @Ignore
   @Test
-  public void testFetchAllActiveFlows() throws Exception {
-    testSetUpForRunningFlows();
-    final List<ExecutableFlow> flows = this.manager.getRunningFlows();
-    for (final Pair<ExecutionReference, ExecutableFlow> pair : this.activeFlows.values()) {
-      Assert.assertTrue(flows.contains(pair.getSecond()));
-    }
-  }
-
-  @Ignore
-  @Test
   public void testFetchActiveFlowByProject() throws Exception {
     testSetUpForRunningFlows();
     final List<Integer> executions = this.manager.getRunningFlows(this.flow1.getProjectId(),
         this.flow1.getFlowId());
     Assert.assertTrue(executions.contains(this.flow1.getExecutionId()));
-    Assert
-        .assertTrue(this.manager.isFlowRunning(this.flow1.getProjectId(), this.flow1.getFlowId()));
   }
 
   @Ignore

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -431,7 +431,6 @@ public class MockExecutorLoader implements ExecutorLoader {
     return fetchQueuedFlows(Status.PREPARING);
   }
 
-  @Override
   public List<Pair<ExecutionReference, ExecutableFlow>> fetchQueuedFlows(Status status)
       throws ExecutorManagerException {
     final List<Pair<ExecutionReference, ExecutableFlow>> queuedFlows =
@@ -443,6 +442,13 @@ public class MockExecutorLoader implements ExecutorLoader {
       }
     }
     return queuedFlows;
+  }
+
+  @Override
+  public List<Integer> selectQueuedFlows(Status status)
+      throws ExecutorManagerException {
+    return this.fetchQueuedFlows(status).stream().map(f -> f.getSecond().getExecutionId()).collect(
+        Collectors.toList());
   }
 
   @Override

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -90,6 +90,27 @@ public class MockExecutorLoader implements ExecutorLoader {
   }
 
   @Override
+  public Pair<ExecutionReference, ExecutableFlow> fetchUnfinishedFlow(final int executionId)
+      throws ExecutorManagerException {
+    return this.activeFlows.get(executionId);
+  }
+
+  @Override
+  public List<Integer> selectUnfinishedFlows(final int projectId, final String flowId) throws ExecutorManagerException {
+    return this.activeFlows.entrySet().stream()
+        .filter(entry -> entry.getValue().getSecond().getProjectId() == projectId && entry.getValue().getSecond().getFlowId().equals(flowId))
+        .map(entry -> entry.getValue().getSecond().getExecutionId())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<Integer> selectUnfinishedFlows() throws ExecutorManagerException {
+    return this.activeFlows.entrySet().stream()
+        .map(entry -> entry.getValue().getSecond().getExecutionId())
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public Map<Integer, Pair<ExecutionReference, ExecutableFlow>> fetchUnfinishedFlowsMetadata()
       throws ExecutorManagerException {
     return this.activeFlows.entrySet().stream()

--- a/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
+++ b/azkaban-common/src/test/java/azkaban/executor/MockExecutorLoader.java
@@ -469,20 +469,20 @@ public class MockExecutorLoader implements ExecutorLoader {
   // TODO(anish-mal) To be used in a future unit test, once System calls to obtain
   // current time have been replaced by Clocks. Clocks are needed in order to write
   // unit tests for duration based features. Without it, the tests end up being flaky.
-  public List<ExecutableFlow> fetchAgedQueuedFlows(final Duration minAge)
+  public List<Integer> selectAgedQueuedFlows(final Duration minAge)
       throws ExecutorManagerException {
-    final List<ExecutableFlow> agedQueuedFlows = new ArrayList<>();
+    final List<Integer> agedQueuedFlowIds = new ArrayList<>();
 
     long timeThreshoold = System.currentTimeMillis() - minAge.toMillis();
     for (final int execId : this.refs.keySet()) {
       if (!this.executionExecutorMapping.containsKey(execId)) {
         ExecutableFlow agedFlow = this.flows.get(execId);
         if (agedFlow.getSubmitTime() < timeThreshoold) {
-          agedQueuedFlows.add(agedFlow);
+          agedQueuedFlowIds.add(execId);
         }
       }
     }
-    return agedQueuedFlows;
+    return agedQueuedFlowIds;
   }
 
   @Override

--- a/azkaban-db/src/main/sql/create.execution_flows.sql
+++ b/azkaban-db/src/main/sql/create.execution_flows.sql
@@ -23,6 +23,8 @@ CREATE INDEX ex_flows_start_time
   ON execution_flows (start_time);
 CREATE INDEX ex_flows_end_time
   ON execution_flows (end_time);
+CREATE INDEX ex_flows_submit_time
+  ON execution_flows (submit_time);
 CREATE INDEX ex_flows_time_range
   ON execution_flows (start_time, end_time);
 CREATE INDEX ex_flows_flows

--- a/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/AzkabanWebServer.java
@@ -631,7 +631,7 @@ public class AzkabanWebServer extends AzkabanServer implements IMBeanRegistrable
          * synchronized, such that we can not make a thread safe subtraction. We need to fix this
          *  in the future.
          */
-        return executorManagerAdapter.getRunningFlows().size();
+        return executorManagerAdapter.getRunningFlowIds().size();
       }
 
       @Override

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -817,7 +817,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     }
 
     final List<Integer> refs =
-        this.executorManagerAdapter.getRunningFlows(project.getId(), flowId);
+        this.executorManagerAdapter.getRunningFlowIds(project.getId(), flowId);
     if (!refs.isEmpty()) {
       ret.put("execIds", refs);
     }


### PR DESCRIPTION
From our investigations, web server unnecessarily loads too many FlowProps objects from database to memory which causes too high memory footprints and thus causing web server out-of-memory easily under decent load. Each FlowProps object is a user defined hashmap which can be huge in size. As a result, we should prevent loading unnecessary FlowProps from MySQL to Memory if possible.

Warning: Possibly read one commit at a time is easier for review

1. Split ExecutorLoader.fetchUnfinishedFlow to fine-grained methods and onboard to rest of the codebase to reduce unnecessary memory footprint:
1.1. When render Azkaban Job/Flow logs for a given executionId in getFlowLogData() OR cancelling flow using cancelFlow(), no need to read all unfinished executions from MySQL and do filter in application layer but should only do filtering where execId == executionId in database layer
1.2. When counting the number of running flows using getRunningFlows() for flow concurrency level check and metrics reporting and etc, no need to read all columns (contains FlowProps) of ExecutableFlow object but only aggregated count or execId column is enough.
2. Replace ExecutorLoader.fetchQueuedFlows with selectQueuedFlows to reduce memory footprint
2.1. When counting the number of queued flows using getQueuedFlowSize(), no need to read all columns (contains FlowProps) of ExecutableFlow object but only aggregated count or execId column is enough.
3. Replace ExecutorLoader.fetchAgedQueuedFlows with selectAgedQueuedFlows to reduce memory footprint
3.1. When counting the number of agedQueued flows using getAgedQueuedFlowSize(), no need to read all columns (contains FlowProps) of ExecutableFlow object but only aggregated count or execId column is enough.
