### PR TITLE
allow disabling Ambassador on web server and call pod's service directly

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -15,7 +15,6 @@
  */
 package azkaban.executor.container;
 
-import static azkaban.Constants.JobProperties.*;
 import static azkaban.executor.ExecutionControllerUtils.clusterQualifiedExecId;
 import static java.util.Objects.requireNonNull;
 
@@ -23,7 +22,6 @@ import azkaban.Constants;
 import azkaban.Constants.ConfigurationKeys;
 import azkaban.Constants.ContainerizedDispatchManagerProperties;
 import azkaban.Constants.FlowParameters;
-import azkaban.Constants.JobProperties;
 import azkaban.container.models.AzKubernetesV1PodBuilder;
 import azkaban.container.models.AzKubernetesV1PodTemplate;
 import azkaban.container.models.AzKubernetesV1ServiceBuilder;
@@ -40,9 +38,7 @@ import azkaban.executor.ExecutorLoader;
 import azkaban.executor.ExecutorManagerException;
 import azkaban.executor.Status;
 import azkaban.executor.container.watch.KubernetesWatch;
-import azkaban.flow.Flow;
 import azkaban.flow.FlowResourceRecommendation;
-import azkaban.flow.ImmutableFlowProps;
 import azkaban.imagemgmt.exception.ImageMgmtException;
 import azkaban.imagemgmt.models.ImageVersion.State;
 import azkaban.imagemgmt.rampup.ImageRampupManager;
@@ -51,16 +47,14 @@ import azkaban.imagemgmt.version.VersionSet;
 import azkaban.imagemgmt.version.VersionSetBuilder;
 import azkaban.imagemgmt.version.VersionSetLoader;
 import azkaban.metrics.ContainerizationMetrics;
-import azkaban.project.Project;
 import azkaban.project.ProjectManager;
-import azkaban.project.ProjectLoader;
 import azkaban.project.ProjectManagerException;
 import azkaban.spi.EventType;
+import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.kubernetes.client.custom.Quantity;
-import io.kubernetes.client.custom.QuantityFormatException;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
@@ -71,25 +65,16 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceList;
-import io.kubernetes.client.util.ClientBuilder;
-import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -154,6 +139,8 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
   public static final String DISABLE_CLEANUP_LABEL_NAME = "cleanup-disabled";
   public static final String DEFAULT_AZKABAN_BASE_IMAGE_NAME = "azkaban-base";
   public static final String DEFAULT_AZKABAN_CONFIG_IMAGE_NAME = "azkaban-config";
+  public static final int DEFAULT_KUBERNETES_SERVICE_PORT = 54343;
+
   private static final int DEFAULT_EXECUTION_ID = -1;
 
   private static final VPARecommendation EMPTY_VPA_RECOMMENDATION = new VPARecommendation(null,
@@ -307,7 +294,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
             DEFAULT_MAX_DISK);
     this.servicePort =
         this.azkProps.getInt(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_PORT,
-            54343);
+            DEFAULT_KUBERNETES_SERVICE_PORT);
     this.serviceTimeout =
         this.azkProps
             .getLong(ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_CREATION_TIMEOUT_MS,
@@ -1354,6 +1341,31 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     return selectorBuilder.toString();
   }
 
