### PR TITLE
Disable job property edit permission when project lock is set

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -199,6 +199,10 @@ public class Constants {
    * Disable adhoc upload on upload-locked projects
    */
   public static final String AZKABAN_DISABLE_ADHOC_UPLOAD_ON_LOCKED = "azkaban.disable.adhoc.upload.on.locked";
+  /*
+   * Disable job properties edit via UI or API on upload-locked projects
+   */
+  public static final String AZKABAN_DISABLE_JOB_PROPS_OVERRIDE_ON_LOCKED = "azkaban.disable.job.props.override.on.locked";
 
   // Azkaban event reporter constants
   public static class EventReporterConstants {

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -442,7 +442,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         }
       } else if (API_SET_JOB_OVERRIDE_PROPERTY.equals(ajaxName)) {
         if (uploadPrivilegeUser != null && disableJobPropsOverrideWhenProjectUploadLocked && project.isUploadLocked()) {
-          ret.put(ERROR_PARAM, "Project " + projectName + "is locked for edit job property while upload privilege user "
+          ret.put(ERROR_PARAM, "Project " + projectName + "is locked for editing job property while upload privilege user "
               + "is set to " + uploadPrivilegeUser + ". If you really need to edit job property, "
               + "please contact oncall to remove this lock.");
           resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -1400,22 +1400,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("projectName", project.getName());
         page.add("projectId", project.getId());
         //params for projectsidebar
-        page.add("description",project.getDescription());
-        page.add("createTimestamp",project.getCreateTimestamp());
-        page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
-        page.add("lastModifiedUser",project.getLastModifiedUser());
-
-        // params for project upload
-        // show if a project has prod identifier
-        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
-        page.add("adhocUpload", project.isAdhocUploadEnabled());
-        page.add("showUploadLockPanel", uploadPrivilegeUser != null);
-        // only show adhocUpload changeable button when this feature is enabled
-        page.add("showAdhocUploadFeature",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
-        // hide upload project button when project prod identifier is set
-        page.add("hideUploadProjectButton",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
+        addProjectSidebarProperties(page, project);
 
         page.add("admins", Utils.flattenToString(
             project.getUsersWithPermission(Type.ADMIN), ","));
@@ -1536,23 +1521,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         }
 
         page.add("projectName", project.getName());
-        //params for projectsidebar
-        page.add("description",project.getDescription());
-        page.add("createTimestamp",project.getCreateTimestamp());
-        page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
-        page.add("lastModifiedUser",project.getLastModifiedUser());
-
-        // params for project upload
-        // show if a project has prod identifier
-        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
-        page.add("adhocUpload", project.isAdhocUploadEnabled());
-        page.add("showUploadLockPanel", uploadPrivilegeUser != null);
-        // only show adhocUpload changeable button when this feature is enabled
-        page.add("showAdhocUploadFeature",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
-        // hide upload project button when project prod identifier is set
-        page.add("hideUploadProjectButton",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
+        addProjectSidebarProperties(page, project);
 
         page.add("username", user.getUserId());
         page.add("admins", Utils.flattenToString(
@@ -1590,6 +1559,32 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     }
 
     page.render();
+  }
+
+  /**
+   * Project sidebar properties shared by multiple web pages are added here.
+   *
+   * @param page the page to add properties to
+   * @param project the current project to add properties from
+   * */
+  private void addProjectSidebarProperties(Page page, Project project) {
+    // basic project properties
+    page.add("description", project.getDescription());
+    page.add("createTimestamp", project.getCreateTimestamp());
+    page.add("lastModifiedTimestamp", project.getLastModifiedTimestamp());
+    page.add("lastModifiedUser", project.getLastModifiedUser());
+
+    // params for project upload
+    // show if a project has prod identifier
+    page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
+    page.add("adhocUpload", project.isAdhocUploadEnabled());
+    page.add("showUploadLockPanel", uploadPrivilegeUser != null);
+    // only show adhocUpload changeable button when this feature is enabled
+    page.add("showAdhocUploadFeature",
+        uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
+    // hide upload project button when project prod identifier is set
+    page.add("hideUploadProjectButton",
+        uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
   }
 
   private void handleJobPage(final HttpServletRequest req, final HttpServletResponse resp,
@@ -1884,22 +1879,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("projectName", project.getName());
         page.add("projectId", project.getId());
         //params for projectsidebar
-        page.add("description",project.getDescription());
-        page.add("createTimestamp",project.getCreateTimestamp());
-        page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
-        page.add("lastModifiedUser",project.getLastModifiedUser());
-
-        // params for project upload
-        // show if a project has prod identifier
-        page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
-        page.add("adhocUpload", project.isAdhocUploadEnabled());
-        page.add("showUploadLockPanel", uploadPrivilegeUser != null);
-        // only show adhocUpload changeable button when this feature is enabled
-        page.add("showAdhocUploadFeature",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
-        // hide upload project button when project prod identifier is set
-        page.add("hideUploadProjectButton",
-            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
+        addProjectSidebarProperties(page, project);
 
         page.add("admins", Utils.flattenToString(
             project.getUsersWithPermission(Type.ADMIN), ","));

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -157,6 +157,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private boolean lockdownUploadProjects = false;
   private boolean enableQuartz = false;
   private boolean disableAdhocUploadWhenProjectUploadLocked = false;
+  private boolean disableJobPropsOverrideWhenProjectUploadLocked = false;
   private String uploadPrivilegeUser;
   private Map<String, List<HTMLFormElement>> alerterPlugins;
 
@@ -197,9 +198,14 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     logger.info("downloadBufferSize: " + this.downloadBufferSize);
 
     // get upload privilege user, if not configured, treated upload as adhoc, no upload lock enabled
+    // this feature flag is fundamental for project security feature enhanced by upload
     this.uploadPrivilegeUser = server.getServerProps().get(AZKABAN_UPLOAD_PRIVILEGE_USER);
+    // a separate feature flag to disable adhoc upload when project upload lock is enabled
     this.disableAdhocUploadWhenProjectUploadLocked =
         server.getServerProps().getBoolean(AZKABAN_DISABLE_ADHOC_UPLOAD_ON_LOCKED, false);
+    // a separate feature flag to disable job props override when project upload lock is enabled
+    this.disableJobPropsOverrideWhenProjectUploadLocked =
+        server.getServerProps().getBoolean(AZKABAN_DISABLE_JOB_PROPS_OVERRIDE_ON_LOCKED, false);
 
     final Map<String, List<HTMLFormElement>> alerterPlugins = new HashMap<>();
     server.getAlerterPlugins().forEach((name, alerter) -> alerterPlugins.put(name,
@@ -435,6 +441,13 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
           ajaxFetchJobInfo(project, ret, req);
         }
       } else if (API_SET_JOB_OVERRIDE_PROPERTY.equals(ajaxName)) {
+        if (uploadPrivilegeUser != null && disableJobPropsOverrideWhenProjectUploadLocked && project.isUploadLocked()) {
+          ret.put(ERROR_PARAM, "Project " + projectName + "is locked for edit job property while upload privilege user "
+              + "is set to " + uploadPrivilegeUser + ". If you really need to edit job property, "
+              + "please contact oncall to remove this lock.");
+          resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          return;
+        }
         if (handleAjaxPermission(project, user, Type.WRITE, ret)) {
           ajaxSetJobOverrideProperty(project, ret, req, user);
         }
@@ -1391,9 +1404,18 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
+
+        // params for project upload
+        // show if a project has prod identifier
         page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
+        // only show adhocUpload changeable button when this feature is enabled
+        page.add("showAdhocUploadFeature",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
+        // hide upload project button when project prod identifier is set
+        page.add("hideUploadProjectButton",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
 
         page.add("admins", Utils.flattenToString(
             project.getUsersWithPermission(Type.ADMIN), ","));
@@ -1519,9 +1541,18 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
+
+        // params for project upload
+        // show if a project has prod identifier
         page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
+        // only show adhocUpload changeable button when this feature is enabled
+        page.add("showAdhocUploadFeature",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
+        // hide upload project button when project prod identifier is set
+        page.add("hideUploadProjectButton",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
 
         page.add("username", user.getUserId());
         page.add("admins", Utils.flattenToString(
@@ -1582,6 +1613,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         throw new AccessControlException("No permission to view project " + projectName + ".");
       }
       page.add("projectName", project.getName());
+      page.add("hideJobPropsEdit",
+          uploadPrivilegeUser != null && disableJobPropsOverrideWhenProjectUploadLocked && project.isUploadLocked());
 
       final Flow flow = project.getFlow(flowNodePath);
       if (flow == null) {
@@ -1855,9 +1888,18 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         page.add("createTimestamp",project.getCreateTimestamp());
         page.add("lastModifiedTimestamp",project.getLastModifiedTimestamp());
         page.add("lastModifiedUser",project.getLastModifiedUser());
+
+        // params for project upload
+        // show if a project has prod identifier
         page.add("projectUploadLock", uploadPrivilegeUser != null && project.isUploadLocked());
         page.add("adhocUpload", project.isAdhocUploadEnabled());
         page.add("showUploadLockPanel", uploadPrivilegeUser != null);
+        // only show adhocUpload changeable button when this feature is enabled
+        page.add("showAdhocUploadFeature",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked);
+        // hide upload project button when project prod identifier is set
+        page.add("hideUploadProjectButton",
+            uploadPrivilegeUser != null && disableAdhocUploadWhenProjectUploadLocked && project.isUploadLocked());
 
         page.add("admins", Utils.flattenToString(
             project.getUsersWithPermission(Type.ADMIN), ","));
@@ -2048,9 +2090,18 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       // uploader is upload privilege user and the project is not protected by feature flag enable.project.adhoc.upload
       // mark the project with UPLOAD LOCK if it is not already, and persist in DB
       if (!project.isAdhocUploadEnabled() && user.getUserId().equals(uploadPrivilegeUser) && !project.isUploadLocked()) {
-          project.setUploadLock(true);
-          this.projectManager.updateProjectSetting(project);
-          logger.info("Project {} is Upload Locked", project.getName());
+        project.setUploadLock(true);
+        this.projectManager.updateProjectSetting(project);
+        logger.info("Project {} is PROD", project.getName());
+      } else if (uploadPrivilegeUser != null && !user.getUserId().equals(uploadPrivilegeUser)) {
+        // when project security lock feature is turned on (only prod project flows would be allowed to push to prod cluster)
+        // and uploader not the upload privileged user, we want to reset prod lock status to false
+        // so that we remain the same restriction "prod project flows would be allowed to push to prod cluster"
+        // regardless we enable/disable AdhocUploadWhenProjectUploadLocked completely
+        project.setUploadLock(false);
+        this.projectManager.updateProjectSetting(project);
+        logger.info("Project {} is non PROD due to uploader {} is not uploadPrivilegeUser {}",
+            project.getName(), user.getUserId(), uploadPrivilegeUser);
       }
 
       registerErrorsAndWarningsFromValidationReport(resp, ret, reports);

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/jobpage.vm
@@ -102,8 +102,10 @@
         <div class="panel panel-default">
           <div class="panel-heading">
             <div class="pull-right">
-              <button id="edit-job-btn" class="btn btn-xs btn-primary" onclick='jobEditView.show("${projectName}", "${flowid}", "${jobid}")'>Edit
-              </button>
+              #if (!$hideJobPropsEdit)
+                <button id="edit-job-btn" class="btn btn-xs btn-primary" onclick='jobEditView.show("${projectName}", "${flowid}", "${jobid}")'>Edit
+                </button>
+              #end
             </div>
             Job Properties
           </div>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectpageheader.vm
@@ -27,8 +27,7 @@
           <button id="project-delete-btn" class="btn btn-sm btn-danger">
             <span class="glyphicon glyphicon-trash"></span> Delete Project
           </button>
-          #set($hideUploadProject = ${projectUploadLock})
-          #if (!${hideUploadProject})
+          #if (!$hideUploadProjectButton)
             <button id="project-upload-btn" class="btn btn-sm btn-primary">
               <span class="glyphicon glyphicon-upload"></span> Upload
             </button>

--- a/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectsidebar.vm
+++ b/azkaban-web-server/src/main/resources/azkaban/webapp/servlet/velocity/projectsidebar.vm
@@ -35,19 +35,20 @@
 
   <hr>
   #if ($showUploadLockPanel)
-    <p><strong>Upload Lock On:</strong> $projectUploadLock</p>
-    <p><strong>Ad hoc Upload Enabled:</strong> <span class="editable" id="adhoc-upload">$adhocUpload</span></p>
-    <div id="adhoc-upload-form" class="editable-form">
-      <div class="input-group">
-        <input type="text" class="form-control input-sm" id="adhoc-upload-edit"
-               placeholder="true/false">
-        <span class="input-group-btn">
-                  <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
-                </span>
+    <p><strong>Project Prod Identifier:</strong> $projectUploadLock</p>
+    #if ($showAdhocUploadFeature)
+      <p><strong>Ad hoc Upload Enabled:</strong> <span class="editable" id="adhoc-upload">$adhocUpload</span></p>
+      <div id="adhoc-upload-form" class="editable-form">
+        <div class="input-group">
+          <input type="text" class="form-control input-sm" id="adhoc-upload-edit"
+                 placeholder="true/false">
+          <span class="input-group-btn">
+                    <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
+                  </span>
+        </div>
       </div>
-    </div>
+    #end
   #end
-
   <hr>
 
   <p><strong>Project admins:</strong> $admins</p>

--- a/azkaban-web-server/src/test/expected/project-side-bar.html
+++ b/azkaban-web-server/src/test/expected/project-side-bar.html
@@ -19,15 +19,15 @@
   <p><strong>Modified by</strong> last_modified_user_name</p>
 
   <hr>
-  <p><strong>Upload Lock On:</strong> true</p>
+  <p><strong>Project Prod Identifier:</strong> true</p>
   <p><strong>Ad hoc Upload Enabled:</strong> <span class="editable" id="adhoc-upload">false</span></p>
   <div id="adhoc-upload-form" class="editable-form">
     <div class="input-group">
       <input type="text" class="form-control input-sm" id="adhoc-upload-edit"
              placeholder="true/false">
       <span class="input-group-btn">
-                      <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
-                    </span>
+                        <button class="btn btn-primary btn-sm" type="button" id="adhoc-upload-btn">Save</button>
+                      </span>
     </div>
   </div>
   <hr>

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectPageHeaderTest.java
@@ -19,7 +19,7 @@ public class ProjectPageHeaderTest {
   @Test
   public void testUploadButtonIsPresent() {
     final VelocityContext context = VelocityContextTestUtil.getInstance();
-    context.put("projectUploadLock", false);
+    context.put("hideUploadProjectButton", false);
 
     final String result =
         VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);
@@ -29,7 +29,7 @@ public class ProjectPageHeaderTest {
   @Test
   public void testUploadButtonIsNotPresent() {
     final VelocityContext context = VelocityContextTestUtil.getInstance();
-    context.put("projectUploadLock", true);
+    context.put("hideUploadProjectButton", true);
 
     final String result =
         VelocityTemplateTestUtil.renderTemplate("projectpageheader", context);

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectSideBarViewTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectSideBarViewTest.java
@@ -39,6 +39,7 @@ public class ProjectSideBarViewTest {
     context.put("projectUploadLock", project.isUploadLocked());
     context.put("adhocUpload", project.isAdhocUploadEnabled());
     context.put("showUploadLockPanel", true);
+    context.put("showAdhocUploadFeature", true);
 
     context.put("admins", "admin_name");
     context.put("userpermission", "admin_permission");


### PR DESCRIPTION
### Summary
This PR is the third step to address the security which restricted the permission to edit job properties when project lock is on. This limitation is aiming to protect production projects from any adhoc modifications unless the projects have to be gone through a review process and reuploaded by upload privileged user who intented to be set by a deployment automation user. This restriction would also be put under a feature flag azkaban.disable.job.props.override.on.locked. 

### Details
- Disable "Job Properties" Edit via UI and via API when project lock is set;
- Fix the lock status when adhocUpload restriction is not set, we should still properly change the project lock status;
- UI improvements:
  1. hide edit button for job properties when lock is on;
  2. show adhocUpload editable only when this feature flag is turned on; Normally we only show the status of project lock in UI;

### Test Done
- test feature flag not set, job property edit function normal;
- test feature flag azkaban.disable.job.props.override.on.locked=true, and project prod identifier is set, no edit button accessible.
- test feature flag azkaban.disable.job.props.override.on.locked=true, project prod identifier not set, job property edit function normal
