### PR TITLE
Fail fast if jobtype image is invalid during dispatching

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -42,6 +42,7 @@ import azkaban.executor.container.watch.KubernetesWatch;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowResourceRecommendation;
 import azkaban.flow.ImmutableFlowProps;
+import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageVersion.State;
 import azkaban.imagemgmt.rampup.ImageRampupManager;
 import azkaban.imagemgmt.version.VersionInfo;
@@ -698,7 +699,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
         versionSetBuilder.addElements(versionMap);
         versionSet = versionSetBuilder.addElements(overlayMap).build();
       }
-    } catch (final IOException e) {
+    } catch (NumberFormatException | IOException | ImageMgmtException e) {
       logger.error("ExecId: {}, Exception in fetching the VersionSet. Error msg: {}",
           executionId, e.getMessage());
       throw new ExecutorManagerException(e);


### PR DESCRIPTION
As an Azkaban user, I want my flow to fail immediately if one of the image required to run the flow is unavailable as it is a non-recoverable error. Currently, the flow will just stuck at Dispatching until eventually getting cleaned up by ContainerCleanupManager.

The reason is we didn't catch necessary exception when fetchVersionSet.

After this fix, the flow fails immediately under such case with these logs:
> Unable to dispatch container in Kubernetes for : 151842
Reason for dispatch failure: azkaban.imagemgmt.exception.ImageMgmtException: Unable to get VersionInfo for image type: spark, image version: 0.0.19999 that is in one of the following states: NEW,TEST,ACTIVE,STABLE.
![image](https://github.com/azkaban/azkaban/assets/18157653/37017346-0081-4205-b99b-23b2a7968caf)


