### PR TITLE
Add "Retries" tab in execution detail page for flow-retry related info

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -65,7 +65,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
         .getOrDefault(FLOW_PARAM_RESTART_STRATEGY, FlowRetryStrategy.DEFAULT.getName());
 
     // shouldn't throw an exception since the string value was validated on execution submission
-    FlowRetryStrategy retryStrategy = FlowRetryStrategy.valueOf(retryStrategyStr);
+    FlowRetryStrategy retryStrategy = FlowRetryStrategy.valueFromName(retryStrategyStr);
     logger.info(String.format("Retry execution of exec Id %d should use %s strategy.",
         originalExFlow.getExecutionId(), retryStrategy));
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -17,6 +17,7 @@ package azkaban.webapp.servlet;
 
 import azkaban.Constants;
 import azkaban.Constants.FlowParameters;
+import azkaban.Constants.FlowRetryStrategy;
 import azkaban.executor.ClusterInfo;
 import azkaban.executor.ConnectorParams;
 import azkaban.executor.ExecutableFlow;
@@ -518,6 +519,28 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("flowid", flow.getFlowId());
     page.add("flowlist", flow.getFlowId().split(Constants.PATH_DELIMITER, 0));
     page.add("pathDelimiter", Constants.PATH_DELIMITER);
+
+    page.add("parentExecutionID", 123);
+    page.add("childExecutionID", 456);
+
+    String autoRetryStatuses = flow.getExecutionOptions().getFlowParameters()
+        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "");
+    if (!autoRetryStatuses.isEmpty()){
+      Map<String, Object> retriesInfo = new HashMap<>();
+      retriesInfo.put("allowedStatuses", autoRetryStatuses);
+      retriesInfo.put("strategy", flow.getExecutionOptions().getFlowParameters()
+          .getOrDefault(FlowParameters.FLOW_PARAM_RESTART_STRATEGY,
+              FlowRetryStrategy.DEFAULT.getName()));
+      retriesInfo.put("userDefinedMax", Integer.valueOf(flow.getExecutionOptions().getFlowParameters()
+          .getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1")));
+      retriesInfo.put("userDefinedCount", flow.getUserDefinedRetryCount());
+      retriesInfo.put("systemDefinedMax", ExecutableFlow.DEFAULT_SYSTEM_FLOW_RETRY_LIMIT);
+      retriesInfo.put("systemDefinedCount", flow.getSystemDefinedRetryCount());
+      retriesInfo.put("rootExecutionID", flow.getFlowRetryRootExecutionID());
+      retriesInfo.put("parentExecutionID", flow.getFlowRetryParentExecutionID());
+      retriesInfo.put("childExecutionID", flow.getFlowRetryChildExecutionID());
+      page.add("retries", retriesInfo);
+    }
 
     // check the current flow definition to see if the flow is locked.
     final Flow currentFlow = project.getFlow(flow.getFlowId());

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -133,6 +133,7 @@
       <li id="flowTriggerlistViewLink"><a href="#triggerslist">Flow Trigger List</a></li>
       <li id="jobslistViewLink"><a href="#jobslist">Job List</a></li>
       <li id="flowLogViewLink"><a href="#log">Flow Log</a></li>
+      <li id="retriesViewLink"><a href="#retries">Retries</a></li>
       <li id="statsViewLink"><a href="#stats">Stats</a></li>
       #foreach ($analyzer in $externalAnalyzers)
         #if (!${analyzer.isLinkUrlValid()})
@@ -290,6 +291,65 @@
         </div>
       </div>
     </div><!-- /.row -->
+  </div><!-- /.container-fill -->
+
+  <div class="container-full" id="retriesView">
+    <div id="flow-stats-container">
+      #if (${retries})
+        <table class="table table-bordered table-condensed">
+          <tbody>
+          <tr>
+            <td class="property-key">Retry on Statuses</td>
+            <td>$retries.allowedStatuses</td>
+          </tr>
+          <tr>
+            <td class="property-key">Retry Strategy</td>
+            <td>$retries.strategy</td>
+          </tr>
+          <tr>
+            <td class="property-key">Root Execution</td>
+            #if (${retries.rootExecutionID} != -1)
+              <td><a href="${context}/executor?execid=${retries.rootExecutionID}">
+                $retries.rootExecutionID</a></td>
+            #else
+              <td>N/A</td>
+            #end
+          </tr>
+          <tr>
+            <td class="property-key">Parent Execution</td>
+            #if (${retries.parentExecutionID} != -1)
+              <td><a href="${context}/executor?execid=${retries.parentExecutionID}">
+                $retries.parentExecutionID</a></td>
+            #else
+              <td>N/A</td>
+            #end
+          </tr>
+          <tr>
+            <td class="property-key">Child Execution</td>
+            #if (${retries.childExecutionID} != -1)
+              <td><a href="${context}/executor?execid=${retries.childExecutionID}">
+                $retries.childExecutionID</a></td>
+            #else
+              <td>N/A</td>
+            #end
+          </tr>
+          <tr>
+            <td class="property-key">System Defined Retries / Max</td>
+            <td>$retries.systemDefinedCount / $retries.systemDefinedMax</td>
+          </tr>
+          <tr>
+            <td class="property-key">User Defined Retries / Max</td>
+            <td>$retries.userDefinedCount / $retries.userDefinedMax</td>
+          </tr>
+          </tbody>
+        </table>
+      #else
+        <div class="callout callout-default">
+          <h4>Flow Retry is not set</h4>
+        </div>
+      #end
+
+    </div>
   </div><!-- /.container-fill -->
 
   ## Error message message dialog.

--- a/azkaban-web-server/src/web/js/azkaban/view/exflow.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/exflow.js
@@ -88,6 +88,7 @@ azkaban.FlowTabView = Backbone.View.extend({
     "click #flowTriggerlistViewLink": "handleFlowTriggerLinkClick",
     "click #jobslistViewLink": "handleJobslistLinkClick",
     "click #flowLogViewLink": "handleLogLinkClick",
+    "click #retriesViewLink": "handleRetriesLinkClick",
     "click #statsViewLink": "handleStatsLinkClick",
     "click #cancelbtn": "handleCancelClick",
     "click #executebtn": "handleRestartClick",
@@ -123,12 +124,14 @@ azkaban.FlowTabView = Backbone.View.extend({
     $("#graphViewLink").addClass("active");
     $("#flowLogViewLink").removeClass("active");
     $("#flowTriggerlistViewLink").removeClass("active");
+    $("#retriesViewLink").removeClass("active");
     $("#statsViewLink").removeClass("active");
 
     $("#jobListView").hide();
     $("#flowTriggerListView").hide();
     $("#graphView").show();
     $("#flowLogView").hide();
+    $("#retriesView").hide();
     $("#statsView").hide();
   },
 
@@ -137,12 +140,14 @@ azkaban.FlowTabView = Backbone.View.extend({
     $("#graphViewLink").removeClass("active");
     $("#flowLogViewLink").removeClass("active");
     $("#flowTriggerlistViewLink").addClass("active");
+    $("#retriesViewLink").removeClass("active");
     $("#statsViewLink").removeClass("active");
 
     $("#jobListView").hide();
     $("#flowTriggerListView").show();
     $("#graphView").hide();
     $("#flowLogView").hide();
+    $("#retriesView").hide();
     $("#statsView").hide();
   },
 
@@ -151,12 +156,14 @@ azkaban.FlowTabView = Backbone.View.extend({
     $("#jobslistViewLink").addClass("active");
     $("#flowLogViewLink").removeClass("active");
     $("#flowTriggerlistViewLink").removeClass("active");
+    $("#retriesViewLink").removeClass("active");
     $("#statsViewLink").removeClass("active");
 
     $("#graphView").hide();
     $("#flowTriggerListView").hide();
     $("#jobListView").show();
     $("#flowLogView").hide();
+    $("#retriesView").hide();
     $("#statsView").hide();
   },
 
@@ -165,12 +172,14 @@ azkaban.FlowTabView = Backbone.View.extend({
     $("#flowTriggerlistViewLink").removeClass("active");
     $("#jobslistViewLink").removeClass("active");
     $("#flowLogViewLink").addClass("active");
+    $("#retriesViewLink").removeClass("active");
     $("#statsViewLink").removeClass("active");
 
     $("#graphView").hide();
     $("#flowTriggerListView").hide();
     $("#jobListView").hide();
     $("#flowLogView").show();
+    $("#retriesView").hide();
     $("#statsView").hide();
   },
 
@@ -179,14 +188,32 @@ azkaban.FlowTabView = Backbone.View.extend({
     $("#flowTriggerlistViewLink").removeClass("active");
     $("#jobslistViewLink").removeClass("active");
     $("#flowLogViewLink").removeClass("active");
+    $("#retriesViewLink").removeClass("active");
     $("#statsViewLink").addClass("active");
 
     $("#graphView").hide();
     $("#flowTriggerListView").hide();
     $("#jobListView").hide();
     $("#flowLogView").hide();
+    $("#retriesView").hide();
     statsView.show();
     $("#statsView").show();
+  },
+
+  handleRetriesLinkClick: function () {
+    $("#graphViewLink").removeClass("active");
+    $("#flowTriggerlistViewLink").removeClass("active");
+    $("#jobslistViewLink").removeClass("active");
+    $("#flowLogViewLink").removeClass("active");
+    $("#retriesViewLink").addClass("active");
+    $("#statsViewLink").removeClass("active");
+
+    $("#graphView").hide();
+    $("#flowTriggerListView").hide();
+    $("#jobListView").hide();
+    $("#flowLogView").hide();
+    $("#retriesView").show();
+    $("#statsView").hide();
   },
 
   handleFlowStatusChange: function () {


### PR DESCRIPTION
**Why we need this**
As the flow-level-retry backend logic being implemented, we need to develop the web UI so as users can get a better understanding of the retry-related information, and the lineage between the original & retried executions.

**What's done**
In execution detail page, added a "Retries" tab that shows a table of all flow-level-retry information.
Including links to its parent / child executions.

**Tests**
Tested in local solo-sever as well as in an test cluster:

When no flow-retry is config:
![Screenshot 2023-05-08 at 10 39 33 AM](https://user-images.githubusercontent.com/31334117/236885364-8d6aad8b-27e2-4574-a64e-3558f3fe9cee.png)

For an execution has been retried:
![Screenshot 2023-05-08 at 12 57 39 PM](https://user-images.githubusercontent.com/31334117/236885422-68774ce1-8aba-407a-ad32-7c36101493b4.png)
