### PR TITLE
Filter out flowParameters starting with azkaban.{flow|job} for non-Azkaban-admin

### DIFF
--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -42,8 +42,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.ServletException;
@@ -276,6 +278,11 @@ public class HttpRequestUtils {
       params.remove(FlowParameters.FLOW_PARAM_DISABLE_POD_CLEANUP);
       // Passing test version will be allowed for Azkaban ADMIN role only
       params.remove(FlowParameters.FLOW_PARAM_ALLOW_IMAGE_TEST_VERSION);
+
+      // "azkaban.{job|flow}" prefix should be runtime generated, not config-able
+      params.entrySet().removeIf(e ->
+          e.getKey().startsWith("azkaban.flow") || e.getKey().startsWith("azkaban.job"));
+
     } else {
       validateIntegerParam(params, ExecutionOptions.FLOW_PRIORITY);
       validateIntegerParam(params, ExecutionOptions.USE_EXECUTOR);

--- a/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
+++ b/azkaban-common/src/test/java/azkaban/server/HttpRequestUtilsTest.java
@@ -87,6 +87,9 @@ public final class HttpRequestUtilsTest {
   public void TestFilterNonAdminOnlyFlowParams() throws IOException,
       ExecutorManagerException, UserManagerException {
     final ExecutableFlow flow = createExecutableFlow();
+    flow.getExecutionOptions().getFlowParameters().put("azkaban.flow.submituser", "abc");
+    flow.getExecutionOptions().getFlowParameters().put("azkaban.job.id", "123");
+
     final UserManager manager = TestUtils.createTestXmlUserManager();
     final User user = manager.getUser("testUser", "testUser");
 
@@ -97,6 +100,10 @@ public final class HttpRequestUtilsTest {
         .containsKey(ExecutionOptions.FLOW_PRIORITY));
     Assert.assertFalse(flow.getExecutionOptions().getFlowParameters()
         .containsKey(ExecutionOptions.USE_EXECUTOR));
+    Assert.assertFalse(flow.getExecutionOptions().getFlowParameters()
+        .containsKey("azkaban.flow.submituser"));
+    Assert.assertFalse(flow.getExecutionOptions().getFlowParameters()
+        .containsKey("azkaban.job.id"));
   }
 
   /* Test that flow properties are retained for admin user */
@@ -104,6 +111,9 @@ public final class HttpRequestUtilsTest {
   public void TestFilterAdminOnlyFlowParams() throws IOException,
       ExecutorManagerException, UserManagerException {
     final ExecutableFlow flow = createExecutableFlow();
+    flow.getExecutionOptions().getFlowParameters().put("azkaban.flow.submituser", "abc");
+    flow.getExecutionOptions().getFlowParameters().put("azkaban.job.id", "123");
+
     final UserManager manager = TestUtils.createTestXmlUserManager();
     final User user = manager.getUser("testAdmin", "testAdmin");
 
@@ -114,6 +124,10 @@ public final class HttpRequestUtilsTest {
         .containsKey(ExecutionOptions.FLOW_PRIORITY));
     Assert.assertTrue(flow.getExecutionOptions().getFlowParameters()
         .containsKey(ExecutionOptions.USE_EXECUTOR));
+    Assert.assertTrue(flow.getExecutionOptions().getFlowParameters()
+        .containsKey("azkaban.flow.submituser"));
+    Assert.assertTrue(flow.getExecutionOptions().getFlowParameters()
+        .containsKey("azkaban.job.id"));
   }
 
   /* Test exception, if param is a valid integer */


### PR DESCRIPTION
**Why we need this**
These parameters starting with `azkaban.{flow|job}` should be generated by the system to honestly track the status of the execution / job, but not config-able by users.

**Tests done**
Simple change, unit tests is good enough