### PR TITLE
Schedule Logic Fix

### DIFF
--- a/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
+++ b/azkaban-common/src/main/java/azkaban/trigger/builtin/BasicTimeChecker.java
@@ -168,7 +168,9 @@ public class BasicTimeChecker implements ConditionChecker {
   public void reset() {
     final NextCheckTime nextCheckTimeObj = calculateNextCheckTime();
     this.nextCheckTime = nextCheckTimeObj.nextValidCheckTimeFromNow;
-    nextCheckTimeObj.missedCheckTimeBeforeNow.remove(nextCheckTimeObj.missedCheckTimeBeforeNow.size() - 1);
+    if (nextCheckTimeObj.missedCheckTimeBeforeNow.size() > 0) {
+      nextCheckTimeObj.missedCheckTimeBeforeNow.remove(nextCheckTimeObj.missedCheckTimeBeforeNow.size() - 1);
+    }
     this.missedCheckTimesBeforeNow = nextCheckTimeObj.missedCheckTimeBeforeNow;
   }
 

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ProjectManagerServlet.java
@@ -786,7 +786,8 @@ public class ProjectManagerServlet extends LoginAbstractAzkabanServlet {
         this.scheduler.unschedule(project);
       }
     } catch (final SchedulerException e) {
-      logger.error("");
+      logger.error("Error removing flow trigger schedules for project {} in removing project process",
+          project.getName(), e);
       throw new ServletException(e);
     }
   }


### PR DESCRIPTION
This reverts commit 6db750049f6fdf7842e18b8d533a3b736429bdf4. In this commit, we introduce a logic to categorize a trigger as expired trigger by examining the calculated nextCheckTime is before NOW. However there are twice update in the schedule loop when the current schedule is right on time to trigger action. In this case, right after trigger actions, the reset time checker is invoked where the trigger's nextCheckTime will be updated to be next valid trigger time after current time; while at the end of the loop, there is also trigger.updateNextCheckTime() to be called, and because the new current time is greater than the last update's current time, it is possible, the updated nextCheckTime is already passed the new current time, and result in catogorizing trigger as EXPIRED trigger

Details
This PR is to remove the second trigger.updateCheckTime() for several reasons:
1. Trigger's metadata would be updated and stored in DB anyways, we don't need frequently update nextCheckTime in one minute (scan interval) basis;
2. Trigger's triggerContition is already relying on NOW>nextCheckTime to trigger action, it means, in every loop we would check if nextCheckTime reaches now, if nextCheckTime is 10:00:00.000 and the check happens at 09:59:59.999, but after several lines when we force to update, now is 10:00:00.001, and we have to find next valid time after now, it would skip 10:00:00.000 to find the next valid value, so 10:00:00 can not be used to trigger actions. To conclude that, if a trigger's status is READY, we only need to update nextCheckTime after the recorded "nextCheckTime" is used to trigger action, otherwise, if the condition is not met, we're not supposed to update nextCheckTime by default, if it is falling too much cycles, the missed schedule logic would capture all the skipped checkTime and only allow the closet-to-now checkTime to remain to be checked.

Test
Add two unit tests to ensure the expiration works properly as expected, and normal trigger should not get impacted.
Schedule System's unit test is normally hard to target on one single corner cases, as the logic is relying on "NOW" (the moment that flipping the trigger's check time), it's usually hard to define if the corner case would happen exactly in this run, we're more hoping the iterations itself would hit the cornor case if possible. Take one use case as an example, we expect the current time is right before the trigger time in several interations to monitor it's keeping performing as it is, but we could only precisely control the first check time, and hard to control later updates because the testing interval is different than the real time interval, if we mock everything to match real time, it would make the test lengthy and slow.