### PR TITLE
Flow-retry - store, log & report the parent-child lineage

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -135,6 +135,7 @@ public class Constants {
 
   // Specifies the source(adhoc, scheduled, event) from where flow execution is triggered
   public static final String EXECUTION_SOURCE_ADHOC = "adhoc";
+  public static final String EXECUTION_SOURCE_RETRY = "retry";
   public static final String EXECUTION_SOURCE_SCHEDULED = "schedule";
   public static final String EXECUTION_SOURCE_EVENT = "event";
 
@@ -209,8 +210,6 @@ public class Constants {
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
     public static final String IS_OOM_KILLED = "isOOMKilled";
     public static final String IS_POD_SIZE_AUTOSCALING_ENABLED = "isPodSizeAutoscaled";
-    public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =
-        "originalFlowExecutionIdBeforeRetry";
     public static final String SLA_OPTIONS = "slaOptions";
     public static final String VERSION_SET = "versionSet";
     public static final String EXECUTOR_TYPE = "executorType";

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -231,6 +231,11 @@ public class Constants {
     public static final String CPU_UTILIZED = "cpuUtilized";
     public static final String MEMORY_UTILIZED_IN_BYTES = "memoryUtilizedInBytes";
     public static final String EXECUTION_SOURCE = "executionSource";
+    public static final String USER_DEFINED_FLOW_RETRY_COUNT_PARAM = "userDefinedFlowRetryCount";
+    public static final String SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM = "systemDefinedFlowRetryCount";
+    public static final String FLOW_RETRY_ROOT_EXECUTION_ID = "flowRetryRootExecutionID";
+    public static final String FLOW_RETRY_PARENT_EXECUTION_ID = "flowRetryParentExecutionID";
+    public static final String FLOW_RETRY_CHILD_EXECUTION_ID = "flowRetryChildExecutionID";
   }
 
   public static class ConfigurationKeys {

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -100,9 +100,9 @@ public class ExecutableFlow extends ExecutableFlowBase {
   // how many times flow level retry happened due to stuck in "Dispatch/Preparing/Ready" status
   private int systemDefinedRetryCount = 0;
   // The IDs of the original ancestor root exec / the direct parent exec / the retried child exec
-  private int flowRetryRootExecutionID = 0;
-  private int flowRetryParentExecutionID = 0;
-  private int flowRetryChildExecutionID = 0;
+  private int flowRetryRootExecutionID = -1;
+  private int flowRetryParentExecutionID = -1;
+  private int flowRetryChildExecutionID = -1;
 
   // For slaOption information
   private String slaOptionStr = "null";

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -67,6 +67,11 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private static final String USER_DEFINED_FLOW_RETRY_COUNT_PARAM = "userDefinedFlowRetryCount";
   private static final String SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM = "systemDefinedFlowRetryCount";
 
+  // Properties but non-define-able parameters
+  private static final String FLOW_RETRY_ROOT_EXECUTION_ID = "flowRetryRootExecutionID";
+  private static final String FLOW_RETRY_PARENT_EXECUTION_ID = "flowRetryParentExecutionID";
+  private static final String FLOW_RETRY_CHILD_EXECUTION_ID = "flowRetryChildExecutionID";
+
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;
   private int scheduleId = -1;
@@ -95,6 +100,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
   private int userDefinedRetryCount = 0;
   // how many times flow level retry happened due to stuck in "Dispatch/Preparing/Ready" status
   private int systemDefinedRetryCount = 0;
+  // The IDs of the original ancestor root exec / the direct parent exec / the retried child exec
+  private int flowRetryRootExecutionID = 0;
+  private int flowRetryParentExecutionID = 0;
+  private int flowRetryChildExecutionID = 0;
 
   // For slaOption information
   private String slaOptionStr = "null";
@@ -328,6 +337,31 @@ public class ExecutableFlow extends ExecutableFlowBase {
     this.systemDefinedRetryCount = systemDefinedRetryCount;
   }
 
+  public int getFlowRetryRootExecutionID() {
+    return flowRetryRootExecutionID;
+  }
+
+  public void setFlowRetryRootExecutionID(int flowRetryRootExecutionID) {
+    this.flowRetryRootExecutionID = flowRetryRootExecutionID;
+  }
+
+  public int getFlowRetryParentExecutionID() {
+    return flowRetryParentExecutionID;
+  }
+
+  public void setFlowRetryParentExecutionID(int flowRetryParentExecutionID) {
+    this.flowRetryParentExecutionID = flowRetryParentExecutionID;
+  }
+
+  public int getFlowRetryChildExecutionID() {
+    return flowRetryChildExecutionID;
+  }
+
+  public void setFlowRetryChildExecutionID(int flowRetryChildExecutionID) {
+    this.flowRetryChildExecutionID = flowRetryChildExecutionID;
+  }
+
+
   @Override
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowObj = new HashMap<>();
@@ -381,6 +415,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
       flowObj.put(VERSIONSET_MD5HEX_PARAM, this.versionSet.getVersionSetMd5Hex());
       flowObj.put(VERSIONSET_ID_PARAM, this.versionSet.getVersionSetId());
     }
+
+    flowObj.put(FLOW_RETRY_ROOT_EXECUTION_ID, flowRetryRootExecutionID);
+    flowObj.put(FLOW_RETRY_PARENT_EXECUTION_ID, flowRetryParentExecutionID);
+    flowObj.put(FLOW_RETRY_CHILD_EXECUTION_ID, flowRetryChildExecutionID);
 
     return flowObj;
   }
@@ -452,6 +490,10 @@ public class ExecutableFlow extends ExecutableFlowBase {
     // Dispatch Method default is POLL
     this.setDispatchMethod(DispatchMethod.fromNumVal(flowObj.getInt(FLOW_DISPATCH_METHOD,
         DispatchMethod.POLL.getNumVal())));
+
+    this.setFlowRetryRootExecutionID(flowObj.getInt(FLOW_RETRY_ROOT_EXECUTION_ID));
+    this.setFlowRetryParentExecutionID(flowObj.getInt(FLOW_RETRY_PARENT_EXECUTION_ID));
+    this.setFlowRetryChildExecutionID(flowObj.getInt(FLOW_RETRY_CHILD_EXECUTION_ID));
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutableFlow.java
@@ -15,6 +15,12 @@
  */
 package azkaban.executor;
 
+import static azkaban.Constants.EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID;
+import static azkaban.Constants.EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID;
+import static azkaban.Constants.EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID;
+import static azkaban.Constants.EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM;
+import static azkaban.Constants.EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM;
+
 import azkaban.DispatchMethod;
 import azkaban.flow.Flow;
 import azkaban.imagemgmt.version.VersionSet;
@@ -62,15 +68,8 @@ public class ExecutableFlow extends ExecutableFlowBase {
   public static final String VERSIONSET_JSON_PARAM = "versionSetJson";
   public static final String VERSIONSET_MD5HEX_PARAM = "versionSetMd5Hex";
   public static final String VERSIONSET_ID_PARAM = "versionSetId";
-  private static final String PARAM_OVERRIDE = "param.override.";
-  private static final String PROJECT_FILE_UPLOAD_USER = "uploadUser";
-  private static final String USER_DEFINED_FLOW_RETRY_COUNT_PARAM = "userDefinedFlowRetryCount";
-  private static final String SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM = "systemDefinedFlowRetryCount";
-
-  // Properties but non-define-able parameters
-  private static final String FLOW_RETRY_ROOT_EXECUTION_ID = "flowRetryRootExecutionID";
-  private static final String FLOW_RETRY_PARENT_EXECUTION_ID = "flowRetryParentExecutionID";
-  private static final String FLOW_RETRY_CHILD_EXECUTION_ID = "flowRetryChildExecutionID";
+  public static final String PARAM_OVERRIDE = "param.override.";
+  public static final String PROJECT_FILE_UPLOAD_USER = "uploadUser";
 
   private final HashSet<String> proxyUsers = new HashSet<>();
   private int executionId = -1;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionOptions.java
@@ -16,8 +16,6 @@
 
 package azkaban.executor;
 
-import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
-
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.sla.SlaOption;
 import azkaban.utils.TypedMapWrapper;
@@ -65,7 +63,6 @@ public class ExecutionOptions {
   public static final String FAILURE_ACTION_OVERRIDE = "failureActionOverride";
   private static final String MAIL_CREATOR = "mailCreator";
   private static final String MEMORY_CHECK = "memoryCheck";
-  private Integer originalFlowExecutionIdBeforeRetry = null;
 
   private boolean notifyOnFirstFailure = true;
   private boolean notifyOnLastFailure = false;
@@ -152,13 +149,6 @@ public class ExecutionOptions {
     options.setFailureActionOverride(wrapper.getBool(FAILURE_ACTION_OVERRIDE,
         false));
     options.setMemoryCheck(wrapper.getBool(MEMORY_CHECK, true));
-
-    // Note: slaOptions was originally outside of execution options, so it parsed and set
-    // separately for the original JSON format. New formats should include slaOptions as
-    // part of execution options.
-
-    options.setOriginalFlowExecutionIdBeforeRetry(wrapper.getInt(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
-        options.originalFlowExecutionIdBeforeRetry));
 
     return options;
   }
@@ -305,11 +295,6 @@ public class ExecutionOptions {
     this.slaOptions = slaOptions;
   }
 
-  public Integer getOriginalFlowExecutionIdBeforeRetry() { return originalFlowExecutionIdBeforeRetry; }
-
-  public void setOriginalFlowExecutionIdBeforeRetry(Integer originalFlowExecutionIdBeforeRetry) { this.originalFlowExecutionIdBeforeRetry =
-      originalFlowExecutionIdBeforeRetry; }
-
   public Map<String, Object> toObject() {
     final HashMap<String, Object> flowOptionObj = new HashMap<>();
 
@@ -330,7 +315,6 @@ public class ExecutionOptions {
     flowOptionObj.put(FAILURE_ACTION_OVERRIDE, this.failureActionOverride);
     flowOptionObj.put(MAIL_CREATOR, this.mailCreator);
     flowOptionObj.put(MEMORY_CHECK, this.memoryCheck);
-    flowOptionObj.put(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY, this.originalFlowExecutionIdBeforeRetry);
     return flowOptionObj;
   }
 
@@ -356,7 +340,6 @@ public class ExecutionOptions {
    * @return
    */
   public void merge(ExecutionOptions overwriteOptions) {
-    this.originalFlowExecutionIdBeforeRetry = overwriteOptions.originalFlowExecutionIdBeforeRetry;
     this.notifyOnFirstFailure = overwriteOptions.notifyOnFirstFailure;
     this.notifyOnLastFailure = overwriteOptions.notifyOnLastFailure;
     this.successEmailsOverride = overwriteOptions.successEmailsOverride;

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -105,6 +105,17 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
       metaData.put(EventReporterConstants.EXECUTOR_TYPE, String.valueOf(ExecutorType.BAREMETAL));
     }
 
+    metaData.put(EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM,
+        String.valueOf(flow.getSystemDefinedRetryCount()));
+    metaData.put(EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM,
+        String.valueOf(flow.getUserDefinedRetryCount()));
+    metaData.put(EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID,
+        String.valueOf(flow.getFlowRetryRootExecutionID()));
+    metaData.put(EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID,
+        String.valueOf(flow.getFlowRetryParentExecutionID()));
+    metaData.put(EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID,
+        String.valueOf(flow.getFlowRetryChildExecutionID()));
+
     return metaData;
   }
 

--- a/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/FlowStatusChangeEventListener.java
@@ -90,11 +90,6 @@ public class FlowStatusChangeEventListener implements EventListener<Event> {
     metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
     metaData.put(EventReporterConstants.END_TIME, String.valueOf(flow.getEndTime()));
 
-    if (flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
-      // original flow execution id is set when there is one
-      metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
-          String.valueOf(flow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
-    }
     if (flow.getVersionSet() != null) { // Save version set information
       metaData.put(EventReporterConstants.VERSION_SET,
           getVersionSetJsonString(flow.getVersionSet()));

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -56,7 +56,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     final ExecutableFlow retryExFlow =
         this.executorManagerAdapter.createExecutableFlow(project, flow);
     retryExFlow.setSubmitUser(originalExFlow.getSubmitUser());
-    retryExFlow.setExecutionSource(Constants.EXECUTION_SOURCE_ADHOC);
+    retryExFlow.setExecutionSource(Constants.EXECUTION_SOURCE_RETRY);
     retryExFlow.setUploadUser(project.getUploadUser());
     // Set up flow ExecutionOptions
     final ExecutionOptions options = originalExFlow.getExecutionOptions();
@@ -80,11 +80,6 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     }
     retryExFlow.setFlowRetryParentExecutionID(originalExFlow.getExecutionId());
 
-    // If a retried flow A gets retried again with a new execution id flow B, the original flow
-    // execution id of flow B should be the same as flow A's original flow execution id.
-    if (options.getOriginalFlowExecutionIdBeforeRetry() == null) {
-      options.setOriginalFlowExecutionIdBeforeRetry(originalExFlow.getExecutionId());
-    }
     retryExFlow.setExecutionOptions(options);
     // Submit new flow for execution
     try {

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -101,8 +101,10 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     }
     // TODO: consider send out email for this information
     logger.info(String.format("Retry execution [%d] successfully, "
-            + "spawning child-execution [%d], and its root-execution was [%d]",
+            + "spawning child-execution [%d], and its root-execution was [%d];"
+            + "system-defined retry count=%d, user-defined retry-count=%d.",
         originalExFlow.getExecutionId(), retryExFlow.getExecutionId(),
-        retryExFlow.getFlowRetryRootExecutionID()));
+        retryExFlow.getFlowRetryRootExecutionID(),
+        retryExFlow.getSystemDefinedRetryCount(), retryExFlow.getUserDefinedRetryCount()));
   }
 }

--- a/azkaban-common/src/test/java/azkaban/executor/OnContainerizedExecutionEventListenerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/OnContainerizedExecutionEventListenerTest.java
@@ -1,0 +1,213 @@
+package azkaban.executor;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import azkaban.DispatchMethod;
+import azkaban.flow.Flow;
+import azkaban.flow.FlowUtils;
+import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import azkaban.utils.TestUtils;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FlowUtils.class})
+public class OnContainerizedExecutionEventListenerTest {
+
+  private Project project1;
+  private Flow flow1;
+  private ExecutableFlow originalExFlow;
+  private ExecutableFlow retriedExFlow;
+  private OnContainerizedExecutionEventListener onContainerizedExecutionEventListener;
+  private ExecutorLoader executorLoader;
+  private ExecutorManagerAdapter executorManagerAdapter;
+
+  @Before
+  public void before()  throws Exception {
+    this.project1 = mock(Project.class);
+    this.flow1 = mock(Flow.class);
+    this.originalExFlow = TestUtils.createTestExecutableFlow("exectest1", "exec1",
+        DispatchMethod.CONTAINERIZED);
+    this.originalExFlow.setFlowRetryRootExecutionID(1000);
+    this.originalExFlow.setFlowRetryRootExecutionID(1001);
+    this.originalExFlow.setExecutionId(1002);
+    this.retriedExFlow = TestUtils.createTestExecutableFlow("exectest1", "exec1",
+        DispatchMethod.CONTAINERIZED);
+    this.originalExFlow.setExecutionId(1010);
+    this.executorLoader = mock(ExecutorLoader.class);
+    this.executorManagerAdapter = mock(ExecutorManagerAdapter.class);
+    this.onContainerizedExecutionEventListener = new OnContainerizedExecutionEventListener(
+        this.executorLoader,
+        this.executorManagerAdapter,
+        mock(ProjectManager.class)
+    );
+  }
+
+  @Test
+  public void testRestartExecutableFlow() throws ExecutorManagerException, IOException {
+    this.originalExFlow.setSystemDefinedRetryCount(1);
+    this.originalExFlow.setUserDefinedRetryCount(1);
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        return this.project1;
+      } else if (invocation.getMethod().getName().equals("getFlow")) {
+        return flow1;
+      }
+      return invocation.callRealMethod();
+    });
+    when(this.executorManagerAdapter.createExecutableFlow(any(), any())).thenReturn(this.retriedExFlow);
+    when(this.executorManagerAdapter.submitExecutableFlow(any(), any())).thenReturn("");
+    doNothing().when(this.executorLoader).updateExecutableFlow(any());
+
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+
+    // validate
+    assertEquals(this.originalExFlow.getSystemDefinedRetryCount(),
+        this.retriedExFlow.getSystemDefinedRetryCount());
+    assertEquals(this.originalExFlow.getUserDefinedRetryCount(),
+        this.retriedExFlow.getUserDefinedRetryCount());
+
+    assertEquals(this.originalExFlow.getFlowRetryRootExecutionID(),
+        this.retriedExFlow.getFlowRetryRootExecutionID());
+    assertEquals(this.originalExFlow.getExecutionId(),
+        this.retriedExFlow.getFlowRetryParentExecutionID());
+
+    assertEquals(this.retriedExFlow.getExecutionId(),
+        this.originalExFlow.getFlowRetryChildExecutionID());
+  }
+
+  @Test
+  public void testRestartExecutableFlow_NoRoot() throws ExecutorManagerException, IOException {
+    this.originalExFlow.setSystemDefinedRetryCount(1);
+    this.originalExFlow.setUserDefinedRetryCount(1);
+    // no root execution
+    this.originalExFlow.setFlowRetryRootExecutionID(-1);
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        return this.project1;
+      } else if (invocation.getMethod().getName().equals("getFlow")) {
+        return flow1;
+      }
+      return invocation.callRealMethod();
+    });
+    when(this.executorManagerAdapter.createExecutableFlow(any(), any())).thenReturn(this.retriedExFlow);
+    when(this.executorManagerAdapter.submitExecutableFlow(any(), any())).thenReturn("");
+    doNothing().when(this.executorLoader).updateExecutableFlow(any());
+
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+
+    // validate
+    assertEquals(this.originalExFlow.getSystemDefinedRetryCount(),
+        this.retriedExFlow.getSystemDefinedRetryCount());
+    assertEquals(this.originalExFlow.getUserDefinedRetryCount(),
+        this.retriedExFlow.getUserDefinedRetryCount());
+
+    // retry-flow should use original flow id as root
+    assertEquals(this.originalExFlow.getExecutionId(),
+        this.retriedExFlow.getFlowRetryRootExecutionID());
+    assertEquals(this.originalExFlow.getExecutionId(),
+        this.retriedExFlow.getFlowRetryParentExecutionID());
+
+    assertEquals(this.retriedExFlow.getExecutionId(),
+        this.originalExFlow.getFlowRetryChildExecutionID());
+  }
+
+  @Test
+  public void testRestartExecutableFlow_failGetProject() throws ExecutorManagerException,
+      IOException {
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        throw new RuntimeException("ops");
+      }
+      return invocation.callRealMethod();
+    });
+
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+
+    // validate
+    verifyZeroInteractions(this.executorManagerAdapter);
+    verifyZeroInteractions(this.executorLoader);
+  }
+
+  @Test
+  public void testRestartExecutableFlow_failGetFlow() throws ExecutorManagerException,
+      IOException {
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        return this.project1;
+      } else if (invocation.getMethod().getName().equals("getFlow")) {
+        throw new RuntimeException("ops");
+      }
+      return invocation.callRealMethod();
+    });
+
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+
+    // validate
+    verifyZeroInteractions(this.executorManagerAdapter);
+    verifyZeroInteractions(this.executorLoader);
+  }
+
+  @Test
+  public void testRestartExecutableFlow_failSubmit() throws ExecutorManagerException,
+      IOException {
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        return this.project1;
+      } else if (invocation.getMethod().getName().equals("getFlow")) {
+        return flow1;
+      }
+      return invocation.callRealMethod();
+    });
+    when(this.executorManagerAdapter.createExecutableFlow(any(), any())).thenReturn(this.retriedExFlow);
+    when(this.executorManagerAdapter.submitExecutableFlow(any(), any()))
+        .thenThrow(new ExecutorManagerException("ops"));
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+
+    // validate
+    verifyZeroInteractions(this.executorLoader);
+  }
+
+  @Test
+  public void testRestartExecutableFlow_failUpdateOriginalExec() throws ExecutorManagerException,
+      IOException {
+    // set up mocking
+    PowerMockito.mockStatic(FlowUtils.class, invocation -> {
+      if (invocation.getMethod().getName().equals("getProject")) {
+        return this.project1;
+      } else if (invocation.getMethod().getName().equals("getFlow")) {
+        return flow1;
+      }
+      return invocation.callRealMethod();
+    });
+    when(this.executorManagerAdapter.createExecutableFlow(any(), any())).thenReturn(this.retriedExFlow);
+    when(this.executorManagerAdapter.submitExecutableFlow(any(), any())).thenReturn("");
+    doThrow(new ExecutorManagerException("ops")).when(this.executorLoader).updateExecutableFlow(any());
+
+    // trigger
+    this.onContainerizedExecutionEventListener.restartExecutableFlow(this.originalExFlow);
+  }
+}

