### PR TITLE
CleanupManager: emit metrics that count the number of stale flows of different statuses

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -471,7 +471,7 @@ public class ContainerCleanupManager {
     try {
       staleFlows = this.executorLoader.fetchStaleFlowsForStatus(status, this.validityMap);
       // emit metrics around stale flows of this status
-      this.containerizationMetrics.markCleanupStaleStatusFlowNumber(status.name(), staleFlows.size());
+      this.containerizationMetrics.addCleanupStaleStatusFlowNumber(status.name(), staleFlows.size());
     } catch (final Exception e) {
       logger.error("Exception occurred while fetching stale flows during clean up." + e);
       return;

--- a/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/ContainerCleanupManager.java
@@ -163,6 +163,8 @@ public class ContainerCleanupManager {
           .info("NumberFormatException while parsing value for: " + AZKABAN_MAX_FLOW_RUNNING_MINS);
     }
 
+    // When adding new status in this map, also update ContainerizationMetricsImpl to add the
+    // corresponding metrics for the status.
     this.validityMap = new Builder<Status,
         Pair<Duration, String>>()
         .put(Status.DISPATCHING,
@@ -468,6 +470,8 @@ public class ContainerCleanupManager {
     List<ExecutableFlow> staleFlows;
     try {
       staleFlows = this.executorLoader.fetchStaleFlowsForStatus(status, this.validityMap);
+      // emit metrics around stale flows of this status
+      this.containerizationMetrics.markCleanupStaleStatusFlowNumber(status.name(), staleFlows.size());
     } catch (final Exception e) {
       logger.error("Exception occurred while fetching stale flows during clean up." + e);
       return;

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -123,7 +123,7 @@ public interface ContainerizationMetrics {
 
   void sendCleanupStaleFlowHeartBeat();
 
-  void markCleanupStaleStatusFlowNumber(String status, long n);
+  void addCleanupStaleStatusFlowNumber(String status, long n);
 
   void sendCleanupYarnApplicationHeartBeat();
 

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetrics.java
@@ -123,6 +123,8 @@ public interface ContainerizationMetrics {
 
   void sendCleanupStaleFlowHeartBeat();
 
+  void markCleanupStaleStatusFlowNumber(String status, long n);
+
   void sendCleanupYarnApplicationHeartBeat();
 
   void recordCleanupStaleFlowTimer(long duration, TimeUnit unit);

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -16,11 +16,14 @@
 
 package azkaban.metrics;
 
+import azkaban.executor.Status;
 import azkaban.utils.Props;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.google.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +44,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   private Timer cleanupStaleFlowTimer, cleanupContainerTimer, cleanupYarnAppTimer;
   private Histogram timeToDispatch;
   private volatile boolean isInitialized = false;
+  private Map<String, CounterGauge> cleanupStaleFlowCounterGauges;
 
   @Inject
   public ContainerizationMetricsImpl(MetricsManager metricsManager) {
@@ -76,6 +80,20 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
     this.cleanupStaleFlowTimer = this.metricsManager.addTimer("Cleanup-Stale-Flow-Timer");
     this.cleanupContainerTimer = this.metricsManager.addTimer("Cleanup-Container-Timer");
     this.cleanupYarnAppTimer = this.metricsManager.addTimer("Cleanup-Yarn-Application-Timer");
+
+    this.cleanupStaleFlowCounterGauges = new HashMap<>();
+    cleanupStaleFlowCounterGauges.put(Status.DISPATCHING.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Dispatching-Flow-Number"));
+    cleanupStaleFlowCounterGauges.put(Status.PREPARING.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Preparing-Flow-Number"));
+    cleanupStaleFlowCounterGauges.put(Status.RUNNING.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Running-Flow-Number"));
+    cleanupStaleFlowCounterGauges.put(Status.PAUSED.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Paused-Flow-Number"));
+    cleanupStaleFlowCounterGauges.put(Status.KILLING.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Killing-Flow-Number"));
+    cleanupStaleFlowCounterGauges.put(Status.FAILED_FINISHING.name(),
+        this.metricsManager.addCounterGauge("Cleanup-Stale-Failed_Finishing-Flow-Number"));
   }
 
   @Override
@@ -183,6 +201,13 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   @Override
   public void sendCleanupStaleFlowHeartBeat() {
     cleanupStaleFlowHeartBeat.mark();
+  }
+
+  @Override
+  public void markCleanupStaleStatusFlowNumber(String status, long n){
+    if (this.cleanupStaleFlowCounterGauges.containsKey(status)) {
+      this.cleanupStaleFlowCounterGauges.get(status).add(n);
+    }
   }
 
   @Override

--- a/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/ContainerizationMetricsImpl.java
@@ -204,7 +204,7 @@ public class ContainerizationMetricsImpl implements ContainerizationMetrics {
   }
 
   @Override
-  public void markCleanupStaleStatusFlowNumber(String status, long n){
+  public void addCleanupStaleStatusFlowNumber(String status, long n){
     if (this.cleanupStaleFlowCounterGauges.containsKey(status)) {
       this.cleanupStaleFlowCounterGauges.get(status).add(n);
     }

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -24,6 +24,7 @@ import org.apache.log4j.Logger;
  * CONTAINERIZED or during unit test
  */
 public class DummyContainerizationMetricsImpl implements ContainerizationMetrics {
+
   private static final Logger logger = Logger.getLogger(ContainerizationMetricsImpl.class);
 
   @Override
@@ -111,11 +112,16 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
 
   @Override
   public void sendCleanupContainerHeartBeat() {
-    
+
   }
 
   @Override
   public void sendCleanupStaleFlowHeartBeat() {
+
+  }
+
+  @Override
+  public void markCleanupStaleStatusFlowNumber(String status, long n) {
 
   }
 

--- a/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
+++ b/azkaban-common/src/main/java/azkaban/metrics/DummyContainerizationMetricsImpl.java
@@ -121,7 +121,7 @@ public class DummyContainerizationMetricsImpl implements ContainerizationMetrics
   }
 
   @Override
-  public void markCleanupStaleStatusFlowNumber(String status, long n) {
+  public void addCleanupStaleStatusFlowNumber(String status, long n) {
 
   }
 


### PR DESCRIPTION
**Why we need this**
By adding these metrics, we got to know the number of stale flows of each concerning statuses, and with this info, we can set up alerts to react to incidents quicker.

**Tests done**
Tested in our staging cluster's webserver, the metrics correctly got published to the metrics system and dashboard can view the outcome.