### PR TITLE
Rename constants to better reflect "retry" of flows; Improve UI wording

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -877,21 +877,21 @@ public class Constants {
         "allow.restart.on.execution.stopped";
     public static final String PROXY_USER_PREFETCH_ALL = "proxy.user.prefetch.all";
 
-    // Constant to define allow restart on a set of terminated status, extends to more statuses
+    // Constant to define allow retry on a set of terminated status, extends to more statuses
     // e.g. "flow.retry.statuses=EXECUTION_STOPPED,FAILED"
-    public static final String FLOW_PARAM_ALLOW_RESTART_ON_STATUS = "flow.retry.statuses";
+    public static final String FLOW_PARAM_ALLOWED_RETRY_STATUS = "flow.retry.statuses";
 
-    // Constant to define at most how many times can restart the flow
+    // Constant to define at most how many times can retry the flow
     public static final String FLOW_PARAM_MAX_RETRIES = "flow.max.retries";
 
-    // Constant to define the strategy to restart the execution, default to "restart_from_root",
-    public static final String FLOW_PARAM_RESTART_STRATEGY = "flow.retry.strategy";
+    // Constant to define the strategy to retry the execution, default to "retryAsNew",
+    public static final String FLOW_PARAM_RETRY_STRATEGY = "flow.retry.strategy";
   }
 
   public enum FlowRetryStrategy {
-    // default restart strategy, restart the execution in a whole, fresh new
+    // default retry strategy, restart the execution in a whole, fresh new
     DEFAULT("retryAsNew"),
-    // restart the execution but disabling the corresponding succeeded nodes in previous execution
+    // retry the execution but disabling the corresponding succeeded nodes in previous execution
     DISABLE_SUCCEEDED_NODES("disableSucceededNodes");
 
     private final String name;

--- a/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
+++ b/azkaban-common/src/main/java/azkaban/executor/ExecutionControllerUtils.java
@@ -43,7 +43,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -220,7 +219,7 @@ public class ExecutionControllerUtils {
 
     // user defined restart statuses list
     final Set<String> restartedStatuses = Arrays.stream(
-        flowParams.getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
+        flowParams.getOrDefault(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "")
             .split("\\s*,\\s*")
     ).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
 
@@ -241,9 +240,10 @@ public class ExecutionControllerUtils {
       logger.info(String.format("ExecutableFlow: %s has `%s=%s but `%s` not set, "
               + "default to retry once",
           flow.getExecutionId(),
-          FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
-          FlowParameters.FLOW_PARAM_MAX_RETRIES,
-          restartedStatuses));
+          FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS,
+          restartedStatuses,
+          FlowParameters.FLOW_PARAM_MAX_RETRIES
+          ));
       flowMaxRetryLimit = 1;
     }
     if (flow.getUserDefinedRetryCount() >= flowMaxRetryLimit) {

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -1,6 +1,6 @@
 package azkaban.executor;
 
-import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_STRATEGY;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_RETRY_STRATEGY;
 
 import azkaban.Constants;
 import azkaban.Constants.FlowRetryStrategy;
@@ -62,7 +62,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     final ExecutionOptions options = originalExFlow.getExecutionOptions();
 
     final String retryStrategyStr = options.getFlowParameters()
-        .getOrDefault(FLOW_PARAM_RESTART_STRATEGY, FlowRetryStrategy.DEFAULT.getName());
+        .getOrDefault(FLOW_PARAM_RETRY_STRATEGY, FlowRetryStrategy.DEFAULT.getName());
 
     // shouldn't throw an exception since the string value was validated on execution submission
     FlowRetryStrategy retryStrategy = FlowRetryStrategy.valueFromName(retryStrategyStr);

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -187,16 +187,16 @@ public class HttpRequestUtils {
             FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false"))
     ){
       flowParameters.put(
-          FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
+          FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS,
           Status.EXECUTION_STOPPED.name() + "," +
-              flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
+              flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "")
       );
       flowParameters.remove(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED);
     }
