### PR TITLE
CleanupManager: only cleaning yarn-apps of executions that are canceled by user or is EXECUTION_STOPPED

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -175,18 +175,16 @@ public class ContainerCleanupManager {
             new Pair<>(Duration.ofMinutes(runningFlowValidity), START_TIME))
         .build();
 
+    // The task will find executions of these statuses and kill all their yarn applications,
+    // ONLY under these set of statuses should their yarn-app being killed.
+    // Counter case: if execution is FAILED, yarn-apps of those jobs defined with "fail-finishing"
+    // should continue running until finish, thus cannot clean them up.
     this.recentTerminatedStatusMap = new Builder<Status, Pair<Duration, String>>()
         .put(Status.EXECUTION_STOPPED,
             new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
         .put(Status.KILLED,
             new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
         .put(Status.KILLING,
-            new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
-        .put(Status.FAILED,
-            new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
-        .put(Status.FAILED_FINISHING,
-            new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
-        .put(Status.FAILED_SUCCEEDED,
             new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))
         .put(Status.CANCELLED,
             new Pair<>(Duration.ofMinutes(recentTerminationValidity), UPDATE_TIME))

--- a/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/container/ContainerCleanupManagerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -220,7 +221,7 @@ public class ContainerCleanupManagerTest {
 
     final ExecutableFlow flow2 = new ExecutableFlow();
     flow2.setExecutionId(2000);
-    flow2.setStatus(Status.FAILED);
+    flow2.setStatus(Status.KILLED);
     flow2.setSubmitUser("dummy-user");
     flow2.setExecutionOptions(new ExecutionOptions());
     final ArrayList<ExecutableFlow> failedFlows = new ArrayList<>();
@@ -230,13 +231,20 @@ public class ContainerCleanupManagerTest {
         .fetchFreshFlowsForStatus(eq(Status.EXECUTION_STOPPED), any(ImmutableMap.class)))
         .thenReturn(execStoppedFlows);
     when(this.executorLoader
-        .fetchFreshFlowsForStatus(eq(Status.FAILED), any(ImmutableMap.class)))
+        .fetchFreshFlowsForStatus(eq(Status.KILLED), any(ImmutableMap.class)))
         .thenReturn(failedFlows);
 
     Set<Integer> recentTerminationFlows = this.cleaner.getRecentlyTerminatedFlows();
     Assert.assertTrue(recentTerminationFlows.contains(1000));
     Assert.assertTrue(recentTerminationFlows.contains(2000));
     Assert.assertEquals(2, recentTerminationFlows.size());
+
+    verify(this.executorLoader, never()).fetchFreshFlowsForStatus(eq(Status.FAILED),
+        any(ImmutableMap.class));
+    verify(this.executorLoader, never()).fetchFreshFlowsForStatus(eq(Status.FAILED_FINISHING),
+        any(ImmutableMap.class));
+    verify(this.executorLoader, never()).fetchFreshFlowsForStatus(eq(Status.FAILED_SUCCEEDED),
+        any(ImmutableMap.class));
   }
 
   @Test


### PR DESCRIPTION
**Why we need this**
To fix an design fault that kills the yarn-apps of jobs defined to be "Finish Current Running" or "Finish All Possible".

**What's done**
Removed "FAILED/FAILED_FINISHING/FAILED_SUCCEEDED" from to-be-cleaned statuses for yarn-app-kill task.

**Tests done**
* unit test
* tested in staging cluster