### PR TITLE
Azkaban security enhancement by cert management

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -463,6 +463,9 @@ public class Constants {
 
     public static final String SECURITY_USER_GROUP = "azkaban.security.user.group";
 
+    // A config to control whether to enable new security model to dynamically change ACLs
+    public static final String ENABLE_SECURITY_CERT_MANAGEMENT = "azkaban.enable.security.cert.management";
+
     public static final String CSR_KEYSTORE_LOCATION = "azkaban.csr.keystore.location";
 
     // dir to keep dependency plugins
@@ -592,6 +595,12 @@ public class Constants {
     * is uploaded by "upload.privilege.user".
     * */
     public static final String AZKABAN_FLOW_PRODUCTION_MARKER = "azkaban.flow.production.marker";
+    /*
+    * A flag to indicate whether the flow should use adhoc certificate or not.
+    * If the flag is set to true, the flow would use adhoc certificate in init container.
+    * Otherwise, the flow would use the existing/default certificate in init container.
+    * */
+    public static final String AZKABAN_FLOW_ADHOC_CERTIFICATE = "azkaban.flow.adhoc.certificate";
   }
 
   public static class JobProperties {

--- a/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
+++ b/azkaban-common/src/main/java/azkaban/container/models/AzKubernetesV1SpecBuilder.java
@@ -162,7 +162,8 @@ public class AzKubernetesV1SpecBuilder {
     }
     public AzKubernetesV1SpecBuilder addSecurityInitContainer(String image,
         ImagePullPolicy imagePullPolicy,
-        final InitContainerType initContainerType, Set<String> proxyUserList, String projectUploadUser ) {
+        final InitContainerType initContainerType,
+        Set<String> proxyUserList, String projectUploadUser, Boolean fetchAdhocCert) {
         V1EnvVar proxyUserEnv = new V1EnvVarBuilder()
             .withName(initContainerType.mountPathKey)
             .withValue(String.join(",", proxyUserList))
@@ -171,9 +172,13 @@ public class AzKubernetesV1SpecBuilder {
             .withName("PROJECT_UPLOAD_USER")
             .withValue(projectUploadUser)
             .build();
+        V1EnvVar fetchAdhocCertEnv = new V1EnvVarBuilder()
+            .withName("FETCH_ADHOC_CERT")
+            .withValue(fetchAdhocCert.toString())
+            .build();
         V1Container initContainer = new V1ContainerBuilder()
             .withName(initContainerType.initPrefix)
-            .addToEnv(proxyUserEnv, projectUploadUserEnv)
+            .addToEnv(proxyUserEnv, projectUploadUserEnv, fetchAdhocCertEnv)
             .withImagePullPolicy(imagePullPolicy.getPolicyVal())
             .withImage(image)
             .build();

--- a/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
+++ b/azkaban-common/src/main/java/azkaban/executor/container/KubernetesContainerizedImpl.java
@@ -1461,10 +1461,11 @@ public class KubernetesContainerizedImpl extends EventHandler implements Contain
     if (this.prefetchAllCredentials) {
       try {
         final String projectUploadUser = flow.getUploadUser();
+        final Boolean fetchAdhocCert = flow.isFetchAdhocCert();
         final String imageFullPath =
             versionSet.getVersion(this.azkabanSecurityInitImageName).get().pathWithVersion();
         v1SpecBuilder.addSecurityInitContainer(imageFullPath, ImagePullPolicy.IF_NOT_PRESENT,
-            InitContainerType.SECURITY, proxyUserList, projectUploadUser);
+            InitContainerType.SECURITY, proxyUserList, projectUploadUser, fetchAdhocCert);
       } catch (final Exception e) {
         throw new ExecutorManagerException("Did not find security image. Failed Proxy User Init "
             + "container");

--- a/azkaban-common/src/main/java/azkaban/flow/Flow.java
+++ b/azkaban-common/src/main/java/azkaban/flow/Flow.java
@@ -21,6 +21,7 @@ import static azkaban.flow.CommonJobProperties.FAILURE_ACTION_PROPERTY;
 import azkaban.Constants;
 import azkaban.executor.mail.DefaultMailCreator;
 import azkaban.utils.Pair;
+import azkaban.utils.SecurityTag;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -50,6 +51,7 @@ public class Flow {
   private static final String ERRORS_PROPERTY = "errors";
   private static final String IS_LOCKED_PROPERTY = "isLocked";
   private static final String FLOW_LOCK_ERROR_MESSAGE_PROPERTY = "flowLockErrorMessage";
+  private static final String SECURITY_TAG_PROPERTY = "securityTag";
 
   private final String id;  // This is actually the node path. I.e. rootFlow:subFlow1:subFlow2
   private int projectId;
@@ -65,6 +67,7 @@ public class Flow {
   private final List<String> failureEmail = new ArrayList<>();
   private final List<String> successEmail = new ArrayList<>();
   private final List<String> overrideEmail = new ArrayList<>();
+  private SecurityTag securityTag;
 
   public String getFailureAction() {
     return failureAction;
@@ -130,6 +133,7 @@ public class Flow {
     final String failureAction = (String) flowObject.getOrDefault(
         FAILURE_ACTION_PROPERTY, flow.getFailureAction()
     );
+    final String securityTag = (String) flowObject.get(SECURITY_TAG_PROPERTY);
     flow.setLayedOut(layedout);
     flow.setEmbeddedFlow(isEmbeddedFlow);
     flow.setAzkabanFlowVersion(azkabanFlowVersion);
@@ -143,6 +147,7 @@ public class Flow {
     flow.addSuccessEmails(successEmails);
     flow.setMailCreator(mailCreator);
     flow.setFailureAction(failureAction);
+    flow.setSecurityTag(securityTag != null ? SecurityTag.valueOf(securityTag) : null);
     // Loading projects
     final Map<String, ImmutableFlowProps> properties = loadPropertiesFromObject(propertiesList);
     flow.addAllFlowProperties(properties.values());
@@ -414,6 +419,9 @@ public class Flow {
     flowObj.put(CONDITION_PROPERTY, this.condition);
     flowObj.put(IS_LOCKED_PROPERTY, this.isLocked);
     flowObj.put(FLOW_LOCK_ERROR_MESSAGE_PROPERTY, this.flowLockErrorMessage);
+    if (this.securityTag != null) {
+      flowObj.put(SECURITY_TAG_PROPERTY, this.securityTag.name());
+    }
 
     if (this.failureAction != null) {
       flowObj.put(FAILURE_ACTION_PROPERTY, this.failureAction);
@@ -544,5 +552,17 @@ public class Flow {
 
   public void setFlowLockErrorMessage(final String flowLockErrorMessage) {
     this.flowLockErrorMessage = flowLockErrorMessage;
+  }
+
+  public SecurityTag getSecurityTag() {
+    return this.securityTag;
+  }
+
+  public void setSecurityTag(final SecurityTag securityTag) {
+    this.securityTag = securityTag;
+  }
+
+  public void unsetSecurityTag() {
+    this.securityTag = null;
   }
 }

--- a/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
+++ b/azkaban-common/src/main/java/azkaban/project/JdbcProjectHandlerSet.java
@@ -26,6 +26,7 @@ import azkaban.utils.JSONUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import azkaban.utils.SecurityTag;
 import azkaban.utils.ThinArchiveUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -51,7 +52,7 @@ class JdbcProjectHandlerSet {
 
     private static final String BASE_QUERY = "SELECT "
         + "prj.id, prj.name, prj.active, prj.modified_time, prj.create_time, prj.version, prj"
-        + ".last_modified_by, prj.description, prj.enc_type, prj.settings_blob, "
+        + ".last_modified_by, prj.description, prj.enc_type, prj.settings_blob, prj.security_tag, "
         + "prm.name, prm.permissions, prm.isGroup, prjver.uploader "
         + "FROM projects prj LEFT JOIN project_versions prjver ON prj.id = prjver.project_id ";
 
@@ -91,6 +92,7 @@ class JdbcProjectHandlerSet {
           final String description = rs.getString(8);
           final int encodingType = rs.getInt(9);
           final byte[] data = rs.getBytes(10);
+          final String securityTag = rs.getString(11);
           final Project project;
           if (data != null) {
             final EncodingType encType = EncodingType.fromInteger(encodingType);
@@ -122,15 +124,16 @@ class JdbcProjectHandlerSet {
           project.setVersion(version);
           project.setLastModifiedUser(lastModifiedBy);
           project.setDescription(description);
+          project.setSecurityTag(securityTag != null ? SecurityTag.valueOf(securityTag) : null);
 
           projects.put(id, project);
         }
 
         // Add the permission to the project
-        final String username = rs.getString(11);
-        final int permissionFlag = rs.getInt(12);
-        final boolean isGroup = rs.getBoolean(13);
-        final String uploader = rs.getString(14);
+        final String username = rs.getString(12);
+        final int permissionFlag = rs.getInt(13);
+        final boolean isGroup = rs.getBoolean(14);
+        final String uploader = rs.getString(15);
         // Setting upload user in project Object
         if (uploader != null) {
           projects.get(id).setUploadUser(uploader);

--- a/azkaban-common/src/main/java/azkaban/project/Project.java
+++ b/azkaban-common/src/main/java/azkaban/project/Project.java
@@ -25,6 +25,7 @@ import azkaban.user.Permission;
 import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Pair;
+import azkaban.utils.SecurityTag;
 import com.google.common.collect.ImmutableMap;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -50,6 +51,8 @@ public class Project extends EventHandler {
   private final HashSet<String> proxyUsers = new HashSet<>();
   private boolean active = true;
   private boolean isUploadLocked = false;
+
+  private SecurityTag securityTag;
 
   private Map<FeatureFlag, Object> featureFlags = new HashMap<>();
   private String description;
@@ -101,6 +104,7 @@ public class Project extends EventHandler {
         (Map<String, Object>) projectObject.get("metadata");
     final Map<String, Object> featureFlagsMap = (Map<String, Object>) projectObject.get("featureFlags");
     final Boolean isUploadLocked = (Boolean) projectObject.get("isUploadLocked");
+    final String tag = (String) projectObject.get("securityTag");
     final Project project = new Project(id, name);
     project.setVersion(version);
     project.setDescription(description);
@@ -111,6 +115,10 @@ public class Project extends EventHandler {
     project.setUploadUser(uploadUser);
     if (isUploadLocked != null) {
       project.setUploadLock(isUploadLocked);
+    }
+
+    if (tag != null) {
+      project.setSecurityTag(SecurityTag.valueOf(tag));
     }
 
     if (featureFlagsMap != null) {
@@ -378,6 +386,9 @@ public class Project extends EventHandler {
 
     projectObject.put("featureFlags", this.featureFlags);
     projectObject.put("isUploadLocked", this.isUploadLocked);
+    if (this.securityTag != null) {
+      projectObject.put("securityTag", this.securityTag.name());
+    }
 
     return projectObject;
   }
@@ -483,6 +494,14 @@ public class Project extends EventHandler {
 
   public void setSource(final String source) {
     this.source = source;
+  }
+
+  public SecurityTag getSecurityTag() {
+    return this.securityTag;
+  }
+
+  public void setSecurityTag(final SecurityTag securityTag) {
+    this.securityTag = securityTag;
   }
 
   public Map<String, Object> getMetadata() {

--- a/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectLoader.java
@@ -22,6 +22,7 @@ import azkaban.project.ProjectLogEvent.EventType;
 import azkaban.user.Permission;
 import azkaban.user.User;
 import azkaban.utils.Props;
+import azkaban.utils.SecurityTag;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -45,6 +46,9 @@ public interface ProjectLoader {
    */
   Project fetchProjectByName(String name) throws ProjectManagerException;
 
+  Project createNewProject(String name, String description, User creator)
+      throws ProjectManagerException;
+
   /**
    * Should create an empty project with the given name and user and adds it to the data store. It
    * will auto assign a unique id for this project if successful.
@@ -54,7 +58,7 @@ public interface ProjectLoader {
    *
    * @throws ProjectManagerException if an active project of the same name exists.
    */
-  Project createNewProject(String name, String description, User creator)
+  Project createNewProject(String name, String description, User creator, SecurityTag securityTag)
       throws ProjectManagerException;
 
   /**

--- a/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
+++ b/azkaban-common/src/main/java/azkaban/project/ProjectManager.java
@@ -37,6 +37,7 @@ import azkaban.user.Permission.Type;
 import azkaban.user.User;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import azkaban.utils.SecurityTag;
 import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 import java.io.File;
@@ -211,6 +212,11 @@ public class ProjectManager {
 
   public Project createProject(final String projectName, final String description,
       final User creator) throws ProjectManagerException {
+    return createProject(projectName, description, creator, null);
+  }
+
+  public Project createProject(final String projectName, final String description,
+      final User creator, final SecurityTag securityTag) throws ProjectManagerException {
     if (projectName == null || projectName.trim().isEmpty()) {
       throw new ProjectManagerException("Project name cannot be empty.");
     } else if (description == null || description.trim().isEmpty()) {
@@ -228,7 +234,7 @@ public class ProjectManager {
         throw new ProjectManagerException("Project already exists.");
       }
       logger.info("Trying to create {} by user {}", projectName, creator.getUserId());
-      newProject = this.projectLoader.createNewProject(projectName, description, creator);
+      newProject = this.projectLoader.createNewProject(projectName, description, creator, securityTag);
       this.cache.putProject(newProject);
     }
 

--- a/azkaban-common/src/main/java/azkaban/utils/SecurityTag.java
+++ b/azkaban-common/src/main/java/azkaban/utils/SecurityTag.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.utils;
+
+/**
+ * A Tag to identify which Azkaban resources would subject to new security model.
+ * This is built in order to maintain backward compatibility for legacy flows.
+ * */
+public enum SecurityTag {
+  NEW_PROJECT,
+  NEW_FLOW,
+  LEGACY_FLOW
+}

--- a/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
+++ b/azkaban-common/src/test/java/azkaban/executor/ExecutableFlowTest.java
@@ -27,6 +27,7 @@ import azkaban.sla.SlaType;
 import azkaban.test.executions.ExecutionsTestUtil;
 import azkaban.utils.JSONUtils;
 import azkaban.utils.Props;
+import azkaban.utils.SecurityTag;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.time.Duration;
@@ -291,6 +292,46 @@ public class ExecutableFlowTest {
 
     final ExecutableFlow parsedExFlow =
         ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
+    testEquals(exFlow, parsedExFlow);
+  }
+
+  @Test
+  public void testAdhocCertTrue() throws Exception {
+    final Flow flow = this.project.getFlow("jobe");
+    flow.setSecurityTag(SecurityTag.NEW_FLOW);
+    this.project.setUploadLock(false);
+
+    final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    exFlow.setDispatchMethod(DispatchMethod.CONTAINERIZED);
+
+    final Object obj = exFlow.toObject();
+    final String exFlowJSON = JSONUtils.toJSON(obj);
+    final Map<String, Object> flowObjMap =
+        (Map<String, Object>) JSONUtils.parseJSONFromString(exFlowJSON);
+
+    final ExecutableFlow parsedExFlow =
+        ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
+    Assert.assertEquals(true, parsedExFlow.isFetchAdhocCert());
+    testEquals(exFlow, parsedExFlow);
+  }
+
+  @Test
+  public void testAdhocCertFalse() throws Exception {
+    final Flow flow = this.project.getFlow("jobe");
+    flow.setSecurityTag(SecurityTag.NEW_FLOW);
+    this.project.setUploadLock(true);
+
+    final ExecutableFlow exFlow = new ExecutableFlow(this.project, flow);
+    exFlow.setDispatchMethod(DispatchMethod.CONTAINERIZED);
+
+    final Object obj = exFlow.toObject();
+    final String exFlowJSON = JSONUtils.toJSON(obj);
+    final Map<String, Object> flowObjMap =
+        (Map<String, Object>) JSONUtils.parseJSONFromString(exFlowJSON);
+
+    final ExecutableFlow parsedExFlow =
+        ExecutableFlow.createExecutableFlow(flowObjMap, exFlow.getStatus());
+    Assert.assertEquals(false, parsedExFlow.isFetchAdhocCert());
     testEquals(exFlow, parsedExFlow);
   }
 

--- a/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/JdbcProjectImplTest.java
@@ -30,6 +30,7 @@ import azkaban.user.Permission;
 import azkaban.user.User;
 import azkaban.utils.HashUtils;
 import azkaban.utils.Props;
+import azkaban.utils.SecurityTag;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
@@ -92,11 +93,11 @@ public class JdbcProjectImplTest {
     this.loader.createNewProject(projectName, projectDescription, user);
     final String projectName2 = "mytestProject2";
     final String projectDescription2 = "This is my new project2";
-    this.loader.createNewProject(projectName2, projectDescription2, user);
+    this.loader.createNewProject(projectName2, projectDescription2, user, SecurityTag.NEW_PROJECT);
     final String projectName3 = "mytestProject3";
     final String projectDescription3 = "This is my new project3";
     final User user2 = new User("testUser2");
-    this.loader.createNewProject(projectName3, projectDescription3, user2);
+    this.loader.createNewProject(projectName3, projectDescription3, user2, SecurityTag.NEW_PROJECT);
   }
 
   @Test
@@ -225,6 +226,16 @@ public class JdbcProjectImplTest {
     Assert.assertEquals(sameProject.getUserPermissions().size(), 1);
     Assert.assertEquals(sameProject.getUserPermissions().get(0).getFirst(), "testUser1");
     Assert.assertEquals(sameProject.getUserPermissions().get(0).getSecond().toString(), "ADMIN");
+  }
+
+  @Test
+  public void testSecurityTag() throws Exception {
+    createThreeProjects();
+    final Project project = this.loader.fetchProjectByName("mytestProject");
+    Assert.assertEquals(null, project.getSecurityTag());
+
+    final Project project2 = this.loader.fetchProjectByName("mytestProject2");
+    Assert.assertEquals(SecurityTag.NEW_PROJECT, project2.getSecurityTag());
   }
 
   @Test

--- a/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/project/ProjectManagerTest.java
@@ -162,7 +162,7 @@ public class ProjectManagerTest {
     final String projectName = "mytestproject";
     final String projectDescription = "This is my new project with lower cases.";
     final User user = new User("testUser1");
-    when(this.projectLoader.createNewProject(projectName, projectDescription, user))
+    when(this.projectLoader.createNewProject(projectName, projectDescription, user, null))
         .thenReturn(new Project(1, projectName));
     this.manager.createProject(projectName, projectDescription, user);
     final String projectName2 = "MYTESTPROJECT";

--- a/azkaban-db/src/main/sql/create.projects.sql
+++ b/azkaban-db/src/main/sql/create.projects.sql
@@ -13,3 +13,6 @@ CREATE TABLE projects (
 
 CREATE INDEX project_name
   ON projects (name);
+
+ALTER TABLE projects
+  ADD COLUMN security_tag VARCHAR(64);

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -55,6 +55,7 @@ import azkaban.utils.JSONUtils;
 import azkaban.utils.Pair;
 import azkaban.utils.Props;
 import azkaban.utils.PropsUtils;
+import azkaban.utils.SecurityTag;
 import azkaban.utils.Utils;
 import azkaban.webapp.AzkabanWebServer;
 import com.google.common.annotations.VisibleForTesting;
@@ -95,7 +96,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static azkaban.Constants.*;
-import static azkaban.project.FeatureFlag.*;
+import static azkaban.Constants.ConfigurationKeys.ENABLE_SECURITY_CERT_MANAGEMENT;
+import static azkaban.project.FeatureFlag.ENABLE_PROJECT_ADHOC_UPLOAD;
 
 
 public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
@@ -156,6 +158,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
   private boolean lockdownCreateProjects = false;
   private boolean lockdownUploadProjects = false;
   private boolean enableQuartz = false;
+  private boolean enableSecurityCertManagement = false;
   private boolean disableAdhocUploadWhenProjectUploadLocked = false;
   private boolean disableJobPropsOverrideWhenProjectUploadLocked = false;
   private String uploadPrivilegeUser;
@@ -180,6 +183,7 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
     this.scheduleManager = server.getScheduleManager();
     this.userManager = server.getUserManager();
     this.scheduler = server.getFlowTriggerScheduler();
+    this.enableSecurityCertManagement = server.getServerProps().getBoolean(ENABLE_SECURITY_CERT_MANAGEMENT, false);
     this.lockdownCreateProjects =
         server.getServerProps().getBoolean(ConfigurationKeys.LOCKDOWN_CREATE_PROJECTS_KEY, false);
     this.enableQuartz = server.getServerProps().getBoolean(ConfigurationKeys.ENABLE_QUARTZ, false);
@@ -1948,7 +1952,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
       status = ERROR_PARAM;
     } else {
       try {
-        this.projectManager.createProject(projectName, projectDescription, user);
+        this.projectManager.createProject(projectName, projectDescription, user,
+            enableSecurityCertManagement ? SecurityTag.NEW_PROJECT : null);
         status = "success";
         action = "redirect";
         final String redirect = "manager?project=" + projectName;


### PR DESCRIPTION
### Summary
This PR is to implement a security update in Azkaban to enhance data protection and access control. Grestin certificates will now utilize a new principal name format for those projects that not uploaded by upload privilege user. This change affects all clusters and is designed to safeguard production data integrity. Existing flows remain unaffected, while new flows will require updated ACLs to accommodate the certificate principal name change. Detailed change would come in init containers following this change.

### Details
- Introduce SecurityTag in each azkaban resource (project.flow) to identify if a flow should subject to new security cert model;
- Only projects are not uploaded by upload-privileged-user and this is NEW_FLOW, the adhoc cert fetch ENV would be passed into init container;
- Otherwise, FETCH_ADHOC_CERT should set to false, means everything remains unchanged.

### Test Done
1. no flag was turned on, expect to see FETCH_ADHOC_CERT = true flag turned on:
2. new project upload && prod_identifier is off, expect to see FETCH_ADHOC_CERT = true yes
3. new project re-upload with different flows && prod_identifier is off, expect to see FETCH_ADHOC_CERT = true yes
4. new project flow && prod_identifier is off, expect to see FETCH_ADHOC_CERT = true  yes new project flow reupload again && prod_identifier is off, expect to see FETCH_ADHOC_CERT = true yes
5. new project/new project flow && crt lock is on, expect to see FETCH_ADHOC_CERT = false yes
6. existing flows == legacy flow, expect to see FETCH_ADHOC_CERT = false yes