### PR TITLE
Implement ExecutionOptions merge() method; remove loading of project-DSL flow-parameter to ExecutableFlow at read; hot fix bugs;

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -356,9 +356,48 @@ public class ExecutionOptions {
    * If conflicts, the values set in the input will get to overwrite the old values.
    * @return
    */
-  public ExecutionOptions merge(ExecutionOptions overwriteOptions) {
-    // TODO: implement it
-    return overwriteOptions;
+  public void merge(ExecutionOptions overwriteOptions) {
+    this.originalFlowExecutionIdBeforeRetry = overwriteOptions.originalFlowExecutionIdBeforeRetry;
+    this.notifyOnFirstFailure = overwriteOptions.notifyOnFirstFailure;
+    this.notifyOnLastFailure = overwriteOptions.notifyOnLastFailure;
+    this.successEmailsOverride = overwriteOptions.successEmailsOverride;
+    this.failureEmailsOverride = overwriteOptions.failureEmailsOverride;
+    this.failureActionOverride = overwriteOptions.failureActionOverride;
+    this.memoryCheck = overwriteOptions.memoryCheck;
+
+    this.successEmails.addAll(overwriteOptions.successEmails);
+    this.failureEmails.addAll(overwriteOptions.failureEmails);
+
+    if (overwriteOptions.pipelineLevel != null) {
+      this.pipelineLevel = overwriteOptions.pipelineLevel;
+    }
+    if (overwriteOptions.pipelineExecId != null) {
+      this.pipelineExecId = overwriteOptions.pipelineExecId;
+    }
+    if (overwriteOptions.queueLevel != null) {
+      this.queueLevel = overwriteOptions.queueLevel;
+    }
+    if (!overwriteOptions.concurrentOption.isEmpty()) {
+      this.concurrentOption = overwriteOptions.concurrentOption;
+    }
+    if (!overwriteOptions.mailCreator.trim().isEmpty()) {
+      this.mailCreator = overwriteOptions.mailCreator;
+    }
+    if (!overwriteOptions.flowParameters.isEmpty()) {
+      this.flowParameters.putAll(overwriteOptions.flowParameters);
+    }
+    if (!overwriteOptions.runtimeProperties.isEmpty()) {
+      this.runtimeProperties.putAll(overwriteOptions.runtimeProperties);
+    }
+    if (overwriteOptions.failureAction != null) {
+      this.failureAction = overwriteOptions.failureAction;
+    }
+    if (!overwriteOptions.initiallyDisabledJobs.isEmpty()) {
+      this.initiallyDisabledJobs = overwriteOptions.initiallyDisabledJobs;
+    }
+    if (!overwriteOptions.slaOptions.isEmpty()) {
+      this.slaOptions = overwriteOptions.slaOptions;
+    }
   }
 
   public enum FailureAction {

--- a/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
+++ b/azkaban-common/src/main/java/azkaban/executor/JdbcExecutorLoader.java
@@ -83,16 +83,7 @@ public class JdbcExecutorLoader implements ExecutorLoader {
   @Override
   public ExecutableFlow fetchExecutableFlow(final int id)
       throws ExecutorManagerException {
-    final ExecutableFlow flow = this.executionFlowDao.fetchExecutableFlow(id);
-    if (null != flow) {
-      try {
-        flow.setFlowParamsFromProps(
-            FlowLoaderUtils.loadPropsForExecutableFlow(this.projectLoader, flow));
-      } catch (ProjectManagerException e) {
-        throw new ExecutorManagerException(e);
-      }
-    }
-    return flow;
+    return this.executionFlowDao.fetchExecutableFlow(id);
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -54,7 +54,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
       return;
     }
     final ExecutableFlow executableFlow =
-        FlowUtils.createExecutableFlow(project, flow, this.executorManagerAdapter, logger);
+        this.executorManagerAdapter.createExecutableFlow(project, flow);
     executableFlow.setSubmitUser(exFlow.getSubmitUser());
     executableFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
     executableFlow.setUploadUser(project.getUploadUser());

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -1,6 +1,7 @@
 package azkaban.executor;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,7 @@ import com.codahale.metrics.MetricRegistry;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.P;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
@@ -73,12 +75,14 @@ public class ExecutionControllerUtilsRestartFlowTest {
     this.executorLoader.uploadExecutableFlow(this.flow1);
     this.nearlineExecutionLogsLoader = new MockExecutionLogsLoader();
 
-    this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props, null,
+    this.projectManager = mock(ProjectManager.class);
+    when(this.projectManager.getProject(projectId)).thenReturn(this.project);
+    when(this.projectManager.loadPropsForExecutableFlow(any())).thenReturn(new Props());
+
+    this.containerizedDispatchManager = new ContainerizedDispatchManager(this.props, this.projectManager,
         this.executorLoader, this.nearlineExecutionLogsLoader, this.offlineExecutionLogsLoader,
         this.commonMetrics, mock(ExecutorApiGateway.class), mock(ContainerizedImpl.class),null,
         null, new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
-    this.projectManager = mock(ProjectManager.class);
-    when(this.projectManager.getProject(projectId)).thenReturn(this.project);
 
     this.listener = new OnContainerizedExecutionEventListener(this.executorLoader,
         this.containerizedDispatchManager, this.projectManager);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -17,6 +17,7 @@ public class ExecutionOptionsTest {
     options1.addAllFlowParameters(
         ImmutableMap.of(
             FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
+            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true",
             FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true")
     );
     options1.setFailureAction(FailureAction.FINISH_ALL_POSSIBLE);
@@ -26,6 +27,7 @@ public class ExecutionOptionsTest {
     overwrite.addAllFlowParameters(
         ImmutableMap.of(
             FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false",
             FlowParameters.FLOW_PARAM_MAX_RETRIES, "1")
     );
     overwrite.setFailureAction(FailureAction.CANCEL_ALL);
@@ -42,6 +44,7 @@ public class ExecutionOptionsTest {
     // check
     Map<String, String> expectFlowParams = ImmutableMap.of(
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "1",
         FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true");
     Map<String, String> flowParams = options1.getFlowParameters();

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -1,0 +1,55 @@
+package azkaban.executor;
+
+import static org.junit.Assert.assertEquals;
+
+import azkaban.Constants.FlowParameters;
+import azkaban.executor.ExecutionOptions.FailureAction;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import org.junit.Test;
+
+public class ExecutionOptionsTest {
+
+  @Test
+  public void testMerge() {
+    ExecutionOptions options1 = new ExecutionOptions();
+    options1.addAllFlowParameters(
+        ImmutableMap.of(
+            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
+            FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true")
+    );
+    options1.setFailureAction(FailureAction.FINISH_ALL_POSSIBLE);
+    options1.setMailCreator("dummy");
+
+    ExecutionOptions overwrite = new ExecutionOptions();
+    overwrite.addAllFlowParameters(
+        ImmutableMap.of(
+            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+            FlowParameters.FLOW_PARAM_MAX_RETRIES, "1")
+    );
+    overwrite.setFailureAction(FailureAction.CANCEL_ALL);
+    overwrite.setMemoryCheck(true);
+    overwrite.setSuccessEmails(ImmutableSet.of("abcd@linkedin.com"));
+    overwrite.setPipelineExecutionId(123);
+    overwrite.setMailCreator("  ");
+    overwrite.addAllRuntimeProperties(
+        ImmutableMap.of("property1", ImmutableMap.of("key", "value")));
+
+    // do the merge
+    options1.merge(overwrite);
+
+    // check
+    Map<String, String> expectFlowParams = ImmutableMap.of(
+        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FlowParameters.FLOW_PARAM_MAX_RETRIES, "1",
+        FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true");
+    Map<String, String> flowParams = options1.getFlowParameters();
+    assertEquals(expectFlowParams, flowParams);
+
+    ExecutionOptions expected = ExecutionOptions.createFromObject(overwrite.toObject());
+    expected.addAllFlowParameters(expectFlowParams);
+    expected.setMailCreator("dummy");
+    assertEquals(expected.toJSON(), options1.toJSON());
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -1027,9 +1027,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     }
     options.setMailCreator(flow.getMailCreator());
 
-
-    ExecutionOptions merged = exflow.getExecutionOptions().merge(options);
-    exflow.setExecutionOptions(merged);
+    exflow.getExecutionOptions().merge(options);
 
     /**
      * If the user has not explicitly overridden the failure action from the UI or

--- a/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/flowtrigger/TriggerInstanceProcessorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import azkaban.executor.ExecutableFlow;
 import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.MockExecutorLoader;
@@ -109,6 +110,7 @@ public class TriggerInstanceProcessorTest {
     this.triggerInstLoader = mock(FlowTriggerInstanceLoader.class);
     this.executorManager = mock(ExecutorManagerAdapter.class);
     this.executorLoader = new MockExecutorLoader();
+    when(this.executorManager.createExecutableFlow(any(), any())).thenReturn(mock(ExecutableFlow.class));
     when(this.executorManager.submitExecutableFlow(any(), anyString())).thenReturn("return");
     final CommonMetrics commonMetrics = new CommonMetrics(new MetricsManager(new MetricRegistry()));
     this.emailer = Mockito.spy(new Emailer(EmailerTest.createMailProperties(), commonMetrics,

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTestBase.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/LoginAbstractAzkabanServletTestBase.java
@@ -15,8 +15,12 @@
  */
 package azkaban.webapp.servlet;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import azkaban.ServiceProvider;
 import azkaban.executor.ExecutableFlow;
+import azkaban.executor.ExecutionOptions;
 import azkaban.executor.ExecutorManagerAdapter;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.flow.Flow;
@@ -87,20 +91,20 @@ public abstract class LoginAbstractAzkabanServletTestBase {
 
     ServiceProvider.SERVICE_PROVIDER.unsetInjector();
     ServiceProvider.SERVICE_PROVIDER.setInjector(this.injector);
-    Mockito.when(this.injector.getInstance(AzkabanWebServer.class))
+    when(this.injector.getInstance(AzkabanWebServer.class))
         .thenReturn(this.azkabanWebServer);
-    Mockito.when(this.injector.getInstance(WebMetrics.class))
+    when(this.injector.getInstance(WebMetrics.class))
         .thenReturn(this.webMetrics);
 
     // This could possibly load
     // azkaban-public/azkaban-web-server/src/main/resources/conf/azkaban.properties
     // , but so far not needed
-    Mockito.when(this.azkabanWebServer.getServerProps()).thenReturn(Props.of());
-    Mockito.when(this.azkabanWebServer.getProjectManager()).thenReturn(this.projectManager);
-    Mockito.when(this.azkabanWebServer.getUserManager()).thenReturn(this.userManager);
-    Mockito.when(this.azkabanWebServer.getExecutorManager()).thenReturn(this.executorManager);
-    Mockito.when(this.azkabanWebServer.getScheduleManager()).thenReturn(this.scheduleManager);
-    Mockito.when(this.azkabanWebServer.getFlowTriggerService()).thenReturn(this.flowTriggerService);
+    when(this.azkabanWebServer.getServerProps()).thenReturn(Props.of());
+    when(this.azkabanWebServer.getProjectManager()).thenReturn(this.projectManager);
+    when(this.azkabanWebServer.getUserManager()).thenReturn(this.userManager);
+    when(this.azkabanWebServer.getExecutorManager()).thenReturn(this.executorManager);
+    when(this.azkabanWebServer.getScheduleManager()).thenReturn(this.scheduleManager);
+    when(this.azkabanWebServer.getFlowTriggerService()).thenReturn(this.flowTriggerService);
 
     mockTesUserWithAdminRole();
 
@@ -112,13 +116,13 @@ public abstract class LoginAbstractAzkabanServletTestBase {
     final User testAdminUser = new User("testAdminUser");
     testAdminUser.addRole("adminRole");
     final Role adminRole = new Role("adminRole", new Permission(Type.ADMIN));
-    Mockito.when(this.userManager.getRole("adminRole")).thenReturn(adminRole);
-    Mockito.when(this.session.getUser()).thenReturn(testAdminUser);
+    when(this.userManager.getRole("adminRole")).thenReturn(adminRole);
+    when(this.session.getUser()).thenReturn(testAdminUser);
   }
 
   protected void mockTestProjectAndFlow() {
     final Project project = new Project(11, "testProject");
-    Mockito.when(this.projectManager.getProject("testProject")).thenReturn(project);
+    when(this.projectManager.getProject("testProject")).thenReturn(project);
     final Flow flow = new Flow("testFlow");
     project.setFlows(ImmutableMap.of(flow.getId(), flow));
   }
@@ -130,6 +134,10 @@ public abstract class LoginAbstractAzkabanServletTestBase {
       exFlow.setExecutionId(99);
       return "Submitted (mocked)";
     }).when(this.executorManager).submitExecutableFlow(this.exFlow.capture(), Mockito.anyString());
+    final ExecutableFlow exFlow = new ExecutableFlow();
+    exFlow.setExecutionId(99);
+    exFlow.setExecutionOptions(new ExecutionOptions());
+    when(this.executorManager.createExecutableFlow(any(Project.class), any(Flow.class))).thenReturn(exFlow);
   }
 
   public static class AzkabanMockHttpServletRequest extends MockHttpServletRequest {


### PR DESCRIPTION
**Why we need this**
As a follow up of #3269, this `ExecutionOptions.merge()` method is required for honoring the flow-parameters defined with DSL with the project uploaded.

Also, because previously the logic that add `project-DSL defined flow-parameter` to `ExecutableFlow` happens at database reading time, it creates confusion between webUI display and real execution setting.

**What's done**
1. merge all the defined fields of another `ExecutionOptions` into "this";
2. hot fix some bugs introduced in previous PR.
3. remove loading `project-DSL defined flow-parameter` to `ExecutableFlow` from DB reading time.

**Tests done**
1. unit tests

![Screenshot 2023-04-17 at 4 56 16 PM](https://user-images.githubusercontent.com/31334117/232636157-fd69b4a7-a288-4741-9487-714b63a31b90.png)


2. end to end test in staging cluster: 

Uploaded the project with DSL setting `param.overwrite.allow.restart.on.execution.stopped=true` to the flow.
Then submit an flow
![Screenshot 2023-04-17 at 6 34 00 PM](https://user-images.githubusercontent.com/31334117/232647501-22335a9b-084b-4039-9307-2f7c005776b2.png)
-execution without setting any flow parameter, the parameter is being honored.


Then submit an flow-execution with `allow.restart.on.execution.stopped=false` from UI:
![Screenshot 2023-04-17 at 6 34 50 PM](https://user-images.githubusercontent.com/31334117/232647197-a515892f-b1be-4070-bfc1-91ee236184f4.png)
![Screenshot 2023-04-17 at 6 34 57 PM](https://user-images.githubusercontent.com/31334117/232647205-44d88fed-a802-46af-954a-271e1f0674e3.png)

The UI-passed-in value `false` is honored, overwriting the DSL value.
![Screenshot 2023-04-17 at 6 35 10 PM](https://user-images.githubusercontent.com/31334117/232647520-0bdac4ca-838f-47c7-a50e-b0ec88092dd4.png)


