### PR TITLE
Fix the bug so can input FlowRetryStrategy from readable name or Enum name

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -935,7 +935,7 @@ public class Constants {
 
     public static FlowRetryStrategy valueFromName(String name) {
       for(FlowRetryStrategy s: FlowRetryStrategy.values()) {
-        if(s.name.equals(name)) {
+        if(s.name.equals(name) || s.name().equals(name)) {
           return s;
         }
       }

--- a/az-core/src/test/java/azkaban/ConstantsTest.java
+++ b/az-core/src/test/java/azkaban/ConstantsTest.java
@@ -1,0 +1,34 @@
+package azkaban;
+
+import static org.junit.Assert.assertEquals;
+
+import azkaban.Constants.FlowRetryStrategy;
+import org.junit.Test;
+
+public class ConstantsTest {
+
+  @Test
+  public void testFlowRetryStrategyValueFromName() {
+    assertEquals(FlowRetryStrategy.DEFAULT, FlowRetryStrategy.valueFromName("retryAsNew"));
+    assertEquals(FlowRetryStrategy.DEFAULT, FlowRetryStrategy.valueFromName("DEFAULT"));
+    assertEquals(FlowRetryStrategy.DISABLE_SUCCEEDED_NODES,
+        FlowRetryStrategy.valueFromName("disableSucceededNodes"));
+    assertEquals(FlowRetryStrategy.DISABLE_SUCCEEDED_NODES,
+        FlowRetryStrategy.valueFromName("DISABLE_SUCCEEDED_NODES"));
+
+    for (FlowRetryStrategy strategy: FlowRetryStrategy.values()) {
+      assertEquals(strategy, FlowRetryStrategy.valueFromName(strategy.getName()));
+      assertEquals(strategy, FlowRetryStrategy.valueFromName(strategy.name()));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFlowRetryStrategyValueFromNameInvalid() {
+    assertEquals(FlowRetryStrategy.DEFAULT, FlowRetryStrategy.valueFromName("bad-value"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFlowRetryStrategyValueFromNameEmpty() {
+    assertEquals(FlowRetryStrategy.DEFAULT, FlowRetryStrategy.valueFromName(""));
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
+++ b/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java
@@ -236,7 +236,7 @@ public class HttpRequestUtils {
     if (flowParameters.containsKey(FlowParameters.FLOW_PARAM_RETRY_STRATEGY)){
       String restartStrategy = flowParameters.get(FlowParameters.FLOW_PARAM_RETRY_STRATEGY);
       try {
-        FlowRetryStrategy restartStrategyEnum = FlowRetryStrategy.valueOf(restartStrategy);
+        FlowRetryStrategy restartStrategyEnum = FlowRetryStrategy.valueFromName(restartStrategy);
       } catch (IllegalArgumentException e){
         errMsg.add(String.format("Invalid %s = %s. Valid values are: %s",
             FlowParameters.FLOW_PARAM_RETRY_STRATEGY, restartStrategy,


### PR DESCRIPTION
**Why we need this**
To fix the bug that user see `"[Invalid flow.retry.strategy = retryAsNew. Valid values are: [retryAsNew, disableSucceededNodes]]`
With this change, both the enum name or the readable name can be accepted.

**Tests done**
Added Unit test, enough for small change