-    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS)) {
+    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS)) {
       // user defined restart-statuses; remove the empty spaces
       final Set<String> statuses = Arrays.stream(
-          flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "")
+          flowParameters.getOrDefault(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "")
               .split("\\s*,\\s*")
       ).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
 
@@ -212,7 +212,7 @@ public class HttpRequestUtils {
                   + "correct\n", str));
         }
       }
-      flowParameters.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS,
+      flowParameters.put(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS,
           Strings.join(statuses, ","));
     }
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_MAX_RETRIES)){
@@ -233,13 +233,13 @@ public class HttpRequestUtils {
         errMsg.add(e.getMessage());
       }
     }
-    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RESTART_STRATEGY)){
-      String restartStrategy = flowParameters.get(FlowParameters.FLOW_PARAM_RESTART_STRATEGY);
+    if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RETRY_STRATEGY)){
+      String restartStrategy = flowParameters.get(FlowParameters.FLOW_PARAM_RETRY_STRATEGY);
       try {
         FlowRetryStrategy restartStrategyEnum = FlowRetryStrategy.valueOf(restartStrategy);
       } catch (IllegalArgumentException e){
         errMsg.add(String.format("Invalid %s = %s. Valid values are: %s",
-            FlowParameters.FLOW_PARAM_RESTART_STRATEGY, restartStrategy,
+            FlowParameters.FLOW_PARAM_RETRY_STRATEGY, restartStrategy,
             FlowRetryStrategy.getNames()));
       }
     }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -27,7 +27,6 @@ import com.codahale.metrics.MetricRegistry;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.P;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
@@ -62,7 +61,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
     this.flow1 = FlowUtils.createExecutableFlow(this.project, this.flow);
     final ExecutionOptions executionOptions = new ExecutionOptions();
     final Map<String, String> flowParam = new HashMap<>();
-    flowParam.put(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED");
+    flowParam.put(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED");
     flowParam.put(FlowParameters.FLOW_PARAM_DISPATCH_EXECUTION_TO_CONTAINER, "true");
     executionOptions.addAllFlowParameters(flowParam);
     this.flow1.setExecutionOptions(executionOptions);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsTest.java
@@ -342,7 +342,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
     testFlow.setExecutionOptions(options);
@@ -359,7 +359,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED"
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED,FAILED"
     ));
     testFlow.setExecutionOptions(options);
 
@@ -395,7 +395,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
     testFlow.setExecutionOptions(options);
@@ -411,7 +411,7 @@ public class ExecutionControllerUtilsTest {
     ExecutableFlow testFlow = new ExecutableFlow();
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "2"
     ));
     testFlow.setExecutionOptions(options);
