### PR TITLE
Provide “job.run.on.java11=true” Job Config to launch Job JVM with Ja…

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/JavaProcessJob.java
@@ -38,6 +38,8 @@ public class JavaProcessJob extends ProcessJob {
   public static final String MAIN_ARGS = "main.args";
   public static final String JVM_PARAMS = "jvm.args";
   public static final String GLOBAL_JVM_PARAMS = "global.jvm.args";
+  public static final String RUN_ON_JAVA11_PARAMS = "job.run.on.java11";
+  public static final String JAVA11_BINARY_PATH = "java11.binary.path";
   public static final String DEPENDENCY_CLS_RAMP_PROP_PREFIX = "azkaban.ramp.jar:";
   public static final String DEPENDENCY_REG_RAMP_PROP_PREFIX = "azkaban.ramp.reg:";
   public static final String DEPENDENCY_CFG_RAMP_PROP_PREFIX = "azkaban.ramp.cfg:";
@@ -48,6 +50,7 @@ public class JavaProcessJob extends ProcessJob {
   public static final String NATIVE_LIBRARY_PATH_PREFIX = "native.library.path.";
 
   public static String JAVA_COMMAND = "java";
+  public static String DEFAULT_JAVA11_COMMAND = "java11";
 
   public JavaProcessJob(final String jobid, final Props sysProps, final Props jobProps,
       final Logger logger) {
@@ -67,8 +70,9 @@ public class JavaProcessJob extends ProcessJob {
   }
 
   protected String createCommandLine() {
-    String command = JAVA_COMMAND + " ";
-    command += getJVMArguments() + " ";
+    String java11_command = getSysProps().getString(JAVA11_BINARY_PATH, DEFAULT_JAVA11_COMMAND);
+    String command = getJobProps().getBoolean(RUN_ON_JAVA11_PARAMS, false) ? java11_command : JAVA_COMMAND;
+    command += " " + getJVMArguments() + " ";
     command += "-Xms" + getInitialMemorySize() + " ";
     command += "-Xmx" + getMaxMemorySize() + " ";
     command += getClassPathParam();

--- a/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
+++ b/azkaban-common/src/test/java/azkaban/jobExecutor/JavaProcessJobTest.java
@@ -128,6 +128,20 @@ public class JavaProcessJobTest {
   }
 
   @Test
+  public void testJava11Job() throws Exception {
+    this.props.put(JavaProcessJob.JAVA11_BINARY_PATH,
+        "java");
+    this.props.put(JavaProcessJob.RUN_ON_JAVA11_PARAMS, "true");
+    this.props.put(JavaProcessJob.JAVA_CLASS,
+        "azkaban.jobExecutor.WordCountLocal");
+    this.props.put("input", inputFile);
+    this.props.put("output", outputFile);
+    this.props.put("classpath", classPaths);
+
+    this.job.run();
+  }
+
+  @Test
   public void noClassPath() throws Exception {
     copyJarToJobDirectory();
     this.props.put(JavaProcessJob.JAVA_CLASS, "azkaban.jobExecutor.WordCountLocal");


### PR DESCRIPTION
…va11 runtime

1. java11_command will point to the JAVA binary specified by "java11.command" config in commonprivate.properties
2. job.run.on.java11 can be either set to default per JobType in <jobtype>/plugin.properties or set in ad-hoc by users per Az Job in Job Configs.