### PR TITLE
Add flow name only filter to VPA filter

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -54,7 +54,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
       return;
     }
     final ExecutableFlow executableFlow =
-        FlowUtils.createExecutableFlow(project, flow, this.executorManagerAdapter, logger);
+        this.executorManagerAdapter.createExecutableFlow(project, flow);
     executableFlow.setSubmitUser(exFlow.getSubmitUser());
     executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
     executableFlow.setUploadUser(project.getUploadUser());

--- a/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/VPAFlowCriteriaTest.java
@@ -45,6 +45,13 @@ public class VPAFlowCriteriaTest {
 
   @Test
   public void testFlowNameFilter() throws Exception {
+    Assert.assertTrue(this.vpaFlowCriteria.flowExists(null, "flow5"));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists(null, "flow4"));
+    Assert.assertFalse(this.vpaFlowCriteria.flowExists(null, "flow3"));
+  }
+
+  @Test
+  public void testProjectFlowNameFilter() throws Exception {
     Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj1", "flow1"));
     Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj2", "flow2"));
     Assert.assertTrue(this.vpaFlowCriteria.flowExists("proj1", "flow3"));

--- a/azkaban-common/src/test/resources/flow_filter.txt
+++ b/azkaban-common/src/test/resources/flow_filter.txt
@@ -2,3 +2,4 @@ proj1:flow1
 proj2:flow2
 proj1:flow3
 proj3
+:flow5

--- a/azkaban-common/src/test/resources/flow_filter2.txt
+++ b/azkaban-common/src/test/resources/flow_filter2.txt
@@ -3,3 +3,4 @@ proj2:flow2
 proj1:flow3
 proj3
 proj2:flow4
+:flow5


### PR DESCRIPTION
Originally, we exclude some (projectName, \*) and (projectName, flowName) from VPA flow resource recommendation feature. It does not work for some edge cases where projectName is different but flowName is the same. As a result, we should further add (\*, flowName) support to exclude them from VPA feature.