### PR TITLE
Add the config control to toggle the ability of disabling upload

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -189,8 +189,16 @@ public class Constants {
   public static final boolean DEFAULT_BACK_EXECUTE_ONCE_ON_MISSED_SCHEDULE = false;
 
   public static final int DEFAULT_AZKABAN_SERVER_EXTERNAL_ANALYZER_TIMEOUT_MS = 1000;
+
+  /*
+   * project upload would be locked once privilege user uploads a project,
+   * locked means no other users can upload, the restriction only apply when @link{AZKABAN_DISABLE_ADHOC_UPLOAD_ON_LOCKED} = true
+   */
   public static final String AZKABAN_UPLOAD_PRIVILEGE_USER = "azkaban.upload.privilege.user";
-  public static final String AZKABAN_DISABLE_ADHOC_UPLOAD = "azkaban.disable.adhoc.upload";
+  /*
+   * Disable adhoc upload on upload-locked projects
+   */
+  public static final String AZKABAN_DISABLE_ADHOC_UPLOAD_ON_LOCKED = "azkaban.disable.adhoc.upload.on.locked";
 
   // Azkaban event reporter constants
   public static class EventReporterConstants {

--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -190,6 +190,7 @@ public class Constants {
 
   public static final int DEFAULT_AZKABAN_SERVER_EXTERNAL_ANALYZER_TIMEOUT_MS = 1000;
   public static final String AZKABAN_UPLOAD_PRIVILEGE_USER = "azkaban.upload.privilege.user";
+  public static final String AZKABAN_DISABLE_ADHOC_UPLOAD = "azkaban.disable.adhoc.upload";
 
   // Azkaban event reporter constants
   public static class EventReporterConstants {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -156,7 +156,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private boolean lockdownCreateProjects = false;
   private boolean lockdownUploadProjects = false;
   private boolean enableQuartz = false;
-  private boolean disableAdhocUploadClusterFlag = false;
+  private boolean disableAdhocUploadWhenProjectUploadLocked = false;
   private String uploadPrivilegeUser;
   private Map<String, List<HTMLFormElement>> alerterPlugins;
 
@@ -198,7 +198,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     // get upload privilege user, if not configured, treated upload as adhoc, no upload lock enabled
     this.uploadPrivilegeUser = server.getServerProps().get(AZKABAN_UPLOAD_PRIVILEGE_USER);
-    this.disableAdhocUploadClusterFlag = server.getServerProps().getBoolean(AZKABAN_DISABLE_ADHOC_UPLOAD, false);
+    this.disableAdhocUploadWhenProjectUploadLocked =
+        server.getServerProps().getBoolean(AZKABAN_DISABLE_ADHOC_UPLOAD_ON_LOCKED, false);
 
     final Map<String, List<HTMLFormElement>> alerterPlugins = new HashMap<>();
     server.getAlerterPlugins().forEach((name, alerter) -> alerterPlugins.put(name,
@@ -1970,7 +1971,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     // fail the upload if the project is UPLOAD locked and the user is not the upload privilege user
     // and the cluster-wide disableAdhocUpload flag is set
-    if (uploadPrivilegeUser != null && disableAdhocUploadClusterFlag
+    if (uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked
         && project.isUploadLocked() && !user.getUserId().equals(uploadPrivilegeUser)) {
       registerError(ret, "Installation Failed. Project '" + projectName + " has UPLOAD LOCK on. \n"
           + "Create a new project to use adhoc upload feature, as crt deployed project would be automatically locked.\n"

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -156,6 +156,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private boolean lockdownCreateProjects = false;
   private boolean lockdownUploadProjects = false;
   private boolean enableQuartz = false;
+  private boolean disableAdhocUploadClusterFlag = false;
   private String uploadPrivilegeUser;
   private Map<String, List<HTMLFormElement>> alerterPlugins;
 
@@ -197,6 +198,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
 
     // get upload privilege user, if not configured, treated upload as adhoc, no upload lock enabled
     this.uploadPrivilegeUser = server.getServerProps().get(AZKABAN_UPLOAD_PRIVILEGE_USER);
+    this.disableAdhocUploadClusterFlag = server.getServerProps().getBoolean(AZKABAN_DISABLE_ADHOC_UPLOAD, false);
 
     final Map<String, List<HTMLFormElement>> alerterPlugins = new HashMap<>();
     server.getAlerterPlugins().forEach((name, alerter) -> alerterPlugins.put(name,
@@ -1965,8 +1967,11 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     if (project == null) {
       return;
     }
+
     // fail the upload if the project is UPLOAD locked and the user is not the upload privilege user
-    if (uploadPrivilegeUser != null && project.isUploadLocked() && !user.getUserId().equals(uploadPrivilegeUser)) {
+    // and the cluster-wide disableAdhocUpload flag is set
+    if (uploadPrivilegeUser != null && disableAdhocUploadClusterFlag
+        && project.isUploadLocked() && !user.getUserId().equals(uploadPrivilegeUser)) {
       registerError(ret, "Installation Failed. Project '" + projectName + " has UPLOAD LOCK on. \n"
           + "Create a new project to use adhoc upload feature, as crt deployed project would be automatically locked.\n"
           + "If you really need enable adhoc upload on the current project, please contact oncall to remove this lock.",


### PR DESCRIPTION
This allows we control and rollout restrictions inside platform gradually and independently to control the effect to users. azkaban.disable.adhoc.upload is set, we can only disallow the adhoc uploads but it would not affect the lock status being updated at the project level.