### PR TITLE
Add logs to record ImageVersion operations

### DIFF
--- a/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/imagemgmt/servlets/ImageVersionServlet.java
@@ -194,6 +194,7 @@ public class ImageVersionServlet extends LoginAbstractAzkabanServlet {
       resp.setHeader("Location",
           SINGLE_IMAGE_VERSION_URI_TEMPLATE.createURI(imageVersionId.toString()));
       sendResponse(resp, HttpServletResponse.SC_CREATED, new HashMap<>());
+      log.info("ImageType {} with imageVersionId {} is created successfully: payload {}", imageType, imageVersionId, imageVersion);
     } catch (final ImageMgmtException e) {
       log.error("Exception while creating image version metadata.", e);
       sendErrorResponse(resp, e.getErrorCode().getCode(), e.getMessage());
@@ -239,6 +240,7 @@ public class ImageVersionServlet extends LoginAbstractAzkabanServlet {
       // Create image version metadata and image version id
       this.imageVersionService.updateImageVersion(imageVersion);
       sendResponse(resp, HttpServletResponse.SC_OK, new HashMap<>());
+      log.info("ImageType {} with imageVersionId {} is updated successfully: payload {}", imageType, idString, imageVersion);
     } catch (final ImageMgmtException e) {
       log.error("Exception while updating image version metadata", e);
       sendErrorResponse(resp, e.getErrorCode().getCode(), e.getMessage());
@@ -289,6 +291,7 @@ public class ImageVersionServlet extends LoginAbstractAzkabanServlet {
       } else {
         sendResponse(resp, HttpServletResponse.SC_OK, deleteResponse.getMessage());
       }
+      log.info("ImageType {} with imageVersionId {} is deleted successfully", imageType, idString);
     } catch (final ImageMgmtException e) {
       log.error("Exception while deleting image version metadata", e);
       sendErrorResponse(resp, e.getErrorCode().getCode(), e.getMessage());


### PR DESCRIPTION
As short-term solution to make ImageVersion operations visible from Azkaban logs.
Long-term solution: put all API body fields to logs in AbstractAzkabanServlet so that every API call params (already support in logs) & body (missing from logs) can be found at logs for history / analysis.