### PR TITLE
Add default outputPath = /tmp/wordcount_{System.nanoTime} to WordCoun…

### DIFF
--- a/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/examples/java/WordCount.java
+++ b/az-hadoop-jobtype-plugin/src/main/java/azkaban/jobtype/examples/java/WordCount.java
@@ -52,7 +52,7 @@ public class WordCount extends AbstractHadoopJob {
   public WordCount(String name, Props props) {
     super(name, props);
     this.inputPath = props.getString("input.path");
-    this.outputPath = props.getString("output.path");
+    this.outputPath = props.getString("output.path", "/tmp/wordcount_" + System.nanoTime());
     this.forceOutputOverwrite =
         props.getBoolean("force.output.overwrite", false);
     this.outputDelete =


### PR DESCRIPTION
…t example to prevent output collision