### PR TITLE
Add UploadLock in project level and have a feature flag enable.project.adhoc.upload to remove the lock

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -186,6 +186,7 @@ public class Constants {
   public static final boolean DEFAULT_BACK_EXECUTE_ONCE_ON_MISSED_SCHEDULE = false;
 
   public static final int DEFAULT_AZKABAN_SERVER_EXTERNAL_ANALYZER_TIMEOUT_MS = 1000;
+  public static final String AZKABAN_UPLOAD_PRIVILEGE_USER = "azkaban.upload.privilege.user";
 
   // Azkaban event reporter constants
   public static class EventReporterConstants {

--- a/azkaban-common/src/main/java/azkaban/project/FeatureFlag.java
+++ b/azkaban-common/src/main/java/azkaban/project/FeatureFlag.java
@@ -1,0 +1,35 @@
+package azkaban.project;
+
+/**
+ * A Feature Flag class contains enum of all feature flags.
+ * */
+public enum FeatureFlag {
+
+  ENABLE_PROJECT_ADHOC_UPLOAD("enable.project.adhoc.upload");
+
+  private final String name;
+
+  FeatureFlag(String name) {
+    this.name = name;
+  }
+
+  public static FeatureFlag fromString(String key) {
+    for (FeatureFlag featureFlag : FeatureFlag.values()) {
+      if (featureFlag.getName().equals(key)) {
+        return featureFlag;
+      }
+    }
+    throw new IllegalArgumentException("FeatureFlag not found for key: " + key);
+  }
+
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+}
+

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -285,6 +285,12 @@ public class ProjectManager {
         modifier.getUserId(), "Description changed to " + description);
   }
 
+  public void updateProjectFeatureFlag(final Project project, final User modifier) throws ProjectManagerException {
+    updateProjectSetting(project);
+    this.projectLoader.postEvent(project, EventType.PROPERTY_OVERRIDE,
+        modifier.getUserId(), "Update project feature flag to " + project.getFeatureFlags());
+  }
+
   public List<ProjectLogEvent> getProjectEventLogs(final Project project,
       final int results, final int skip) throws ProjectManagerException {
     return this.projectLoader.getProjectEvents(project, results, skip);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/LoginAbstractAzkabanServlet.java
@@ -590,6 +590,12 @@ public abstract class LoginAbstractAzkabanServlet extends AbstractAzkabanServlet
     return false;
   }
 
+  protected boolean hasAzkabanAdminPermission(final User user) {
+    final UserManager userManager = getApplication().getUserManager();
+    return user.getRoles().stream()
+        .anyMatch(role -> userManager.getRole(role).getPermission().isPermissionSet(Permission.Type.ADMIN));
+  }
+
   /**
    * Filter Project based on user authorization
    *

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -1388,7 +1388,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
-        page.add("projectUploadLock", project.isUploadLocked());
+        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
 
@@ -1516,7 +1516,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
-        page.add("projectUploadLock", project.isUploadLocked());
+        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
 
@@ -1852,7 +1852,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
-        page.add("projectUploadLock", project.isUploadLocked());
+        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
 
@@ -1966,7 +1966,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       return;
     }
     // fail the upload if the project is UPLOAD locked and the user is not the upload privilege user
-    if (project.isUploadLocked() && !user.getUserId().equals(uploadPrivilegeUser)) {
+    if (uploadPrivilegeUser != null && project.isUploadLocked() && !user.getUserId().equals(uploadPrivilegeUser)) {
       registerError(ret, "Installation Failed. Project '" + projectName + " has UPLOAD LOCK on. \n"
           + "Create a new project to use adhoc upload feature, as crt deployed project would be automatically locked.\n"
           + "If you really need enable adhoc upload on the current project, please contact oncall to remove this lock.",

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
@@ -27,7 +27,8 @@
           <button id="project-delete-btn" class="btn btn-sm btn-danger">
             <span class="glyphicon glyphicon-trash"></span> Delete Project
           </button>
-          #if (!$hideUploadProject)
+          #set($hideUploadProject = ${projectUploadLock})
+          #if (!${hideUploadProject})
             <button id="project-upload-btn" class="btn btn-sm btn-primary">
               <span class="glyphicon glyphicon-upload"></span> Upload
             </button>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectsidebar.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectsidebar.vm
@@ -34,6 +34,21 @@
   <p><strong>Modified by</strong> $lastModifiedUser</p>
 
   <hr>
+  #if ($showUploadLockPanel)
+    <p><strong>Upload Lock On:</strong> $projectUploadLock</p>
+    <p><strong>Ad hoc Upload Enabled:</strong> <span class="editable" id="adhoc-upload">$adhocUpload</span></p>
+    <div id="adhoc-upload-form" class="editable-form">
+      <div class="input-group">
+        <input type="text" class="form-control input-sm" id="adhoc-upload-edit"
+               placeholder="true/false">
+        <span class="input-group-btn">
+                  <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
+                </span>
+      </div>
+    </div>
+  #end
+
+  <hr>
 
   <p><strong>Project admins:</strong> $admins</p>
   <p><strong>Your Permissions:</strong> $userpermission.toString()</p>

--- a/azkaban-web-server/src/test/expected/project-side-bar.html
+++ b/azkaban-web-server/src/test/expected/project-side-bar.html
@@ -19,6 +19,18 @@
   <p><strong>Modified by</strong> last_modified_user_name</p>
 
   <hr>
+  <p><strong>Upload Lock On:</strong> true</p>
+  <p><strong>Ad hoc Upload Enabled:</strong> <span class="editable" id="adhoc-upload">false</span></p>
+  <div id="adhoc-upload-form" class="editable-form">
+    <div class="input-group">
+      <input type="text" class="form-control input-sm" id="adhoc-upload-edit"
+             placeholder="true/false">
+      <span class="input-group-btn">
+                      <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
+                    </span>
+    </div>
+  </div>
+  <hr>
 
   <p><strong>Project admins:</strong> admin_name</p>
   <p><strong>Your Permissions:</strong> admin_permission</p>

--- a/azkaban-web-server/src/test/java/azkaban/fixture/MockProject.java
+++ b/azkaban-web-server/src/test/java/azkaban/fixture/MockProject.java
@@ -1,5 +1,6 @@
 package azkaban.fixture;
 
+import azkaban.project.FeatureFlag;
 import azkaban.project.Project;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -21,6 +22,8 @@ public class MockProject {
     final Project project = new Project(1, "test_project");
     project.setDescription("My project description");
     project.setLastModifiedUser("last_modified_user_name");
+    project.setUploadLock(true);
+    project.addFeatureFlags(FeatureFlag.ENABLE_PROJECT_ADHOC_UPLOAD, false);
 
     final DateFormat dateFormat = new SimpleDateFormat("yyyy:MM:dd:HH:mm:ss");
     try {

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
@@ -19,7 +19,7 @@ public class ProjectPageHeaderTest {
   @Test
   public void testUploadButtonIsPresent() {
     final VelocityContext context = VelocityContextTestUtil.getInstance();
-    context.put("hideUploadProject", false);
+    context.put("projectUploadLock", false);
 
     final String result =
         VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);
@@ -29,7 +29,7 @@ public class ProjectPageHeaderTest {
   @Test
   public void testUploadButtonIsNotPresent() {
     final VelocityContext context = VelocityContextTestUtil.getInstance();
-    context.put("hideUploadProject", true);
+    context.put("projectUploadLock", true);
 
     final String result =
         VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectSideBarViewTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectSideBarViewTest.java
@@ -36,6 +36,9 @@ public class ProjectSideBarViewTest {
     context.put("createTimestamp",project.getCreateTimestamp());
     context.put("lastModifiedTimestamp",project.getLastModifiedTimestamp());
     context.put("lastModifiedUser",project.getLastModifiedUser());
+    context.put("projectUploadLock", project.isUploadLocked());
+    context.put("adhocUpload", project.isAdhocUploadEnabled());
+    context.put("showUploadLockPanel", true);
 
     context.put("admins", "admin_name");
     context.put("userpermission", "admin_permission");

--- a/azkaban-web-server/src/web/js/azkaban/view/project-modals.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-modals.js
@@ -81,7 +81,9 @@ var projectDescription;
 azkaban.ProjectDescriptionView = Backbone.View.extend({
   events: {
     "click #project-description": "handleDescriptionEdit",
-    "click #project-description-btn": "handleDescriptionSave"
+    "click #project-description-btn": "handleDescriptionSave",
+    "click #adhoc-upload": "handleUploadSettingEdit",
+    "click #adhoc-upload-btn": "handleUploadSettingSave",
   },
 
   initialize: function (settings) {
@@ -129,6 +131,51 @@ azkaban.ProjectDescriptionView = Backbone.View.extend({
         $('#project-description').addClass('editable-placeholder');
       }
       $('#project-description').show();
+    };
+    $.get(requestURL, requestData, successHandler, "json");
+  },
+
+  handleUploadSettingEdit: function (evt) {
+    console.log("Edit Upload Setting");
+    var value = null;
+    if ($('#adhoc-upload').hasClass('editable-placeholder')) {
+      value = '';
+      $('#adhoc-upload').removeClass('editable-placeholder');
+    }
+    else {
+      value = $('#adhoc-upload').text();
+    }
+    $('#adhoc-upload-edit').attr("value", value);
+    $('#adhoc-upload').hide();
+    $('#adhoc-upload-form').show();
+  },
+
+  handleUploadSettingSave: function (evt) {
+    var newText = $('#adhoc-upload-edit').val();
+    if ($('#adhoc-upload-edit').hasClass('has-error')) {
+      $('#adhoc-upload-edit').removeClass('has-error');
+    }
+    var requestURL = contextURL + "/manager";
+    var requestData = {
+      "project": projectName,
+      "ajax": "changeUploadSetting",
+      "adhocUpload": newText
+    };
+    var successHandler = function (data) {
+      if (data.error) {
+        $('#adhoc-upload-edit').addClass('has-error');
+        alert(data.error);
+        return;
+      }
+      $('#adhoc-upload-form').hide();
+      if (newText !== '') {
+        $('#adhoc-upload').text(newText);
+      }
+      else {
+        $('#adhoc-upload').text('true or false');
+        $('#adhoc-upload').addClass('editable-placeholder');
+      }
+      $('#adhoc-upload').show();
     };
     $.get(requestURL, requestData, successHandler, "json");
   },

--- a/azkaban-web-server/src/web/js/azkaban/view/project-modals.js
+++ b/azkaban-web-server/src/web/js/azkaban/view/project-modals.js
@@ -177,7 +177,7 @@ azkaban.ProjectDescriptionView = Backbone.View.extend({
       }
       $('#adhoc-upload').show();
     };
-    $.get(requestURL, requestData, successHandler, "json");
+    $.post(requestURL, requestData, successHandler, "json");
   },
 
   render: function () {


### PR DESCRIPTION
### Summary
This project aims to protect grid security by attaching an Upload Lock to each project. The Upload Lock can be enabled by setting the config value azkaban.upload.privilege.user to the name of a privileged user who can upload projects. If this value is not set, no lock will be applied and the project will behave as usual. Once the privileged user has deployed a project, the Upload Lock will be automatically activated and prevent any ad hoc uploads from other users, unless the ad hoc upload feature flag is enabled. The ad hoc upload feature flag can only be accessed by azkaban admin. If it is enabled, it will override the Upload Lock and allow any user to upload projects, regardless of whether the privileged user has deployed or not.

### Details
    - Introduce Project Level Feature Flag as current azkaban does not have project level properties;
    - Add two ajax API to change project upload settings, changeUploadSettings will require azkaban admin to access
    - Auto add lock during privilege deployment if applies, disable adhoc upload when UploadLock is on
    - Add status on UI and allow changes directly from UI. (See pic)
    - Disable Upload Button once UploadLock is set. (See pic)
    - Hide UploadSetting panel if no privilege user is provided.

### Tests Done
Below testing are performed based on the upload privileged user is "crt", using CRTLock in the testing plan:
>1.AdhocUpload=true -> CRTLock=false
>         -> deploy by crt, the state doesn't change.
>         -> deploy manually, the state doesn't change.
>         -> restart web server, the state doesn't change.
>         -> disable adhocProject 
>                        ---> lastModifierUser is crt, CRTLock=true
>                        ---> lastModifierUser is not crt, the state doesn't change

> 2.AdhocUpload=false -> deploy by CRT, CRTLock = true
>         -> restart web server, the state doesn't change.
>         -> deploy manually, blocked/Forbidden
>         -> deploy on CRT, ok
>         -> enable adhocUpload, CRTLock=false

init state with CRT lock on
<img width="416" alt="Screenshot 2023-05-08 at 2 52 08 PM" src="https://github.com/azkaban/azkaban/assets/23374030/e069282f-55ec-4385-9d25-8b2c3c8565dd">
Disabled it by enable adhoc feature flag
<img width="400" alt="Screenshot 2023-05-08 at 2 52 37 PM" src="https://github.com/azkaban/azkaban/assets/23374030/a3c6710e-514b-41cd-accf-75f4c58fa86b">
Succeed
<img width="401" alt="Screenshot 2023-05-08 at 2 52 52 PM" src="https://github.com/azkaban/azkaban/assets/23374030/97deee58-e4eb-4dc3-8b63-7f0619f53fe2">
Hide upload when lock is on
<img width="356" alt="Screenshot 2023-05-15 at 3 56 08 PM" src="https://github.com/azkaban/azkaban/assets/23374030/a95a6e47-a982-4377-9c5e-ffbe3854be2c">