### PR TITLE
flow-retry: emit count metrics

### DIFF
--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -24,9 +24,9 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
   private final ExecutorLoader executorLoader;
   private final ExecutorManagerAdapter executorManagerAdapter;
   private final ProjectManager projectManager;
-  // number of missed schedules with no back execution enabled
+  // number flow retries using "RetryAsNew" strategy
   private final Counter flowRetryRetryAsNewStrategyCounter;
-  // number of missed schedules with back execution enabled
+  // number flow retries using "DisableSucceededNodes" strategy
   private final Counter flowRetryDisableSucceededNodesStrategyCounter;
 
 

--- a/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
+++ b/azkaban-common/src/main/java/azkaban/executor/OnContainerizedExecutionEventListener.java
@@ -7,8 +7,10 @@ import azkaban.Constants.FlowRetryStrategy;
 import azkaban.DispatchMethod;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowUtils;
+import azkaban.metrics.MetricsManager;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
+import com.codahale.metrics.Counter;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.slf4j.Logger;
@@ -22,13 +24,23 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
   private final ExecutorLoader executorLoader;
   private final ExecutorManagerAdapter executorManagerAdapter;
   private final ProjectManager projectManager;
+  // number of missed schedules with no back execution enabled
+  private final Counter flowRetryRetryAsNewStrategyCounter;
+  // number of missed schedules with back execution enabled
+  private final Counter flowRetryDisableSucceededNodesStrategyCounter;
+
 
   @Inject
   public OnContainerizedExecutionEventListener(final ExecutorLoader executorLoader,
-      ExecutorManagerAdapter executorManagerAdapter, ProjectManager projectManager) {
+      ExecutorManagerAdapter executorManagerAdapter, ProjectManager projectManager,
+      final MetricsManager metricsManager) {
     this.executorLoader = executorLoader;
     this.executorManagerAdapter = executorManagerAdapter;
     this.projectManager = projectManager;
+    this.flowRetryRetryAsNewStrategyCounter = metricsManager
+        .addCounter("flow-retry-retry-as-new-count");
+    this.flowRetryDisableSucceededNodesStrategyCounter = metricsManager
+        .addCounter("flow-retry-disable-succeeded-nodes-count");
   }
 
   @Override
@@ -72,6 +84,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
     switch (retryStrategy) {
       case DISABLE_SUCCEEDED_NODES:
         try {
+          this.flowRetryDisableSucceededNodesStrategyCounter.inc();
           disableSucceededSkippedJobsInRetryFlow(originalExFlow, retryExFlow);
         } catch (ExecutorManagerException e){
           // TODO: consider notify user via email too
@@ -83,6 +96,7 @@ public class OnContainerizedExecutionEventListener implements OnExecutionEventLi
         }
         break;
       default:
+        this.flowRetryRetryAsNewStrategyCounter.inc();
         logger.info(String.format("Use default strategy when restarting the execution %s",
           originalExFlow.getExecutionId()));
     }

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutionControllerUtilsRestartFlowTest.java
@@ -41,8 +41,8 @@ public class ExecutionControllerUtilsRestartFlowTest {
   private ExecutionLogsLoader offlineExecutionLogsLoader;
   private User user;
   private ContainerizedDispatchManager containerizedDispatchManager;
-  private final CommonMetrics commonMetrics = new CommonMetrics(
-      new MetricsManager(new MetricRegistry()));
+  private MetricsManager metricsManager = new MetricsManager(new MetricRegistry());
+  private final CommonMetrics commonMetrics = new CommonMetrics(metricsManager);
   private ProjectManager projectManager;
   private static final int executionId = 111;
   private static final int projectId = 1;
@@ -84,7 +84,7 @@ public class ExecutionControllerUtilsRestartFlowTest {
         null, new DummyEventListener(), new DummyContainerizationMetricsImpl(), null);
 
     this.listener = new OnContainerizedExecutionEventListener(this.executorLoader,
-        this.containerizedDispatchManager, this.projectManager);
+        this.containerizedDispatchManager, this.projectManager, this.metricsManager);
     ExecutionControllerUtils.onExecutionEventListener = this.listener;
   }
 

--- a/azkaban-common/src/test/java/azkaban/executor/OnContainerizedExecutionEventListenerTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/OnContainerizedExecutionEventListenerTest.java
@@ -12,9 +12,11 @@ import static org.mockito.Mockito.when;
 import azkaban.DispatchMethod;
 import azkaban.flow.Flow;
 import azkaban.flow.FlowUtils;
+import azkaban.metrics.MetricsManager;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.utils.TestUtils;
+import com.codahale.metrics.MetricRegistry;
 import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +54,8 @@ public class OnContainerizedExecutionEventListenerTest {
     this.onContainerizedExecutionEventListener = new OnContainerizedExecutionEventListener(
         this.executorLoader,
         this.executorManagerAdapter,
-        mock(ProjectManager.class)
+        mock(ProjectManager.class),
+        new MetricsManager(new MetricRegistry())
     );
   }
 


### PR DESCRIPTION
**Why we need this**
To make flow-retry a fully functional feature, adding observability

**What's dione** 
Emit metrics when restarting the executin, separately for each retry-strategy

**Tests done** 
Tested in staging cluster:
* Started a flow with retry option and kill its yarn-app to fail it 
* The flow got retry and in metric dashboard saw the counted data point