--- a/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
+++ b/azkaban-exec-server/src/main/java/azkaban/execapp/FlowRunner.java
@@ -1726,6 +1726,18 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
         metaData.put(EventReporterConstants.IS_ROOT_FLOW, "false");
       } else {
         metaData.put(EventReporterConstants.IS_ROOT_FLOW, "true");
+        ExecutableFlow executableFlow = (ExecutableFlow) flow;
+        metaData.put(EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM,
+            String.valueOf(executableFlow.getSystemDefinedRetryCount()));
+        metaData.put(EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM,
+            String.valueOf(executableFlow.getUserDefinedRetryCount()));
+        metaData.put(EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID,
+            String.valueOf(executableFlow.getFlowRetryRootExecutionID()));
+        metaData.put(EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID,
+            String.valueOf(executableFlow.getFlowRetryParentExecutionID()));
+        metaData.put(EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID,
+            String.valueOf(executableFlow.getFlowRetryChildExecutionID()));
+
       }
       // Azkaban executor hostname
       metaData.put(EventReporterConstants.AZ_HOST, props.getString(AZKABAN_SERVER_HOST_NAME,
@@ -1740,11 +1752,6 @@ public class FlowRunner extends EventHandler<Event> implements Runnable {
       metaData.put(EventReporterConstants.EXECUTION_ID, String.valueOf(rootFlow.getExecutionId()));
       metaData.put(EventReporterConstants.START_TIME, String.valueOf(flow.getStartTime()));
       metaData.put(EventReporterConstants.SUBMIT_TIME, String.valueOf(rootFlow.getSubmitTime()));
-      if (rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry() != null) {
-        // original flow execution id is set when there is one
-        metaData.put(EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY,
-            String.valueOf(rootFlow.getExecutionOptions().getOriginalFlowExecutionIdBeforeRetry()));
-      }
       // Flow_Status_Changed event attributes: flowVersion, failedJobId, modifiedBy
       metaData.put(EventReporterConstants.FLOW_VERSION,
           String.valueOf(rootFlow.getAzkabanFlowVersion()));

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -20,7 +20,6 @@ import static azkaban.Constants.EventReporterConstants.AZ_HOST;
 import static azkaban.Constants.EventReporterConstants.AZ_WEBSERVER;
 import static azkaban.Constants.EventReporterConstants.EXECUTOR_TYPE;
 import static azkaban.Constants.EventReporterConstants.FLOW_NAME;
-import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_NAME;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_UPLOADER_IP_ADDR;
 import static azkaban.Constants.EventReporterConstants.PROJECT_FILE_UPLOAD_TIME;
@@ -398,8 +397,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
         ServerUtils.getVersionSetJsonString(versionSet), flowMetadata.get(VERSION_SET)); // Checks version set
     Assert.assertEquals("Event metadata not created as expected", "BAREMETAL",
         flowMetadata.get(EXECUTOR_TYPE)); // Checks executor type
-    Assert.assertNull("Event metadata not created as expected.",
-        flowMetadata.get(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY));
   }
 
   @Test

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -16,6 +16,7 @@
 package azkaban.webapp.servlet;
 
 import azkaban.Constants;
+import azkaban.Constants.EventReporterConstants;
 import azkaban.executor.ClusterInfo;
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlow;
@@ -995,6 +996,16 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     ret.put("execid", exFlow.getExecutionId());
     ret.put("projectId", exFlow.getProjectId());
     ret.put("project", project.getName());
+    ret.put(EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM,
+        exFlow.getSystemDefinedRetryCount());
+    ret.put(EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM,
+        exFlow.getUserDefinedRetryCount());
+    ret.put(EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID,
+        exFlow.getFlowRetryRootExecutionID());
+    ret.put(EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID,
+        exFlow.getFlowRetryParentExecutionID());
+    ret.put(EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID,
+        exFlow.getFlowRetryChildExecutionID());
 
     final Map<String, Object> flowObj = getExecutableNodeInfo(exFlow);
     ret.putAll(flowObj);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -17,6 +17,7 @@ package azkaban.webapp.servlet;
 
 import azkaban.Constants;
 import azkaban.Constants.EventReporterConstants;
+import azkaban.Constants.FlowParameters;
 import azkaban.executor.ClusterInfo;
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlow;
@@ -996,16 +997,21 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     ret.put("execid", exFlow.getExecutionId());
     ret.put("projectId", exFlow.getProjectId());
     ret.put("project", project.getName());
-    ret.put(EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM,
-        exFlow.getSystemDefinedRetryCount());
-    ret.put(EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM,
-        exFlow.getUserDefinedRetryCount());
-    ret.put(EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID,
-        exFlow.getFlowRetryRootExecutionID());
-    ret.put(EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID,
-        exFlow.getFlowRetryParentExecutionID());
-    ret.put(EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID,
-        exFlow.getFlowRetryChildExecutionID());
+    
+    String autoRetryStatuses = exFlow.getExecutionOptions().getFlowParameters()
+        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "");
+    if (!autoRetryStatuses.isEmpty()){
+      ret.put(EventReporterConstants.SYSTEM_DEFINED_FLOW_RETRY_COUNT_PARAM,
+          exFlow.getSystemDefinedRetryCount());
+      ret.put(EventReporterConstants.USER_DEFINED_FLOW_RETRY_COUNT_PARAM,
+          exFlow.getUserDefinedRetryCount());
+      ret.put(EventReporterConstants.FLOW_RETRY_ROOT_EXECUTION_ID,
+          exFlow.getFlowRetryRootExecutionID());
+      ret.put(EventReporterConstants.FLOW_RETRY_PARENT_EXECUTION_ID,
+          exFlow.getFlowRetryParentExecutionID());
+      ret.put(EventReporterConstants.FLOW_RETRY_CHILD_EXECUTION_ID,
+          exFlow.getFlowRetryChildExecutionID());
+    }
 
     final Map<String, Object> flowObj = getExecutableNodeInfo(exFlow);
     ret.putAll(flowObj);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -16,7 +16,6 @@
 package azkaban.webapp.servlet;
 
 import azkaban.Constants;