@@ -435,7 +435,7 @@ public class ExecutionControllerUtilsTest {
 
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED,FAILED",
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED,FAILED",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "0"
     ));
     when(testFlow.getExecutionOptions()).thenReturn(options);

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionOptionsTest.java
@@ -16,7 +16,7 @@ public class ExecutionOptionsTest {
     ExecutionOptions options1 = new ExecutionOptions();
     options1.addAllFlowParameters(
         ImmutableMap.of(
-            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
+            FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED",
             FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true",
             FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true")
     );
@@ -26,7 +26,7 @@ public class ExecutionOptionsTest {
     ExecutionOptions overwrite = new ExecutionOptions();
     overwrite.addAllFlowParameters(
         ImmutableMap.of(
-            FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+            FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED",
             FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false",
             FlowParameters.FLOW_PARAM_MAX_RETRIES, "1")
     );
@@ -43,7 +43,7 @@ public class ExecutionOptionsTest {
 
     // check
     Map<String, String> expectFlowParams = ImmutableMap.of(
-        FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED",
         FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false",
         FlowParameters.FLOW_PARAM_MAX_RETRIES, "1",
         FlowParameters.FLOW_PARAM_ENABLE_DEV_POD, "true");

--- a/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/watch/KubernetesWatchTest.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,7 +67,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +142,7 @@ public class KubernetesWatchTest {
   private Project project = mock(Project.class);
   private ProjectManager projectManager = mock(ProjectManager.class);
   private Map<String, String> flowParam = ImmutableMap.of(
-      FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED");
+      FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED");
   private EventListener eventListener = new DummyEventListener();
 
   @Before

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -17,9 +17,9 @@ package azkaban.server;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_EXECUTION_RESTART_LIMIT;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED;
-import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS;
 import static azkaban.Constants.FlowParameters.FLOW_PARAM_MAX_RETRIES;
-import static azkaban.Constants.FlowParameters.FLOW_PARAM_RESTART_STRATEGY;
+import static azkaban.Constants.FlowParameters.FLOW_PARAM_RETRY_STRATEGY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import azkaban.Constants.FlowRetryStrategy;
@@ -297,7 +297,7 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -308,7 +308,7 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED"
     ));
 
     // if not defined, has default value to [EXECUTION_STOPPED, FAILED]
@@ -321,7 +321,7 @@ public final class HttpRequestUtilsTest {
     ExecutionOptions options = new ExecutionOptions();
     // KILLED is not defined
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "super-bad-status, not-an-azkaban-status"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "super-bad-status, not-an-azkaban-status"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -334,7 +334,7 @@ public final class HttpRequestUtilsTest {
     ExecutionOptions options = new ExecutionOptions();
     // KILLED is not defined
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "KILLED, EXECUTION_STOPPED"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "KILLED, EXECUTION_STOPPED"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -346,12 +346,12 @@ public final class HttpRequestUtilsTest {
     ExecutionOptions options = new ExecutionOptions();
     // KILLED is not defined
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, ", EXECUTION_STOPPED,, ,    "
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, ", EXECUTION_STOPPED,, ,    "
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
     Assert.assertEquals(
-        options.getFlowParameters().get(FLOW_PARAM_ALLOW_RESTART_ON_STATUS),
+        options.getFlowParameters().get(FLOW_PARAM_ALLOWED_RETRY_STATUS),
         "EXECUTION_STOPPED");
   }
 
@@ -389,7 +389,7 @@ public final class HttpRequestUtilsTest {
   public void testValidatePreprocessFlowParamWithAllValidSettings() throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "EXECUTION_STOPPED",
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "EXECUTION_STOPPED",
         FLOW_PARAM_MAX_RETRIES, "2"
     ));
 
@@ -402,14 +402,14 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED",
         FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "true"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
     Map<String, String> result = options.getFlowParameters();
     Assert.assertTrue(
-        result.get(FLOW_PARAM_ALLOW_RESTART_ON_STATUS).contains("EXECUTION_STOPPED"));
+        result.get(FLOW_PARAM_ALLOWED_RETRY_STATUS).contains("EXECUTION_STOPPED"));
   }
 
   @Test
@@ -417,14 +417,14 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED",
         FLOW_PARAM_ALLOW_RESTART_ON_EXECUTION_STOPPED, "false"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
     Map<String, String> result = options.getFlowParameters();
     Assert.assertFalse(
-        result.get(FLOW_PARAM_ALLOW_RESTART_ON_STATUS).contains("EXECUTION_STOPPED"));
+        result.get(FLOW_PARAM_ALLOWED_RETRY_STATUS).contains("EXECUTION_STOPPED"));
   }
 
   @Test
@@ -432,7 +432,7 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -445,8 +445,8 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
-        FLOW_PARAM_RESTART_STRATEGY, FlowRetryStrategy.DISABLE_SUCCEEDED_NODES.name()
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED",
+        FLOW_PARAM_RETRY_STRATEGY, FlowRetryStrategy.DISABLE_SUCCEEDED_NODES.name()
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);
@@ -457,8 +457,8 @@ public final class HttpRequestUtilsTest {
       throws ServletException {
     ExecutionOptions options = new ExecutionOptions();
     options.addAllFlowParameters(ImmutableMap.of(
-        FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "FAILED",
-        FLOW_PARAM_RESTART_STRATEGY, "some bad wrong text"
+        FLOW_PARAM_ALLOWED_RETRY_STATUS, "FAILED",
+        FLOW_PARAM_RETRY_STRATEGY, "some bad wrong text"
     ));
 
     HttpRequestUtils.validatePreprocessFlowParameters(options, testAzProps);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ExecutorServlet.java
@@ -523,12 +523,12 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     page.add("childExecutionID", 456);
 
     String autoRetryStatuses = flow.getExecutionOptions().getFlowParameters()
-        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "");
+        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "");
     if (!autoRetryStatuses.isEmpty()){
       Map<String, Object> retriesInfo = new HashMap<>();
       retriesInfo.put("allowedStatuses", autoRetryStatuses);
       retriesInfo.put("strategy", flow.getExecutionOptions().getFlowParameters()
-          .getOrDefault(FlowParameters.FLOW_PARAM_RESTART_STRATEGY,
+          .getOrDefault(FlowParameters.FLOW_PARAM_RETRY_STRATEGY,
               FlowRetryStrategy.DEFAULT.getName()));
       retriesInfo.put("userDefinedMax", Integer.valueOf(flow.getExecutionOptions().getFlowParameters()
           .getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1")));
@@ -1021,7 +1021,7 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
     ret.put("project", project.getName());
 
     String autoRetryStatuses = exFlow.getExecutionOptions().getFlowParameters()
-        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOW_RESTART_ON_STATUS, "");
+        .getOrDefault(FlowParameters.FLOW_PARAM_ALLOWED_RETRY_STATUS, "");
     if (!autoRetryStatuses.isEmpty()){
       Integer userDefinedMaxRetry = Integer.valueOf(exFlow.getExecutionOptions().getFlowParameters()
           .getOrDefault(FlowParameters.FLOW_PARAM_MAX_RETRIES, "1"));
@@ -1029,6 +1029,9 @@ public class ExecutorServlet extends LoginAbstractAzkabanServlet {
       Map<String, Object> retriesInfo = new HashMap<>();
       retriesInfo.put("allowedStatuses", autoRetryStatuses);
       retriesInfo.put("userDefinedMax", userDefinedMaxRetry);
+      retriesInfo.put("strategy", exFlow.getExecutionOptions().getFlowParameters()
+          .getOrDefault(FlowParameters.FLOW_PARAM_RETRY_STRATEGY,
+              FlowRetryStrategy.DEFAULT.getName()));
       retriesInfo.put("userDefinedCount", exFlow.getUserDefinedRetryCount());
       retriesInfo.put("systemDefinedMax", ExecutableFlow.DEFAULT_SYSTEM_FLOW_RETRY_LIMIT);
       retriesInfo.put("systemDefinedCount", exFlow.getSystemDefinedRetryCount());

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/executingflowpage.vm
@@ -334,18 +334,18 @@
             #end
           </tr>
           <tr>
-            <td class="property-key">System Defined Retries / Max</td>
+            <td class="property-key">System Defined Retries / Max Limit</td>
             <td>$retries.systemDefinedCount / $retries.systemDefinedMax</td>
           </tr>
           <tr>
-            <td class="property-key">User Defined Retries / Max</td>
+            <td class="property-key">User Defined Retries / Max Limit</td>
             <td>$retries.userDefinedCount / $retries.userDefinedMax</td>
           </tr>
           </tbody>
         </table>
       #else
         <div class="callout callout-default">
-          <h4>Flow Retry is not set</h4>
+          <h4>Flow retry not set</h4>
         </div>
       #end
 


### PR DESCRIPTION
**What's done**
- Rename flow-retry related constants
- improve wording in the webUI 
- fix logging typo

