### PR TITLE
Add timeout to dependency download at project upload stage

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -388,6 +388,8 @@ public class Constants {
     public static final String AZKABAN_DEPENDENCY_MAX_DOWNLOAD_TRIES = "azkaban.dependency.max.download.tries";
     public static final String AZKABAN_DEPENDENCY_DOWNLOAD_THREADPOOL_SIZE =
         "azkaban.dependency.download.threadpool.size";
+    public static final String AZKABAN_DEPENDENCY_DOWNLOAD_TIMEOUT_SECONDS =
+        "azkaban.dependency.download.timeout.seconds";
     public static final String AZKABAN_STORAGE_TYPE = "azkaban.storage.type";
     public static final String AZKABAN_STORAGE_LOCAL_BASEDIR = "azkaban.storage.local.basedir";
     public static final String HADOOP_CONF_DIR_PATH = "hadoop.conf.dir.path";

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectImpl.java
@@ -702,7 +702,6 @@ public class JdbcProjectImpl implements ProjectLoader {
       throws ProjectManagerException {
     // We do one at a time instead of batch... because well, the batch could be
     // large.
-    logger.info("Uploading flows");
     try {
       for (final Flow flow : flows) {
         uploadFlow(project, version, flow, this.defaultEncodingType);
@@ -752,7 +751,7 @@ public class JdbcProjectImpl implements ProjectLoader {
     final String json = JSONUtils.toJSON(flow.toObject());
     final byte[] data = convertJsonToBytes(encType, json);
 
-    logger.info("Flow upload " + flow.getId() + " is byte size " + data.length);
+    logger.info("Flow upload " + flow.getId() + " in project " + project.getName() + " is byte size " + data.length);
     final String INSERT_FLOW =
         "INSERT INTO project_flows (project_id, version, flow_id, modified_time, encoding_type, json) values (?,?,?,?,?,?)";
     try {

--- a/azkaban-common/src/main/java/azkaban/utils/DependencyTransferManager.java
+++ b/azkaban-common/src/main/java/azkaban/utils/DependencyTransferManager.java
@@ -19,6 +19,7 @@ package azkaban.utils;
 import azkaban.Constants;
 import azkaban.spi.DependencyFile;
 import azkaban.spi.Storage;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -47,6 +48,7 @@ import static azkaban.utils.ThinArchiveUtils.*;
 @Singleton
 public class DependencyTransferManager {
   private static final int DEFAULT_NUM_THREADS = 32;
+  private static final int DEFAULT_TIMEOUT_SECONDS =300;
 
   public final int dependencyMaxDownloadTries;
 
@@ -66,7 +68,7 @@ public class DependencyTransferManager {
         new ThreadFactoryBuilder().setNameFormat("azk-dependency-pool-%d").build());
     this.dependencyMaxDownloadTries =
         props.getInt(Constants.ConfigurationKeys.AZKABAN_DEPENDENCY_MAX_DOWNLOAD_TRIES, 2);
-    this.dependencyDownloadMaxTimeout = props.getInt(AZKABAN_DEPENDENCY_DOWNLOAD_TIMEOUT_SECONDS, 300);
+    this.dependencyDownloadMaxTimeout = props.getInt(AZKABAN_DEPENDENCY_DOWNLOAD_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_SECONDS);
   }
 
   /**
@@ -204,7 +206,8 @@ public class DependencyTransferManager {
    * Add timeout to the download process.
    * @throws TimeoutException, if the download process takes longer than the timeout.
    * */
-  private void waitForAllToSucceedOrOneToFail(final CompletableFuture<?>[] futures)
+  @VisibleForTesting
+  void waitForAllToSucceedOrOneToFail(final CompletableFuture<?>[] futures)
       throws InterruptedException, ExecutionException, TimeoutException {
     CompletableFuture<?> failure = new CompletableFuture();
     for (CompletableFuture<?> f : futures) {

--- a/azkaban-common/src/test/java/azkaban/project/ArchiveUnthinnerTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/ArchiveUnthinnerTest.java
@@ -124,7 +124,7 @@ public class ArchiveUnthinnerTest {
         }
       });
       return null;
-    }).when(this.dependencyTransferManager).downloadAllDependencies(any(Set.class));
+    }).when(this.dependencyTransferManager).downloadAllDependencies(any(Set.class), eq(project.getName()));
 
     // When the unthinner attempts to get a validationKey for the project, return our sample one.
     when(this.validatorUtils.getCacheKey(eq(this.project), eq(this.projectFolder), any()))
@@ -411,7 +411,7 @@ public class ArchiveUnthinnerTest {
 
     // When we attempt to download the dependencies, throw an error
     doThrow(new DependencyTransferException())
-        .when(this.dependencyTransferManager).downloadAllDependencies(depSetEq(depSetAB));
+        .when(this.dependencyTransferManager).downloadAllDependencies(depSetEq(depSetAB), eq(project.getName()));
 
     // Run the ArchiveUnthinner!
     runUnthinner();

--- a/azkaban-common/src/test/java/azkaban/utils/DependencyTransferManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/utils/DependencyTransferManagerTest.java
@@ -86,7 +86,7 @@ public class DependencyTransferManagerTest {
   @Test
   public void testDownloadEmptySet() throws Exception {
     // Make sure there are no failures when we download with an empty set (it should do nothing)
-    this.dependencyTransferManager.downloadAllDependencies(Collections.emptySet());
+    this.dependencyTransferManager.downloadAllDependencies(Collections.emptySet(), null);
   }
 
   @Test
@@ -99,7 +99,7 @@ public class DependencyTransferManagerTest {
     }).when(this.storage).getDependency(any());
 
     // Download depA and depB
-    this.dependencyTransferManager.downloadAllDependencies(depSetAB);
+    this.dependencyTransferManager.downloadAllDependencies(depSetAB, null);
 
     // Assert that the content was written to the files
     assertEquals(ThinArchiveTestUtils.getDepAContent(), FileUtils.readFileToString(depA.getFile()));
@@ -115,7 +115,7 @@ public class DependencyTransferManagerTest {
       .doReturn(IOUtils.toInputStream(ThinArchiveTestUtils.getDepAContent())).when(this.storage).getDependency(any());
 
     // Download ONLY depA
-    this.dependencyTransferManager.downloadAllDependencies(depSetA);
+    this.dependencyTransferManager.downloadAllDependencies(depSetA, null);
 
     verify(this.storage, times(2)).getDependency(depEq(depA));
   }
@@ -130,6 +130,6 @@ public class DependencyTransferManagerTest {
       return IOUtils.toInputStream(content);
     }).when(this.storage).getDependency(any());
 
-    this.dependencyTransferManager.downloadAllDependencies(depSetAB);
+    this.dependencyTransferManager.downloadAllDependencies(depSetAB, null);
   }
 }

--- a/azkaban-exec-server/src/main/java/azkaban/container/ContainerizedFlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/container/ContainerizedFlowPreparer.java
@@ -70,7 +70,8 @@ public class ContainerizedFlowPreparer extends AbstractFlowPreparer {
   public void setup(final ExecutableFlow flow) throws ExecutorManagerException {
     final ProjectDirectoryMetadata projectDirMetadata = new ProjectDirectoryMetadata(
             flow.getProjectId(),
-            flow.getVersion());
+            flow.getVersion(),
+            flow.getProjectName());
     final long flowPrepStartTime = System.currentTimeMillis();
     final int execId = flow.getExecutionId();
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/AbstractFlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/AbstractFlowPreparer.java
@@ -155,7 +155,7 @@ public abstract class AbstractFlowPreparer {
 
     try {
       final long start = System.currentTimeMillis();
-      this.dependencyTransferManager.downloadAllDependencies(depFiles);
+      this.dependencyTransferManager.downloadAllDependencies(depFiles, proj.getProjectName());
       LOGGER.info("Downloading {} JAR dependencies for project {} when preparing "
                       + "execution [execid {}] completed in {} second(s)",
               dependencies.size(), proj, execId, (System.currentTimeMillis() - start) / 1000);

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowPreparer.java
@@ -81,7 +81,8 @@ public class FlowPreparer extends AbstractFlowPreparer {
     try {
       final ProjectDirectoryMetadata project = new ProjectDirectoryMetadata(
           flow.getProjectId(),
-          flow.getVersion());
+          flow.getVersion(),
+          flow.getProjectName());
 
       final long flowPrepStartTime = System.currentTimeMillis();
 

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectDirectoryMetadata.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/ProjectDirectoryMetadata.java
@@ -25,20 +25,28 @@ import java.nio.file.attribute.FileTime;
 public class ProjectDirectoryMetadata {
   private final int projectId;
   private final int version;
+  private final String projectName;
   private File installedDir;
   private Long dirSizeInByte;
   private FileTime lastAccessTime;
 
-  public ProjectDirectoryMetadata(final int projectId, final int version) {
+  /**
+   * Used in flow preparation
+   * */
+  public ProjectDirectoryMetadata(final int projectId, final int version, final String projectName) {
     checkArgument(projectId > 0);
     checkArgument(version > 0);
 
     this.projectId = projectId;
     this.version = version;
+    this.projectName = projectName;
   }
 
+  /**
+   * Used in project cache clean-up
+   * */
   ProjectDirectoryMetadata(final int projectId, final int version, final File installedDir) {
-    this(projectId, version);
+    this(projectId, version, Integer.toString(projectId));
     this.installedDir = installedDir;
   }
 
@@ -56,6 +64,10 @@ public class ProjectDirectoryMetadata {
 
   int getVersion() {
     return this.version;
+  }
+
+  String getProjectName() {
+    return this.projectName;
   }
 
   File getInstalledDir() {

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowPreparerTest.java
@@ -37,9 +37,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import static azkaban.test.executions.ThinArchiveTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -171,7 +169,7 @@ public class FlowPreparerTest extends FlowPreparerTestBase {
     this.instance.downloadProjectIfNotExists(proj, 124);
 
     // This is a fat zip, so we should not attempt to download anything! (we try to download an empty set of dependencies)
-    verify(this.dependencyTransferManager).downloadAllDependencies(eq(Collections.emptySet()));
+    verify(this.dependencyTransferManager).downloadAllDependencies(eq(Collections.emptySet()), anyString());
   }
 
   @Test
@@ -182,6 +180,6 @@ public class FlowPreparerTest extends FlowPreparerTestBase {
 
     // This is a thin zip, we expect both dependencies to be downloaded
     Set<Dependency> expectedDownloadedDeps = ThinArchiveTestUtils.getDepSetAB();
-    verify(this.dependencyTransferManager).downloadAllDependencies(depSetEq(expectedDownloadedDeps));
+    verify(this.dependencyTransferManager).downloadAllDependencies(depSetEq(expectedDownloadedDeps), anyString());
   }
 }

--- a/azkaban-spi/src/main/java/azkaban/spi/Dependency.java
+++ b/azkaban-spi/src/main/java/azkaban/spi/Dependency.java
@@ -122,6 +122,11 @@ public class Dependency {
   }
 
   @Override
+  public String toString() {
+    return this.fileName + "/" + this.destination;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(this.sha1);
   }

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1971,13 +1971,21 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         containerizedDispatchManager.getContainerFlowCriteria().reloadFlowFilter();
       }
     } catch (final Exception e) {
-      logger.info("Installation Failed for project {}", projectName, e);
+      logger.error("Installation failed for project {}", projectName, e);
       String error = e.getMessage();
       if (error.length() > 512) {
         error = error.substring(0, 512) + "<br>Too many errors to display.<br>";
       }
       registerError(ret, "Installation Failed.<br>" + error, resp,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    } catch (final Throwable e) {
+      logger.error("Severe Error: unable to upload for project {}", projectName, e);
+      registerError(ret, "Server Encounter an unknown Error. <br>", resp,
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      // rethrow the error as for now we don't know how to recover from it
+      // usually nonExceptionError is severe one.
+      // TODO: if it is outofmemory error, we should restart the server directly.
+      throw e;
     } finally {
       if (out != null) {
         out.close();

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -724,7 +724,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     try {
       for (final Schedule schedule : this.scheduleManager.getSchedules()) {
         if (schedule.getProjectId() == project.getId()) {
-          logger.info("removing schedule " + schedule.getScheduleId());
+          logger.info("removing schedule {} for project {}", schedule.getScheduleId(), project.getName());
           this.scheduleManager.removeSchedule(schedule);
         }
       }
@@ -738,6 +738,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         this.scheduler.unschedule(project);
       }
     } catch (final SchedulerException e) {
+      logger.error("");
       throw new ServletException(e);
     }
   }
@@ -1970,7 +1971,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         containerizedDispatchManager.getContainerFlowCriteria().reloadFlowFilter();
       }
     } catch (final Exception e) {
-      logger.info("Installation Failed.", e);
+      logger.info("Installation Failed for project {}", projectName, e);
       String error = e.getMessage();
       if (error.length() > 512) {
         error = error.substring(0, 512) + "<br>Too many errors to display.<br>";


### PR DESCRIPTION
This PR is mostly optimization for gcn-38523 where upload project zips was hanging during validationProject, but it is unclear to us which part (download dependency, or validate dependency) failed, or it's possible that upload thread suddenly gone was caused by maybe uncaught exception/throwable (for example, Downloading Dependencies if any exception, the completableFuture.completeExceptionally(Throwable), we throw throwable instead of Exception).
Basically two scenarios could cause a "hanging" upload:
- Downloading itself is hanging, such as waiting inputStream;
- There is a throwable, but our code does not have such logic to handle it, so this thread just dead without telling CRT it is failed;

To address the issue above, a few optimization were made:
- Add default timeout 5 minutes for each dependency download tasks. Allow config to override the default value;
- Optimize logs for download/validate dependency part to improve debug efficiency;
- Add catch native Throwable logic;