### PR TITLE
Fix schedule expiration bug

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -392,6 +392,7 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
         } catch (final Throwable th) {
           //skip this trigger, moving on to the next one
           TriggerManager.logger.error("Failed to process trigger with id : " + t, th);
+          th.printStackTrace();
         } finally {
           t.unlock();
         }

--- a/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/TriggerManager.java
@@ -391,8 +391,7 @@ public class TriggerManager extends EventHandler implements TriggerManagerAdapte
           }
         } catch (final Throwable th) {
           //skip this trigger, moving on to the next one
-          TriggerManager.logger.error("Failed to process trigger with id : " + t, th);
-          th.printStackTrace();
+          TriggerManager.logger.error("Failed to process trigger with id : " + t, th.fillInStackTrace());
         } finally {
           t.unlock();
         }

--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -168,7 +168,9 @@ public class BasicTimeChecker implements ConditionChecker {
   public void reset() {
     final NextCheckTime nextCheckTimeObj = calculateNextCheckTime();
     this.nextCheckTime = nextCheckTimeObj.nextValidCheckTimeFromNow;
-    nextCheckTimeObj.missedCheckTimeBeforeNow.remove(nextCheckTimeObj.missedCheckTimeBeforeNow.size() - 1);
+    if (nextCheckTimeObj.missedCheckTimeBeforeNow.size() > 0) {
+      nextCheckTimeObj.missedCheckTimeBeforeNow.remove(nextCheckTimeObj.missedCheckTimeBeforeNow.size() - 1);
+    }
     this.missedCheckTimesBeforeNow = nextCheckTimeObj.missedCheckTimeBeforeNow;
   }
 


### PR DESCRIPTION
### Bug Summary
When a cron expression has expiration date itself, current system would not handle such edge case properly and everytime the triggers loop over, the trigger that satisfied with trigger condition would try to fire execution everytime. Thus we see the bug presented as the schedule executions flow in minutely frequent level when the schedule should past.

### Fix Details
Even at latest quartz 2.5.0, the getFinalFireTime's implementation is still missing: https://www.javadoc.io/static/org.quartz-scheduler/quartz/2.5.0-rc1/org/quartz/CronExpression.html#getFinalFireTime(). To identify the last execution, we simply check whether the getNextCheckTime updated is in the past, usually getNextCheckTime should update to a future time after now, however, if it is returning a past value, we could treat this trigger as expired state, thus the cleanup/removal logic would be triggered properly.

### Test
scheduled a flow at 14:45 at the time 14:44, expecting only one execution would be triggered.
<img width="1185" alt="Screenshot 2023-06-26 at 3 40 51 PM" src="https://github.com/azkaban/azkaban/assets/23374030/56335bf0-d628-45ed-9004-b17585befd5a">
And until 15:00, the actual matches the expectation.
<img width="1510" alt="Screenshot 2023-06-26 at 3 42 07 PM" src="https://github.com/azkaban/azkaban/assets/23374030/39371814-11a8-4cc9-9cfe-7db9f8bbbd82">