-import azkaban.Constants.EventReporterConstants;
 import azkaban.Constants.FlowParameters;
 import azkaban.executor.ClusterInfo;
 import azkaban.executor.ConnectorParams;
@@ -56,11 +55,9 @@ import azkaban.utils.Props;
 import azkaban.webapp.AzkabanWebServer;
 import azkaban.webapp.plugin.PluginRegistry;
 import azkaban.webapp.plugin.ViewerPlugin;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1004,19 +1001,20 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     String autoRetryStatuses = exFlow.getExecutionOptions().getFlowParameters()
         .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "");
     if (!autoRetryStatuses.isEmpty()){
-      Integer maxRetry = Integer.valueOf(exFlow.getExecutionOptions().getFlowParameters()
+      Integer userDefinedMaxRetry = Integer.valueOf(exFlow.getExecutionOptions().getFlowParameters()
           .getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1"));
 
       Map<String, Object> retriesInfo = new HashMap<>();
       retriesInfo.put("allowedStatuses", autoRetryStatuses);
-      retriesInfo.put("userDefinedMax", maxRetry);
+      retriesInfo.put("userDefinedMax", userDefinedMaxRetry);
       retriesInfo.put("userDefinedCount", exFlow.getUserDefinedRetryCount());
+      retriesInfo.put("systemDefinedMax", ExecutableFlow.DEFAULT_SYSTEM_FLOW_RETRY_LIMIT);
       retriesInfo.put("systemDefinedCount", exFlow.getSystemDefinedRetryCount());
       retriesInfo.put("rootExecutionID", exFlow.getFlowRetryRootExecutionID());
       retriesInfo.put("parentExecutionID", exFlow.getFlowRetryParentExecutionID());
       retriesInfo.put("childExecutionID", exFlow.getFlowRetryChildExecutionID());
 
-      ret.put("retries", (new JSONObject(retriesInfo)).toString());
+      ret.put("retries", retriesInfo);
     }
 
     final Map<String, Object> flowObj = getExecutableNodeInfo(exFlow);


### PR DESCRIPTION
**Why we need this**
* As the flow-level-retry happens, we should let users know about the which execution is the "child" retried one, and which is the retried's "parent" execution. 
* In following PRs, we will also need to improve the webUI so as this information can be exposed to users in an efficient way.

**What's done**
1. add fields for an `ExecutableFlow`'s flow-level-retry `Root / (Direct) Parent / (Direct) Child` ExecutionIDs;
2. populate and persistent these fields for both the original and retried execution after successfully retrying;
3. log these lineage info + the retry-counts, also report these fields in the flow status event reporter.
4. expose all flow-retry info in ajax `fetchexecflow` endpoint

**Tests done**
1. unit tests
2. end to end tested in staging cluster:

Started execution 788402 with retry-enabled, and kill the pod to trigger EXECUTION_STOPPED status
![Screenshot 2023-04-19 at 2 22 21 PM](https://user-images.githubusercontent.com/31334117/233205414-a7102617-8993-43af-8f80-8fb6aea783a2.png)

Verify that the original execution 788402 has `flowRetryChildExecutionID` updated.
![Screenshot 2023-04-19 at 2 22 49 PM](https://user-images.githubusercontent.com/31334117/233206468-c16add9c-e970-44b0-b1e4-93a38490b9d4.png)

And the retried execution 788403 has `flowRetry{Root,Parent}ExecutionID` updated.
![Screenshot 2023-04-19 at 2 22 57 PM](https://user-images.githubusercontent.com/31334117/233206504-be55a657-2d78-484a-b758-f3515e559a1e.png)

Also webserver log this:
![Screenshot 2023-04-19 at 2 25 26 PM](https://user-images.githubusercontent.com/31334117/233205957-38a046df-3c81-4d74-8954-396351680ef0.png)

---
Plus, when "Prepare execution" on one of these executions, these flow-retry properties all be cleaned
![Screenshot 2023-04-19 at 2 27 55 PM](https://user-images.githubusercontent.com/31334117/233206521-d8c34773-c8a9-4f9a-81a3-e6761e97b44f.png)
