### PR TITLE
fix flow trigger lost caused by failure project upload

### DIFF
--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -112,7 +112,10 @@ public class ScheduleManager implements TriggerAgent {
     return new ArrayList<>(this.scheduleIDMap.values());
   }
 
-  public List<Schedule> getALlSchedules() {
+  /**
+   * Retrieves a copy of the list of all schedules regardless the status, active or inactive ones.
+   */
+  public List<Schedule> getAllSchedules() {
     try {
       return this.loader.loadAllSchedules();
     } catch (ScheduleManagerException e) {

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -103,13 +103,22 @@ public class ScheduleManager implements TriggerAgent {
   }
 
   /**
-   * Retrieves a copy of the list of schedules.
+   * Retrieves a copy of the list of updated schedules.
    */
   public List<Schedule> getSchedules()
       throws ScheduleManagerException {
     final List<Schedule> updates = this.loader.loadUpdatedSchedules();
     refreshLocal(updates);
     return new ArrayList<>(this.scheduleIDMap.values());
+  }
+
+  public List<Schedule> getALlSchedules() {
+    try {
+      return this.loader.loadAllSchedules();
+    } catch (ScheduleManagerException e) {
+      logger.error("Failed to load all schedules", e);
+      return new ArrayList<>();
+    }
   }
 
   /**

--- a/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/TriggerBasedScheduleLoader.java
@@ -167,7 +167,7 @@ public class TriggerBasedScheduleLoader implements ScheduleLoader {
           triggerTimeChecker.getCronExpression(),
           t.isBackExecuteOnceOnMiss());
     } else {
-      logger.error("Failed to parse schedule from trigger!");
+      logger.error("Failed to parse schedule from trigger {}!", t.getTriggerId());
       throw new ScheduleManagerException(
           "Failed to parse schedule from trigger!");
     }

--- a/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
+++ b/azkaban-web-server/src/main/java/azkaban/flowtrigger/quartz/FlowTriggerScheduler.java
@@ -179,23 +179,30 @@ public class FlowTriggerScheduler {
   }
 
   /**
-   * Unschedule all possible flows in a project
-   */
-  public void unschedule(final Project project) throws SchedulerException {
-    for (final Flow flow : project.getFlows()) {
+   * Unschedule all possible flows
+   * */
+  public void unschedule(final List<Flow> flows, String projectName) throws SchedulerException {
+    for (final Flow flow : flows) {
       if (!flow.isEmbeddedFlow()) {
         try {
           if (this.scheduler
               .unscheduleJob(FlowTriggerQuartzJob.JOB_NAME, generateGroupName(flow))) {
-            logger.info("Flow {}.{} unregistered from scheduler", project.getName(), flow.getId());
+            logger.info("Flow {}.{} unregistered from scheduler", projectName, flow.getId());
           }
         } catch (final SchedulerException e) {
-          logger.error("Fail to unregister flow from scheduler {}.{}", project.getName(),
+          logger.error("Fail to unregister flow from scheduler {}.{}", projectName,
               flow.getId(), e);
           throw e;
         }
       }
     }
+  }
+
+  /**
+   * Unschedule all possible flows in a project
+   */
+  public void unschedule(final Project project) throws SchedulerException {
+    unschedule(project.getFlows(), project.getName());
   }
 
   private String generateGroupName(final Flow flow) {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -67,7 +67,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -2051,7 +2051,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     final Set<String> flowNameList = project.getFlows().stream().map(f -> f.getId()).collect(
         Collectors.toSet());
 
-    for (final Schedule schedule : scheduleManager.getALlSchedules()) {
+    for (final Schedule schedule : scheduleManager.getAllSchedules()) {
       if (schedule.getProjectId() == project.getId() &&
           !flowNameList.contains(schedule.getFlowName())) {
         scheduleManager.removeSchedule(schedule);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1938,18 +1938,20 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       out = new BufferedOutputStream(new FileOutputStream(archiveFile));
       IOUtils.copy(item.getInputStream(), out);
       out.close();
-      if (this.enableQuartz) {
-        //todo chengren311: should maintain atomicity,
-        // e.g, if uploadProject fails, associated schedule shouldn't be added.
-        this.scheduler.unschedule(project);
-      }
 
       // get the locked flows for the project, so that they can be locked again after upload
       final List<Pair<String, String>> lockedFlows = getLockedFlows(project);
+      // record the existing project flows before upload
+      final List<Flow> existingFlows = project.getFlows();
 
+      // validate project zip's dependencies and persist the new project metadata into DB
       final Map<String, ValidationReport> reports = this.projectManager
           .uploadProject(project, archiveFile, lowercaseExtension, user, props, uploaderIPAddr);
+
+      // Post-processing after upload
+      // reschedule data triggers if quartz is enabled
       if (this.enableQuartz) {
+        this.scheduler.unschedule(existingFlows, projectName);
         this.scheduler.schedule(project, user.getUserId());
       }
 
@@ -2045,12 +2047,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
    * @param onDeletedSchedule a callback function to execute with every deleted schedule
    */
   static void removeScheduleOfDeletedFlows(final Project project,
-      final ScheduleManager scheduleManager, final Consumer<Schedule> onDeletedSchedule)
-      throws ScheduleManagerException {
+      final ScheduleManager scheduleManager, final Consumer<Schedule> onDeletedSchedule) {
     final Set<String> flowNameList = project.getFlows().stream().map(f -> f.getId()).collect(
         Collectors.toSet());
 
-    for (final Schedule schedule : scheduleManager.getSchedules()) {
+    for (final Schedule schedule : scheduleManager.getALlSchedules()) {
       if (schedule.getProjectId() == project.getId() &&
           !flowNameList.contains(schedule.getFlowName())) {
         scheduleManager.removeSchedule(schedule);

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
@@ -79,7 +79,7 @@ public class ProjectManagerServletTest {
         now + 30, now + 30, null, null, now + 30, now + 30, now + 30, "testUser3", null, null, false);
     schedules.add(sched3);
 
-    when(this.scheduleManager.getALlSchedules()).thenReturn(new ArrayList<>(schedules));
+    when(this.scheduleManager.getAllSchedules()).thenReturn(new ArrayList<>(schedules));
     doAnswer(invocation -> schedules.remove(invocation.getArguments()[0]))
         .when(this.scheduleManager).removeSchedule(any(Schedule.class));
     this.projectManagerServlet

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
@@ -79,7 +79,7 @@ public class ProjectManagerServletTest {
         now + 30, now + 30, null, null, now + 30, now + 30, now + 30, "testUser3", null, null, false);
     schedules.add(sched3);
 
-    when(this.scheduleManager.getSchedules()).thenReturn(new ArrayList<>(schedules));
+    when(this.scheduleManager.getALlSchedules()).thenReturn(new ArrayList<>(schedules));
     doAnswer(invocation -> schedules.remove(invocation.getArguments()[0]))
         .when(this.scheduleManager).removeSchedule(any(Schedule.class));
     this.projectManagerServlet


### PR DESCRIPTION
## Summary
Azkaban allows users to define flow triggers in HadoopDSL format, they're parsed and scheduled in the process of upload. The initial order is unscheduleTrigger -> handleUploadZip -> some postHandleWork such as rescheduleTrigger. However handleUploadZip step is a bit fragile and might fail due to intermittent issues from infra side, for example, artifatory down. It would lead to project upload in a broken stage where the previous triggers were removed by that broken upload. This PR is to change the order of unscheduleTrigger, moving it after uploadZip.

## Details
- adjust order of unschedule QuartzJob, so even if uploadFile fails, the previous trigger remains unimpacted.
- fix remove schedule logic by using getAllSchedule instead of getUpdatedSchedule.