### PR TITLE
Add support for schedule deletion notification

### DIFF
--- a/az-core/src/main/java/azkaban/Constants.java
+++ b/az-core/src/main/java/azkaban/Constants.java
@@ -182,8 +182,9 @@ public class Constants {
   public static final String PARAM_OVERRIDE_FILE = "param_override.properties";
 
   /**
-   * Missed Schedule Props
+   * Schedule Manager Props
    * */
+  public static final String SCHEDULE_EMAILER_ENABLED = "azkaban.schedule.emailer.enabled";
   public static final String MISSED_SCHEDULE_MANAGER_ENABLED = "azkaban.missed.schedule.manager.enabled";
   public static final String MISSED_SCHEDULE_THREAD_POOL_SIZE = "azkaban.missed.schedule.task.threads";
   public static final boolean DEFAULT_BACK_EXECUTE_ONCE_ON_MISSED_SCHEDULE = false;

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleChangeEmailerManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleChangeEmailerManager.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.scheduler;
+
+import azkaban.Constants;
+import azkaban.executor.ExecutionOptions;
+import azkaban.flow.NoSuchAzkabanResourceException;
+import azkaban.metrics.MetricsManager;
+import azkaban.sla.SlaOption;
+import azkaban.utils.Emailer;
+import azkaban.utils.Props;
+import com.codahale.metrics.Meter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Future;
+import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ScheduleChangeEmailerManager is designed to send email notification to flow owners when schedule is deleted,
+ * it can be extended further to send emails on different scenarios especially on schedule change.
+ * */
+public class ScheduleChangeEmailerManager extends ScheduleEmailerManager {
+  private final boolean scheduleDeletionEmailerEnabled;
+  private final Meter scheduleDeletionCount;
+  @Inject
+  public ScheduleChangeEmailerManager(Props azkProps, Emailer emailer, MetricsManager metricsManager) {
+    super(azkProps, emailer, "azk-schedule-deletion-emailer-task-pool");
+    this.scheduleDeletionEmailerEnabled = azkProps.getBoolean(Constants.SCHEDULE_EMAILER_ENABLED, false);
+    this.scheduleDeletionCount = metricsManager.addMeter("schedule-deletion-count");
+  }
+
+  @Override
+  public boolean isEmailerManagerEnabled() {
+    return this.scheduleDeletionEmailerEnabled;
+  }
+
+  public void addNotificationTaskOnScheduleDelete(@NotNull final Schedule schedule,
+      final String userName, String reason) {
+    this.scheduleDeletionCount.mark();
+    if (!scheduleDeletionEmailerEnabled) {
+      this.log.info("Schedule deletion email feature is not enabled. Skip sending email.");
+      return;
+    }
+    try {
+      List<String> emailRecipients = getEmailRecipientsFromSchedule(schedule);
+      if (emailRecipients.isEmpty()) {
+        this.log.info("No email recipients found for schedule {}", schedule.toString());
+        return;
+      }
+      final Future taskFuture = this.executor.submit(
+          new ScheduleDeletionTask(this.emailer, emailRecipients, schedule, userName, reason));
+    } catch (Exception e) {
+      log.error("Failed to add email notification task for schedule deletion of {}", schedule.toString(), e);
+    }
+  }
+
+  /**
+   * Fetch email recipients from schedule. If slaOptions is not empty, use slaOptions to get email recipients,
+   * otherwise use successEmails and failureEmails provided from executionOptions of schedule.
+   * */
+  @VisibleForTesting
+  protected List<String> getEmailRecipientsFromSchedule(Schedule schedule) {
+    ExecutionOptions executionOptions = schedule.getExecutionOptions();
+    List<SlaOption> slaOptions = executionOptions.getSlaOptions();
+    Set<String> emailRecipients = new HashSet<>();
+    if (slaOptions != null && !slaOptions.isEmpty()) {
+      slaOptions.stream().filter(slaOption -> slaOption != null && slaOption.getEmails() != null)
+          .map(SlaOption::getEmails).forEach(emailRecipients::addAll);
+    } else {
+      emailRecipients.addAll(executionOptions.getFailureEmails());
+      emailRecipients.addAll(executionOptions.getSuccessEmails());
+    }
+    return new ArrayList<>(emailRecipients);
+  }
+
+  public static class ScheduleDeletionTask implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduleDeletionTask.class);
+    private final Emailer emailer;
+    // emailRecipients to notify users the schedules missed
+    private final List<String> emailRecipients;
+    // the email body
+    private final String emailMessage;
+
+    public ScheduleDeletionTask(final Emailer emailer,
+        final List<String> emailRecipients,
+        final Schedule schedule,
+        final String user,
+        final String reason) {
+      this.emailer = emailer;
+      this.emailRecipients = emailRecipients;
+      final MessageFormat messageFormat = new MessageFormat(
+          "This is an auto generated email to notify flow owners. \n"
+              + "The schedule id {0} with cron expression {1} for flow {2} in project {3} "
+              + "has been deleted by user {4} due to the following reason: {5}. ");
+      this.emailMessage = messageFormat.format(
+          new Object[]{String.valueOf(schedule.getScheduleId()), schedule.getCronExpression(), schedule.getFlowName(),
+              schedule.getProjectName(), user, reason});
+    }
+    @Override
+    public void run() {
+      try {
+        emailer.sendEmail(this.emailRecipients, "Azkaban Schedule Deletion Notification", this.emailMessage);
+      } catch (final Exception e) {
+        LOG.error("Failed to send email to " + emailRecipients + " due to exception", e);
+      }
+    }
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleEmailerManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleEmailerManager.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package azkaban.scheduler;
+
+import azkaban.Constants;
+import azkaban.flow.Flow;
+import azkaban.flow.FlowUtils;
+import azkaban.metrics.MetricsManager;
+import azkaban.project.Project;
+import azkaban.project.ProjectManager;
+import azkaban.trigger.builtin.ExecuteFlowAction;
+import azkaban.utils.DaemonThreadFactory;
+import azkaban.utils.Emailer;
+import azkaban.utils.Props;
+import azkaban.utils.TimeUtils;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This abstract class is to provide a failure recover manager for schedules.
+ * Schedule might be missed to execute, schedule might be deleted, and this class provide a generic way to handle
+ * the notification to users by email.
+ * */
+@Singleton
+public abstract class ScheduleEmailerManager {
+  protected final Logger log;
+
+  protected ExecutorService executor;
+  // TODO: Refactored to AlerterHolder to support Iris use case
+  protected final Emailer emailer;
+
+  // parameters to adjust the thread pool size
+  protected final int threadPoolSize;
+  private final int DEFAULT_THREAD_POOL_SIZE = 5;
+  private final String threadPoolName;
+
+  public ScheduleEmailerManager(final Props azkProps,
+      final Emailer emailer,
+      final String threadPoolName) {
+    this.log = LoggerFactory.getLogger(getClass().getSimpleName());
+    this.emailer = emailer;
+    this.threadPoolSize = azkProps.getInt(Constants.MISSED_SCHEDULE_THREAD_POOL_SIZE, this.DEFAULT_THREAD_POOL_SIZE);
+    this.threadPoolName = threadPoolName;
+  }
+
+  protected abstract boolean isEmailerManagerEnabled();
+
+  public void start() {
+    // Create the thread pool
+    this.executor =
+        isEmailerManagerEnabled() ? Executors.newFixedThreadPool(this.threadPoolSize,
+            new DaemonThreadFactory(this.threadPoolName)) : null;
+    if (isEmailerManagerEnabled()) {
+      log.info("{} is ready to take tasks.", getClass().getSimpleName());
+    } else {
+      log.info("{} is disabled.", getClass().getSimpleName());
+    }
+  }
+
+  public boolean stop() throws InterruptedException {
+    if (this.executor != null) {
+      this.executor.shutdown();
+      if (!this.executor.awaitTermination(30, TimeUnit.SECONDS)) {
+        this.executor.shutdownNow();
+      }
+    }
+    return true;
+  }
+}

--- a/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
+++ b/azkaban-common/src/main/java/azkaban/scheduler/ScheduleManager.java
@@ -54,6 +54,8 @@ public class ScheduleManager implements TriggerAgent {
   private final ScheduleLoader loader;
   private final ProjectManager projectManager;
 
+  private final ScheduleChangeEmailerManager scheduleChangeEmailerManager;
+
   private final Map<Integer, Schedule> scheduleIDMap =
       new ConcurrentHashMap<>();
   private final Map<Pair<Integer, String>, Schedule> scheduleIdentityPairMap =
@@ -63,9 +65,12 @@ public class ScheduleManager implements TriggerAgent {
    * Give the schedule manager a loader class that will properly load the schedule.
    */
   @Inject
-  public ScheduleManager(final ScheduleLoader loader, final ProjectManager projectManager) {
+  public ScheduleManager(final ScheduleLoader loader,
+      final ProjectManager projectManager,
+      final ScheduleChangeEmailerManager scheduleChangeEmailerManager) {
     this.projectManager = projectManager;
     this.loader = loader;
+    this.scheduleChangeEmailerManager = scheduleChangeEmailerManager;
   }
 
   /**
@@ -120,6 +125,7 @@ public class ScheduleManager implements TriggerAgent {
           logMessage);
     }
     removeSchedule(s);
+    this.scheduleChangeEmailerManager.addNotificationTaskOnScheduleDelete(s, "azkaban", "Schedule Expired" );
   }
 
   /**

--- a/azkaban-common/src/test/java/azkaban/scheduler/ScheduleChangeEmailerManagerTest.java
+++ b/azkaban-common/src/test/java/azkaban/scheduler/ScheduleChangeEmailerManagerTest.java
@@ -1,0 +1,100 @@
+package azkaban.scheduler;
+
+import azkaban.Constants;
+import azkaban.executor.ExecutionOptions;
+import azkaban.metrics.MetricsManager;
+import azkaban.sla.SlaAction;
+import azkaban.sla.SlaOption;
+import azkaban.sla.SlaType;
+import azkaban.utils.Emailer;
+import azkaban.utils.Props;
+import com.codahale.metrics.Meter;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+public class ScheduleChangeEmailerManagerTest {
+  ScheduleChangeEmailerManager scheduleChangeEmailerManager;
+  MetricsManager metricsManager;
+  Meter fakeMeter;
+  Emailer emailer;
+
+  @Before
+  public void setup() {
+    this.emailer = mock(Emailer.class);
+    this.metricsManager = mock(MetricsManager.class);
+    this.fakeMeter = new Meter();
+    final Props azkProps = new Props();
+    azkProps.put(Constants.SCHEDULE_EMAILER_ENABLED, "true");
+    when(this.metricsManager.addMeter(any())).thenReturn(this.fakeMeter);
+
+    this.scheduleChangeEmailerManager = new ScheduleChangeEmailerManager(azkProps, this.emailer, this.metricsManager);
+    this.scheduleChangeEmailerManager.start();
+  }
+
+  @After
+  public void cleanup() throws InterruptedException {
+    this.scheduleChangeEmailerManager.stop();
+  }
+
+  @Test
+  public void testGetEmailRecipientsFromSchedule() {
+    String flowName = "testFlow";
+    String email = "test-azkaban-sla@linkedin.com";
+    long firstSchedTime = System.currentTimeMillis();
+    long endSchedTime = firstSchedTime + 100000;
+    ExecutionOptions executionOptions = new ExecutionOptions();
+    final List<SlaOption> slaOptions = new ArrayList<>();
+    slaOptions.add(
+        new SlaOption.SlaOptionBuilder(SlaType.FLOW_FINISH, flowName, Duration.ofHours(1))
+            .setActions(Collections.singleton(SlaAction.KILL))
+            .setEmails(Collections.singletonList(email))
+            .createSlaOption());
+    executionOptions.setSlaOptions(slaOptions);
+    Schedule schedule = new Schedule(1, 123, "testProject", flowName,"ready",
+        firstSchedTime, endSchedTime, DateTimeZone.getDefault(), null, DateTime.now().getMillis(), firstSchedTime,
+        firstSchedTime, "testUser", executionOptions, "0 * * * * *", false);
+    assertThat(this.scheduleChangeEmailerManager.getEmailRecipientsFromSchedule(schedule)).contains(email);
+  }
+
+  @Test
+  public void testGetEmailRecipientsWithoutSLAEmail() {
+    String flowName = "testFlow";
+    String email = "test-azkaban@linkedin.com";
+    long firstSchedTime = System.currentTimeMillis();
+    long endSchedTime = firstSchedTime + 100000;
+    ExecutionOptions executionOptions = new ExecutionOptions();
+    executionOptions.setFailureEmails(Collections.singletonList(email));
+    Schedule schedule = new Schedule(1, 123, "testProject", flowName,"ready",
+        firstSchedTime, endSchedTime, DateTimeZone.getDefault(), null, DateTime.now().getMillis(), firstSchedTime,
+        firstSchedTime, "testUser", executionOptions, "0 * * * * *", false);
+    assertThat(this.scheduleChangeEmailerManager.getEmailRecipientsFromSchedule(schedule)).contains(email);
+  }
+  @Test
+  public void testAddEmailTask() {
+    String flowName = "testFlow";
+    String email = "test-azkaban@linkedin.com";
+    long firstSchedTime = System.currentTimeMillis();
+    long endSchedTime = firstSchedTime + 100000;
+    ExecutionOptions executionOptions = new ExecutionOptions();
+    executionOptions.setFailureEmails(Collections.singletonList(email));
+    Schedule schedule = new Schedule(1, 123, "testProject", flowName,"ready",
+        firstSchedTime, endSchedTime, DateTimeZone.getDefault(), null, DateTime.now().getMillis(), firstSchedTime,
+        firstSchedTime, "testUser", executionOptions, "0 * * * * *", false);
+    // verify task is added into queue
+    assertThatCode(
+        () -> scheduleChangeEmailerManager.addNotificationTaskOnScheduleDelete(schedule, "test", "Project Removal")
+    ).doesNotThrowAnyException();
+  }
+}

--- a/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
+++ b/azkaban-web-server/src/main/java/azkaban/webapp/servlet/ScheduleServlet.java
@@ -27,6 +27,7 @@ import azkaban.project.Project;
 import azkaban.project.ProjectLogEvent.EventType;
 import azkaban.project.ProjectManager;
 import azkaban.scheduler.Schedule;
+import azkaban.scheduler.ScheduleChangeEmailerManager;
 import azkaban.scheduler.ScheduleManager;
 import azkaban.scheduler.ScheduleManagerException;
 import azkaban.server.AzkabanAPI;
@@ -86,6 +87,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
   private static final Logger logger = LoggerFactory.getLogger(ScheduleServlet.class);
   private ProjectManager projectManager;
   private ScheduleManager scheduleManager;
+  private ScheduleChangeEmailerManager scheduleChangeEmailerManager;
   private UserManager userManager;
   private Map<String, List<HTMLFormElement>> alerterPlugins;
 
@@ -100,6 +102,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
     this.userManager = server.getUserManager();
     this.projectManager = server.getProjectManager();
     this.scheduleManager = server.getScheduleManager();
+    this.scheduleChangeEmailerManager = server.getScheduleChangeEmailerManager();
     final Map<String, List<HTMLFormElement>> alerterPlugins = new HashMap<>();
     server.getAlerterPlugins().forEach((name, alerter) -> alerterPlugins.put(name,
         (alerter.getViewParameters() != null ? alerter.getViewParameters()
@@ -416,6 +419,7 @@ public class ScheduleServlet extends LoginAbstractAzkabanServlet {
 
     this.scheduleManager.removeSchedule(sched);
     logger.info("User " + user.getUserId() + " has removed schedule " + sched.getScheduleName());
+    this.scheduleChangeEmailerManager.addNotificationTaskOnScheduleDelete(sched, user.getUserId(), "User Operation");
     this.projectManager.postProjectEvent(project, EventType.SCHEDULE, user.getUserId(),
         "Schedule " + sched.toString() + " has been removed.");
 

--- a/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
+++ b/azkaban-web-server/src/test/java/azkaban/webapp/servlet/ProjectManagerServletTest.java
@@ -29,6 +29,7 @@ import azkaban.project.DirectoryYamlFlowLoader;
 import azkaban.project.Project;
 import azkaban.project.ProjectManager;
 import azkaban.scheduler.Schedule;
+import azkaban.scheduler.ScheduleChangeEmailerManager;
 import azkaban.scheduler.ScheduleManager;
 import azkaban.server.session.Session;
 import azkaban.test.executions.ExecutionsTestUtil;
@@ -55,6 +56,7 @@ public class ProjectManagerServletTest {
 
   private final ScheduleManager scheduleManager = mock(ScheduleManager.class);
   private final ProjectManagerServlet projectManagerServlet = mock(ProjectManagerServlet.class);
+  private final ScheduleChangeEmailerManager scheduleChangeEmailerManager = mock(ScheduleChangeEmailerManager.class);
 
   @Test
   public void testRemoveScheduleOfDeletedFlows() throws Exception {
@@ -83,7 +85,7 @@ public class ProjectManagerServletTest {
     doAnswer(invocation -> schedules.remove(invocation.getArguments()[0]))
         .when(this.scheduleManager).removeSchedule(any(Schedule.class));
     this.projectManagerServlet
-        .removeScheduleOfDeletedFlows(project, this.scheduleManager, schedule -> {
+        .removeScheduleOfDeletedFlows(project, this.scheduleManager, this.scheduleChangeEmailerManager, schedule -> {
         });
     Assert.assertEquals(2, schedules.size());
     Assert.assertTrue(schedules.containsAll(Arrays.asList(sched2, sched3)));


### PR DESCRIPTION
Summary 
Add support to enable email notification for users when the schedule has been deleted. This is a default enabled feature for all flows, toggled by a feature flag. For email recipients, we first use SLA setting's email address, if the schedule does not have SLA set, we would look for success or failure email settings for executions as recipients.