### PR TITLE
Remove unused field executionRetriedByAzkaban, relaced by retry-count

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -207,7 +207,6 @@ public class Constants {
     public static final String FLOW_KILL_DURATION = "flowKillDuration";
     public static final String FLOW_PAUSE_DURATION = "flowPauseDuration";
     public static final String FLOW_PREPARATION_DURATION = "flowPreparationDuration";
-    public static final String EXECUTION_RETRIED_BY_AZKABAN = "executionRetriedByAzkaban";
     public static final String IS_OOM_KILLED = "isOOMKilled";
     public static final String IS_POD_SIZE_AUTOSCALING_ENABLED = "isPodSizeAutoscaled";
     public static final String ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY =

--- a/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
+++ b/azkaban-exec-server/src/test/java/azkaban/execapp/FlowRunnerTest.java
@@ -18,7 +18,6 @@ package azkaban.execapp;
 
 import static azkaban.Constants.EventReporterConstants.AZ_HOST;
 import static azkaban.Constants.EventReporterConstants.AZ_WEBSERVER;
-import static azkaban.Constants.EventReporterConstants.EXECUTION_RETRIED_BY_AZKABAN;
 import static azkaban.Constants.EventReporterConstants.EXECUTOR_TYPE;
 import static azkaban.Constants.EventReporterConstants.FLOW_NAME;
 import static azkaban.Constants.EventReporterConstants.ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY;
@@ -399,8 +398,6 @@ public class FlowRunnerTest extends FlowRunnerTestBase {
         ServerUtils.getVersionSetJsonString(versionSet), flowMetadata.get(VERSION_SET)); // Checks version set
     Assert.assertEquals("Event metadata not created as expected", "BAREMETAL",
         flowMetadata.get(EXECUTOR_TYPE)); // Checks executor type
-    Assert.assertEquals("Event metadata not created as expected.", "false",
-        flowMetadata.get(EXECUTION_RETRIED_BY_AZKABAN));
     Assert.assertNull("Event metadata not created as expected.",
         flowMetadata.get(ORIGINAL_FLOW_EXECUTION_ID_BEFORE_RETRY));
   }


### PR DESCRIPTION
**Why we need this**
As the `executionRetriedByAzkaban` is already replaced by `{user,system}DefinedFlowRetryCount`, removing all its reference to be cleaner.