+  /**
+   * Given a flow ID, return the callable endpoint of the flow pod's service where the flow is executed on. The endpoint
+   * is accessible by another pod which resides in the same k8s cluster.
+   * Naming rule of the endpoint: "[serviceName].[namespace]:[servicePort]"
+   * The returned endpoint is presented by a {@link Pair} consisting of the host name and port.
+   *
+   * @param azkProps the Azkaban props
+   * @param executionId the execution ID
+   * @return a {@link Pair} consisting of the endpoint host and port
+   */
+  public static Pair<String, Integer> getFlowServiceEndpoint(final Props azkProps, int executionId) {
+    requireNonNull(azkProps, "azkaban properties must not be null");
+    final String clusterName = azkProps.getString(ConfigurationKeys.AZKABAN_CLUSTER_NAME,
+        DEFAULT_CLUSTER_NAME);
+    final String serviceNamePrefix = azkProps.getString(
+        ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_NAME_PREFIX, DEFAULT_SERVICE_NAME_PREFIX);
+    final String namespace = azkProps
+        .getString(ContainerizedDispatchManagerProperties.KUBERNETES_NAMESPACE);
+
+    String serviceName = getServiceNameHelper(serviceNamePrefix, clusterName, executionId);
+    Integer servicePort = azkProps.getInt(Constants.ContainerizedDispatchManagerProperties.KUBERNETES_SERVICE_PORT,
+        DEFAULT_KUBERNETES_SERVICE_PORT);
+    return new Pair<>(String.join(".", serviceName, namespace), servicePort);
+  }
+
   @Override
   public void setVPARampUp(final int rampUp) {
     this.vpaRampUp = rampUp;
@@ -1591,7 +1603,7 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    * @return
    */
   private String getServiceName(final int executionId) {
-    return String.join("-", this.servicePrefix, this.clusterName, String.valueOf(executionId));
+    return getServiceNameHelper(this.servicePrefix, this.clusterName, executionId);
   }
 
   /**
@@ -1603,6 +1615,20 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
    */
   private String getPodName(final int executionId) {
     return String.join("-", this.podPrefix, this.clusterName, String.valueOf(executionId));
+  }
+
+  /**
+   * A helper method to generate a k8s service name of the given execution ID.
+   * @param serviceNamePrefix prefix of the k8s service
+   * @param clusterName current cluster's name
+   * @param executionId ID of the execution on the pod
+   * @return the k8s service name of the given execution ID
+   */
+  public static String getServiceNameHelper(
+      final String serviceNamePrefix,
+      final String clusterName,
+      final int executionId) {
+    return String.join("-", serviceNamePrefix, clusterName, String.valueOf(executionId));
   }
 
   private final Set<State> getImageVersionState(Map<String, String> flowParams) {

--- a/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ContainerizedDispatchManagerTest.java
@@ -115,6 +115,7 @@ public class ContainerizedDispatchManagerTest {
     this.props.put(Constants.ConfigurationKeys.MAX_CONCURRENT_RUNS_ONEFLOW, 1);
     this.props.put(ContainerizedDispatchManagerProperties.CONTAINERIZED_IMPL_TYPE,
         ContainerizedImplType.KUBERNETES.name());
+    this.props.put(ContainerizedDispatchManagerProperties.KUBERNETES_NAMESPACE, "cop-dev");
     props.put(Constants.
             ContainerizedDispatchManagerProperties.CONTAINERIZED_FLOW_FILTER_FILE,
         "src/test/resources/flow_filter.txt");

--- a/azkaban-web-server/build.gradle
+++ b/azkaban-web-server/build.gradle
@@ -15,7 +15,8 @@ buildscript {
 // manage NodeJS distributions, use them from there.
 // ***npm install*** installs all dependencies in package.json. It will only run when changes are made to package.json
 plugins {
-    id "com.moowork.node" version "1.2.0"
+//    id "com.moowork.node" version "1.2.0"
+    id("com.github.node-gradle.node") version "2.2.0"
 }
 
 node {


### PR DESCRIPTION
This PR allows us to disable the reverse proxy for the executor resources on k8s pods and the web server uses the flow pod's *Service* endpoint to interact with the executor pods.

If the executor pod is deployed with a Service, it usually can be directly reached from another pod in the same cluster. Thus, if the Azkaban web server is containerized and running in the same k8s cluster, the reverse proxy (e.g. Ambassador) is not needed anymore and the web server can talk to the executor pod with the URL: `http://[serviceName].[namespace]:[servicePod]`. Note that it still holds even the web server pod and executor pod are under different namespaces (tho they have to be in the same k8s cluster).

## How to Enable
To fully enable this feature, two fields in azkaban.properties might need to be changed:

```
# Set to false to disable the reverse proxy
azkaban.executor.reverse.proxy.enabled=false
# Set to false if the Service of the pod only support HTTP
azkaban.executor.client.tls.enabled=false
```

## Test Done
- Tested on a cluster where the web server is **NOT** containerized to make sure the code changes will not break anything;
- Tested on a cluster where the web server **IS** containerized
	- Still enable the reverse proxy to make sure nothing is broken by the code changes;
	- Disable the reverse proxy, and trigger flows to verify:
		- Flow status can be correctly showed on UI;
		- Logs of running jobs can be fetched on UI;
		- Running flows can be killed on UI.

Also confirmed the web server is indeed using the Service endpoint when talking to the executor pods:

```
2023/07/17 22:19:13.363 +0000  INFO [ExecutorApiClient] [215351125@qtp-146799499-0] [Azkaban] URI is: http://fc-svc-z50azweb50-19.grid-integration-testing:54343/container
```
